### PR TITLE
fix: bootstrap hint API OpenAPI契約を同期

### DIFF
--- a/docs/03_implementation/community_nodes/services_bootstrap.md
+++ b/docs/03_implementation/community_nodes/services_bootstrap.md
@@ -16,6 +16,7 @@
 - **HTTP（外部公開は User API に集約）**
   - `GET /v1/bootstrap/nodes`（node descriptor の一覧/差分）
   - `GET /v1/bootstrap/topics/:topic/services`（topic_service の一覧）
+  - `GET /v1/bootstrap/hints/latest?since=<seq>`（更新ヒント。新規がなければ `204`）
 - **イベント（KIP）**
   - 39000/39001 を定期発行し、クライアントは gossip/DHT/既知URL 経由で収集できる
 
@@ -38,6 +39,7 @@ v1 では「**DB上の広告設定**」を入力として `bootstrap` が 39000/
 
 1. **DB（正）**: 署名済み event JSON と失効判定（`exp`）の根拠
 2. **HTTP（正）**: `User API` の `GET /v1/bootstrap/*`（配布I/Fの正。差分取得/キャッシュ制御をここで提供）
+   - 更新通知の短経路として `GET /v1/bootstrap/hints/latest` を提供するが、最終整合は `nodes/services` を再取得して行う
 3. **gossip（ヒント）**: 39000/39001 の更新通知・加速（取りこぼし前提）
 4. **DHT（ヒント）**: node の HTTP endpoint 発見（必要なら descriptor hash 程度）
 5. **既知URL（シード）**: 手動固定/配布された接続先（HTTP取得の起点）

--- a/docs/03_implementation/community_nodes/user_api.md
+++ b/docs/03_implementation/community_nodes/user_api.md
@@ -158,6 +158,7 @@ User API は「ユーザーが何をできるか」を DB の状態で決める�
 
 - `GET /v1/bootstrap/nodes`（node descriptor の一覧/差分）
 - `GET /v1/bootstrap/topics/:topic/services`（topic_service の一覧）
+- `GET /v1/bootstrap/hints/latest?since=<seq>`（更新ヒントの最新スナップショット。新規がなければ `204`）
 
 配布ポリシー（v1）:
 - 39000/39001 は `bootstrap` が署名生成し、DB に保存された **署名済み event JSON** を配布する（User API は生成しない）

--- a/kukuri-community-node/apps/admin-console/openapi/user-api.json
+++ b/kukuri-community-node/apps/admin-console/openapi/user-api.json
@@ -131,6 +131,73 @@
         }
       }
     },
+    "/v1/bootstrap/hints/latest": {
+      "get": {
+        "tags": [
+          "crate"
+        ],
+        "operationId": "bootstrap_hint_latest_doc",
+        "parameters": [
+          {
+            "name": "since",
+            "in": "query",
+            "description": "Return a hint only when latest seq is greater than this value",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": true,
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BootstrapHintLatestResponse"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": ""
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/bootstrap/nodes": {
       "get": {
         "tags": [
@@ -828,6 +895,26 @@
   },
   "components": {
     "schemas": {
+      "BootstrapHintLatestResponse": {
+        "type": "object",
+        "required": [
+          "seq",
+          "received_at",
+          "hint"
+        ],
+        "properties": {
+          "hint": {},
+          "received_at": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "seq": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
       "ErrorResponse": {
         "type": "object",
         "required": [

--- a/kukuri-community-node/crates/cn-user-api/src/openapi.rs
+++ b/kukuri-community-node/crates/cn-user-api/src/openapi.rs
@@ -1,10 +1,18 @@
 #![allow(dead_code)]
 
 use axum::http::HeaderMap;
+use serde::Serialize;
 use utoipa::openapi::server::ServerBuilder;
-use utoipa::OpenApi;
+use utoipa::{OpenApi, ToSchema};
 
 use crate::{ErrorResponse, HealthStatus};
+
+#[derive(Serialize, ToSchema)]
+pub struct BootstrapHintLatestResponse {
+    pub seq: u64,
+    pub received_at: i64,
+    pub hint: serde_json::Value,
+}
 
 #[derive(OpenApi)]
 #[openapi(
@@ -19,6 +27,7 @@ use crate::{ErrorResponse, HealthStatus};
         consent_status_doc,
         consent_accept_doc,
         bootstrap_nodes_doc,
+        bootstrap_hint_latest_doc,
         bootstrap_services_doc,
         subscription_request_doc,
         subscription_list_doc,
@@ -35,7 +44,7 @@ use crate::{ErrorResponse, HealthStatus};
         personal_delete_create_doc,
         personal_delete_get_doc
     ),
-    components(schemas(HealthStatus, ErrorResponse)),
+    components(schemas(HealthStatus, ErrorResponse, BootstrapHintLatestResponse)),
     tags(
         (name = "user-api", description = "Kukuri community node user API")
     )
@@ -139,6 +148,24 @@ fn consent_accept_doc() {}
     responses((status = 200, body = serde_json::Value), (status = 401, body = ErrorResponse))
 )]
 fn bootstrap_nodes_doc() {}
+
+#[utoipa::path(
+    get,
+    path = "/v1/bootstrap/hints/latest",
+    params((
+        "since" = Option<u64>,
+        Query,
+        description = "Return a hint only when latest seq is greater than this value"
+    )),
+    responses(
+        (status = 200, body = BootstrapHintLatestResponse),
+        (status = 204),
+        (status = 401, body = ErrorResponse),
+        (status = 428, body = ErrorResponse),
+        (status = 429, body = ErrorResponse)
+    )
+)]
+fn bootstrap_hint_latest_doc() {}
 
 #[utoipa::path(
     get,

--- a/kukuri-community-node/crates/cn-user-api/src/openapi_contract_tests.rs
+++ b/kukuri-community-node/crates/cn-user-api/src/openapi_contract_tests.rs
@@ -32,6 +32,44 @@ async fn openapi_contract_contains_user_paths() {
     assert!(payload
         .pointer("/paths/~1v1~1bootstrap~1nodes/get")
         .is_some());
+    assert!(payload
+        .pointer("/paths/~1v1~1bootstrap~1hints~1latest/get")
+        .is_some());
+    assert_eq!(
+        payload
+            .pointer("/paths/~1v1~1bootstrap~1hints~1latest/get/parameters/0/name")
+            .and_then(Value::as_str),
+        Some("since")
+    );
+    assert_eq!(
+        payload
+            .pointer(
+                "/paths/~1v1~1bootstrap~1hints~1latest/get/responses/200/content/application~1json/schema/$ref"
+            )
+            .and_then(Value::as_str),
+        Some("#/components/schemas/BootstrapHintLatestResponse")
+    );
+    assert!(payload
+        .pointer("/paths/~1v1~1bootstrap~1hints~1latest/get/responses/204")
+        .is_some());
+    assert!(payload
+        .pointer("/paths/~1v1~1bootstrap~1hints~1latest/get/responses/401")
+        .is_some());
+    assert!(payload
+        .pointer("/paths/~1v1~1bootstrap~1hints~1latest/get/responses/428")
+        .is_some());
+    assert!(payload
+        .pointer("/paths/~1v1~1bootstrap~1hints~1latest/get/responses/429")
+        .is_some());
+    assert!(payload
+        .pointer("/components/schemas/BootstrapHintLatestResponse/properties/seq")
+        .is_some());
+    assert!(payload
+        .pointer("/components/schemas/BootstrapHintLatestResponse/properties/received_at")
+        .is_some());
+    assert!(payload
+        .pointer("/components/schemas/BootstrapHintLatestResponse/properties/hint")
+        .is_some());
     assert!(payload.pointer("/paths/~1v1~1search/get").is_some());
     assert!(payload
         .pointer("/paths/~1v1~1personal-data-deletion-requests/post")


### PR DESCRIPTION
## What Changed
- cn-user-api の OpenAPI path 一覧に /v1/bootstrap/hints/latest を追加
- OpenAPI schema に BootstrapHintLatestResponse を追加し、since query / 200,204,401,428,429 レスポンスを明示
- openapi_contract_tests を拡張し、hints endpoint の path・query・response・schema を契約として固定
- apps/admin-console/openapi/user-api.json を再生成
- 関連設計ドキュメントの bootstrap endpoint 一覧を最小更新

## Why
- 実装済みの bootstrap hint endpoint が OpenAPI/設計ドキュメントに露出されておらず、契約面で不整合があったため。

## Test Evidence
- cargo run --locked -p cn-cli -- openapi export --service user-api --output apps/admin-console/openapi/user-api.json --pretty
- docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test -p cn-user-api openapi_contract_contains_user_paths -- --nocapture"
- docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test -p cn-user-api bootstrap_hint_latest_contract_returns_latest_payload_after_since -- --nocapture"
- gh act --workflows .github/workflows/test.yml --job format-check (success)
- gh act --workflows .github/workflows/test.yml --job native-test-linux (success)
- gh act --workflows .github/workflows/test.yml --job community-node-tests (failed: 既知の tuple concurrently updated 競合 in cn-admin-api 契約テスト)

Refs #5
