### PR TITLE
docs: ドキュメント索引と参照先を更新 (SUMMARY / implementation / activeContext)

### DIFF
--- a/docs/01_project/activeContext/summary.md
+++ b/docs/01_project/activeContext/summary.md
@@ -1,4 +1,4 @@
-# activeContext 概要（最終確認日: 2025年09月15日）
+# activeContext 概要（最終確認日: 2026年02月02日）
 
 このディレクトリは、直近の意思決定・タスク運用・計画中/保管中の資料を集約します。参照順は以下のとおりです。
 
@@ -12,7 +12,7 @@
 - iroh-native-dht-plan.md: iroh Mainline DHT 移行計画
 - tauri_app_experience_design.md: Tauri アプリの体験設計
 - tauri_app_implementation_plan.md: 実装計画
-- artefacts/document_date_format_inventory.md: ドキュメント日付表記ルールと棚卸し（2025年10月22日更新）
+- artefacts/document_date_format_inventory.md: ドキュメント日付表記ルールと棚卸し
 - deprecation/
   - gossip_manager_deprecation.md: GossipManager 廃止の経緯
   - distributed-topic-tracker-plan.md: 旧分散トラッカー計画の保管（廃止）
@@ -24,5 +24,5 @@
 - ブロッカー: `tasks/context/blockers.md` に記録。解決後は削除
 
 補足
-- ドキュメントの日付は `YYYY年MM月DD日`（例: 2025年09月15日）表記で統一
+- ドキュメントの日付は `YYYY年MM月DD日`（例: 2026年02月02日）表記で統一
 - `docs/SUMMARY.md` から本ディレクトリへ辿れるように維持すること

--- a/docs/01_project/activeContext/tasks/completed/2026-02-02.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-02.md
@@ -13,3 +13,8 @@
 - [x] `./scripts/test-docker.ps1 ts`（act/useRouter 警告あり、失敗なし）
 - [x] `gh act --workflows .github/workflows/test.yml --job format-check`
 - [x] `gh act --workflows .github/workflows/test.yml --job native-test-linux`
+
+## docs 以下の記述更新と現行状況の整理
+- [x] docs/SUMMARY.md を最新のドキュメント構成に合わせて刷新し、進行状況の参照先を activeContext に集約
+- [x] docs/03_implementation/summary.md の索引を実ファイル構成に合わせて再整理
+- [x] docs/01_project/activeContext/summary.md の最終確認日と参照情報を更新

--- a/docs/03_implementation/summary.md
+++ b/docs/03_implementation/summary.md
@@ -1,63 +1,51 @@
 # 実装ドキュメント概要
 
-**最終更新**: 2026年01月22日
+**最終更新**: 2026年02月02日
 
-このディレクトリには、Kukuriプロジェクトの実装に関する詳細なドキュメントが含まれています。
+このディレクトリには、Kukuriプロジェクトの実装に関する詳細なドキュメントを集約しています。
+最新の実装状況は `docs/01_project/activeContext/tasks/` と進捗レポートを参照してください。
 
 ## ドキュメント一覧
 
-### 基本実装計画
-- [implementation_plan.md](./implementation_plan.md) - プロジェクト全体の実装計画（MVP・ベータ版）
+### 実装計画・方針
+- [implementation_plan.md](./implementation_plan.md) - 段階的な実装計画
+- [error_handling_guidelines.md](./error_handling_guidelines.md) - エラーハンドリング指針
+- [send_sync_trait_bounds_implementation.md](./send_sync_trait_bounds_implementation.md) - Rust制約整理
 
-### コミュニティノード
-- [community_nodes/summary.md](./community_nodes/summary.md) - コミュニティノード（bootstrap/relay/index/moderation/trust）実装計画
+### P2P / iroh / Gossip
+- [dht_integration_guide.md](./dht_integration_guide.md) - DHT統合ガイド
+- [p2p_mainline_runbook.md](./p2p_mainline_runbook.md) - Mainline DHT運用手順
+- [p2p_event_routing_design.md](./p2p_event_routing_design.md) - イベントルーティング設計
+- [p2p_dht_test_strategy.md](./p2p_dht_test_strategy.md) - DHTテスト戦略
+- [iroh_gossip_integration_design.md](./iroh_gossip_integration_design.md) - iroh-gossip統合設計
+- [iroh_gossip_implementation_plan.md](./iroh_gossip_implementation_plan.md) - 実装計画
+- [iroh_gossip_implementation_status.md](./iroh_gossip_implementation_status.md) - 実装状況の整理
+- [iroh_gossip_api_v090.md](./iroh_gossip_api_v090.md) / [iroh_v090_specification.md](./iroh_v090_specification.md) - 旧API仕様（参照用）
 
-### ストレージ実装
-- [storage_implementation_guide.md](./storage_implementation_guide.md) - ストレージ実装のガイドライン
+### Nostr
+- [nostr_event_validation.md](./nostr_event_validation.md) - Nostrイベント検証
+- [nostr_reactions_implementation.md](./nostr_reactions_implementation.md) - リアクション実装
 
-### P2P通信実装
-- [iroh_v090_specification.md](./iroh_v090_specification.md) - iroh v0.90.0の詳細仕様書
-- [iroh_gossip_integration_design.md](./iroh_gossip_integration_design.md) - iroh-gossip統合設計書
-- [iroh_gossip_implementation_plan.md](./iroh_gossip_implementation_plan.md) - P2P機能の詳細実装計画
+### ストレージ / SQLx
+- [storage_implementation_guide.md](./storage_implementation_guide.md) - ストレージ実装
+- [sqlx_best_practices.md](./sqlx_best_practices.md) - SQLx運用ベストプラクティス
+- [sqlx_offline_mode_guide.md](./sqlx_offline_mode_guide.md) - SQLxオフライン準備
 
-### Nostr実装
-- [nostr_reactions_implementation.md](./nostr_reactions_implementation.md) - Nostrリアクション機能実装ガイド 🆕
+### テスト / QA
+- [testing_guide.md](./testing_guide.md) - テスト戦略
+- [docker_test_environment.md](./docker_test_environment.md) - Dockerテスト環境
+- [e2e_test_setup.md](./e2e_test_setup.md) - E2Eテスト環境セットアップ
+- [e2e_test_implementation_plan.md](./e2e_test_implementation_plan.md) - E2E導入計画
+- [e2e_test_stabilization.md](./e2e_test_stabilization.md) - E2E安定化メモ
+- [windows_test_docker_runbook.md](./windows_test_docker_runbook.md) - Windows環境のテスト運用
+- [zustand_testing_best_practices.md](./zustand_testing_best_practices.md) - Zustandテスト
 
-### テスト
-- [testing_guide.md](./testing_guide.md) - テスト戦略と実装ガイド
-- [zustand_testing_best_practices.md](./zustand_testing_best_practices.md) - Zustandストアのテストベストプラクティス
-
-### 品質・コーディング規約
-- [error_handling_guidelines.md](./error_handling_guidelines.md) - エラーハンドリングガイドライン 🆕
-
-## 実装状況
-
-### 完了済み
-- ✅ **基盤構築**: Tauri v2、React、TypeScript、Rust基礎
-- ✅ **UIコンポーネント**: shadcn/ui、レイアウト、ルーティング
-- ✅ **状態管理**: Zustand、Tanstack Query
-- ✅ **認証・ユーザー管理**: 鍵生成、ログイン/ログアウト、セキュアストレージ
-- ✅ **Nostr統合**: nostr-sdk、リレー接続、イベント送受信
-- ✅ **P2P基礎実装**: iroh-gossip v0.90.0統合
-- ✅ **P2Pトピック管理**: トピック参加・離脱、メッセージング
-- ✅ **P2P Nostr統合**: イベント変換、ハイブリッド配信
-- ✅ **データ連携**: リアルタイム更新、トピック別タイムライン
-- ✅ **リアクション機能**: 返信、引用、いいね、ブースト、ブックマーク、カスタムリアクション
-- ✅ **投稿機能**: リッチテキストエディタ、下書き管理、メディア埋め込み
-- ✅ **検索機能**: 基本的な検索UI実装
-
-### 進行中
-- 🔄 **Phase 4準備**: オフラインファースト機能の設計
-
-### 次のステップ
-- [ ] オフラインファースト機能の実装（Phase 4）
-- [ ] ローカルファーストデータ管理
-- [ ] 楽観的UI更新の拡張
-- [ ] 同期と競合解決
+### 追加ガイド
+- [trending_metrics_job.md](./trending_metrics_job.md) - トレンドメトリクスジョブ
 
 ## 関連ドキュメント
-
-- [プロジェクト構造](../03_development_setup/project_structure.md)
+- [プロジェクト構造](../02_architecture/project_structure.md)
 - [システム設計](../02_architecture/system_design.md)
-- [現在のタスク](../01_project/activeContext/current_tasks.md)
+- [activeContext 概要](../01_project/activeContext/summary.md)
+- [進行中タスク](../01_project/activeContext/tasks/status/in_progress.md)
 - [進捗レポート](../01_project/progressReports/)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,260 +1,52 @@
 # kukuri ドキュメント概要
-補足: ActiveContext の最新索引は `docs/01_project/activeContext/summary.md` を参照（最終更新: 2025年09月15日）。
 
-**最終更新**: 2025年08月16日（DHT基盤Discovery Layer移行決定）
+補足: 最新の作業状況・意思決定は `docs/01_project/activeContext/summary.md` と
+`docs/01_project/activeContext/tasks/` を参照してください（最終確認: 2026年02月02日）。
+
+**最終更新**: 2026年02月02日
 
 ## プロジェクト概要
-kukuriは、Nostrプロトコルをベースとした完全分散型トピック中心ソーシャルアプリケーションです。BitTorrent Mainline DHTを基盤とした分散型ピア発見により、中央サーバー依存を完全に排除し、検閲耐性とユーザー主権を実現します。
+kukuriは、Nostrプロトコルをベースとした完全分散型トピック中心ソーシャルアプリケーションです。
+BitTorrent Mainline DHT を基盤とした分散型ピア発見により、中央サーバー依存を排除し、
+検閲耐性とユーザー主権を実現することを目指します。
 
 ## ドキュメント構成
 
 ### 01_project/ - プロジェクト管理
 - **design_doc.md**: プロジェクトの全体設計書
 - **requirements.md**: 機能要件・非機能要件定義
-- **roadmap.md**: プロジェクトロードマップ ✨新規
-- **activeContext/**: 現在の作業状況
-  - current_tasks.md: 進行中のタスク
-  - current_environment.md: 開発環境情報
-  - issuesAndNotes.md: 既知の問題と注意事項
-  - iroh-native-dht-plan.md: irohネイティブDHT実装計画 ✨最重要
-  - distributed-topic-tracker-plan.md: [DEPRECATED] 旧DHT実装計画
-  - tauri_app_experience_design.md: Tauriアプリ体験設計
-  - tauri_app_implementation_plan.md: Tauriアプリ実装計画
-  - **tasks/**: タスク管理システム
-    - priority/critical.md: 最重要タスク
-    - status/in_progress.md: 進行中タスク
-- **progressReports/**: 進捗レポート
+- **roadmap.md**: ロードマップ
+- **setup_guide.md** / **windows_setup_guide.md**: 開発環境セットアップ
+- **activeContext/**: 現在の作業状況・決定事項・タスク管理
+  - `tasks/priority/critical.md`: 最重要タスク
+  - `tasks/status/in_progress.md`: 進行中タスク
+  - `tasks/completed/YYYY-MM-DD.md`: 完了タスクの記録
+- **progressReports/**: 進捗レポート（重要な変更の記録）
+- **deprecated/**: 役目を終えた計画・設計の保管庫（参照のみ）
 
 ### 02_architecture/ - アーキテクチャ設計
-- **system_design.md**: システム設計詳細（DHT更新済み）
-  - レイヤー構成（BitTorrent DHT統合）
-  - データモデル
-  - API設計
-  - セキュリティ設計
-- **dht_discovery_architecture.md**: DHT基盤Discovery Layerアーキテクチャ ✨新規
-  - irohビルトインDHT統合
-  - セキュリティモデル
-  - パフォーマンス要件
+- **system_design.md**: システム設計詳細
+- **dht_discovery_architecture.md**: DHT基盤Discovery Layerアーキテクチャ
 - **project_structure.md**: プロジェクト構造
-  - ディレクトリ構成
-  - ファイル構造詳細
-  - 開発ワークフロー
-
-### 03_features/ - 機能仕様
-- 各機能の詳細仕様書（作成予定）
-
-### 04_data/ - データ設計
-- データベーススキーマ
-- Nostrイベント仕様（作成予定）
+- **iroh_gossip_review.md** / **storage_comparison_report.md**: 調査・比較資料
 
 ### 03_implementation/ - 実装ガイド
-- **dht_integration_guide.md**: DHT統合実装ガイド ✨最重要
-  - 依存関係とセットアップ
-  - P2Pモジュール実装
-  - イベントハンドリング
-  - テスト戦略
-- **implementation_plan.md**: 段階的実装計画
-  - Phase 1: DHT統合 (2週間) ✨更新
-  - Phase 2: ベータ版 (3ヶ月)
-  - Phase 3: 正式リリース
-- **storage_implementation_guide.md**: ストレージ実装ガイド
-- **testing_guide.md**: テスト戦略と実装ガイド
-- **e2e_test_setup.md**: E2Eテスト環境セットアップガイド（WebdriverIO + tauri-driver）
-- **e2e_test_implementation_plan.md**: E2Eテスト導入プラン（初期設計文書）
-- **iroh_gossip_integration_design.md**: iroh-gossip統合設計
-- **iroh_gossip_implementation_plan.md**: iroh-gossip実装計画
-- **iroh_gossip_test_implementation.md**: P2P機能テスト実装詳細
+- **summary.md**: 実装ドキュメントの索引
+- **dht_integration_guide.md** / **p2p_mainline_runbook.md**: P2P/DHT運用・実装
+- **testing_guide.md** / **e2e_test_setup.md**: テストガイド
+- **sqlx_* / storage_implementation_guide.md**: ストレージ関連
+- **error_handling_guidelines.md**: エラーハンドリング指針
 
-## 技術スタック
+### kips/・nips/ - 仕様・提案
+- **kips/**: Kukuri Improvement Proposals
+- **nips/**: Nostr Improvement Proposals
 
-### フロントエンド
-- React 18 + TypeScript
-- Vite (ビルドツール)
-- shadcn/ui (UIコンポーネント)
-- Zustand (状態管理)
-- Tanstack Query/Router
+### apis/ - ローカルAPI JSON
+- `docs/apis/` に iroh 系 API JSON を配置
 
-### バックエンド
-- Tauri v2 (デスクトップフレームワーク)
-- Rust (コアロジック)
-- iroh (P2P通信基盤)
-- iroh-gossip (トピックベースイベント配信)
-- nostr-sdk (Nostrプロトコル)
-- SQLite (ローカルDB)
+## 開発状況の参照先
+最新の進行状況・完了事項は、以下のドキュメントを起点に確認してください。
 
-### インフラ
-- Cloudflare Workers / Docker (ピア発見)
-- 分散マーケットプレイス (検索・推薦)
-
-## 現在の開発状況 (2025年08月14日時点)
-
-### 最新の完了項目
-- ✅ **E2Eテスト基盤構築（2025年08月14日）**
-  - WebdriverIO環境セットアップ完了
-  - tauri-driver + Microsoft Edge Driver導入
-  - 基本テストファイル作成（basic.spec.ts, nostr.spec.ts）
-  - デバッグビルド作成・テスト実行成功
-  - 実装時間: 約4時間
-
-- ✅ **Result型統一完了（2025年08月14日）**
-  - 全サービス層のResult型をAppErrorに統一
-  - インフラ層（Repository, P2P, 暗号化）の統一
-  - From実装の追加（7種類のエラー型変換）
-  - コンパイルエラー解消（22件→0件）
-  - ビルド成功達成
-
-- ✅ **v2アーキテクチャ移行 Phase 1-3（2025年08月14日）**
-  - 49コマンドのv2実装完了
-  - 5層クリーンアーキテクチャ確立
-  - 依存性逆転の原則（DIP）適用
-  - トレイトベース設計実装
-
-### 現在の状況
-- ✅ **ビルド**: 成功（警告175件、主に未使用インポート）
-- ✅ **E2Eテスト基盤**: 構築完了（2025年08月14日）
-  - WebdriverIO + tauri-driver環境構築
-  - 6/8テスト成功（基盤動作確認済み）
-  - 実行時間: 約34秒
-- 🔄 **次フェーズ**: E2Eテスト安定化とPhase 7
-  - E2Eテストの待機処理改善
-  - data-testid属性追加
-  - OfflineService詳細実装
-  - → 詳細: activeContext/current_tasks.md
-
-### 完了済み機能
-- ✅ **新アーキテクチャ（クリーンアーキテクチャ）**
-  - ドメイン層（エンティティ、値オブジェクト）
-  - インフラストラクチャ層（リポジトリ、P2P、キャッシュ）
-  - アプリケーション層（サービス実装）
-  - プレゼンテーション層（DTO、ハンドラー、コマンド）
-  - 依存性逆転の原則（DIP）適用
-
-- ✅ **パフォーマンス最適化**
-  - メモリキャッシュ層（TTLサポート、50倍高速化）
-  - バッチ処理（最大100件一括処理）
-  - 並行処理最適化（npub変換5倍高速化）
-  - ハンドラー再利用（生成コスト50倍削減）
-
-- ✅ **基盤実装**
-  - Tauri v2プロジェクト構造
-  - フロントエンド基盤（React 18 + TypeScript）
-  - Rust基盤（鍵管理、暗号化、DB）
-  - Tauriコマンドインターフェース
-  - Windows/macOS/Linuxクロスプラットフォーム対応
-
-- ✅ **Nostr統合**
-  - Nostr SDK統合（v0.42.0）
-  - イベント送受信機能
-  - リレー接続・ヘルスチェック
-  - 双方向同期（Nostr ↔ P2P）
-
-- ✅ **P2P通信実装**
-  - iroh-gossip統合（Day 1-5）
-  - トピック管理機能
-  - メッセージ署名・検証
-  - イベント変換機能（Day 6）
-  - 双方向同期機能（Day 7）
-  - ハイブリッド配信（Day 8）
-  - UI統合（Day 9）
-
-- ✅ **UI/UX**
-  - 基本レイアウト・ルーティング
-  - P2P状態表示（サイドバー）
-  - トピックメッシュ可視化
-  - P2Pデバッグパネル
-
-- ✅ **テスト・品質保証**
-  - 517個のフロントエンドテスト
-  - 156個のバックエンドテスト
-  - 型チェック・リント完全クリーン
-  - E2E/統合テスト基盤
-
-- ✅ **データ連携・機能実装（Phase 2-3完了）**
-  - 投稿の実データ取得・表示
-  - トピック管理機能（作成・編集・削除）
-  - リアルタイム更新機能
-  - 返信・引用機能（NIP-10準拠）
-  - 検索機能（投稿・トピック・ユーザー）
-  - 手動P2P接続機能
-  - リッチテキストエディタ（Markdownサポート）
-  - メディア埋め込み機能
-  - 下書き管理機能
-  - 予約投稿UI（バックエンド実装は保留）
-
-### 最近の成果
-- 🚀 **Phase 6 コマンド最適化完了（2025年08月13日）**
-  - バッチ処理による一括処理（最大100件）
-  - メモリキャッシュで50倍高速化実現
-  - 並行処理でCPU効率5倍向上
-  - パフォーマンステスト・ベンチマーク整備
-- 🏗️ **Phase 5 クリーンアーキテクチャ移行（2025年08月13日）**
-  - 5層構造による責務分離実現
-  - 44個の新規ファイル作成
-  - テスト構造の改善（unit/integration/common）
-  - 依存性逆転の原則（DIP）適用
-- 🎯 **タイムライン機能の改善（2025年08月02日）**
-  - アカウント追加時に#publicトピックへの自動参加
-  - トピック別タイムライン表示機能
-  - 未同期投稿の「未同期」バッジ表示
-  - 前回表示トピックの復元機能
-  - タイムラインへの遷移導線の追加
-- 🎆 **Windows環境アカウント永続化問題の解決（2025年08月02日）**
-  - keyringライブラリのwindows-nativeフィーチャー有効化
-  - Entry::new_with_target()からシンプルなEntry::new()に変更
-  - 全プラットフォームで統一的な実装を実現
-
-### 進行中の作業
-- ⏳ パフォーマンステスト（Day 10）
-- 🔧 Tauriアプリケーション Phase 3.3（その他のリアクション機能）
-
-## 開発フェーズ
-
-1. **Phase 1 (MVP)**: 基本機能実装 **[進行中]**
-   - ユーザー管理 ✅
-   - トピック作成・参加 ✅
-   - 基本的なP2P通信 ✅
-   - UI/UX実装 90%完了
-
-2. **Phase 2 (ベータ)**: 高度な機能
-   - 画像・動画対応
-   - 検索・サジェスト機能
-   - パフォーマンス最適化
-
-3. **Phase 3**: エンタープライズ機能
-   - トークンエコノミー
-   - 高度なプライバシー機能
-   - プラグインシステム
-
-## 主要な設計決定
-
-- **Nostr互換性**: 既存のNostrエコシステムとの相互運用性を維持
-- **ハイブリッドP2P**: 純粋なP2Pの課題を回避しつつ分散性を確保
-- **プライバシーファースト**: エンドツーエンド暗号化とローカル処理を優先
-- **開発者フレンドリー**: OSSファーストでコミュニティ駆動の開発
-
-## 更新履歴
-- 2025年08月14日: Result型統一完了、ビルドエラー解消
-- 2025年08月14日: v2アーキテクチャ移行 Phase 1-3完了（49コマンド実装）
-- 2025年08月13日: Phase 6 プレゼンテーション層への統合完了
-- 2025年08月13日: コマンド最適化実装（50倍高速化達成）
-- 2025年08月02日: Windows環境アカウント永続化問題の完全解決
-- 2025年08月01日: Phase 3.2 新規投稿機能の拡張完了 - テスト総数517件に増加
-- 2025年07月31日: Phase 3.1 トピック参加・離脱機能の改善完了
-- 2025年07月30日: Phase 2.4 追加機能の完全実装
-- 2025年07月29日: フロントエンドテストエラー完全解消 - 342件全てのテストが成功
-- 2025年07月28日: Phase 2.2完了 - トピック管理と投稿作成機能の実装
-- 2025年07月28日: Phase 2.1完了 - トピック一覧の実データ取得・表示機能実装
-- 2025年07月28日: Phase 2.1部分完了 - 投稿の実データ取得・表示機能実装
-- 2025年07月28日: Tauriアプリケーション Phase 1（認証フロー）のテスト作成完了
-- 2025年07月28日: 実装優先順位決定（Tauriアプリ優先、手動P2P接続機能追加）
-- 2025年07月28日: Tauriアプリケーション体験設計と実装計画作成
-- 2025年07月28日: ドキュメント全体の更新（最新実装状況を反映）
-- 2025年07月27日: Nostr統合 Day 9（P2P UI統合）完了
-- 2025年07月27日: フロントエンドのテスト・型・リントエラー完全解消
-- 2025年07月27日: Zustandテストのモック実装問題解決
-- 2025年07月27日: テスト・型・リント修正作業（any型警告解消、署名検証修正）
-- 2025年07月27日: P2Pトピック管理機能の包括的テスト実装
-- 2025年07月26日: Prettier導入と開発環境改善
-- 2025年07月26日: インテグレーションテスト実装、テストガイド追加
-- 2025年07月26日: iroh-gossip採用に伴う技術スタック更新
-- 2025年07月25日: 初版作成
+- `docs/01_project/activeContext/summary.md`
+- `docs/01_project/activeContext/tasks/status/in_progress.md`
+- `docs/01_project/progressReports/`


### PR DESCRIPTION
### Motivation
- 古い記載や参照先が残っており最新の作業状況へ辿りづらかったため、ドキュメント索引を整理して現行の参照先（activeContext）に集約しました。

### Description
- `docs/SUMMARY.md` を現行のドキュメント構成に合わせて再編し、最終更新日と参照先を更新しました。 
- `docs/03_implementation/summary.md` を実ファイル構成に合わせて索引を整理し関連リンクを整備しました。 
- `docs/01_project/activeContext/summary.md` の最終確認日を更新するとともに参照情報を明確化し、`docs/01_project/activeContext/tasks/completed/2026-02-02.md` に今回の作業完了項目を追記しました。

### Testing
- 変更はドキュメントのみのため、自動化されたテストは実行しておらずテストは行っていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d868dbcc8328a23550c8d53b9771)