### PR TITLE
feat: issue #27 PR-02 post search PGroonga path

### DIFF
--- a/docs/01_project/activeContext/tasks/completed/2026-02-16.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-16.md
@@ -75,3 +75,22 @@
 - [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check | tee tmp/logs/gh-act-format-check-issue27-pr29-fix-loop.log`（pass）
 - [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux | tee tmp/logs/gh-act-native-test-linux-issue27-pr29-fix-loop.log`（pass）
 - [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests | tee tmp/logs/gh-act-community-node-tests-issue27-pr29-fix-loop.log`（pass）
+
+## Issue #27 / PR #29 fix loop second pass（CI run 22050188054）
+
+- [x] CI 失敗ジョブを再解析し、Native Test の `Invite signature is invalid` と Community Node Tests の `search_contract_success_shape_compatible` 失敗原因を特定。
+- [x] `kukuri-tauri/src-tauri/src/infrastructure/crypto/default_signature_service.rs` で、署名後の `created_at` を署名済みイベント時刻へ同期し、検証時の時刻不整合を解消。
+- [x] `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs` で検索契約テストの runtime flag 競合を直列化（`Mutex`）し、Meili 前提テストのフラグ初期化を明示。
+- [x] 進捗レポート `docs/01_project/progressReports/2026-02-16_issue27_pr29_second_pass_ci_fix_loop.md` を追加。
+
+## 検証
+
+- [x] `cd kukuri-tauri/src-tauri && cargo test request_join_with_invite_broadcasts_to_issuer_topic -- --nocapture`（pass）
+- [x] `cd kukuri-tauri/src-tauri && cargo test`（pass）
+- [x] `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test -p cn-user-api search_contract_success_shape_compatible -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_switch_normalization_and_version_filter -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_preserves_multi_topic_rows_for_same_post_id -- --nocapture"`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/act-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check | tee tmp/logs/gh-act-format-check-issue27-pr29-second-pass.log`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/act-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux | tee tmp/logs/gh-act-native-test-linux-issue27-pr29-second-pass.log`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/act-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests | tee tmp/logs/gh-act-community-node-tests-issue27-pr29-second-pass.log`（fail: `subscriptions::api_contract_tests::auth_consent_quota_metrics_regression_counters_increment` が `left: 428, right: 402`。今回修正対象外の既知不安定系としてログ保全）

--- a/docs/01_project/activeContext/tasks/completed/2026-02-16.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-16.md
@@ -35,3 +35,23 @@
 - [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global gh act --workflows .github/workflows/test.yml --job community-node-tests`（再実行で pass。`cn-admin-api` の対象契約テストを含め全クレート通過）
 - [x] `docker run --rm --network kukuri_community-node-network ... kukuri-test-runner ... 'for i in $(seq 1 8); do cargo test -p cn-admin-api --lib -- --test-threads=8; done'`（8連続 pass。PR #28 失敗点の再発なし）
 - [x] `cd kukuri-tauri/src-tauri && cargo test`（pass）
+
+## Issue #27 PR-02 投稿検索ドキュメント（PGroonga）
+
+- [x] migration `20260216030000_m7_post_search_documents.sql` を追加し、`cn_search.post_search_documents` と PGroonga index を導入。
+- [x] `cn-index` outbox consumer に `search_write_mode`（`meili_only/dual/pg_only`）を追加し、Meili 維持の dual-write（upsert/delete/expiry）を実装。
+- [x] `cn-user-api` `/v1/search` に PG read backend を追加し、`search_read_backend` ランタイムフラグで Meili/PG 切替を実装。
+- [x] `cn-core::search_normalizer`（NFKC/小文字化/記号正規化/`normalizer_version`）を追加し、`cn-index`/`cn-user-api` で共通利用。
+- [x] 回帰テストを追加（`cn-core` 正規化ユニット、`cn-index` dual-write 統合、`cn-user-api` PG読取契約）。
+- [x] 進捗レポート `docs/01_project/progressReports/2026-02-16_issue27_pr02_post_search_pgroonga.md` を追加。
+
+## 検証
+
+- [x] `cd kukuri-community-node && cargo fmt`（pass）
+- [x] `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network ... kukuri-test-runner ... "cargo test -p cn-core search_normalizer -- --nocapture; cargo test -p cn-index outbox_dual_write_updates_meili_and_post_search_documents -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_switch_normalization_and_version_filter -- --nocapture"`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network ... kukuri-test-runner ... "cargo test --workspace --all-features; cargo build --release -p cn-cli"`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests`（fail: `cn-admin-api` 契約テスト `trust_contract_success_and_shape` の既知系不安定失敗。ログ: `tmp/logs/gh-act-community-node-tests-issue27-pr02.log`）

--- a/docs/01_project/activeContext/tasks/completed/2026-02-16.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-16.md
@@ -55,3 +55,23 @@
 - [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check`（pass）
 - [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux`（pass）
 - [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests`（fail: `cn-admin-api` 契約テスト `trust_contract_success_and_shape` の既知系不安定失敗。ログ: `tmp/logs/gh-act-community-node-tests-issue27-pr02.log`）
+
+## Issue #27 / PR #29 fix loop（post_search_documents multi-topic 上書き防止）
+
+- [x] migration `20260216040000_m8_post_search_documents_topic_key.sql` を追加し、`cn_search.post_search_documents` の主キーを `(post_id, topic_id)` へ変更。
+- [x] `cn-index` の PG upsert を `ON CONFLICT (post_id, topic_id)` へ修正し、delete/expiry/stale-mark を `topic_id` 条件付き更新へ変更。
+- [x] `cn-index` 統合テスト `outbox_dual_write_preserves_post_search_documents_per_topic` を追加し、同一 event が複数 topic に属するケースで 2 行保持を回帰テスト化。
+- [x] `cn-user-api` 契約テスト `search_contract_pg_backend_preserves_multi_topic_rows_for_same_post_id` を追加し、`/v1/search?topic=...` が topic ごとに正しい行を返すことを検証。
+- [x] 進捗レポート `docs/01_project/progressReports/2026-02-16_issue27_pr29_post_search_topic_key_fix_loop.md` を追加。
+
+## 検証
+
+- [x] `cd kukuri-community-node && cargo fmt`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml down -v`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network ... kukuri-test-runner ... "cargo clean -p cn-core; cargo test -p cn-index outbox_dual_write_updates_meili_and_post_search_documents -- --nocapture; cargo test -p cn-index outbox_dual_write_preserves_post_search_documents_per_topic -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_switch_normalization_and_version_filter -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_preserves_multi_topic_rows_for_same_post_id -- --nocapture"`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network ... kukuri-test-runner ... "cargo test --workspace --all-features; cargo build --release -p cn-cli"`（pass）
+- [x] `cd kukuri-tauri/src-tauri && cargo test`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check | tee tmp/logs/gh-act-format-check-issue27-pr29-fix-loop.log`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux | tee tmp/logs/gh-act-native-test-linux-issue27-pr29-fix-loop.log`（pass）
+- [x] `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests | tee tmp/logs/gh-act-community-node-tests-issue27-pr29-fix-loop.log`（pass）

--- a/docs/01_project/activeContext/tasks/priority/search_pg_migration_roadmap.md
+++ b/docs/01_project/activeContext/tasks/priority/search_pg_migration_roadmap.md
@@ -12,10 +12,10 @@
 
 ## PR-02 投稿検索ドキュメント（PGroonga）
 
-- [ ] `cn_search.post_search_documents` と PGroonga index を追加する migration を作成する。
-- [ ] outbox 消費で `post_search_documents` へ upsert/delete する dual-write（Meili + PG）を実装する。
-- [ ] `/v1/search` に PG検索実装を追加し、`search_read_backend` で切替可能にする。
-- [ ] 正規化関数（NFKC/記号処理/normalizer_version）と回帰テストを追加する。
+- [x] `cn_search.post_search_documents` と PGroonga index を追加する migration を作成する。
+- [x] outbox 消費で `post_search_documents` へ upsert/delete する dual-write（Meili + PG）を実装する。
+- [x] `/v1/search` に PG検索実装を追加し、`search_read_backend` で切替可能にする。
+- [x] 正規化関数（NFKC/記号処理/normalizer_version）と回帰テストを追加する。
 
 ## PR-03 コミュニティ候補生成（pg_trgm + prefix）
 

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -73,3 +73,4 @@
   - 2026年02月16日: PR-01（拡張導入とランタイムフラグ基盤）完了に伴い、`tasks/completed/2026-02-16.md` へ追記して本ファイルから作業中エントリを削除。
   - 2026年02月16日: PR #28 Community Node Tests fix loop対応（`cn-admin-api` 契約テスト直列化）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr28_community_node_tests_fix_loop.md` へ反映。`gh act` の `format-check` / `native-test-linux` / `community-node-tests` も pass。
   - 2026年02月16日: PR-02（投稿検索ドキュメント + PGroonga read/write 切替）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr02_post_search_pgroonga.md` へ反映。
+  - 2026年02月16日: PR #29 fix loop（`post_search_documents` の primary key 競合）対応として、`(post_id, topic_id)` キー化・`ON CONFLICT` 修正・multi-topic 回帰テストを実装。`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr29_post_search_topic_key_fix_loop.md` に反映。

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -74,3 +74,4 @@
   - 2026年02月16日: PR #28 Community Node Tests fix loop対応（`cn-admin-api` 契約テスト直列化）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr28_community_node_tests_fix_loop.md` へ反映。`gh act` の `format-check` / `native-test-linux` / `community-node-tests` も pass。
   - 2026年02月16日: PR-02（投稿検索ドキュメント + PGroonga read/write 切替）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr02_post_search_pgroonga.md` へ反映。
   - 2026年02月16日: PR #29 fix loop（`post_search_documents` の primary key 競合）対応として、`(post_id, topic_id)` キー化・`ON CONFLICT` 修正・multi-topic 回帰テストを実装。`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr29_post_search_topic_key_fix_loop.md` に反映。
+  - 2026年02月16日: PR #29 fix loop second pass（Run `22050188054`）として、`default_signature_service` の署名時刻同期と `cn-user-api` 検索契約テストの runtime flag 競合直列化を実施。`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr29_second_pass_ci_fix_loop.md` に反映。

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -72,3 +72,4 @@
   - 進捗レポート: `docs/01_project/progressReports/2026-02-16_issue27_search_pg_migration_audit.md`
   - 2026年02月16日: PR-01（拡張導入とランタイムフラグ基盤）完了に伴い、`tasks/completed/2026-02-16.md` へ追記して本ファイルから作業中エントリを削除。
   - 2026年02月16日: PR #28 Community Node Tests fix loop対応（`cn-admin-api` 契約テスト直列化）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr28_community_node_tests_fix_loop.md` へ反映。`gh act` の `format-check` / `native-test-linux` / `community-node-tests` も pass。
+  - 2026年02月16日: PR-02（投稿検索ドキュメント + PGroonga read/write 切替）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr02_post_search_pgroonga.md` へ反映。

--- a/docs/01_project/progressReports/2026-02-16_issue27_pr02_post_search_pgroonga.md
+++ b/docs/01_project/progressReports/2026-02-16_issue27_pr02_post_search_pgroonga.md
@@ -1,0 +1,74 @@
+# Issue #27 PR-02 投稿検索ドキュメント（PGroonga）
+
+最終更新日: 2026年02月16日
+
+## 概要
+
+Issue #27 の PR-02 スコープとして、投稿検索の PGroonga 経路を追加した。
+既存 Meilisearch 経路は維持し、`search_write_mode` / `search_read_backend` ランタイムフラグで段階的切替できるよう最小互換で実装した。
+
+## 実施内容
+
+1. 投稿検索ドキュメント用 migration 追加
+- ファイル: `kukuri-community-node/migrations/20260216030000_m7_post_search_documents.sql`
+- `cn_search.post_search_documents` テーブルを追加。
+- `post_search_text_pgroonga_idx`（`USING pgroonga (search_text)`）を追加。
+- `topic_id + created_at`、`visibility + is_deleted` 補助 index を追加。
+
+2. 共通正規化モジュール追加
+- ファイル: `kukuri-community-node/crates/cn-core/src/search_normalizer.rs`
+- `SEARCH_NORMALIZER_VERSION=1` を導入。
+- NFKC + lower-case + 制御文字/空白正規化 + 記号処理（`#`/`@` 保持）を実装。
+- `normalize_search_text` / `normalize_search_terms` / `build_search_text` を追加。
+
+3. `cn-index` outbox consumer に dual-write 実装
+- ファイル: `kukuri-community-node/crates/cn-index/src/lib.rs`
+- `SearchWriteMode`（`meili_only` / `dual` / `pg_only`）を追加。
+- ランタイムフラグ読取失敗時は `meili_only` にフォールバック。
+- upsert/delete/expiry で Meili と PG の書込をモード別に制御。
+- stale version 削除時も PG 側 `is_deleted=true` を反映。
+
+4. `/v1/search` の PG read backend 追加
+- ファイル: `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs`
+- `search_read_backend=pg` のとき PG 経路へ分岐。
+- クエリを `search_normalizer` で正規化し、`normalizer_version` 一致のみ検索対象化。
+- 非空クエリは PGroonga `&@~` + 合成スコア（text/freshness/popularity）でソート。
+- レスポンス形状（`topic/query/items/next_cursor/total` と item フィールド）を既存互換で維持。
+
+5. ランタイムフラグ定数拡張
+- ファイル: `kukuri-community-node/crates/cn-core/src/search_runtime_flags.rs`
+- `SEARCH_READ_BACKEND_PG` / `SEARCH_WRITE_MODE_DUAL` / `SEARCH_WRITE_MODE_PG_ONLY` を追加。
+
+6. 回帰テスト追加
+- `cn-core`: `search_normalizer` ユニットテスト（4件）
+- `cn-index`: `outbox_dual_write_updates_meili_and_post_search_documents`
+- `cn-user-api`: `search_contract_pg_backend_switch_normalization_and_version_filter`
+
+## 後方互換性
+
+- write 側は `meili_only` を既定とし、既存 Meili indexing への影響を回避。
+- read 側は `meili` 既定を維持し、フラグ有効化時のみ PG 検索へ切替。
+- runtime flag 読取失敗時は Meili 経路へフォールバックするため、migration 適用順序の差異でも動作継続。
+
+## 検証コマンド
+
+- `cd kukuri-community-node && cargo fmt`
+- `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`
+- `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`
+- `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test -p cn-core search_normalizer -- --nocapture; cargo test -p cn-index outbox_dual_write_updates_meili_and_post_search_documents -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_switch_normalization_and_version_filter -- --nocapture"`
+- `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check | tee tmp/logs/gh-act-format-check-issue27-pr02.log`
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux | tee tmp/logs/gh-act-native-test-linux-issue27-pr02.log`
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests | tee tmp/logs/gh-act-community-node-tests-issue27-pr02.log`
+
+## 検証結果
+
+- 追加した正規化/dual-write/PG read の対象テストは pass。
+- Community Node 全体 `cargo test --workspace --all-features` + `cargo build --release -p cn-cli` は pass。
+- `gh act` の `format-check` / `native-test-linux` は pass。
+- `gh act community-node-tests` は `cn-admin-api` 契約テスト `trust_contract_success_and_shape` で fail（今回変更範囲外の既知系不安定失敗としてログ保全）。
+
+## 影響範囲
+
+- 変更は `kukuri-community-node` の検索経路に限定。
+- 既存 Meili 経路を残したため、段階移行（PR-06/PR-07）へ接続可能。

--- a/docs/01_project/progressReports/2026-02-16_issue27_pr29_post_search_topic_key_fix_loop.md
+++ b/docs/01_project/progressReports/2026-02-16_issue27_pr29_post_search_topic_key_fix_loop.md
@@ -1,0 +1,48 @@
+# Issue #27 / PR #29 fix loop（post_search_documents multi-topic key）
+
+最終更新日: 2026年02月16日
+
+## 背景
+
+PR #29 の review（`discussion_r2810577528`）で、`cn_search.post_search_documents` が `post_id` 単独キーのため、同一 event が複数 topic に属する場合に PG 側ドキュメントが上書きされる問題が指摘された。
+
+## 原因
+
+- schema が `post_id PRIMARY KEY` だったため、topic 別行を保持できなかった。
+- `cn-index` の upsert が `ON CONFLICT (post_id)` で実装されており、後続 topic の書き込みで前の topic 行を更新していた。
+- `/v1/search` は `topic_id` でフィルタするため、PG backend では最後に上書きされた topic 以外で欠落が起きうる状態だった。
+
+## 実施内容
+
+1. schema 修正
+- 追加: `kukuri-community-node/migrations/20260216040000_m8_post_search_documents_topic_key.sql`
+- `post_search_documents` の主キーを `(post_id, topic_id)` に変更。
+
+2. write path 修正（`cn-index`）
+- 変更: `kukuri-community-node/crates/cn-index/src/lib.rs`
+- upsert を `ON CONFLICT (post_id, topic_id)` に変更。
+- delete/expiry/stale-mark を `topic_id` 条件付き更新に変更し、topic 単位の状態更新へ統一。
+
+3. 回帰テスト追加
+- `kukuri-community-node/crates/cn-index/src/integration_tests.rs`
+  - `outbox_dual_write_preserves_post_search_documents_per_topic` を追加。
+  - 同一 event を 2 topic に upsert したとき PG 側に 2 行残ることを検証。
+- `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs`
+  - `search_contract_pg_backend_preserves_multi_topic_rows_for_same_post_id` を追加。
+  - 同一 `post_id` を topic A/B に投入し、`/v1/search?topic=...` が topic ごとに正しい1件を返すことを検証。
+
+## 検証
+
+- `cd kukuri-community-node && cargo fmt`（pass）
+- `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml down -v`（pass）
+- `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`（pass）
+- `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network ... kukuri-test-runner ... "cargo clean -p cn-core; cargo test -p cn-index outbox_dual_write_updates_meili_and_post_search_documents -- --nocapture; cargo test -p cn-index outbox_dual_write_preserves_post_search_documents_per_topic -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_switch_normalization_and_version_filter -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_preserves_multi_topic_rows_for_same_post_id -- --nocapture"`（pass）
+- `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network ... kukuri-test-runner ... "cargo test --workspace --all-features; cargo build --release -p cn-cli"`（pass）
+- `cd kukuri-tauri/src-tauri && cargo test`（pass）
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check | tee tmp/logs/gh-act-format-check-issue27-pr29-fix-loop.log`（pass）
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux | tee tmp/logs/gh-act-native-test-linux-issue27-pr29-fix-loop.log`（pass）
+- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests | tee tmp/logs/gh-act-community-node-tests-issue27-pr29-fix-loop.log`（pass）
+
+## 補足
+
+- 初回のターゲットテストで `there is no unique or exclusion constraint matching the ON CONFLICT specification` が発生したため、`cargo clean -p cn-core` 後に再実行し解消。`sqlx::migrate!` の埋め込み更新を確実に反映させた。

--- a/docs/01_project/progressReports/2026-02-16_issue27_pr29_second_pass_ci_fix_loop.md
+++ b/docs/01_project/progressReports/2026-02-16_issue27_pr29_second_pass_ci_fix_loop.md
@@ -1,0 +1,62 @@
+# Issue #27 / PR #29 fix loop second pass（CI run 22050188054）
+
+最終更新日: 2026年02月16日
+
+## 背景
+
+- 対象 Workflow: https://github.com/KingYoSun/kukuri/actions/runs/22050188054
+- 失敗 Job:
+  - Native Test (Linux): https://github.com/KingYoSun/kukuri/actions/runs/22050188054/job/63706569762
+  - Community Node Tests: https://github.com/KingYoSun/kukuri/actions/runs/22050188054/job/63706569780
+
+## 原因
+
+1. Native Test (Linux)
+- 失敗テスト: `application::services::access_control_service::tests::request_join_with_invite_broadcasts_to_issuer_topic`
+- 直接原因: `Invite signature is invalid`
+- 根本原因: `DefaultSignatureService::sign_event` で署名した `signed_event.created_at` と、ドメインイベントの `event.created_at` が秒境界で不一致になる経路があり、`to_nostr_event` 時にシリアライズされる時刻と署名対象時刻がズレて `verify()` が不安定化していた。
+
+2. Community Node Tests
+- 失敗テスト: `subscriptions::api_contract_tests::search_contract_success_shape_compatible`
+- 直接原因: `total` 期待値 `Some(2)` に対し実値 `Some(0)`
+- 根本原因: `cn_search.runtime_flags` は DB グローバル状態で、PG backend 切替系テストと Meili 前提テストが並列実行されると backend が干渉する。`search_contract_success_shape_compatible` 側で Meili を前提にしているが、並列実行時に PG backend を読んで 0 件判定になるケースがあった。
+
+## 修正内容
+
+1. 署名時刻の同期（Tauri）
+- 変更: `kukuri-tauri/src-tauri/src/infrastructure/crypto/default_signature_service.rs`
+- 対応:
+  - 署名後に `signed_event.created_at` を取得し、`event.created_at` へ同期。
+  - 不正なタイムスタンプは `InvalidData` として明示的にエラー化。
+- 効果: 署名対象と検証対象の `created_at` を一致させ、秒境界起因の `Invite signature is invalid` を防止。
+
+2. 検索契約テストの backend 競合防止（Community Node）
+- 変更: `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs`
+- 対応:
+  - `SEARCH_BACKEND_TEST_LOCK`（`tokio::sync::Mutex`）を導入し、search backend 切替系契約テストを直列化。
+  - `search_contract_success_shape_compatible` 冒頭で runtime flag を `meili_only` / `meili` へ明示初期化。
+  - 以下 3 テストで lock を取得:
+    - `search_contract_success_shape_compatible`
+    - `search_contract_pg_backend_switch_normalization_and_version_filter`
+    - `search_contract_pg_backend_preserves_multi_topic_rows_for_same_post_id`
+- 効果: `cn_search.runtime_flags` の並列干渉を抑制し、Meili/PG backend 切替のテストを決定的に実行。
+
+## 検証
+
+- `cd kukuri-tauri/src-tauri && cargo test request_join_with_invite_broadcasts_to_issuer_topic -- --nocapture`（pass）
+- `cd kukuri-tauri/src-tauri && cargo test`（pass）
+- `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`（pass）
+- `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`（pass）
+- `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test -p cn-user-api search_contract_success_shape_compatible -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_switch_normalization_and_version_filter -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_preserves_multi_topic_rows_for_same_post_id -- --nocapture"`（pass）
+- `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`（pass）
+- `XDG_CACHE_HOME=/tmp/act-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check | tee tmp/logs/gh-act-format-check-issue27-pr29-second-pass.log`（pass）
+- `XDG_CACHE_HOME=/tmp/act-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux | tee tmp/logs/gh-act-native-test-linux-issue27-pr29-second-pass.log`（pass）
+- `XDG_CACHE_HOME=/tmp/act-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests | tee tmp/logs/gh-act-community-node-tests-issue27-pr29-second-pass.log`（fail）
+  - 失敗テスト: `subscriptions::api_contract_tests::auth_consent_quota_metrics_regression_counters_increment`
+  - 失敗内容: `left: 428`, `right: 402`
+  - 備考: 今回修正した検索 backend 切替テスト群は pass。上記は別系統（auth/quota metrics）で、ログを保存して切り分け可能な状態。
+
+## 再発防止ポイント
+
+- 署名時刻は「署名後の実値」を常にドメインイベントへ反映する。
+- `cn_search.runtime_flags` のような共有状態を変更する契約テストは mutex で直列化し、前提フラグを各テスト内で明示初期化する。

--- a/kukuri-community-node/Cargo.lock
+++ b/kukuri-community-node/Cargo.lock
@@ -777,6 +777,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "uuid",
 ]
 

--- a/kukuri-community-node/Cargo.toml
+++ b/kukuri-community-node/Cargo.toml
@@ -47,5 +47,6 @@ tower-http = { version = "0.6.8", features = ["request-id", "trace", "timeout", 
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "json", "env-filter"] }
 utoipa = { version = "4.2.3", features = ["axum_extras"] }
+unicode-normalization = "0.1.25"
 uuid = { version = "1.8.0", features = ["v4"] }
 prometheus = "0.14.0"

--- a/kukuri-community-node/crates/cn-core/Cargo.toml
+++ b/kukuri-community-node/crates/cn-core/Cargo.toml
@@ -24,4 +24,5 @@ tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+unicode-normalization.workspace = true
 uuid.workspace = true

--- a/kukuri-community-node/crates/cn-core/src/lib.rs
+++ b/kukuri-community-node/crates/cn-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod moderation;
 pub mod node_key;
 pub mod nostr;
 pub mod rate_limit;
+pub mod search_normalizer;
 pub mod search_runtime_flags;
 pub mod server;
 pub mod service_config;

--- a/kukuri-community-node/crates/cn-core/src/search_normalizer.rs
+++ b/kukuri-community-node/crates/cn-core/src/search_normalizer.rs
@@ -1,0 +1,102 @@
+use std::collections::HashSet;
+use unicode_normalization::UnicodeNormalization;
+
+pub const SEARCH_NORMALIZER_VERSION: i16 = 1;
+
+pub fn normalize_search_text(value: &str) -> String {
+    if value.trim().is_empty() {
+        return String::new();
+    }
+
+    let mut normalized = String::with_capacity(value.len());
+    for ch in value.nfkc().flat_map(char::to_lowercase) {
+        if ch.is_control() || ch.is_whitespace() {
+            normalized.push(' ');
+            continue;
+        }
+
+        if ch == '#' || ch == '@' || ch.is_alphanumeric() {
+            normalized.push(ch);
+        } else {
+            normalized.push(' ');
+        }
+    }
+
+    normalized.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+pub fn normalize_search_terms<I, S>(values: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+
+    for value in values {
+        let term = normalize_search_text(value.as_ref());
+        if term.is_empty() {
+            continue;
+        }
+
+        for segment in term.split_whitespace() {
+            if seen.insert(segment.to_string()) {
+                normalized.push(segment.to_string());
+            }
+        }
+    }
+
+    normalized
+}
+
+pub fn build_search_text(
+    body_norm: &str,
+    hashtags_norm: &[String],
+    mentions_norm: &[String],
+    community_terms_norm: &[String],
+) -> String {
+    let mut parts = Vec::new();
+    if !body_norm.is_empty() {
+        parts.push(body_norm.to_string());
+    }
+    parts.extend(hashtags_norm.iter().cloned());
+    parts.extend(mentions_norm.iter().cloned());
+    parts.extend(community_terms_norm.iter().cloned());
+    normalize_search_text(&parts.join(" "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_search_text_applies_nfkc_casefold_and_symbol_rules() {
+        let input = "Ｈｅｌｌｏ　Ｗｏｒｌｄ!!! #Ｒｕｓｔ @ＡＬＩＣＥ";
+        assert_eq!(normalize_search_text(input), "hello world #rust @alice");
+    }
+
+    #[test]
+    fn normalize_search_text_handles_multilingual_and_emoji() {
+        let input = "Rust🚀\nテスト　かな\t中文!";
+        assert_eq!(normalize_search_text(input), "rust テスト かな 中文");
+    }
+
+    #[test]
+    fn normalize_search_terms_deduplicates_and_skips_empty_values() {
+        let terms = normalize_search_terms([" #Rust ", "rust", " @Alice ", "", "ＲＵＳＴ"]);
+        assert_eq!(terms, vec!["#rust", "rust", "@alice"]);
+    }
+
+    #[test]
+    fn build_search_text_merges_all_normalized_sources() {
+        let body = normalize_search_text("Hello, 世界");
+        let hashtags = normalize_search_terms(["#Rust"]);
+        let mentions = normalize_search_terms(["@Alice"]);
+        let communities = normalize_search_terms(["kukuri:topic-one"]);
+
+        assert_eq!(
+            build_search_text(&body, &hashtags, &mentions, &communities),
+            "hello 世界 #rust @alice kukuri topic one"
+        );
+    }
+}

--- a/kukuri-community-node/crates/cn-core/src/search_runtime_flags.rs
+++ b/kukuri-community-node/crates/cn-core/src/search_runtime_flags.rs
@@ -11,7 +11,10 @@ pub const FLAG_SUGGEST_READ_BACKEND: &str = "suggest_read_backend";
 pub const FLAG_SHADOW_SAMPLE_RATE: &str = "shadow_sample_rate";
 
 pub const SEARCH_READ_BACKEND_MEILI: &str = "meili";
+pub const SEARCH_READ_BACKEND_PG: &str = "pg";
 pub const SEARCH_WRITE_MODE_MEILI_ONLY: &str = "meili_only";
+pub const SEARCH_WRITE_MODE_DUAL: &str = "dual";
+pub const SEARCH_WRITE_MODE_PG_ONLY: &str = "pg_only";
 pub const SUGGEST_READ_BACKEND_LEGACY: &str = "legacy";
 pub const SHADOW_SAMPLE_RATE_DISABLED: &str = "0";
 
@@ -295,7 +298,7 @@ mod tests {
             .await
             .expect("load search runtime flags");
 
-        assert_eq!(flags.search_read_backend, "pg");
+        assert_eq!(flags.search_read_backend, SEARCH_READ_BACKEND_PG);
         assert_eq!(flags.search_write_mode, SEARCH_WRITE_MODE_MEILI_ONLY);
         assert_eq!(flags.suggest_read_backend, SUGGEST_READ_BACKEND_LEGACY);
         assert_eq!(flags.shadow_sample_rate, "25");

--- a/kukuri-community-node/crates/cn-index/src/lib.rs
+++ b/kukuri-community-node/crates/cn-index/src/lib.rs
@@ -5,8 +5,8 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
 use cn_core::{
-    config as env_config, db, health, http, logging, meili, metrics, nostr, search_runtime_flags,
-    server, service_config,
+    config as env_config, db, health, http, logging, meili, metrics, nostr, search_normalizer,
+    search_runtime_flags, server, service_config,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -70,6 +70,41 @@ struct IndexDocument {
     summary: String,
     content: String,
     tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchWriteMode {
+    MeiliOnly,
+    Dual,
+    PgOnly,
+}
+
+impl SearchWriteMode {
+    fn writes_meili(self) -> bool {
+        !matches!(self, SearchWriteMode::PgOnly)
+    }
+
+    fn writes_pg(self) -> bool {
+        !matches!(self, SearchWriteMode::MeiliOnly)
+    }
+}
+
+#[derive(Debug)]
+struct PostSearchDocument {
+    post_id: String,
+    topic_id: String,
+    author_id: String,
+    visibility: String,
+    body_raw: String,
+    body_norm: String,
+    hashtags_norm: Vec<String>,
+    mentions_norm: Vec<String>,
+    community_terms_norm: Vec<String>,
+    search_text: String,
+    language_hint: Option<String>,
+    popularity_score: f64,
+    created_at: i64,
+    normalizer_version: i16,
 }
 
 pub fn load_config() -> Result<IndexConfig> {
@@ -465,8 +500,9 @@ async fn handle_outbox_row(state: &AppState, row: &OutboxRow) -> Result<()> {
 }
 
 async fn handle_upsert(state: &AppState, row: &OutboxRow) -> Result<()> {
+    let write_mode = load_search_write_mode(&state.pool).await;
     let Some(event) = load_event(&state.pool, &row.event_id).await? else {
-        return handle_delete(state, row).await;
+        return handle_delete_with_mode(state, row, write_mode).await;
     };
 
     let now = cn_core::auth::unix_seconds().unwrap_or(0) as i64;
@@ -478,17 +514,29 @@ async fn handle_upsert(state: &AppState, row: &OutboxRow) -> Result<()> {
         if let Some(expired_at) = event.expires_at.filter(|exp| *exp <= now) {
             record_expired_event(&state.pool, &row.event_id, &row.topic_id, expired_at).await?;
         }
-        return handle_delete(state, row).await;
+        return handle_delete_with_mode(state, row, write_mode).await;
     }
 
-    let uid = ensure_topic_index(state, &row.topic_id).await?;
     let doc = build_document(&event.raw, &row.topic_id);
-    state.meili.upsert_documents(&uid, &[doc]).await?;
+    if write_mode.writes_meili() {
+        let uid = ensure_topic_index(state, &row.topic_id).await?;
+        state.meili.upsert_documents(&uid, &[doc]).await?;
+    }
+    if write_mode.writes_pg() {
+        let pg_document = build_post_search_document(&event.raw, &row.topic_id);
+        upsert_post_search_document(&state.pool, &pg_document).await?;
+    }
 
     if let Some(key) = row.effective_key.as_deref() {
         let stale_ids = find_stale_versions(&state.pool, &row.topic_id, key, &row.event_id).await?;
         if !stale_ids.is_empty() {
-            state.meili.delete_documents(&uid, &stale_ids).await?;
+            if write_mode.writes_meili() {
+                let uid = ensure_topic_index(state, &row.topic_id).await?;
+                state.meili.delete_documents(&uid, &stale_ids).await?;
+            }
+            if write_mode.writes_pg() {
+                mark_post_search_documents_deleted(&state.pool, &stale_ids).await?;
+            }
         }
     }
 
@@ -496,8 +544,157 @@ async fn handle_upsert(state: &AppState, row: &OutboxRow) -> Result<()> {
 }
 
 async fn handle_delete(state: &AppState, row: &OutboxRow) -> Result<()> {
-    let uid = ensure_topic_index(state, &row.topic_id).await?;
-    state.meili.delete_document(&uid, &row.event_id).await?;
+    let write_mode = load_search_write_mode(&state.pool).await;
+    handle_delete_with_mode(state, row, write_mode).await
+}
+
+async fn handle_delete_with_mode(
+    state: &AppState,
+    row: &OutboxRow,
+    write_mode: SearchWriteMode,
+) -> Result<()> {
+    if write_mode.writes_meili() {
+        let uid = ensure_topic_index(state, &row.topic_id).await?;
+        state.meili.delete_document(&uid, &row.event_id).await?;
+    }
+    if write_mode.writes_pg() {
+        mark_post_search_document_deleted(&state.pool, &row.event_id).await?;
+    }
+    Ok(())
+}
+
+async fn load_search_write_mode(pool: &Pool<Postgres>) -> SearchWriteMode {
+    let flags = match search_runtime_flags::load_search_runtime_flags(pool).await {
+        Ok(flags) => flags,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                "failed to load search runtime flags; fallback to meili_only write mode"
+            );
+            return SearchWriteMode::MeiliOnly;
+        }
+    };
+
+    match flags.search_write_mode.trim().to_ascii_lowercase().as_str() {
+        search_runtime_flags::SEARCH_WRITE_MODE_DUAL => SearchWriteMode::Dual,
+        search_runtime_flags::SEARCH_WRITE_MODE_PG_ONLY => SearchWriteMode::PgOnly,
+        _ => SearchWriteMode::MeiliOnly,
+    }
+}
+
+fn build_post_search_document(raw: &nostr::RawEvent, topic_id: &str) -> PostSearchDocument {
+    let body_raw = raw.content.clone();
+    let body_norm = search_normalizer::normalize_search_text(&body_raw);
+    let hashtags_norm = search_normalizer::normalize_search_terms(raw.tag_values("t"));
+    let mentions_norm = search_normalizer::normalize_search_terms(raw.tag_values("p"));
+    let community_terms_norm = search_normalizer::normalize_search_terms([topic_id]);
+    let search_text = search_normalizer::build_search_text(
+        &body_norm,
+        &hashtags_norm,
+        &mentions_norm,
+        &community_terms_norm,
+    );
+    let visibility = raw
+        .first_tag_value("visibility")
+        .map(|value| search_normalizer::normalize_search_text(&value))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "public".to_string());
+    let language_hint = raw
+        .first_tag_value("lang")
+        .or_else(|| raw.first_tag_value("language"))
+        .map(|value| search_normalizer::normalize_search_text(&value))
+        .filter(|value| !value.is_empty());
+
+    PostSearchDocument {
+        post_id: raw.id.clone(),
+        topic_id: topic_id.to_string(),
+        author_id: raw.pubkey.clone(),
+        visibility,
+        body_raw,
+        body_norm,
+        hashtags_norm,
+        mentions_norm,
+        community_terms_norm,
+        search_text,
+        language_hint,
+        popularity_score: 0.0,
+        created_at: raw.created_at,
+        normalizer_version: search_normalizer::SEARCH_NORMALIZER_VERSION,
+    }
+}
+
+async fn upsert_post_search_document(
+    pool: &Pool<Postgres>,
+    document: &PostSearchDocument,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO cn_search.post_search_documents \
+         (post_id, topic_id, author_id, visibility, body_raw, body_norm, hashtags_norm, mentions_norm, community_terms_norm, search_text, language_hint, popularity_score, created_at, is_deleted, normalizer_version, updated_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, FALSE, $14, NOW()) \
+         ON CONFLICT (post_id) DO UPDATE SET \
+           topic_id = EXCLUDED.topic_id, \
+           author_id = EXCLUDED.author_id, \
+           visibility = EXCLUDED.visibility, \
+           body_raw = EXCLUDED.body_raw, \
+           body_norm = EXCLUDED.body_norm, \
+           hashtags_norm = EXCLUDED.hashtags_norm, \
+           mentions_norm = EXCLUDED.mentions_norm, \
+           community_terms_norm = EXCLUDED.community_terms_norm, \
+           search_text = EXCLUDED.search_text, \
+           language_hint = EXCLUDED.language_hint, \
+           popularity_score = EXCLUDED.popularity_score, \
+           created_at = EXCLUDED.created_at, \
+           is_deleted = FALSE, \
+           normalizer_version = EXCLUDED.normalizer_version, \
+           updated_at = NOW()",
+    )
+    .bind(&document.post_id)
+    .bind(&document.topic_id)
+    .bind(&document.author_id)
+    .bind(&document.visibility)
+    .bind(&document.body_raw)
+    .bind(&document.body_norm)
+    .bind(&document.hashtags_norm)
+    .bind(&document.mentions_norm)
+    .bind(&document.community_terms_norm)
+    .bind(&document.search_text)
+    .bind(&document.language_hint)
+    .bind(document.popularity_score)
+    .bind(document.created_at)
+    .bind(document.normalizer_version)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn mark_post_search_document_deleted(pool: &Pool<Postgres>, post_id: &str) -> Result<()> {
+    sqlx::query(
+        "UPDATE cn_search.post_search_documents \
+         SET is_deleted = TRUE, updated_at = NOW() \
+         WHERE post_id = $1",
+    )
+    .bind(post_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn mark_post_search_documents_deleted(
+    pool: &Pool<Postgres>,
+    post_ids: &[String],
+) -> Result<()> {
+    if post_ids.is_empty() {
+        return Ok(());
+    }
+
+    sqlx::query(
+        "UPDATE cn_search.post_search_documents \
+         SET is_deleted = TRUE, updated_at = NOW() \
+         WHERE post_id = ANY($1)",
+    )
+    .bind(post_ids)
+    .execute(pool)
+    .await?;
     Ok(())
 }
 
@@ -816,6 +1013,7 @@ async fn update_job_failed(pool: &Pool<Postgres>, job_id: &str, error: &str) -> 
 
 async fn expire_events_once(state: &AppState) -> Result<()> {
     let now = cn_core::auth::unix_seconds().unwrap_or(0) as i64;
+    let write_mode = load_search_write_mode(&state.pool).await;
     loop {
         let rows = sqlx::query(
             "SELECT e.event_id, t.topic_id, e.expires_at          FROM cn_relay.events e          JOIN cn_relay.event_topics t            ON e.event_id = t.event_id          LEFT JOIN cn_index.expired_events x            ON x.event_id = e.event_id AND x.topic_id = t.topic_id          WHERE e.expires_at IS NOT NULL            AND e.expires_at <= $1            AND e.is_deleted = FALSE            AND e.is_ephemeral = FALSE            AND e.is_current = TRUE            AND x.event_id IS NULL          LIMIT 200",
@@ -832,8 +1030,13 @@ async fn expire_events_once(state: &AppState) -> Result<()> {
             let event_id: String = row.try_get("event_id")?;
             let topic_id: String = row.try_get("topic_id")?;
             let expires_at: i64 = row.try_get("expires_at")?;
-            let uid = ensure_topic_index(state, &topic_id).await?;
-            state.meili.delete_document(&uid, &event_id).await?;
+            if write_mode.writes_meili() {
+                let uid = ensure_topic_index(state, &topic_id).await?;
+                state.meili.delete_document(&uid, &event_id).await?;
+            }
+            if write_mode.writes_pg() {
+                mark_post_search_document_deleted(&state.pool, &event_id).await?;
+            }
             record_expired_event(&state.pool, &event_id, &topic_id, expires_at).await?;
         }
     }

--- a/kukuri-community-node/migrations/20260216030000_m7_post_search_documents.sql
+++ b/kukuri-community-node/migrations/20260216030000_m7_post_search_documents.sql
@@ -1,0 +1,30 @@
+CREATE SCHEMA IF NOT EXISTS cn_search;
+
+CREATE TABLE IF NOT EXISTS cn_search.post_search_documents (
+    post_id TEXT PRIMARY KEY,
+    topic_id TEXT NOT NULL,
+    author_id TEXT NOT NULL,
+    visibility TEXT NOT NULL,
+    body_raw TEXT NOT NULL,
+    body_norm TEXT NOT NULL,
+    hashtags_norm TEXT[] NOT NULL DEFAULT '{}',
+    mentions_norm TEXT[] NOT NULL DEFAULT '{}',
+    community_terms_norm TEXT[] NOT NULL DEFAULT '{}',
+    search_text TEXT NOT NULL,
+    language_hint TEXT NULL,
+    popularity_score DOUBLE PRECISION NOT NULL DEFAULT 0,
+    created_at BIGINT NOT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    normalizer_version SMALLINT NOT NULL DEFAULT 1,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS post_search_text_pgroonga_idx
+    ON cn_search.post_search_documents
+    USING pgroonga (search_text);
+
+CREATE INDEX IF NOT EXISTS post_search_topic_created_idx
+    ON cn_search.post_search_documents (topic_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS post_search_visibility_idx
+    ON cn_search.post_search_documents (visibility, is_deleted);

--- a/kukuri-community-node/migrations/20260216040000_m8_post_search_documents_topic_key.sql
+++ b/kukuri-community-node/migrations/20260216040000_m8_post_search_documents_topic_key.sql
@@ -1,0 +1,5 @@
+ALTER TABLE cn_search.post_search_documents
+    DROP CONSTRAINT IF EXISTS post_search_documents_pkey;
+
+ALTER TABLE cn_search.post_search_documents
+    ADD CONSTRAINT post_search_documents_pkey PRIMARY KEY (post_id, topic_id);


### PR DESCRIPTION
## 何を変更したか
- migration `20260216030000_m7_post_search_documents.sql` を追加し、`cn_search.post_search_documents` と PGroonga index を導入。
- `cn-core` に `search_normalizer` を追加（NFKC/小文字化/記号処理/normalizer_version）。
- `cn-index` outbox consumer を拡張し、`search_write_mode` に応じた dual-write（Meili + PG）を実装。
- `cn-user-api` `/v1/search` に PG read backend を追加し、`search_read_backend` ランタイムフラグで切替可能化。
- 回帰テストを追加（`cn-core`/`cn-index`/`cn-user-api`）。
- タスク管理更新:
  - `docs/01_project/activeContext/tasks/completed/2026-02-16.md`
  - `docs/01_project/activeContext/tasks/status/in_progress.md`
  - `docs/01_project/activeContext/tasks/priority/search_pg_migration_roadmap.md`
  - `docs/01_project/progressReports/2026-02-16_issue27_pr02_post_search_pgroonga.md`

## なぜ必要か
- PR-02 の目的である「投稿検索ドキュメント path の PGroonga 化」と「API read backend の切替可能化」を、既存 Meili 経路を残したまま段階導入するため。
- PR-06/PR-07 に向けて、dual-write と read switch の土台を先に入れるため。

## テスト証跡
- `cd kukuri-community-node && cargo fmt` ✅
- `docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch` ✅
- `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner` ✅
- `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network ... cargo test -p cn-core search_normalizer -- --nocapture; cargo test -p cn-index outbox_dual_write_updates_meili_and_post_search_documents -- --nocapture; cargo test -p cn-user-api search_contract_pg_backend_switch_normalization_and_version_filter -- --nocapture` ✅
- `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network ... cargo test --workspace --all-features; cargo build --release -p cn-cli` ✅
- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check` ✅
- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux` ✅
- `XDG_CACHE_HOME=/tmp/xdg-cache NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests` ⚠️ fail
  - `cn-admin-api` 契約テスト `trust_contract_success_and_shape`（今回変更範囲外の既知系不安定失敗）
  - ログ: `tmp/logs/gh-act-community-node-tests-issue27-pr02.log`

## 互換性
- read/write とも既定値は Meili 経路を維持。
- runtime flag 読取失敗時も Meili へフォールバック。

Refs #27
