### PR TITLE
test: add state-layer P2P bootstrap integration coverage

### DIFF
--- a/kukuri-tauri/src-tauri/src/lib.rs
+++ b/kukuri-tauri/src-tauri/src/lib.rs
@@ -27,6 +27,9 @@ pub mod ops {
 
 #[doc(hidden)]
 pub mod test_support {
+    pub mod state {
+        pub use crate::state::{AppState, handle_bootstrap_gossip_event};
+    }
     pub mod application {
         pub use crate::application::ports;
         pub use crate::application::services;
@@ -47,6 +50,7 @@ pub mod test_support {
     }
     pub mod presentation {
         pub use crate::presentation::dto;
+        pub use crate::presentation::handlers;
     }
     pub mod shared {
         pub use crate::shared::{config, error};

--- a/kukuri-tauri/src-tauri/tests/p2p_bootstrap_integration.rs
+++ b/kukuri-tauri/src-tauri/tests/p2p_bootstrap_integration.rs
@@ -1,0 +1,268 @@
+use chrono::Utc;
+use kukuri_lib::test_support::application::ports::group_key_store::GroupKeyStore;
+use kukuri_lib::test_support::application::shared::tests::p2p::fixtures::nostr_to_domain;
+use kukuri_lib::test_support::infrastructure::crypto::DefaultKeyManager;
+use kukuri_lib::test_support::infrastructure::storage::{
+    SecureGroupKeyStore, secure_storage::DefaultSecureStorage,
+};
+use kukuri_lib::test_support::presentation::dto::community_node_dto::{
+    CommunityNodeBootstrapServicesRequest, CommunityNodeConfigNodeRequest,
+    CommunityNodeConfigRequest, CommunityNodeRoleConfig,
+};
+use kukuri_lib::test_support::presentation::handlers::CommunityNodeHandler;
+use kukuri_lib::test_support::state::handle_bootstrap_gossip_event;
+use nostr_sdk::prelude::{Event as NostrEvent, EventBuilder, Keys, Kind, Tag};
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::Duration as StdDuration;
+use tiny_http::{Header, Response, Server};
+
+#[derive(Debug)]
+struct MockHttpResponse {
+    status: u16,
+    body: serde_json::Value,
+}
+
+impl MockHttpResponse {
+    fn json(status: u16, body: serde_json::Value) -> Self {
+        Self { status, body }
+    }
+}
+
+fn spawn_json_sequence_server(
+    responses: Vec<MockHttpResponse>,
+) -> (String, Receiver<String>, thread::JoinHandle<()>) {
+    let server = Server::http("127.0.0.1:0").expect("mock server");
+    let base_url = format!("http://{}", server.server_addr());
+    let (tx, rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        for response_spec in responses {
+            let request = match server.recv_timeout(StdDuration::from_secs(8)) {
+                Ok(Some(request)) => request,
+                Ok(None) => break,
+                Err(_) => break,
+            };
+            let path = request
+                .url()
+                .split('?')
+                .next()
+                .unwrap_or_default()
+                .to_string();
+            let _ = tx.send(path);
+
+            let mut response = Response::from_string(response_spec.body.to_string());
+            response.add_header(
+                Header::from_bytes("Content-Type", "application/json")
+                    .expect("content-type header"),
+            );
+            response = response.with_status_code(response_spec.status);
+            let _ = request.respond(response);
+        }
+    });
+
+    (base_url, rx, handle)
+}
+
+fn join_with_timeout(handle: thread::JoinHandle<()>, timeout: StdDuration) {
+    let start = std::time::Instant::now();
+    while !handle.is_finished() {
+        assert!(
+            start.elapsed() < timeout,
+            "mock server join timed out after {:?}",
+            timeout
+        );
+        thread::sleep(StdDuration::from_millis(10));
+    }
+    handle.join().expect("mock server thread panicked");
+}
+
+fn build_node_descriptor_event(marker: &str) -> NostrEvent {
+    let keys = Keys::generate();
+    let exp = Utc::now().timestamp() + 600;
+    let d_tag = format!("descriptor:{marker}");
+    let exp_str = exp.to_string();
+    let tags = vec![
+        Tag::parse(["d", d_tag.as_str()]).expect("d"),
+        Tag::parse(["k", "kukuri"]).expect("k"),
+        Tag::parse(["ver", "1"]).expect("ver"),
+        Tag::parse(["exp", exp_str.as_str()]).expect("exp"),
+        Tag::parse(["role", "bootstrap"]).expect("role"),
+    ];
+    let content = json!({
+        "schema": "kukuri-node-desc-v1",
+        "name": format!("state-layer-node-{marker}"),
+        "roles": ["bootstrap"],
+        "endpoints": { "http": format!("https://{marker}.example") }
+    })
+    .to_string();
+
+    EventBuilder::new(Kind::Custom(39000), content)
+        .tags(tags)
+        .sign_with_keys(&keys)
+        .expect("sign descriptor")
+}
+
+fn build_topic_service_event(topic_id: &str, marker: &str) -> NostrEvent {
+    let keys = Keys::generate();
+    let exp = Utc::now().timestamp() + 600;
+    let d_tag = format!("topic_service:{topic_id}:bootstrap:public:{marker}");
+    let exp_str = exp.to_string();
+    let tags = vec![
+        Tag::parse(["d", d_tag.as_str()]).expect("d"),
+        Tag::parse(["t", topic_id]).expect("t"),
+        Tag::parse(["role", "bootstrap"]).expect("role"),
+        Tag::parse(["scope", "public"]).expect("scope"),
+        Tag::parse(["k", "kukuri"]).expect("k"),
+        Tag::parse(["ver", "1"]).expect("ver"),
+        Tag::parse(["exp", exp_str.as_str()]).expect("exp"),
+    ];
+    let content = json!({
+        "schema": "kukuri-topic-service-v1",
+        "topic": topic_id,
+        "role": "bootstrap",
+        "scope": "public",
+        "marker": marker,
+    })
+    .to_string();
+
+    EventBuilder::new(Kind::Custom(39001), content)
+        .tags(tags)
+        .sign_with_keys(&keys)
+        .expect("sign topic service")
+}
+
+fn contains_event_id(items: &[Value], event_id: &str) -> bool {
+    items
+        .iter()
+        .any(|item| item.get("id").and_then(Value::as_str) == Some(event_id))
+}
+
+fn test_handler() -> Arc<CommunityNodeHandler> {
+    let key_manager = Arc::new(DefaultKeyManager::new());
+    let secure_storage = Arc::new(DefaultSecureStorage::new());
+    let group_key_store =
+        Arc::new(SecureGroupKeyStore::new(secure_storage.clone())) as Arc<dyn GroupKeyStore>;
+
+    Arc::new(CommunityNodeHandler::new(
+        key_manager,
+        secure_storage,
+        group_key_store,
+    ))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn state_layer_p2p_bootstrap_receive_links_refresh_and_ingest() {
+    let handler = test_handler();
+
+    let topic_id = format!(
+        "kukuri:state-layer-bootstrap-{}",
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+    let service_path = format!("/v1/bootstrap/topics/{topic_id}/services");
+    let now = Utc::now().timestamp();
+
+    let refresh_node_event_1 = build_node_descriptor_event("refresh-1");
+    let refresh_topic_event = build_topic_service_event(&topic_id, "refresh-topic");
+    let refresh_node_event_2 = build_node_descriptor_event("refresh-2");
+
+    let (base_url, request_rx, handle) = spawn_json_sequence_server(vec![
+        MockHttpResponse::json(
+            200,
+            json!({
+                "items": [serde_json::to_value(&refresh_node_event_1).expect("refresh node 1 json")],
+                "next_refresh_at": now + 3600,
+            }),
+        ),
+        MockHttpResponse::json(
+            200,
+            json!({
+                "items": [serde_json::to_value(&refresh_topic_event).expect("refresh topic json")],
+                "next_refresh_at": now + 3600,
+            }),
+        ),
+        MockHttpResponse::json(
+            200,
+            json!({
+                "items": [serde_json::to_value(&refresh_node_event_2).expect("refresh node 2 json")],
+                "next_refresh_at": now + 3600,
+            }),
+        ),
+    ]);
+
+    handler.clear_config().await.expect("clear config");
+    handler
+        .set_config(CommunityNodeConfigRequest {
+            nodes: vec![CommunityNodeConfigNodeRequest {
+                base_url,
+                roles: Some(CommunityNodeRoleConfig {
+                    labels: false,
+                    trust: false,
+                    search: false,
+                    bootstrap: true,
+                }),
+            }],
+        })
+        .await
+        .expect("set config");
+
+    let gossip_topic_event = build_topic_service_event(&topic_id, "gossip-ingest-topic");
+    let gossip_topic_domain = nostr_to_domain(&gossip_topic_event);
+    handle_bootstrap_gossip_event(Arc::clone(&handler), gossip_topic_domain.clone()).await;
+
+    let request_1 = request_rx
+        .recv_timeout(StdDuration::from_secs(5))
+        .expect("request 1");
+    assert_eq!(request_1, "/v1/bootstrap/nodes");
+    let request_2 = request_rx
+        .recv_timeout(StdDuration::from_secs(5))
+        .expect("request 2");
+    assert_eq!(request_2, service_path);
+
+    let gossip_node_event = build_node_descriptor_event("gossip-ingest-node");
+    let gossip_node_domain = nostr_to_domain(&gossip_node_event);
+    handle_bootstrap_gossip_event(Arc::clone(&handler), gossip_node_domain.clone()).await;
+
+    let request_3 = request_rx
+        .recv_timeout(StdDuration::from_secs(5))
+        .expect("request 3");
+    assert_eq!(request_3, "/v1/bootstrap/nodes");
+
+    handler
+        .clear_config()
+        .await
+        .expect("clear config after refresh checks");
+
+    let nodes = handler
+        .list_bootstrap_nodes()
+        .await
+        .expect("list bootstrap nodes after ingest");
+    let node_items = nodes
+        .get("items")
+        .and_then(Value::as_array)
+        .expect("node items");
+    assert!(contains_event_id(
+        node_items,
+        gossip_node_domain.id.as_str()
+    ));
+
+    let services = handler
+        .list_bootstrap_services(CommunityNodeBootstrapServicesRequest {
+            base_url: None,
+            topic_id,
+        })
+        .await
+        .expect("list bootstrap services after ingest");
+    let service_items = services
+        .get("items")
+        .and_then(Value::as_array)
+        .expect("service items");
+    assert!(contains_event_id(
+        service_items,
+        gossip_topic_domain.id.as_str()
+    ));
+
+    join_with_timeout(handle, StdDuration::from_secs(3));
+}


### PR DESCRIPTION
## 変更内容
- `kukuri-tauri/src-tauri/tests/p2p_bootstrap_integration.rs` を追加し、stateレイヤーの 39000/39001 受信導線を統合テストで固定。
- `state.rs` の 39000/39001 受信処理を `handle_bootstrap_gossip_event` に抽出し、受信時に同一ロジックを呼び出す形へ整理。
- `lib.rs` の `test_support` に state/presentation の必要公開を最小追加し、統合テストから state 処理と handler を利用可能にした。

## なぜ必要か
- 既存は `community_node_handler` 単体で `refresh_bootstrap_from_hint` を検証していたが、P2P受信経由で state 層が `refresh_bootstrap_from_hint` と `ingest_bootstrap_event` を連結実行する回帰検知が不足していたため。

## テスト証跡
- `cd kukuri-tauri/src-tauri && cargo test --test p2p_bootstrap_integration`
  - 結果: `1 passed; 0 failed`
- `XDG_CACHE_HOME=/tmp/.cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check`
  - 結果: 成功
- `XDG_CACHE_HOME=/tmp/.cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux`
  - 結果: 成功
- `XDG_CACHE_HOME=/tmp/.cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`
  - 結果: 失敗（既存の `contract_tests::admin_mutations_fail_when_audit_log_write_fails` が `left: 200 / right: 500` で失敗）

Refs #5
