### PR TITLE
feat: enforce per-pubkey pending subscription-request limit in cn-user-api

### DIFF
--- a/docs/01_project/activeContext/tasks/completed/2026-02-15.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-15.md
@@ -49,3 +49,17 @@
   - community-node Docker 経路で `cargo test --workspace --all-features` + `cargo build --release -p cn-cli` を完走。
   - `gh act --job format-check` / `--job native-test-linux` / `--job community-node-tests` を実行（`community-node-tests` は初回 flaky 失敗後の再実行で成功）。
 - 進捗レポート: `docs/01_project/progressReports/2026-02-15_issue22_pending_request_limit_cn_user_api.md`
+
+## Issue #22 Task1 フォローアップ完了（PR #23 レビュー修正、2026年02月15日）
+
+- 対象: PR #23 レビューコメント `r2809304474`（`pg_advisory_xact_lock(hashtext($1))` の衝突リスク指摘）
+- 実施内容:
+  - `cn-user-api` の pending 上限判定で使う advisory lock を `hashtext` 1キー方式から、`blake3` 由来の 2 キー方式（`pg_advisory_xact_lock($1, $2)`）へ置換。
+  - 同一 pubkey で鍵が安定すること・異なる pubkey で鍵ペアが変化することをユニットテストで固定。
+- 検証:
+  - Community Node の Docker 経路で `cargo test --workspace --all-features` と `cargo build --release -p cn-cli` を再実行し成功（1回目 deadlock は flaky として再実行で解消）。
+  - セッション完了時に `gh act --job format-check` / `--job native-test-linux` / `--job community-node-tests` を実行。
+    - `format-check`: 成功
+    - `native-test-linux`: 成功
+    - `community-node-tests`: 既知 flaky（`cn-admin-api` 契約テストの `tuple concurrently updated` / `trigger already exists`）で再実行後も失敗
+- 進捗レポート: `docs/01_project/progressReports/2026-02-15_issue22_pr23_advisory_lock_collision_fix.md`

--- a/docs/01_project/activeContext/tasks/completed/2026-02-15.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-15.md
@@ -36,3 +36,16 @@
   - commit `b865ec92115efffb97768c1ed009292104ce1aeb` 起点の DoS上限タスクは未完であることを確認。
   - roadmap に未完4タスクを再起票し、`in_progress.md` に Issue #22 の次アクションを反映。
 - 進捗レポート: `docs/01_project/progressReports/2026-02-15_issue22_community_nodes_reaudit.md`
+
+## Issue #22 Task1 完了（2026年02月15日）
+
+- 対象: `cn-user-api` の申請同時保留数上限（per pubkey）実装 + 拒否契約の反映（Issue #22）
+- 実施内容:
+  - `create_subscription_request` で pending 件数判定を追加し、上限超過時に `429` を返すよう実装。
+  - 拒否契約を `code=PENDING_SUBSCRIPTION_REQUEST_LIMIT_REACHED` + `details(metric/current/limit/scope)` で固定。
+  - `cn-user-api` 契約テストへ最小回帰（上限到達時拒否）を追加。
+  - OpenAPI と設計ドキュメント（`topic_subscription_design.md` / `user_api.md`）を更新。
+- 検証:
+  - community-node Docker 経路で `cargo test --workspace --all-features` + `cargo build --release -p cn-cli` を完走。
+  - `gh act --job format-check` / `--job native-test-linux` / `--job community-node-tests` を実行（`community-node-tests` は初回 flaky 失敗後の再実行で成功）。
+- 進捗レポート: `docs/01_project/progressReports/2026-02-15_issue22_pending_request_limit_cn_user_api.md`

--- a/docs/01_project/activeContext/tasks/priority/community_nodes_roadmap.md
+++ b/docs/01_project/activeContext/tasks/priority/community_nodes_roadmap.md
@@ -235,8 +235,10 @@
 
 ## 未実装/不足事項（2026年02月15日 再調査追記）
 
-- [ ] `cn-user-api`: `topic_subscription_design.md` の DoS 要件（申請の同時保留数上限 per pubkey）を実装する。現状 `create_subscription_request` は `check_topic_limit`（active 件数）しか見ておらず pending 件数を制御していないため、上限判定と拒否レスポンス契約（status code / error code / details）を定義して反映する。
+- [x] `cn-user-api`: `topic_subscription_design.md` の DoS 要件（申請の同時保留数上限 per pubkey）を実装する。現状 `create_subscription_request` は `check_topic_limit`（active 件数）しか見ておらず pending 件数を制御していないため、上限判定と拒否レスポンス契約（status code / error code / details）を定義して反映する。
+  - 2026年02月15日: `create_subscription_request` に pending 件数上限（`subscription_request.max_pending_per_pubkey`）を実装し、`429` / `PENDING_SUBSCRIPTION_REQUEST_LIMIT_REACHED` / `details(metric,current,limit,scope)` を固定。
 - [ ] `cn-user-api` 契約テスト: 申請の同時保留数上限を追加検証する（上限未満で受理、上限到達時に拒否、approve/reject 後に再申請可能）。
+  - 2026年02月15日: 最小回帰として「上限到達時の拒否」1ケースは追加済み。approve/reject 後の再申請を含む広範シナリオ行列は次PRで実施。
 - [ ] `cn-admin-api` + `cn-user-api` + `cn-relay`: `topic_subscription_design.md` の DoS 要件（node-level の同時取込 topic 数上限）を実装する。現状 `approve_subscription_request` は `cn_admin.node_subscriptions` を無制限で upsert するため、上限設定と承認時の超過拒否フローを追加する。
 - [ ] テスト補完: node-level topic 上限の回帰テストを追加する（`cn-admin-api` 契約テストで承認拒否契約を固定、`cn-relay` 統合テストで上限超過時に新規 topic subscribe が増えないことを検証）。
 

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -13,10 +13,9 @@
 ### 2026年02月15日 Issue #22 Community Nodes 再監査（DoS上限要件）
 
 - 目的: `docs/03_implementation/community_nodes` と `community_nodes_roadmap.md` を再監査し、commit `b865ec92115efffb97768c1ed009292104ce1aeb` 起点の未完タスクと追加不足を確定する。
-- 状態: 監査完了（実装タスク4件を `tasks/priority/community_nodes_roadmap.md` の「2026年02月15日 再調査追記」に起票済み）。
+- 状態: 監査完了（実装タスク4件を `tasks/priority/community_nodes_roadmap.md` の「2026年02月15日 再調査追記」に起票済み）。Task1（`cn-user-api` pending 同時保留数上限 + 拒否契約 + 最小回帰）は `feat/issue22-pending-request-limit` で実装完了。
 - 次アクション（1タスク=1PR）:
-  - `cn-user-api` の申請同時保留数上限（per pubkey）実装 + 拒否契約の反映
-  - `cn-user-api` 契約テスト（同時保留数上限）
+  - `cn-user-api` 契約テスト（同時保留数上限の広範シナリオ行列）
   - node-level 同時取込 topic 数上限の実装（`cn-admin-api` + `cn-user-api` + `cn-relay`）
   - node-level 上限の回帰テスト（`cn-admin-api` 契約 + `cn-relay` 統合）
 

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -13,7 +13,7 @@
 ### 2026年02月15日 Issue #22 Community Nodes 再監査（DoS上限要件）
 
 - 目的: `docs/03_implementation/community_nodes` と `community_nodes_roadmap.md` を再監査し、commit `b865ec92115efffb97768c1ed009292104ce1aeb` 起点の未完タスクと追加不足を確定する。
-- 状態: 監査完了（実装タスク4件を `tasks/priority/community_nodes_roadmap.md` の「2026年02月15日 再調査追記」に起票済み）。Task1（`cn-user-api` pending 同時保留数上限 + 拒否契約 + 最小回帰）は `feat/issue22-pending-request-limit` で実装完了。
+- 状態: 監査完了（実装タスク4件を `tasks/priority/community_nodes_roadmap.md` の「2026年02月15日 再調査追記」に起票済み）。Task1（`cn-user-api` pending 同時保留数上限 + 拒否契約 + 最小回帰）は `feat/issue22-pending-request-limit` で実装完了。PR #23 のレビュー指摘（`pg_advisory_xact_lock(hashtext($1))` の衝突リスク）に対して、同ブランチで 2 キー advisory lock へ差し替える追補修正を適用済み。
 - 次アクション（1タスク=1PR）:
   - `cn-user-api` 契約テスト（同時保留数上限の広範シナリオ行列）
   - node-level 同時取込 topic 数上限の実装（`cn-admin-api` + `cn-user-api` + `cn-relay`）

--- a/docs/01_project/progressReports/2026-02-15_issue22_pending_request_limit_cn_user_api.md
+++ b/docs/01_project/progressReports/2026-02-15_issue22_pending_request_limit_cn_user_api.md
@@ -1,0 +1,58 @@
+# Issue #22 Task1: `cn-user-api` pending 同時保留数上限実装
+
+作成日: 2026年02月15日
+
+## 概要
+
+- 対象: `POST /v1/topic-subscription-requests`（`cn-user-api`）
+- 目的: DoS 要件「申請の同時保留数上限（per pubkey）」を実装し、上限到達時の拒否契約を固定する。
+- スコープ外: node-level 同時取込 topic 上限と、その広範なシナリオ行列テストは次PR（Issue #22 Task2以降）へ分離。
+
+## 実施内容
+
+- `create_subscription_request` に pending 件数判定を追加。
+  - `cn_user.topic_subscription_requests` の `status='pending'` 件数を pubkey 単位で集計。
+  - 競合時の過剰受理を抑えるため `pg_advisory_xact_lock(hashtext(pubkey))` で同一 pubkey の判定・挿入を直列化。
+- 上限設定を `user-api` の service config から読取。
+  - `config_json.subscription_request.max_pending_per_pubkey`
+  - 未設定時デフォルト: `5`
+- OpenAPI と契約テストへ 429 応答を反映。
+- 最小回帰として「上限到達時に拒否し、追加行が挿入されない」契約テストを追加。
+
+## 拒否契約（上限到達時）
+
+- HTTP status: `429 Too Many Requests`
+- `code`: `PENDING_SUBSCRIPTION_REQUEST_LIMIT_REACHED`
+- `details`:
+  - `metric`: `topic_subscription_requests.pending`
+  - `scope`: `pubkey`
+  - `current`: 現在の pending 件数
+  - `limit`: 設定上限
+
+## 変更ファイル
+
+- `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs`
+- `kukuri-community-node/crates/cn-user-api/src/lib.rs`
+- `kukuri-community-node/crates/cn-user-api/src/openapi.rs`
+- `kukuri-community-node/crates/cn-user-api/src/openapi_contract_tests.rs`
+- `kukuri-community-node/apps/admin-console/openapi/user-api.json`
+- `docs/03_implementation/community_nodes/topic_subscription_design.md`
+- `docs/03_implementation/community_nodes/user_api.md`
+- `docs/01_project/activeContext/tasks/status/in_progress.md`
+- `docs/01_project/activeContext/tasks/completed/2026-02-15.md`
+
+## 検証
+
+- Community Node（Docker 経路）:
+  - `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`
+  - `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`
+  - `docker run --rm --network kukuri_community-node-network ... cargo test --workspace --all-features; cargo build --release -p cn-cli`（成功）
+- `gh act`:
+  - `format-check` 成功
+  - `native-test-linux` 成功
+  - `community-node-tests` は初回 `tuple concurrently updated` で失敗、再実行で成功
+
+## 次アクション
+
+- Issue #22 Task2 で「同時保留数上限の広範シナリオ行列（approve/reject 後の再申請など）」を契約テストとして拡張する。
+- node-level 同時取込 topic 上限の実装と回帰テストを別PRで実施する。

--- a/docs/01_project/progressReports/2026-02-15_issue22_pr23_advisory_lock_collision_fix.md
+++ b/docs/01_project/progressReports/2026-02-15_issue22_pr23_advisory_lock_collision_fix.md
@@ -1,0 +1,50 @@
+# Issue #22 / PR #23 レビュー修正: advisory lock 衝突リスク低減
+
+作成日: 2026年02月15日
+
+## 背景
+
+- 対象レビュー: `https://github.com/KingYoSun/kukuri/pull/23#discussion_r2809304474`
+- 指摘内容: `pg_advisory_xact_lock(hashtext($1))` は 32-bit ハッシュのため、異なる pubkey 間の衝突で不要な直列化が起こり得る。
+
+## 対応内容
+
+- `cn-user-api` の pending 上限判定ロックを以下へ変更:
+  - 変更前: `pg_advisory_xact_lock(hashtext($1))`
+  - 変更後: `blake3` で pubkey から 64-bit 相当（2 x 32-bit）鍵を導出し、`pg_advisory_xact_lock($1, $2)` を使用
+- 鍵導出ヘルパーを追加:
+  - `advisory_lock_keys_for_pubkey(pubkey: &str) -> (i32, i32)`
+  - 固定コンテキスト `cn-user-api.topic-subscription-request.pending-limit` を混ぜて導出
+- テスト追加:
+  - 同一 pubkey で鍵ペアが安定すること
+  - 異なる pubkey で鍵ペアが異なること
+
+## 変更ファイル
+
+- `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs`
+- `docs/01_project/activeContext/tasks/status/in_progress.md`
+- `docs/01_project/activeContext/tasks/completed/2026-02-15.md`
+- `docs/01_project/progressReports/2026-02-15_issue22_pr23_advisory_lock_collision_fix.md`
+
+## 検証
+
+- Community Node（Docker 経路）
+  - `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`
+  - `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`
+  - `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`
+- 実行結果
+  - 1回目: `cn-admin-api` 契約テストで `40P01 deadlock detected`（既知 flaky）
+  - 2回目: 全クレートテスト + `cn-cli` release build 成功
+- `gh act`（`.github/workflows/test.yml`）
+  - `XDG_CACHE_HOME=/tmp/xdg-cache ACT_CACHE_DIR=/tmp/xdg-cache/act NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check`
+    - 成功
+  - `XDG_CACHE_HOME=/tmp/xdg-cache ACT_CACHE_DIR=/tmp/xdg-cache/act NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux`
+    - 成功
+  - `XDG_CACHE_HOME=/tmp/xdg-cache ACT_CACHE_DIR=/tmp/xdg-cache/act NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`
+    - 失敗（再実行でも失敗）
+    - 失敗理由: `cn-admin-api` 契約テスト `admin_mutations_fail_when_audit_log_write_fails` が `tuple concurrently updated` / `trigger already exists` で不安定化（既知 flaky）
+
+## 影響範囲
+
+- pending 上限判定時の pubkey ロックキー生成のみ。
+- API 契約（レスポンス構造・ステータス）や DB スキーマには変更なし。

--- a/docs/03_implementation/community_nodes/topic_subscription_design.md
+++ b/docs/03_implementation/community_nodes/topic_subscription_design.md
@@ -155,6 +155,8 @@
 
 - 購読申請の rate limit（IP + pubkey）
 - 申請の同時保留数上限（per pubkey）
+  - `cn-user-api` は `POST /v1/topic-subscription-requests` で pending 件数を判定し、上限到達時は `429 Too Many Requests` を返す。
+  - エラー契約: `code="PENDING_SUBSCRIPTION_REQUEST_LIMIT_REACHED"`、`details.metric="topic_subscription_requests.pending"`、`details.current`、`details.limit`、`details.scope="pubkey"`。
+  - 上限値は `cn_admin.service_configs(service='user-api').config_json.subscription_request.max_pending_per_pubkey` で設定し、未設定時のデフォルトは `5`。
 - node-level の同時取込 topic 数上限（ノード運用者の資源制約）
 - 自動承認する場合は、支払い/クレジット/招待capability等の担保が必要
-

--- a/docs/03_implementation/community_nodes/user_api.md
+++ b/docs/03_implementation/community_nodes/user_api.md
@@ -169,6 +169,8 @@ User API は「ユーザーが何をできるか」を DB の状態で決める�
 ### topic購読
 
 - `POST /v1/topic-subscription-requests`
+  - DoS ガード（pending 同時保留数上限）に到達した場合は `429 Too Many Requests` を返す。
+  - エラー契約: `code="PENDING_SUBSCRIPTION_REQUEST_LIMIT_REACHED"` と `details.metric/current/limit/scope`。
 - `GET /v1/topic-subscriptions`
 - `DELETE /v1/topic-subscriptions/:topic_id`（解約/停止）
 

--- a/kukuri-community-node/apps/admin-console/openapi/user-api.json
+++ b/kukuri-community-node/apps/admin-console/openapi/user-api.json
@@ -744,6 +744,46 @@
                 "schema": {}
               }
             }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/kukuri-community-node/crates/cn-user-api/src/lib.rs
+++ b/kukuri-community-node/crates/cn-user-api/src/lib.rs
@@ -224,6 +224,9 @@ pub async fn run(config: UserApiConfig) -> Result<()> {
             "auth_per_minute": 20,
             "public_per_minute": 120,
             "protected_per_minute": 120
+        },
+        "subscription_request": {
+            "max_pending_per_pubkey": 5
         }
     });
     let bootstrap_default = json!({

--- a/kukuri-community-node/crates/cn-user-api/src/openapi.rs
+++ b/kukuri-community-node/crates/cn-user-api/src/openapi.rs
@@ -179,7 +179,13 @@ fn bootstrap_services_doc() {}
     post,
     path = "/v1/topic-subscription-requests",
     request_body = serde_json::Value,
-    responses((status = 200, body = serde_json::Value))
+    responses(
+        (status = 200, body = serde_json::Value),
+        (status = 401, body = ErrorResponse),
+        (status = 402, body = ErrorResponse),
+        (status = 428, body = ErrorResponse),
+        (status = 429, body = ErrorResponse)
+    )
 )]
 fn subscription_request_doc() {}
 

--- a/kukuri-community-node/crates/cn-user-api/src/openapi_contract_tests.rs
+++ b/kukuri-community-node/crates/cn-user-api/src/openapi_contract_tests.rs
@@ -72,6 +72,17 @@ async fn openapi_contract_contains_user_paths() {
         .is_some());
     assert!(payload.pointer("/paths/~1v1~1search/get").is_some());
     assert!(payload
+        .pointer("/paths/~1v1~1topic-subscription-requests/post/responses/429")
+        .is_some());
+    assert_eq!(
+        payload
+            .pointer(
+                "/paths/~1v1~1topic-subscription-requests/post/responses/429/content/application~1json/schema/$ref"
+            )
+            .and_then(Value::as_str),
+        Some("#/components/schemas/ErrorResponse")
+    );
+    assert!(payload
         .pointer("/paths/~1v1~1personal-data-deletion-requests/post")
         .is_some());
 }


### PR DESCRIPTION
## What changed
- Added per-pubkey pending subscription-request concurrency limit enforcement in `cn-user-api` `create_subscription_request`.
- Added explicit rejection contract when limit is reached:
  - status: `429 Too Many Requests`
  - code: `PENDING_SUBSCRIPTION_REQUEST_LIMIT_REACHED`
  - details: `metric`, `scope`, `current`, `limit`
- Added minimal regression coverage for limit-reached rejection in `cn-user-api` contract tests.
- Reflected contract in user OpenAPI (`/v1/topic-subscription-requests` 429 response) and regenerated `apps/admin-console/openapi/user-api.json`.
- Updated related design/spec docs and task/progress tracking files.

## Why
- Satisfy Issue #22 DoS requirement for per-pubkey concurrent pending subscription-request limit in `cn-user-api`.
- Keep node-level topic limit and broad scenario-matrix expansion out of this PR as scoped.

## Test evidence
- Community node container path:
  - `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`
  - `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`
  - `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -e RUST_TEST_THREADS=1 -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`
- Required `gh act` jobs:
  - `NPM_CONFIG_PREFIX=/tmp/npm-global XDG_CACHE_HOME=/tmp/.cache ACT_CACHE_DIR=/tmp/.cache/act DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check` (pass)
  - `NPM_CONFIG_PREFIX=/tmp/npm-global XDG_CACHE_HOME=/tmp/.cache ACT_CACHE_DIR=/tmp/.cache/act DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux` (pass)
  - `NPM_CONFIG_PREFIX=/tmp/npm-global XDG_CACHE_HOME=/tmp/.cache ACT_CACHE_DIR=/tmp/.cache/act DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests` (initial flaky failure `tuple concurrently updated`, rerun pass)

Refs #22
