### PR TITLE
feat: enforce node-level concurrent topic-ingestion limit for approvals

### DIFF
--- a/docs/01_project/activeContext/tasks/completed/2026-02-15.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-15.md
@@ -95,3 +95,25 @@
   - `cd kukuri-community-node && cargo test -p cn-user-api openapi_contract_ -- --nocapture`（成功, 1 passed）
   - `git diff --exit-code -- kukuri-community-node/apps/admin-console/openapi/*.json kukuri-community-node/apps/admin-console/src/generated/admin-api.ts`（HEAD更新後に成功）
 - 進捗レポート: `docs/01_project/progressReports/2026-02-15_issue22_pr24_openapi_artifacts_fix.md`
+
+## Issue #22 Task3 完了（node-level 同時取込 topic 数上限の実装、2026年02月15日）
+
+- 対象: `cn-admin-api` + `cn-user-api` + `cn-relay` 境界の承認フローで node-level 同時取込 topic 数上限を強制し、超過時の拒否契約を明示する（Issue #22）。
+- 実施内容:
+  - `cn-admin-api` の `approve_subscription_request` に node-level 上限チェックを追加し、上限超過時は `429` / `NODE_SUBSCRIPTION_TOPIC_LIMIT_REACHED` / `details(metric=current/limit/scope)` を返すよう実装。
+  - 承認時の競合を避けるため、node-level 上限判定に transaction advisory lock（2キー）を導入。
+  - 上限設定を `cn_admin.service_configs(service='relay').config_json.node_subscription.max_concurrent_topics` から参照し、未設定時は既定値（`100`）を適用。
+  - `cn-relay` 側にも同一設定キーを追加し、enabled topic 読み込みを `max_concurrent_topics` 上限内（`ORDER BY updated_at DESC` + `LIMIT`）へ揃えた。
+  - OpenAPI 契約に `POST /v1/admin/subscription-requests/{request_id}/approve` の `429` レスポンスを追加し、生成物（`apps/admin-console/openapi/admin-api.json` / `src/generated/admin-api.ts`）を更新。
+  - `cn-admin-api` 契約テストに over-limit 拒否ケースを追加（承認拒否契約と pending 維持を検証）。
+- 検証:
+  - `cd kukuri-community-node && cargo fmt --all`（成功）
+  - `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`（成功）
+  - `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`（成功）
+  - `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -e RUST_TEST_THREADS=1 -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`（成功）
+  - `cd kukuri-community-node && cargo run --locked -p cn-cli -- openapi export --service user-api --output apps/admin-console/openapi/user-api.json --pretty && cargo run --locked -p cn-cli -- openapi export --service admin-api --output apps/admin-console/openapi/admin-api.json --pretty`（成功）
+  - `cd kukuri-community-node/apps/admin-console && pnpm install --frozen-lockfile && pnpm generate:api`（成功）
+  - `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check`（成功, ログ: `tmp/logs/gh-act-format-check-issue22-node-level-topic-limit.log`）
+  - `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux`（成功, ログ: `tmp/logs/gh-act-native-test-linux-issue22-node-level-topic-limit.log`）
+  - `NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`（成功, ログ: `tmp/logs/gh-act-community-node-tests-issue22-node-level-topic-limit.log`）
+- 進捗レポート: `docs/01_project/progressReports/2026-02-15_issue22_node_level_topic_ingestion_limit.md`

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -13,9 +13,8 @@
 ### 2026年02月15日 Issue #22 Community Nodes 再監査（DoS上限要件）
 
 - 目的: `docs/03_implementation/community_nodes` と `community_nodes_roadmap.md` を再監査し、commit `b865ec92115efffb97768c1ed009292104ce1aeb` 起点の未完タスクと追加不足を確定する。
-- 状態: 監査完了（実装タスク4件を `tasks/priority/community_nodes_roadmap.md` の「2026年02月15日 再調査追記」に起票済み）。Task1（`cn-user-api` pending 同時保留数上限 + 拒否契約 + 最小回帰）は `feat/issue22-pending-request-limit` で実装完了。PR #23 のレビュー指摘（`pg_advisory_xact_lock(hashtext($1))` の衝突リスク）に対して、同ブランチで 2 キー advisory lock へ差し替える追補修正を適用済み。続いて Task2（`cn-user-api` 契約テスト拡張: under-limit 受理 / at-limit 拒否 / approve・reject 後の再申請）を `feat/issue22-pending-limit-contract-tests` で実装完了。PR #24 の `OpenAPI Artifacts Check` 失敗は `apps/admin-console/openapi/user-api.json` の末尾改行差分であることを特定し、生成物に合わせるフォローアップ修正を適用済み。
+- 状態: 監査完了（実装タスク4件を `tasks/priority/community_nodes_roadmap.md` の「2026年02月15日 再調査追記」に起票済み）。Task1（`cn-user-api` pending 同時保留数上限 + 拒否契約 + 最小回帰）は `feat/issue22-pending-request-limit` で実装完了。PR #23 のレビュー指摘（`pg_advisory_xact_lock(hashtext($1))` の衝突リスク）に対して、同ブランチで 2 キー advisory lock へ差し替える追補修正を適用済み。続いて Task2（`cn-user-api` 契約テスト拡張: under-limit 受理 / at-limit 拒否 / approve・reject 後の再申請）を `feat/issue22-pending-limit-contract-tests` で実装完了。PR #24 の `OpenAPI Artifacts Check` 失敗は `apps/admin-console/openapi/user-api.json` の末尾改行差分であることを特定し、生成物に合わせるフォローアップ修正を適用済み。Task3（node-level 同時取込 topic 数上限の実装）は `feat/issue22-node-level-topic-limit` で実装完了。
 - 次アクション（1タスク=1PR）:
-  - node-level 同時取込 topic 数上限の実装（`cn-admin-api` + `cn-user-api` + `cn-relay`）
   - node-level 上限の回帰テスト（`cn-admin-api` 契約 + `cn-relay` 統合）
 
 ### 2025年11月20日 MVP動作確認シナリオ整理

--- a/docs/01_project/progressReports/2026-02-15_issue22_node_level_topic_ingestion_limit.md
+++ b/docs/01_project/progressReports/2026-02-15_issue22_node_level_topic_ingestion_limit.md
@@ -1,0 +1,70 @@
+# Issue #22 Task3: node-level 同時取込 topic 数上限の実装
+
+作成日: 2026年02月15日
+
+## 概要
+
+- 対象: `cn-admin-api` / `cn-user-api` / `cn-relay` の購読承認フロー境界
+- 目的: `topic_subscription_design.md` の DoS 要件にある node-level 同時取込 topic 数上限を承認時に強制し、超過時に明示契約で拒否する。
+- スコープ外: node-level 上限に関する専用の回帰テスト拡張（`cn-relay` 側統合シナリオ拡張を含む）は次PRで実施。
+
+## 実施内容
+
+- `cn-admin-api`:
+  - `approve_subscription_request` に node-level 上限チェックを追加。
+  - 上限判定は transaction 内で advisory lock（2キー）を取得して実行し、同時承認時の競合超過を防止。
+  - 上限超過時は `429 Too Many Requests` + `code=NODE_SUBSCRIPTION_TOPIC_LIMIT_REACHED` + `details(metric/scope/current/limit)` を返す。
+  - OpenAPI に `POST /v1/admin/subscription-requests/{request_id}/approve` の `429` レスポンスを追加。
+  - 契約テスト `subscription_request_approve_rejects_when_node_topic_limit_reached` を追加し、拒否契約と pending 維持を固定。
+- `cn-core`:
+  - `service_config` に `node_subscription.max_concurrent_topics` パーサを追加し、既定値 `100` を定義。
+- `cn-relay`:
+  - runtime config に `node_subscription.max_concurrent_topics` を追加。
+  - relay の enabled topic 同期/health 判定で `max_concurrent_topics` を参照し、`ORDER BY updated_at DESC LIMIT` で購読対象を上限内に制約。
+
+## 契約として固定した仕様
+
+- 承認で新規 topic 有効化が必要な場合、`enabled=true` 件数が上限以上だと承認を拒否する。
+- 拒否レスポンス:
+  - `status`: `429`
+  - `code`: `NODE_SUBSCRIPTION_TOPIC_LIMIT_REACHED`
+  - `details.metric`: `node_subscriptions.enabled_topics`
+  - `details.scope`: `node`
+  - `details.current` / `details.limit`: 判定時の値
+- 超過拒否時は `topic_subscription_requests.status` は `pending` のまま残り、`topic_subscriptions` / `node_subscriptions` の副作用は発生しない。
+
+## 変更ファイル
+
+- `kukuri-community-node/crates/cn-admin-api/src/subscriptions.rs`
+- `kukuri-community-node/crates/cn-admin-api/src/openapi.rs`
+- `kukuri-community-node/crates/cn-admin-api/src/lib.rs`
+- `kukuri-community-node/crates/cn-admin-api/src/contract_tests.rs`
+- `kukuri-community-node/crates/cn-core/src/service_config.rs`
+- `kukuri-community-node/crates/cn-relay/src/config.rs`
+- `kukuri-community-node/crates/cn-relay/src/gossip.rs`
+- `kukuri-community-node/crates/cn-relay/src/lib.rs`
+- `kukuri-community-node/apps/admin-console/openapi/admin-api.json`
+- `kukuri-community-node/apps/admin-console/src/generated/admin-api.ts`
+- `docs/01_project/activeContext/tasks/status/in_progress.md`
+- `docs/01_project/activeContext/tasks/completed/2026-02-15.md`
+
+## 検証
+
+- Community Node（Docker 経路）
+  - `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`
+  - `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`
+  - `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -e RUST_TEST_THREADS=1 -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`
+  - 結果: `success`
+- OpenAPI 生成物
+  - `cd kukuri-community-node && cargo run --locked -p cn-cli -- openapi export --service user-api --output apps/admin-console/openapi/user-api.json --pretty && cargo run --locked -p cn-cli -- openapi export --service admin-api --output apps/admin-console/openapi/admin-api.json --pretty`
+  - `cd kukuri-community-node/apps/admin-console && pnpm install --frozen-lockfile && pnpm generate:api`
+  - 結果: `success`
+- AGENTS 必須 `gh act` ジョブ
+  - `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check`
+  - `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux`
+  - `NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`
+  - 結果: `success`（ログ: `tmp/logs/gh-act-format-check-issue22-node-level-topic-limit.log`, `tmp/logs/gh-act-native-test-linux-issue22-node-level-topic-limit.log`, `tmp/logs/gh-act-community-node-tests-issue22-node-level-topic-limit.log`）
+
+## 次アクション
+
+- Issue #22 の残タスクとして、node-level 上限の専用回帰テスト（`cn-admin-api` 契約 + `cn-relay` 統合）を次PRで実施する。

--- a/kukuri-community-node/apps/admin-console/openapi/admin-api.json
+++ b/kukuri-community-node/apps/admin-console/openapi/admin-api.json
@@ -2046,6 +2046,16 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/kukuri-community-node/apps/admin-console/src/generated/admin-api.ts
+++ b/kukuri-community-node/apps/admin-console/src/generated/admin-api.ts
@@ -2592,6 +2592,14 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
     };
     subscription_requests_reject_doc: {

--- a/kukuri-community-node/crates/cn-admin-api/src/contract_tests.rs
+++ b/kukuri-community-node/crates/cn-admin-api/src/contract_tests.rs
@@ -1074,6 +1074,11 @@ async fn openapi_contract_contains_admin_paths() {
         .pointer("/paths/~1v1~1admin~1services~1{service}~1config/put/responses/400")
         .is_some());
     assert!(payload
+        .pointer(
+            "/paths/~1v1~1admin~1subscription-requests~1{request_id}~1approve/post/responses/429"
+        )
+        .is_some());
+    assert!(payload
         .pointer("/paths/~1v1~1admin~1access-control~1memberships/get")
         .is_some());
     assert!(payload
@@ -3535,6 +3540,122 @@ async fn subscription_requests_and_node_subscriptions_contract_success() {
         stored_policy.get("retention_days").and_then(Value::as_i64),
         Some(7)
     );
+}
+
+#[tokio::test]
+async fn subscription_request_approve_rejects_when_node_topic_limit_reached() {
+    let state = test_state().await;
+    let session_id = insert_admin_session(&state.pool).await;
+
+    let mut effective_enabled_topics = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM cn_admin.node_subscriptions WHERE enabled = TRUE",
+    )
+    .fetch_one(&state.pool)
+    .await
+    .expect("count existing enabled node subscriptions");
+    if effective_enabled_topics == 0 {
+        let existing_topic_id = format!("kukuri:topic:limit-existing:{}", Uuid::new_v4());
+        sqlx::query(
+            "INSERT INTO cn_admin.node_subscriptions (topic_id, enabled, ref_count) VALUES ($1, TRUE, 1)",
+        )
+        .bind(&existing_topic_id)
+        .execute(&state.pool)
+        .await
+        .expect("insert existing enabled node subscription");
+        effective_enabled_topics = 1;
+    }
+
+    upsert_service_config(
+        &state.pool,
+        "relay",
+        json!({
+            "node_subscription": {
+                "max_concurrent_topics": effective_enabled_topics
+            }
+        }),
+    )
+    .await;
+
+    let requester_pubkey = Keys::generate().public_key().to_hex();
+    let topic_id = format!("kukuri:topic:limit-over:{}", Uuid::new_v4());
+    let request_id =
+        insert_subscription_request(&state.pool, &requester_pubkey, &topic_id, json!(["search"]))
+            .await;
+
+    let app = Router::new()
+        .route(
+            "/v1/admin/subscription-requests/{request_id}/approve",
+            post(subscriptions::approve_subscription_request),
+        )
+        .with_state(state.clone());
+
+    let (status, payload) = post_json(
+        app,
+        &format!("/v1/admin/subscription-requests/{request_id}/approve"),
+        json!({ "review_note": "over-limit approval should fail" }),
+        &session_id,
+    )
+    .await;
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        payload.get("code").and_then(Value::as_str),
+        Some("NODE_SUBSCRIPTION_TOPIC_LIMIT_REACHED")
+    );
+    assert_eq!(
+        payload.pointer("/details/metric").and_then(Value::as_str),
+        Some("node_subscriptions.enabled_topics")
+    );
+    assert_eq!(
+        payload.pointer("/details/scope").and_then(Value::as_str),
+        Some("node")
+    );
+    assert_eq!(
+        payload.pointer("/details/current").and_then(Value::as_i64),
+        Some(effective_enabled_topics)
+    );
+    assert_eq!(
+        payload.pointer("/details/limit").and_then(Value::as_i64),
+        Some(effective_enabled_topics)
+    );
+
+    let request_status = sqlx::query_scalar::<_, String>(
+        "SELECT status FROM cn_user.topic_subscription_requests WHERE request_id = $1",
+    )
+    .bind(&request_id)
+    .fetch_one(&state.pool)
+    .await
+    .expect("fetch request status after over-limit failure");
+    assert_eq!(request_status, "pending");
+
+    let topic_subscription_count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM cn_user.topic_subscriptions WHERE topic_id = $1 AND subscriber_pubkey = $2",
+    )
+    .bind(&topic_id)
+    .bind(&requester_pubkey)
+    .fetch_one(&state.pool)
+    .await
+    .expect("count topic subscriptions after over-limit failure");
+    assert_eq!(topic_subscription_count, 0);
+
+    let node_subscription_count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM cn_admin.node_subscriptions WHERE topic_id = $1",
+    )
+    .bind(&topic_id)
+    .fetch_one(&state.pool)
+    .await
+    .expect("count node subscriptions after over-limit failure");
+    assert_eq!(node_subscription_count, 0);
+
+    upsert_service_config(
+        &state.pool,
+        "relay",
+        json!({
+            "node_subscription": {
+                "max_concurrent_topics": cn_core::service_config::DEFAULT_MAX_CONCURRENT_NODE_TOPICS
+            }
+        }),
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/kukuri-community-node/crates/cn-admin-api/src/lib.rs
+++ b/kukuri-community-node/crates/cn-admin-api/src/lib.rs
@@ -68,6 +68,11 @@ impl ApiError {
             details: None,
         }
     }
+
+    fn with_details(mut self, details: Value) -> Self {
+        self.details = Some(details);
+        self
+    }
 }
 
 impl From<sqlx::Error> for ApiError {

--- a/kukuri-community-node/crates/cn-admin-api/src/openapi.rs
+++ b/kukuri-community-node/crates/cn-admin-api/src/openapi.rs
@@ -443,7 +443,11 @@ fn subscription_requests_list_doc() {}
     path = "/v1/admin/subscription-requests/{request_id}/approve",
     params(("request_id" = String, Path, description = "Subscription request identifier")),
     request_body = ReviewRequest,
-    responses((status = 200, body = StatusResponse), (status = 404, body = ErrorResponse))
+    responses(
+        (status = 200, body = StatusResponse),
+        (status = 404, body = ErrorResponse),
+        (status = 429, body = ErrorResponse)
+    )
 )]
 fn subscription_requests_approve_doc() {}
 


### PR DESCRIPTION
## What changed
- `cn-admin-api` の購読承認フローに node-level 同時取込 topic 上限チェックを追加し、上限超過時に `429` / `NODE_SUBSCRIPTION_TOPIC_LIMIT_REACHED` を返すようにしました。
- 上限判定は transaction advisory lock（2キー）で直列化し、同時承認時の超過競合を防止しました。
- 上限値を `cn_admin.service_configs(service='relay').config_json.node_subscription.max_concurrent_topics` から参照し、未設定時は既定値 `100` を適用する共通パーサを `cn-core` に追加しました。
- `cn-relay` の runtime config と topic 同期/health 判定を同一の `max_concurrent_topics` に接続し、`ORDER BY updated_at DESC, topic_id ASC LIMIT ...` で購読対象を制約しました。
- OpenAPI 契約に `POST /v1/admin/subscription-requests/{request_id}/approve` の `429` を追加し、admin-console 向け生成物を更新しました。
- タスク管理ドキュメント更新（`in_progress` / `completed` / progress report）を実施しました。

## Why
- Issue #22 の DoS 対策要件（node-level 同時取込 topic 数上限）を、承認時点で明示契約つきに強制するためです。
- relay 側の実効購読トピック数と承認判定の設定源を揃え、境界の挙動不一致を最小化するためです。

## Test evidence
- `cd kukuri-community-node && cargo fmt --all`
- `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`
- `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`
- `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -e RUST_TEST_THREADS=1 -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`
- `cd kukuri-community-node && cargo run --locked -p cn-cli -- openapi export --service user-api --output apps/admin-console/openapi/user-api.json --pretty && cargo run --locked -p cn-cli -- openapi export --service admin-api --output apps/admin-console/openapi/admin-api.json --pretty`
- `cd kukuri-community-node/apps/admin-console && pnpm install --frozen-lockfile && pnpm generate:api`
- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check`
- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux`
- `NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`

Refs #22
