### PR TITLE
ci: run docker test suite on PR with timeout safeguards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: test-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   RUST_VERSION: 1.86
@@ -89,7 +89,8 @@ jobs:
     name: Docker Test Suite
     runs-on: ubuntu-latest
     needs: [change-scope]
-    if: github.event_name == 'push' && needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.docs_only != 'true'
+    timeout-minutes: 95
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -106,11 +107,20 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Run all tests in Docker
+        timeout-minutes: 90
         env:
           KUKURI_TEST_RUNNER_IMAGE: ${{ needs.change-scope.outputs.test_runner_image }}
         run: |
+          set -euo pipefail
           chmod +x scripts/test-docker.sh
-          ./scripts/test-docker.sh all
+          timeout --signal=TERM --kill-after=5m 85m ./scripts/test-docker.sh all
+
+      - name: Collect Docker diagnostics on failure
+        if: failure() || cancelled()
+        run: |
+          docker ps -a || true
+          docker compose --project-name kukuri_tests -f docker-compose.test.yml ps || true
+          docker compose --project-name kukuri_tests -f docker-compose.test.yml logs --tail 200 || true
 
       - name: Upload test results
         if: always()
@@ -118,6 +128,12 @@ jobs:
         with:
           name: test-results
           path: test-results/
+
+      - name: Cleanup Docker resources
+        if: always()
+        run: |
+          docker compose --project-name kukuri_tests -f docker-compose.test.yml down --remove-orphans --volumes || true
+          docker system prune -af || true
 
   desktop-e2e:
     name: Desktop E2E (Community Node, Docker)
@@ -531,7 +547,8 @@ jobs:
 
   pr-required-checks:
     name: PR Required Checks
-    needs: [format-check, native-test-linux, community-node-tests, openapi-artifacts-check, build-test-windows]
+    needs:
+      [change-scope, format-check, native-test-linux, community-node-tests, openapi-artifacts-check, build-test-windows, docker-test]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -541,7 +558,8 @@ jobs:
              [[ "${{ needs.native-test-linux.result }}" != "success" ]] || \
              [[ "${{ needs.community-node-tests.result }}" != "success" ]] || \
              [[ "${{ needs.openapi-artifacts-check.result }}" != "success" && "${{ needs.openapi-artifacts-check.result }}" != "skipped" ]] || \
-             [[ "${{ needs.build-test-windows.result }}" != "success" ]]; then
+             [[ "${{ needs.build-test-windows.result }}" != "success" ]] || \
+             [[ "${{ needs.docker-test.result }}" != "success" && ! ("${{ needs.change-scope.outputs.docs_only }}" == "true" && "${{ needs.docker-test.result }}" == "skipped") ]]; then
             echo "Fast-lane checks failed."
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,14 +106,60 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Resolve test-runner image name
+        id: docker-test-image
+        shell: bash
+        run: |
+          set -euo pipefail
+          image_name="$(docker compose --project-name kukuri_tests -f docker-compose.test.yml config --images | grep -E 'test-runner$' | head -n1 || true)"
+          if [[ -z "$image_name" ]]; then
+            image_name="kukuri_tests-test-runner"
+          fi
+          echo "image_name=${image_name}" >>"$GITHUB_OUTPUT"
+          echo "Resolved test-runner image: ${image_name}"
+
+      - name: Log test-runner image info (before)
+        shell: bash
+        run: |
+          set -euo pipefail
+          image_name="${{ steps.docker-test-image.outputs.image_name }}"
+          echo "KUKURI_TEST_RUNNER_IMAGE is intentionally empty in docker-test job."
+          echo "Target test-runner image: ${image_name}"
+          docker image ls --digests --no-trunc "$image_name" || true
+          if docker image inspect "$image_name" >/dev/null 2>&1; then
+            docker image inspect "$image_name" --format 'ImageID={{ .Id }}'
+            docker image inspect "$image_name" --format 'RepoTags={{ join .RepoTags ", " }}'
+            docker image inspect "$image_name" --format 'RepoDigests={{ join .RepoDigests ", " }}'
+            docker image inspect "$image_name" | jq '.[0] | {Id, RepoTags, RepoDigests, Created, Size, Architecture, Os}'
+          else
+            echo "No local image found for ${image_name} before suite execution."
+          fi
+
       - name: Run all tests in Docker
         timeout-minutes: 90
         env:
-          KUKURI_TEST_RUNNER_IMAGE: ${{ needs.change-scope.outputs.test_runner_image }}
+          KUKURI_TEST_RUNNER_IMAGE: ''
         run: |
           set -euo pipefail
           chmod +x scripts/test-docker.sh
           timeout --signal=TERM --kill-after=5m 85m ./scripts/test-docker.sh all
+
+      - name: Log test-runner image info (after)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          image_name="${{ steps.docker-test-image.outputs.image_name }}"
+          echo "Target test-runner image: ${image_name}"
+          docker image ls --digests --no-trunc "$image_name" || true
+          if docker image inspect "$image_name" >/dev/null 2>&1; then
+            docker image inspect "$image_name" --format 'ImageID={{ .Id }}'
+            docker image inspect "$image_name" --format 'RepoTags={{ join .RepoTags ", " }}'
+            docker image inspect "$image_name" --format 'RepoDigests={{ join .RepoDigests ", " }}'
+            docker image inspect "$image_name" | jq '.[0] | {Id, RepoTags, RepoDigests, Created, Size, Architecture, Os}'
+          else
+            echo "No local image found for ${image_name} after suite execution."
+          fi
 
       - name: Collect Docker diagnostics on failure
         if: failure() || cancelled()


### PR DESCRIPTION
## Summary
- Enable `docker-test-suite` for PRs (not only push/main) so hang regressions are detected before merge.
- Add timeout safeguards to heavy-lane execution in CI to avoid indefinite stalls.
- Keep fast-lane/required-check logic consistent with new heavy-lane behavior.

## Why
`main` runs repeatedly stalled/cancelled in Docker Test Suite. We need PR-time execution + fail-fast controls to catch and constrain hangs earlier.

## Validation
- Local Docker Test Suite equivalent executed via `gh act` job path and completed with timeout guards active.
- Workflow syntax/branch-conditional behavior validated.

Closes #14
