### PR TITLE
fix: fail community-node desktop E2E on skipped/pending tests

### DIFF
--- a/kukuri-tauri/src/tests/unit/e2e/wdioDesktopConfig.test.ts
+++ b/kukuri-tauri/src/tests/unit/e2e/wdioDesktopConfig.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const E2E_FORBID_PENDING = 'E2E_FORBID_PENDING';
+
+const importConfig = async (forbidPending?: string) => {
+  const previous = process.env[E2E_FORBID_PENDING];
+  if (forbidPending === undefined) {
+    delete process.env[E2E_FORBID_PENDING];
+  } else {
+    process.env[E2E_FORBID_PENDING] = forbidPending;
+  }
+
+  try {
+    vi.resetModules();
+    const module = await import('../../../../tests/e2e/wdio.desktop.ts');
+    return module.config;
+  } finally {
+    if (previous === undefined) {
+      delete process.env[E2E_FORBID_PENDING];
+    } else {
+      process.env[E2E_FORBID_PENDING] = previous;
+    }
+  }
+};
+
+describe('wdio.desktop pending enforcement', () => {
+  it('keeps forbidPending disabled by default', async () => {
+    const config = await importConfig();
+    expect(config.mochaOpts?.forbidPending).toBe(false);
+  });
+
+  it('enables forbidPending when E2E_FORBID_PENDING=1', async () => {
+    const config = await importConfig('1');
+    expect(config.mochaOpts?.forbidPending).toBe(true);
+  });
+});

--- a/scripts/docker/run-desktop-e2e.sh
+++ b/scripts/docker/run-desktop-e2e.sh
@@ -6,9 +6,13 @@ OUTPUT_DIR="$APP_DIR/tests/e2e/output"
 SCENARIO_NAME="${SCENARIO:-desktop-e2e}"
 RESULT_DIR="/app/test-results/desktop-e2e"
 LOG_DIR="/app/tmp/logs/desktop-e2e"
+export E2E_FORBID_PENDING=0
+export E2E_COMMUNITY_NODE_P2P_INVITE=0
 if [[ "$SCENARIO_NAME" == "community-node-e2e" ]]; then
   RESULT_DIR="/app/test-results/community-node-e2e"
   LOG_DIR="/app/tmp/logs/community-node-e2e"
+  export E2E_FORBID_PENDING=1
+  export E2E_COMMUNITY_NODE_P2P_INVITE=1
 fi
 
 mkdir -p "$RESULT_DIR" "$LOG_DIR" "$OUTPUT_DIR"
@@ -25,6 +29,9 @@ echo "=== ${SCENARIO_NAME}: building debug bundle ==="
 pnpm e2e:build
 
 echo "=== ${SCENARIO_NAME}: running pnpm e2e:ci ==="
+if [[ "$E2E_FORBID_PENDING" == "1" ]]; then
+  echo "=== ${SCENARIO_NAME}: enforcing pending/skip as failures ==="
+fi
 E2E_COMMAND=(pnpm e2e:ci)
 export E2E_SKIP_BUILD=1
 if [[ -z "${TAURI_DRIVER_PORT:-}" ]]; then


### PR DESCRIPTION
## What changed
- `scripts/docker/run-desktop-e2e.sh` に community-node シナリオ専用の厳格モードを追加し、`E2E_FORBID_PENDING=1` を付与
- 同スクリプトで `E2E_COMMUNITY_NODE_P2P_INVITE=1` を community-node 実行時に付与し、invite spec が不必要に skip しないよう調整
- `kukuri-tauri/tests/e2e/wdio.desktop.ts` の `mochaOpts` に `forbidPending` を導入（環境変数でON/OFF）
- `kukuri-tauri/src/tests/unit/e2e/wdioDesktopConfig.test.ts` を追加し、`forbidPending` 切替の検証を追加

## Why
- community-node desktop E2E で `this.skip()` / pending が発生しても CI が false-green になるケースを防ぐため
- community-node 実行時は skip/pending を失敗扱いにし、想定どおりシナリオが実行されない場合に CI を確実に落とすため

## Test evidence
- `cd kukuri-tauri && pnpm vitest run src/tests/unit/e2e/wdioDesktopConfig.test.ts` ✅
- `cd kukuri-tauri && pnpm eslint tests/e2e/wdio.desktop.ts src/tests/unit/e2e/wdioDesktopConfig.test.ts` ✅
- `bash -n scripts/docker/run-desktop-e2e.sh` ✅
- `XDG_CACHE_HOME=/tmp/xdg-cache ACT_CACHE_DIR=/tmp/act-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check` ✅
- `XDG_CACHE_HOME=/tmp/xdg-cache ACT_CACHE_DIR=/tmp/act-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux` ✅
- `XDG_CACHE_HOME=/tmp/xdg-cache ACT_CACHE_DIR=/tmp/act-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests` ❌（2回実行して再現。`contract_tests::transactional_admin_mutations_rollback_when_audit_log_write_fails` が `tuple concurrently updated` または status assertion mismatch で失敗）

Refs #5
