### PR TITLE
feat: Issue #27 PR-01 拡張導入とランタイムフラグ基盤

### DIFF
--- a/docs/01_project/activeContext/tasks/completed/2026-02-16.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-16.md
@@ -20,10 +20,18 @@
 - [x] `cn-core::search_runtime_flags` を追加し、`cn-user-api` / `cn-index` の検索ランタイムフラグ読取を共通化。
 - [x] 正本を `cn_search.runtime_flags` に確定（`service_configs` は既存用途のみ維持）。
 
+## Issue #27 / PR #28 Community Node Tests fix loop（cn-admin-api 契約テスト直列化）
+
+- [x] PR #28 CI失敗ログ（Run `22048263032` / Job `63700968967`）を解析し、`subscription_request_approve_rejects_when_node_topic_limit_reached` の不安定失敗原因を特定。
+- [x] `kukuri-community-node/crates/cn-admin-api/src/contract_tests.rs` に `relay_subscription_approval_test_lock` を追加し、`service='relay'` を共有する承認系契約テスト 5件を直列化。
+- [x] `transactional_admin_mutations_rollback_when_audit_log_write_fails` / `..._commit_fails` / `subscription_requests_and_node_subscriptions_contract_success` / `subscription_request_approve_rejects_when_node_topic_limit_reached` / `...already_exceeded` の競合を解消。
+- [x] 進捗レポート `docs/01_project/progressReports/2026-02-16_issue27_pr28_community_node_tests_fix_loop.md` を追加。
+
 ## 検証
 
 - [x] `docker compose -f docker-compose.test.yml build community-node-postgres test-runner`（PGroonga 導入済み Postgres イメージの再現性確認）
-- [x] `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v \"$(git rev-parse --show-toplevel):/workspace\" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc \"set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli\"`（pass）
 - [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check`（pass）
 - [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux`（pass）
-- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`（2回実行。いずれも `cn-admin-api` 契約テストの既存不安定失敗で fail: `trust_contract_success_and_shape` / `subscription_request_approve_rejects_when_node_topic_limit_already_exceeded`）
+- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`（再実行で pass。`cn-admin-api` の対象契約テストを含め全クレート通過）
+- [x] `docker run --rm --network kukuri_community-node-network ... kukuri-test-runner ... 'for i in $(seq 1 8); do cargo test -p cn-admin-api --lib -- --test-threads=8; done'`（8連続 pass。PR #28 失敗点の再発なし）
+- [x] `cd kukuri-tauri/src-tauri && cargo test`（pass）

--- a/docs/01_project/activeContext/tasks/completed/2026-02-16.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-16.md
@@ -12,3 +12,18 @@
 ## 検証
 
 - [x] docs-only 更新のため、テスト/ビルド/`gh act` は実施不要（`AGENTS.md` の「`./docs` 配下のみ更新では不要」ルールに従う）。
+
+## Issue #27 PR-01 拡張導入とランタイムフラグ基盤
+
+- [x] `kukuri-community-node/docker/postgres-age/Dockerfile` に PGroonga 導入を追加。
+- [x] migration `20260216020000_m6_search_runtime_flags.sql` を追加し、`pg_trgm` / `pgroonga` / `age` / `cn_search.runtime_flags` を初期化。
+- [x] `cn-core::search_runtime_flags` を追加し、`cn-user-api` / `cn-index` の検索ランタイムフラグ読取を共通化。
+- [x] 正本を `cn_search.runtime_flags` に確定（`service_configs` は既存用途のみ維持）。
+
+## 検証
+
+- [x] `docker compose -f docker-compose.test.yml build community-node-postgres test-runner`（PGroonga 導入済み Postgres イメージの再現性確認）
+- [x] `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v \"$(git rev-parse --show-toplevel):/workspace\" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc \"set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli\"`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`（2回実行。いずれも `cn-admin-api` 契約テストの既存不安定失敗で fail: `trust_contract_success_and_shape` / `subscription_request_approve_rejects_when_node_topic_limit_already_exceeded`）

--- a/docs/01_project/activeContext/tasks/priority/search_pg_migration_roadmap.md
+++ b/docs/01_project/activeContext/tasks/priority/search_pg_migration_roadmap.md
@@ -6,9 +6,9 @@
 
 ## PR-01 拡張導入と移行フラグ基盤
 
-- [ ] `kukuri-community-node/docker/postgres-age/Dockerfile` に PGroonga 導入手順を追加し、`docker compose` build で再現性を確認する。
-- [ ] migration を追加し、`pg_trgm` / `pgroonga` / `age` の extension と `cn_search.runtime_flags` を作成する。
-- [ ] 検索フラグの正本を `cn_admin.service_configs` か `cn_search.runtime_flags` のどちらかに確定し、`cn-user-api` / `cn-index` の読取実装を統一する。
+- [x] `kukuri-community-node/docker/postgres-age/Dockerfile` に PGroonga 導入手順を追加し、`docker compose` build で再現性を確認する。
+- [x] migration を追加し、`pg_trgm` / `pgroonga` / `age` の extension と `cn_search.runtime_flags` を作成する。
+- [x] 検索フラグの正本を `cn_search.runtime_flags` に確定し、`cn-user-api` / `cn-index` の読取実装を `cn-core::search_runtime_flags` へ統一する。
 
 ## PR-02 投稿検索ドキュメント（PGroonga）
 

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -71,3 +71,4 @@
   - 未着手タスク起票: `docs/01_project/activeContext/tasks/priority/search_pg_migration_roadmap.md`
   - 進捗レポート: `docs/01_project/progressReports/2026-02-16_issue27_search_pg_migration_audit.md`
   - 2026年02月16日: PR-01（拡張導入とランタイムフラグ基盤）完了に伴い、`tasks/completed/2026-02-16.md` へ追記して本ファイルから作業中エントリを削除。
+  - 2026年02月16日: PR #28 Community Node Tests fix loop対応（`cn-admin-api` 契約テスト直列化）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr28_community_node_tests_fix_loop.md` へ反映。`gh act` の `format-check` / `native-test-linux` / `community-node-tests` も pass。

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -70,3 +70,4 @@
   - 監査結果: `docs/01_project/activeContext/search_pg_migration/issue27_initial_audit_2026-02-16.md`
   - 未着手タスク起票: `docs/01_project/activeContext/tasks/priority/search_pg_migration_roadmap.md`
   - 進捗レポート: `docs/01_project/progressReports/2026-02-16_issue27_search_pg_migration_audit.md`
+  - 2026年02月16日: PR-01（拡張導入とランタイムフラグ基盤）完了に伴い、`tasks/completed/2026-02-16.md` へ追記して本ファイルから作業中エントリを削除。

--- a/docs/01_project/progressReports/2026-02-16_issue27_pr01_extensions_flags_foundation.md
+++ b/docs/01_project/progressReports/2026-02-16_issue27_pr01_extensions_flags_foundation.md
@@ -1,0 +1,68 @@
+# Issue #27 PR-01 拡張導入とランタイムフラグ基盤
+
+最終更新日: 2026年02月16日
+
+## 概要
+
+Issue #27 の PR-01 スコープとして、検索 PG 移行の土台（拡張導入・runtime flags 基盤）を最小差分で実装した。
+検索機能本体の切替は行わず、既存挙動（Meilisearch read）を維持して後続 PR のための準備のみ追加している。
+
+## 実施内容
+
+1. Postgres イメージに PGroonga 導入
+- ファイル: `kukuri-community-node/docker/postgres-age/Dockerfile`
+- `groonga-apt-source-latest-bookworm.deb` を導入し、`postgresql-16-pgdg-pgroonga` をインストール。
+- 既存 AGE ビルド手順は維持。
+
+2. 拡張/フラグ migration 追加
+- ファイル: `kukuri-community-node/migrations/20260216020000_m6_search_runtime_flags.sql`
+- `CREATE EXTENSION IF NOT EXISTS pg_trgm;`
+- `CREATE EXTENSION IF NOT EXISTS pgroonga;`
+- `CREATE EXTENSION IF NOT EXISTS age;`
+- `cn_search.runtime_flags` 作成と初期値 seed（`search_read_backend=meili` など）を追加。
+
+3. runtime flags 読取基盤を `cn-core` に追加
+- ファイル: `kukuri-community-node/crates/cn-core/src/search_runtime_flags.rs`
+- `SearchRuntimeFlags` / `watch_search_runtime_flags` を実装。
+- `cn_search.runtime_flags` が未作成の場合は互換デフォルト値へフォールバックするため、後方互換を確保。
+- migration 後に `age` / `pg_trgm` / `pgroonga` が存在することをテストで検証。
+
+4. `cn-user-api` / `cn-index` の読取経路を共通化
+- ファイル: `kukuri-community-node/crates/cn-user-api/src/lib.rs`
+- ファイル: `kukuri-community-node/crates/cn-index/src/lib.rs`
+- 起動時に `cn_core::search_runtime_flags::watch_search_runtime_flags` を起動し、同一読取経路へ統一。
+
+5. モジュール公開
+- ファイル: `kukuri-community-node/crates/cn-core/src/lib.rs`
+- `pub mod search_runtime_flags;` を追加。
+
+## 設計判断
+
+- 検索ランタイムフラグの正本は `cn_search.runtime_flags` とした。
+- `cn_admin.service_configs` は既存用途を維持し、検索移行フラグの読取は新設 `cn_search.runtime_flags` へ統一した。
+- この PR では read/write 切替ロジック自体は導入せず、観測可能な挙動変更を避けた。
+
+## 検証コマンド
+
+- `docker compose -f docker-compose.test.yml build community-node-postgres test-runner`
+- `docker compose -f docker-compose.test.yml up -d --force-recreate community-node-postgres community-node-meilisearch`
+- `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check`
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux`
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`
+
+## 検証結果
+
+- Community Node コンテナ経路: `cargo test --workspace --all-features` / `cargo build --release -p cn-cli` は pass。
+- `gh act format-check`: pass（`tmp/logs/gh-act-format-check-issue27-pr01.log`）
+- `gh act native-test-linux`: pass（`tmp/logs/gh-act-native-test-linux-issue27-pr01.log`）
+- `gh act community-node-tests`: fail（2回再実行、いずれも `cn-admin-api` 契約テストの既存不安定失敗）
+  - 1回目: `trust_contract_success_and_shape`
+  - 2回目: `subscription_request_approve_rejects_when_node_topic_limit_already_exceeded`
+  - ログ: `tmp/logs/gh-act-community-node-tests-issue27-pr01.log`, `tmp/logs/gh-act-community-node-tests-issue27-pr01-rerun.log`
+
+## 影響範囲
+
+- 検索移行の基盤（DB 拡張・フラグ読取）に限定。
+- 既存 API の検索結果ロジック・書込みロジックは未変更。
+- 後続 PR（PR-02 以降）で PG 検索実装へ段階移行可能な状態を用意。

--- a/docs/01_project/progressReports/2026-02-16_issue27_pr28_community_node_tests_fix_loop.md
+++ b/docs/01_project/progressReports/2026-02-16_issue27_pr28_community_node_tests_fix_loop.md
@@ -1,0 +1,49 @@
+# Issue #27 / PR #28 Community Node Tests fix loop（cn-admin-api 契約テスト競合解消）
+
+最終更新日: 2026年02月16日
+
+## 概要
+
+PR #28 の Community Node Tests 失敗（Run `22048263032` / Job `63700968967`）を調査し、`cn-admin-api` 契約テストの並列競合を最小差分で解消した。
+Issue #27 PR-01 の基盤変更に影響を広げず、テスト側の直列化のみを実施した。
+
+## 失敗原因
+
+1. 失敗テストは `contract_tests::subscription_request_approve_rejects_when_node_topic_limit_reached`。
+2. `service='relay'` の `cn_admin.service_configs` と `cn_admin.node_subscriptions` を共有する複数契約テストが並列実行され、期待値と実測値が競合した。
+3. 具体的には以下が同時に発生しうる状態だった。
+- `max_concurrent_topics` が別テストで上書きされ、`429` 期待が `200` になる。
+- `transactional_admin_mutations_rollback_when_audit_log_write_fails` などで `500` 期待が `429` になる。
+
+## 実施内容
+
+1. `kukuri-community-node/crates/cn-admin-api/src/contract_tests.rs` に `relay_subscription_approval_test_lock`（`OnceLock<tokio::sync::Mutex<()>>`）を追加。
+2. 共有状態に依存する以下 5 テストへ同一ロックを導入して直列化。
+- `transactional_admin_mutations_rollback_when_audit_log_write_fails`
+- `transactional_admin_mutations_rollback_when_commit_fails`
+- `subscription_requests_and_node_subscriptions_contract_success`
+- `subscription_request_approve_rejects_when_node_topic_limit_reached`
+- `subscription_request_approve_rejects_when_node_topic_limit_already_exceeded`
+
+## 検証コマンド
+
+- `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`
+- `export BUILDX_CONFIG=/tmp/buildx; docker compose -f docker-compose.test.yml build test-runner`
+- `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc 'set -euo pipefail; source /usr/local/cargo/env; for i in $(seq 1 8); do cargo test -p cn-admin-api --lib -- --test-threads=8; done'`
+- `cd kukuri-tauri/src-tauri && cargo test`
+- `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc 'set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli'`
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check`
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux`
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`
+
+## 検証結果
+
+1. `cn-admin-api` 反復実行（8連続）で対象失敗の再発なし。
+2. `kukuri-tauri/src-tauri` の `cargo test` は pass。
+3. `gh act` の `format-check` / `native-test-linux` / `community-node-tests` はすべて pass。
+4. `community-node-tests` では `cn-admin-api` 43件（対象の承認系契約テスト含む）を含めて全クレート通過し、PR #28 の失敗条件は解消。
+
+## 影響範囲
+
+- 変更は `cn-admin-api` 契約テストに限定。
+- アプリ実装・DB スキーマ・API 契約の本体挙動は変更なし。

--- a/kukuri-community-node/crates/cn-core/src/lib.rs
+++ b/kukuri-community-node/crates/cn-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod moderation;
 pub mod node_key;
 pub mod nostr;
 pub mod rate_limit;
+pub mod search_runtime_flags;
 pub mod server;
 pub mod service_config;
 pub mod topic;

--- a/kukuri-community-node/crates/cn-core/src/search_runtime_flags.rs
+++ b/kukuri-community-node/crates/cn-core/src/search_runtime_flags.rs
@@ -1,0 +1,310 @@
+use anyhow::Result;
+use sqlx::{Pool, Postgres, Row};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tokio::time;
+
+pub const FLAG_SEARCH_READ_BACKEND: &str = "search_read_backend";
+pub const FLAG_SEARCH_WRITE_MODE: &str = "search_write_mode";
+pub const FLAG_SUGGEST_READ_BACKEND: &str = "suggest_read_backend";
+pub const FLAG_SHADOW_SAMPLE_RATE: &str = "shadow_sample_rate";
+
+pub const SEARCH_READ_BACKEND_MEILI: &str = "meili";
+pub const SEARCH_WRITE_MODE_MEILI_ONLY: &str = "meili_only";
+pub const SUGGEST_READ_BACKEND_LEGACY: &str = "legacy";
+pub const SHADOW_SAMPLE_RATE_DISABLED: &str = "0";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchRuntimeFlags {
+    pub search_read_backend: String,
+    pub search_write_mode: String,
+    pub suggest_read_backend: String,
+    pub shadow_sample_rate: String,
+}
+
+impl Default for SearchRuntimeFlags {
+    fn default() -> Self {
+        Self {
+            search_read_backend: SEARCH_READ_BACKEND_MEILI.to_string(),
+            search_write_mode: SEARCH_WRITE_MODE_MEILI_ONLY.to_string(),
+            suggest_read_backend: SUGGEST_READ_BACKEND_LEGACY.to_string(),
+            shadow_sample_rate: SHADOW_SAMPLE_RATE_DISABLED.to_string(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SearchRuntimeFlagsHandle {
+    state: Arc<RwLock<SearchRuntimeFlags>>,
+}
+
+impl SearchRuntimeFlagsHandle {
+    pub async fn get(&self) -> SearchRuntimeFlags {
+        self.state.read().await.clone()
+    }
+}
+
+pub async fn watch_search_runtime_flags(
+    pool: Pool<Postgres>,
+    poll_interval: Duration,
+    service: &'static str,
+) -> Result<SearchRuntimeFlagsHandle> {
+    let initial = load_search_runtime_flags(&pool).await?;
+    log_search_runtime_flags(service, "startup", &initial);
+
+    let state = Arc::new(RwLock::new(initial));
+    let state_ref = Arc::clone(&state);
+
+    tokio::spawn(async move {
+        let poll_interval = if poll_interval.is_zero() {
+            Duration::from_secs(1)
+        } else {
+            poll_interval
+        };
+
+        let mut poll_timer = time::interval(poll_interval);
+        poll_timer.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+        poll_timer.tick().await;
+
+        loop {
+            poll_timer.tick().await;
+            match load_search_runtime_flags(&pool).await {
+                Ok(next) => {
+                    let mut guard = state_ref.write().await;
+                    if *guard != next {
+                        log_search_runtime_flags(service, "poll", &next);
+                        *guard = next;
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        service = service,
+                        error = %err,
+                        "search runtime flags refresh failed"
+                    );
+                }
+            }
+        }
+    });
+
+    Ok(SearchRuntimeFlagsHandle { state })
+}
+
+pub async fn load_search_runtime_flags(pool: &Pool<Postgres>) -> Result<SearchRuntimeFlags> {
+    let rows = match sqlx::query("SELECT flag_name, flag_value FROM cn_search.runtime_flags")
+        .fetch_all(pool)
+        .await
+    {
+        Ok(rows) => rows,
+        Err(err) if is_missing_runtime_flags_table(&err) => {
+            tracing::warn!(
+                error = %err,
+                "cn_search.runtime_flags is unavailable; using compatibility defaults"
+            );
+            return Ok(SearchRuntimeFlags::default());
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    let mut flags = SearchRuntimeFlags::default();
+    for row in rows {
+        let flag_name: String = row.try_get("flag_name")?;
+        let flag_value: String = row.try_get("flag_value")?;
+        apply_flag_value(&mut flags, &flag_name, &flag_value);
+    }
+
+    Ok(flags)
+}
+
+pub fn log_search_runtime_flags(service: &str, trigger: &str, flags: &SearchRuntimeFlags) {
+    tracing::info!(
+        service = service,
+        trigger = trigger,
+        search_read_backend = %flags.search_read_backend,
+        search_write_mode = %flags.search_write_mode,
+        suggest_read_backend = %flags.suggest_read_backend,
+        shadow_sample_rate = %flags.shadow_sample_rate,
+        "search runtime flags loaded"
+    );
+}
+
+fn apply_flag_value(flags: &mut SearchRuntimeFlags, flag_name: &str, flag_value: &str) {
+    let value = flag_value.trim();
+    if value.is_empty() {
+        return;
+    }
+
+    match flag_name.trim() {
+        FLAG_SEARCH_READ_BACKEND => flags.search_read_backend = value.to_string(),
+        FLAG_SEARCH_WRITE_MODE => flags.search_write_mode = value.to_string(),
+        FLAG_SUGGEST_READ_BACKEND => flags.suggest_read_backend = value.to_string(),
+        FLAG_SHADOW_SAMPLE_RATE => flags.shadow_sample_rate = value.to_string(),
+        _ => {}
+    }
+}
+
+fn is_missing_runtime_flags_table(err: &sqlx::Error) -> bool {
+    match err {
+        sqlx::Error::Database(db_err) => {
+            matches!(db_err.code().as_deref(), Some("42P01") | Some("3F000"))
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::postgres::PgPoolOptions;
+    use std::collections::HashSet;
+    use std::sync::OnceLock;
+    use tokio::sync::{Mutex, OnceCell};
+
+    static MIGRATIONS: OnceCell<()> = OnceCell::const_new();
+
+    fn database_url() -> String {
+        std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://cn:cn_password@localhost:5432/cn".to_string())
+    }
+
+    fn db_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    async fn ensure_migrated(pool: &Pool<Postgres>) {
+        MIGRATIONS
+            .get_or_init(|| async {
+                crate::migrations::run(pool)
+                    .await
+                    .expect("run community-node migrations");
+            })
+            .await;
+    }
+
+    async fn test_pool() -> Pool<Postgres> {
+        let pool = PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url())
+            .await
+            .expect("connect database");
+        ensure_migrated(&pool).await;
+        pool
+    }
+
+    async fn seed_flags(
+        pool: &Pool<Postgres>,
+        search_read_backend: &str,
+        shadow_sample_rate: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO cn_search.runtime_flags (flag_name, flag_value, updated_by) VALUES ($1, $2, 'test') ON CONFLICT (flag_name) DO UPDATE SET flag_value = EXCLUDED.flag_value, updated_at = NOW(), updated_by = EXCLUDED.updated_by",
+        )
+        .bind(FLAG_SEARCH_READ_BACKEND)
+        .bind(search_read_backend)
+        .execute(pool)
+        .await
+        .expect("upsert search_read_backend");
+
+        sqlx::query(
+            "INSERT INTO cn_search.runtime_flags (flag_name, flag_value, updated_by) VALUES ($1, $2, 'test') ON CONFLICT (flag_name) DO UPDATE SET flag_value = EXCLUDED.flag_value, updated_at = NOW(), updated_by = EXCLUDED.updated_by",
+        )
+        .bind(FLAG_SEARCH_WRITE_MODE)
+        .bind(SEARCH_WRITE_MODE_MEILI_ONLY)
+        .execute(pool)
+        .await
+        .expect("upsert search_write_mode");
+
+        sqlx::query(
+            "INSERT INTO cn_search.runtime_flags (flag_name, flag_value, updated_by) VALUES ($1, $2, 'test') ON CONFLICT (flag_name) DO UPDATE SET flag_value = EXCLUDED.flag_value, updated_at = NOW(), updated_by = EXCLUDED.updated_by",
+        )
+        .bind(FLAG_SUGGEST_READ_BACKEND)
+        .bind(SUGGEST_READ_BACKEND_LEGACY)
+        .execute(pool)
+        .await
+        .expect("upsert suggest_read_backend");
+
+        sqlx::query(
+            "INSERT INTO cn_search.runtime_flags (flag_name, flag_value, updated_by) VALUES ($1, $2, 'test') ON CONFLICT (flag_name) DO UPDATE SET flag_value = EXCLUDED.flag_value, updated_at = NOW(), updated_by = EXCLUDED.updated_by",
+        )
+        .bind(FLAG_SHADOW_SAMPLE_RATE)
+        .bind(shadow_sample_rate)
+        .execute(pool)
+        .await
+        .expect("upsert shadow_sample_rate");
+    }
+
+    #[test]
+    fn default_flags_are_backward_compatible_with_meili() {
+        let flags = SearchRuntimeFlags::default();
+        assert_eq!(flags.search_read_backend, SEARCH_READ_BACKEND_MEILI);
+        assert_eq!(flags.search_write_mode, SEARCH_WRITE_MODE_MEILI_ONLY);
+        assert_eq!(flags.suggest_read_backend, SUGGEST_READ_BACKEND_LEGACY);
+        assert_eq!(flags.shadow_sample_rate, SHADOW_SAMPLE_RATE_DISABLED);
+    }
+
+    #[tokio::test]
+    async fn load_search_runtime_flags_reads_seeded_defaults() {
+        let _guard = db_test_lock().lock().await;
+        let pool = test_pool().await;
+
+        seed_flags(
+            &pool,
+            SEARCH_READ_BACKEND_MEILI,
+            SHADOW_SAMPLE_RATE_DISABLED,
+        )
+        .await;
+
+        let flags = load_search_runtime_flags(&pool)
+            .await
+            .expect("load search runtime flags");
+
+        assert_eq!(flags.search_read_backend, SEARCH_READ_BACKEND_MEILI);
+        assert_eq!(flags.search_write_mode, SEARCH_WRITE_MODE_MEILI_ONLY);
+        assert_eq!(flags.suggest_read_backend, SUGGEST_READ_BACKEND_LEGACY);
+        assert_eq!(flags.shadow_sample_rate, SHADOW_SAMPLE_RATE_DISABLED);
+    }
+
+    #[tokio::test]
+    async fn migrations_enable_required_search_extensions() {
+        let _guard = db_test_lock().lock().await;
+        let pool = test_pool().await;
+
+        let installed: Vec<String> =
+            sqlx::query_scalar("SELECT extname FROM pg_extension WHERE extname = ANY($1::text[])")
+                .bind(vec!["age", "pg_trgm", "pgroonga"])
+                .fetch_all(&pool)
+                .await
+                .expect("query installed extensions");
+
+        let installed_set: HashSet<String> = installed.into_iter().collect();
+        assert!(installed_set.contains("age"));
+        assert!(installed_set.contains("pg_trgm"));
+        assert!(installed_set.contains("pgroonga"));
+    }
+
+    #[tokio::test]
+    async fn load_search_runtime_flags_reads_runtime_overrides() {
+        let _guard = db_test_lock().lock().await;
+        let pool = test_pool().await;
+
+        seed_flags(&pool, "pg", "25").await;
+
+        let flags = load_search_runtime_flags(&pool)
+            .await
+            .expect("load search runtime flags");
+
+        assert_eq!(flags.search_read_backend, "pg");
+        assert_eq!(flags.search_write_mode, SEARCH_WRITE_MODE_MEILI_ONLY);
+        assert_eq!(flags.suggest_read_backend, SUGGEST_READ_BACKEND_LEGACY);
+        assert_eq!(flags.shadow_sample_rate, "25");
+
+        seed_flags(
+            &pool,
+            SEARCH_READ_BACKEND_MEILI,
+            SHADOW_SAMPLE_RATE_DISABLED,
+        )
+        .await;
+    }
+}

--- a/kukuri-community-node/crates/cn-index/src/lib.rs
+++ b/kukuri-community-node/crates/cn-index/src/lib.rs
@@ -5,7 +5,8 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
 use cn_core::{
-    config as env_config, db, health, http, logging, meili, metrics, nostr, server, service_config,
+    config as env_config, db, health, http, logging, meili, metrics, nostr, search_runtime_flags,
+    server, service_config,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -106,6 +107,12 @@ pub async fn run(config: IndexConfig) -> Result<()> {
         "index",
         default_config,
         Duration::from_secs(config.config_poll_seconds),
+    )
+    .await?;
+    let _search_runtime_flags = search_runtime_flags::watch_search_runtime_flags(
+        pool.clone(),
+        Duration::from_secs(config.config_poll_seconds),
+        SERVICE_NAME,
     )
     .await?;
     let health_targets = Arc::new(health::parse_health_targets(

--- a/kukuri-community-node/crates/cn-user-api/src/lib.rs
+++ b/kukuri-community-node/crates/cn-user-api/src/lib.rs
@@ -5,7 +5,10 @@ use axum::http::{HeaderMap, HeaderValue};
 use axum::response::IntoResponse;
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
-use cn_core::{config, db, http, logging, meili, metrics, node_key, server, service_config};
+use cn_core::{
+    config, db, http, logging, meili, metrics, node_key, search_runtime_flags, server,
+    service_config,
+};
 use nostr_sdk::prelude::Keys;
 use serde::Serialize;
 use serde_json::json;
@@ -249,6 +252,12 @@ pub async fn run(config: UserApiConfig) -> Result<()> {
         "bootstrap",
         bootstrap_default,
         Duration::from_secs(config.config_poll_seconds),
+    )
+    .await?;
+    let _search_runtime_flags = search_runtime_flags::watch_search_runtime_flags(
+        pool.clone(),
+        Duration::from_secs(config.config_poll_seconds),
+        SERVICE_NAME,
     )
     .await?;
 

--- a/kukuri-community-node/docker/postgres-age/Dockerfile
+++ b/kukuri-community-node/docker/postgres-age/Dockerfile
@@ -8,10 +8,16 @@ RUN apt-get update \
         flex \
         git \
         postgresql-server-dev-16 \
+        wget \
     && update-ca-certificates \
+    && wget -O /tmp/groonga-apt-source-latest-bookworm.deb https://packages.groonga.org/debian/groonga-apt-source-latest-bookworm.deb \
+    && apt-get install -y --no-install-recommends /tmp/groonga-apt-source-latest-bookworm.deb \
+    && rm -f /tmp/groonga-apt-source-latest-bookworm.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-16-pgdg-pgroonga \
     && git clone --branch release/PG16/1.6.0 --depth 1 https://github.com/apache/age.git /tmp/age \
     && cd /tmp/age \
     && make install \
     && rm -rf /tmp/age \
-    && apt-get purge -y --auto-remove build-essential git \
+    && apt-get purge -y --auto-remove build-essential git wget \
     && rm -rf /var/lib/apt/lists/*

--- a/kukuri-community-node/migrations/20260216020000_m6_search_runtime_flags.sql
+++ b/kukuri-community-node/migrations/20260216020000_m6_search_runtime_flags.sql
@@ -1,0 +1,20 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS pgroonga;
+CREATE EXTENSION IF NOT EXISTS age;
+
+CREATE SCHEMA IF NOT EXISTS cn_search;
+
+CREATE TABLE IF NOT EXISTS cn_search.runtime_flags (
+    flag_name TEXT PRIMARY KEY,
+    flag_value TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by TEXT NOT NULL
+);
+
+INSERT INTO cn_search.runtime_flags (flag_name, flag_value, updated_by)
+VALUES
+    ('search_read_backend', 'meili', 'migration'),
+    ('search_write_mode', 'meili_only', 'migration'),
+    ('suggest_read_backend', 'legacy', 'migration'),
+    ('shadow_sample_rate', '0', 'migration')
+ON CONFLICT (flag_name) DO NOTHING;


### PR DESCRIPTION
## What changed
- `kukuri-community-node/docker/postgres-age/Dockerfile` に PGroonga 導入手順を追加
- migration `20260216020000_m6_search_runtime_flags.sql` を追加し、`pg_trgm` / `pgroonga` / `age` と `cn_search.runtime_flags` を初期化
- `cn-core` に `search_runtime_flags` モジュールを追加し、runtime flags の読取・ポーリング基盤を実装
- `cn-user-api` / `cn-index` の起動時読取経路を `cn_core::search_runtime_flags` に統一
- タスク管理/進捗ドキュメントを更新

## Why
- 検索 PG 移行（PR-01）の土台として、拡張導入と runtime flags の基盤を先行で整備するため
- 既存検索挙動（Meilisearch read）を変えずに、後続 PR での段階移行を可能にするため

## Test evidence
### Community Node container path
- `docker compose -f docker-compose.test.yml build community-node-postgres test-runner`
- `docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`
- 結果: pass

### AGENTS required `gh act`
- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job format-check`
  - pass（`tmp/logs/gh-act-format-check-issue27-pr01.log`）
- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job native-test-linux`
  - pass（`tmp/logs/gh-act-native-test-linux-issue27-pr01.log`）
- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`
  - fail（再実行でも fail）
  - 1回目失敗: `contract_tests::trust_contract_success_and_shape`
  - 2回目失敗: `contract_tests::subscription_request_approve_rejects_when_node_topic_limit_already_exceeded`
  - ログ: `tmp/logs/gh-act-community-node-tests-issue27-pr01.log`, `tmp/logs/gh-act-community-node-tests-issue27-pr01-rerun.log`

Refs #27
