### PR TITLE
feat: relay/gossip bridge for bootstrap hints (v1 A)

### DIFF
--- a/docs/01_project/activeContext/tasks/priority/community_nodes_roadmap.md
+++ b/docs/01_project/activeContext/tasks/priority/community_nodes_roadmap.md
@@ -200,11 +200,11 @@
 
 ## 未実装/不足事項（2026年02月14日 監査追記）
 
-- [ ] （継続）`cn-bootstrap` hint 受信経路は未実装。`pg_notify('cn_bootstrap_hint')` は DB 内通知のため、クライアント再取得トリガには **受信ブリッジ実装方針の確定**（relay/gossip bridge か User API push channel か）が必要。
-- [ ] 受信ブリッジ方針決定後、以下を1タスクとして実装する:
-  - [ ] hint 受信で `/v1/bootstrap/nodes` と `/v1/bootstrap/topics/{topic_id}/services` を再取得し、キャッシュを更新する
-  - [ ] 取りこぼし前提のため、既存 `next_refresh_at` ポーリングと併用する
-  - [ ] 実ノードE2E（通知受信→HTTP再取得→キャッシュ更新反映）を追加する
+- [x] （解消）Manager 決定により v1 は **A) relay/gossip bridge のみ** を採用（B: User API push は defer）。
+- [x] 受信ブリッジ（A）を実装し、以下を満たす:
+  - [x] hint 受信で `/v1/bootstrap/nodes` と `/v1/bootstrap/topics/{topic_id}/services` を再取得し、キャッシュを更新する
+  - [x] 取りこぼし前提のため、既存 `next_refresh_at` ポーリングと併用する
+  - [x] relay 側で `pg_notify('cn_bootstrap_hint')` を gossip ヒント配信へ橋渡しし、受信で HTTP 再取得が動作する統合テストを追加する
 
 ## 参照（設計）
 


### PR DESCRIPTION
## Summary
Implements Manager-confirmed v1 decision (Issue #5): **A) relay/gossip bridge only**.

### What changed
- `cn-relay`
  - Added bootstrap hint bridge listener for `pg_notify('cn_bootstrap_hint')`
  - On hint receive, relay republishes current bootstrap events (`39000` descriptor + topic `39001`) to gossip topic(s)
- `kukuri-tauri`
  - Added `refresh_bootstrap_from_hint(...)` to force HTTP refresh of:
    - `/v1/bootstrap/nodes`
    - `/v1/bootstrap/topics/{topic_id}/services`
  - Wired gossip `39000/39001` receive path to run HTTP refresh (and keep existing event ingestion)
  - Added handler test: hint refresh fetches nodes+services and updates cache
- `cn-relay` integration test
  - Added test that `pg_notify('cn_bootstrap_hint')` causes gossip delivery of bootstrap events
- roadmap updated: 2026-02-14 follow-up resolved with v1 A path

## Issue
- Closes remaining implementation task under #5 workflow
- Related: https://github.com/KingYoSun/kukuri/issues/5

## Tests
- Added/updated tests in:
  - `cn-relay/src/integration_tests.rs`
  - `community_node_handler.rs` tests

(See issue comment for execution notes in this environment.)
