### PR TITLE
docs: sync PR-02 key/conflict doc with merged schema

### DIFF
--- a/docs/01_project/activeContext/tasks/completed/2026-02-16.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-16.md
@@ -279,3 +279,15 @@
 - [x] docs-only 更新のため、テスト/ビルド/`gh act` は実施不要（`AGENTS.md` の「`./docs` 配下のみ更新では不要」ルールに従う）。
 - [x] `git diff --check`（pass: whitespace/error なし）。
 - [x] `rg -n "recorded_at|index-search-v1" docs/01_project/activeContext/search_pg_migration/PR-07_cutover_runbook.md docs/03_implementation/community_nodes/ops_runbook.md`（pass: 対象ファイルで一致なし）。
+
+## Issue #27 最終再監査（PR-01..PR-07 マージ後）
+
+- [x] `references/community-nodes-strict-audit-checklist.md` の有無を再確認し、未存在のため Issue #5 fallback gate（`https://github.com/KingYoSun/kukuri/issues/5#issuecomment-3900483686`）で監査を実施。
+- [x] 監査要求3点（runtime flags / cutover docs、PG search docs / suggest path / backfill-shadow、migrations / runbook）を実装・ドキュメント・OpenAPIの三層で突合。
+- [x] 最終再監査レポート `docs/01_project/progressReports/2026-02-16_issue27_final_reaudit.md` を追加。
+- [x] 追加フォローアップ 4件（ドキュメント整合）を抽出し、`docs/01_project/activeContext/tasks/status/in_progress.md` に反映。
+
+## 検証
+
+- [x] docs-only 更新のため、テスト/ビルド/`gh act` は実施不要（`AGENTS.md` の「`./docs` 配下のみ更新では不要」ルールに従う）。
+- [x] `git diff --check`（pass: whitespace/error なし）。

--- a/docs/01_project/activeContext/tasks/completed/2026-02-16.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-16.md
@@ -267,6 +267,20 @@
 - [x] docs-only 更新のため、テスト/ビルド/`gh act` は実施不要（`AGENTS.md` の「`./docs` 配下のみ更新では不要」ルールに従う）。
 - [x] `git diff --check`（pass: whitespace/error なし）。
 
+## Issue #27 最終再監査フォローアップ（PR-02 key/conflict docs sync）
+
+- [x] `docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md` の DDL を `(post_id, topic_id)` 複合主キーへ更新。
+- [x] 同ドキュメントの backfill 手順を `ON CONFLICT (post_id, topic_id)` へ更新し、`m7 -> m8` の migration 履歴注記を追加。
+- [x] `docs/01_project/activeContext/tasks/status/in_progress.md` の Issue #27 最終再監査フォローアップ残タスクを 3件へ更新（residual task #1 完了反映）。
+- [x] 進捗レポート `docs/01_project/progressReports/2026-02-16_issue27_followup_pr02_key_conflict_doc_sync.md` を追加。
+
+## 検証
+
+- [x] docs-only 更新のため、テスト/ビルド/`gh act` は実施不要（`AGENTS.md` の「`./docs` 配下のみ更新では不要」ルールに従う）。
+- [x] `git diff --check`（pass: whitespace/error なし）。
+- [x] `rg -n "post_id TEXT PRIMARY KEY|ON CONFLICT \\(post_id\\)" docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md`（pass: 一致なし）。
+- [x] `rg -n "PRIMARY KEY \\(post_id, topic_id\\)|ON CONFLICT \\(post_id, topic_id\\)|20260216040000_m8_post_search_documents_topic_key.sql" docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md`（pass）。
+
 ## Issue #27 / PR #34 fix loop（cutover runbook review comments）
 
 - [x] review 指摘 `discussion_r2811782984` に対応し、`PR-07_cutover_runbook.md` の 5%/25%/50% 手順を binary な read backend 切替から `shadow_sample_rate` 段階へ修正。100% 段階のみ `search_read_backend` / `suggest_read_backend` を `pg` へ切替する手順に更新。

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -85,3 +85,14 @@
   - 2026年02月16日: PR #33 fix loop（stale `running` backfill reclaim）を完了し、`claim_backfill_job` の stale lease 再取得、lease fencing（`started_at` トークン）と回帰テストを追加。`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr33_stale_running_backfill_reclaim_fix_loop.md` に反映。
   - 2026年02月16日: PR-07（cutover runbook/finalization）を完了し、カナリア切替手順、PG検索監視ダッシュボード項目、品質/性能ゲート閾値、5分以内ロールバック手順、Meili 段階撤去条件を Runbook 化。`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr07_cutover_runbook_finalization.md` に反映。
   - 2026年02月16日: PR #34 fix loop（cutover runbook review comments）を完了し、5%/25%/50% 手順を `shadow_sample_rate` 段階へ修正、zero-result SQL を `created_at` へ修正、Index lag consumer ラベルを `index-v1` へ修正。`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_pr34_cutover_runbook_fix_loop.md` に反映。
+  - 2026年02月16日: Issue #27 最終再監査を実施（`chore/issue27-final-reaudit`）。実装面は整合したが、PG検索関連ドキュメントに 4件の整合タスクを抽出し、`progressReports/2026-02-16_issue27_final_reaudit.md` へ記録。
+
+### 2026年02月16日 Issue #27 最終再監査フォローアップ（ドキュメント整合）
+
+- 目的: Issue #27 クローズ前に、検索PG移行の運用/設計ドキュメントと実装の齟齬を解消する。
+- 状態: 着手（最終再監査で抽出した残タスクを順次反映）。
+- 残タスク:
+  1. `PR-02_post_search_pgroonga.md` の DDL と backfill 手順を `(post_id, topic_id)` 主キー・`ON CONFLICT (post_id, topic_id)` 前提へ更新する。
+  2. `docs/03_implementation/community_nodes/user_api.md` に `/v1/communities/suggest` と検索ランタイムフラグ運用を追記する。
+  3. `docs/03_implementation/community_nodes/services_index.md` の Meili-only 記述を、Issue #27 後の dual-write/backfill/shadow/cutover 運用へ更新する。
+  4. `docs/03_implementation/community_nodes/ops_runbook.md` の PG cutover 監視説明を、`shadow_sample_rate` カナリア→100% read 切替の順序に合わせて明確化する。

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -90,9 +90,10 @@
 ### 2026年02月16日 Issue #27 最終再監査フォローアップ（ドキュメント整合）
 
 - 目的: Issue #27 クローズ前に、検索PG移行の運用/設計ドキュメントと実装の齟齬を解消する。
-- 状態: 着手（最終再監査で抽出した残タスクを順次反映）。
+- 状態: 着手（残タスク 3件）。
+- 進捗メモ:
+  - 2026年02月16日: 残タスク #1（`PR-02_post_search_pgroonga.md` の `(post_id, topic_id)` 主キー・`ON CONFLICT` 記述同期）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_followup_pr02_key_conflict_doc_sync.md` に反映。
 - 残タスク:
-  1. `PR-02_post_search_pgroonga.md` の DDL と backfill 手順を `(post_id, topic_id)` 主キー・`ON CONFLICT (post_id, topic_id)` 前提へ更新する。
-  2. `docs/03_implementation/community_nodes/user_api.md` に `/v1/communities/suggest` と検索ランタイムフラグ運用を追記する。
-  3. `docs/03_implementation/community_nodes/services_index.md` の Meili-only 記述を、Issue #27 後の dual-write/backfill/shadow/cutover 運用へ更新する。
-  4. `docs/03_implementation/community_nodes/ops_runbook.md` の PG cutover 監視説明を、`shadow_sample_rate` カナリア→100% read 切替の順序に合わせて明確化する。
+  1. `docs/03_implementation/community_nodes/user_api.md` に `/v1/communities/suggest` と検索ランタイムフラグ運用を追記する。
+  2. `docs/03_implementation/community_nodes/services_index.md` の Meili-only 記述を、Issue #27 後の dual-write/backfill/shadow/cutover 運用へ更新する。
+  3. `docs/03_implementation/community_nodes/ops_runbook.md` の PG cutover 監視説明を、`shadow_sample_rate` カナリア→100% read 切替の順序に合わせて明確化する。

--- a/docs/01_project/progressReports/2026-02-16_issue27_final_reaudit.md
+++ b/docs/01_project/progressReports/2026-02-16_issue27_final_reaudit.md
@@ -1,0 +1,59 @@
+# Issue #27 最終再監査（PR-01..PR-07 マージ後）
+
+作成日: 2026年02月16日
+
+## 監査前提
+
+- strict checklist: `references/community-nodes-strict-audit-checklist.md` はリポジトリ内に存在しないため、Issue #5 fallback gate を適用。
+  - fallback: https://github.com/KingYoSun/kukuri/issues/5#issuecomment-3900483686
+- 監査対象:
+  - `docs/01_project/activeContext/search_pg_migration/PR-01..PR-07`
+  - `kukuri-community-node/migrations/2026021602*_m6~m12*.sql`
+  - `kukuri-community-node/crates/cn-core/src/search_runtime_flags.rs`
+  - `kukuri-community-node/crates/cn-index/src/lib.rs`
+  - `kukuri-community-node/crates/cn-user-api/src/{lib.rs,subscriptions.rs,bootstrap.rs}`
+  - `docs/03_implementation/community_nodes/{ops_runbook.md,user_api.md,services_index.md}`
+
+## Gate 判定（PASS/FAIL）
+
+| Gate | 判定 | 根拠 |
+|---|---|---|
+| Gate1: codex CLI 実行品質 | PASS | 実コマンドで再監査（`find` / `rg` / `nl -ba` / `sed` / `gh api`）を実施し、placeholder 判定なし。 |
+| Gate2: `GET /v1/bootstrap/hints/latest` 401/428/429 境界契約 | PASS | `kukuri-community-node/crates/cn-user-api/src/bootstrap.rs:424`, `kukuri-community-node/crates/cn-user-api/src/bootstrap.rs:440`, `kukuri-community-node/crates/cn-user-api/src/bootstrap.rs:477` を確認。 |
+| Gate3: `spawn_bootstrap_hint_listener` 実DB受信経路 | PASS | 実装 `kukuri-community-node/crates/cn-user-api/src/lib.rs:367`、実DB通知テスト `kukuri-community-node/crates/cn-user-api/src/lib.rs:520` を確認。 |
+| Gate4: `CommunityNodePanel.tsx` / `PostSearchResults.tsx` 対応テスト | PASS | `kukuri-tauri/src/tests/unit/components/settings/CommunityNodePanel.test.tsx:117`、`kukuri-tauri/src/tests/unit/components/search/PostSearchResults.test.tsx:130` を確認。 |
+| Gate5: エビデンステーブル付き報告 | PASS | 本レポートの「Issue #27 整合性監査」セクションで、ファイル/コマンド/結果を明示。 |
+| Gate6: Issue #27 要件整合（runtime flags/cutover、PG search/suggest/backfill、migration/runbook） | FAIL | 実装は概ね整合だが、運用・設計ドキュメントに4件の残差分あり（下表）。 |
+
+## Issue #27 整合性監査
+
+| 監査項目 | 実装/ドキュメント | 確認コマンド | 結果 |
+|---|---|---|---|
+| runtime flags 定義と実装 | `kukuri-community-node/migrations/20260216020000_m6_search_runtime_flags.sql:14`、`kukuri-community-node/crates/cn-core/src/search_runtime_flags.rs:8`、`kukuri-community-node/crates/cn-user-api/src/lib.rs:257`、`kukuri-community-node/crates/cn-index/src/lib.rs:183` | `nl -ba ...`, `rg -n "search_read_backend|search_write_mode|suggest_read_backend|shadow_sample_rate"` | **整合（PASS）**: フラグ seed / ローダー / watcher は一致。 |
+| cutover 手順（5/25/50/100） | `docs/01_project/activeContext/search_pg_migration/PR-07_cutover_runbook.md:18`、`docs/03_implementation/community_nodes/ops_runbook.md:106` | `nl -ba ...`, `rg -n "shadow_sample_rate|search_read_backend"` | **不整合（FAIL）**: PR-07 は 5/25/50 を `shadow_sample_rate` で運用、100% で read 切替だが、`ops_runbook.md` は `search_read_backend=pg` の段階適用中と読める表現が残存。 |
+| 投稿検索ドキュメント DDL と実migration | `docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md:17`、`kukuri-community-node/migrations/20260216040000_m8_post_search_documents_topic_key.sql:1`、`kukuri-community-node/crates/cn-index/src/lib.rs:1694` | `nl -ba ...`, `rg -n "ON CONFLICT \\(post_id, topic_id\\)"` | **不整合（FAIL）**: 実装は `(post_id, topic_id)` 主キーだが、PR-02 文書は `post_id` 単独主キー/`ON CONFLICT(post_id)` 記載のまま。 |
+| suggest path の公開仕様 | `kukuri-community-node/crates/cn-user-api/src/lib.rs:326`、`kukuri-community-node/apps/admin-console/openapi/user-api.json:268`、`docs/03_implementation/community_nodes/user_api.md:179` | `rg -n "/v1/communities/suggest|/v1/search"` | **不整合（FAIL）**: 実装と OpenAPI には `/v1/communities/suggest` があるが、`user_api.md` の API 一覧に未記載。 |
+| backfill/shadow 実装と Runbook | `kukuri-community-node/migrations/20260216080000_m12_search_backfill_shadow.sql:3`、`kukuri-community-node/crates/cn-index/src/lib.rs:2149`、`kukuri-community-node/crates/cn-user-api/src/subscriptions.rs:796`、`docs/01_project/activeContext/search_pg_migration/PR-07_cutover_runbook.md:101` | `rg -n "backfill_jobs|shadow_read_logs|overlap_at_10|latency_delta"` | **整合（PASS）**: テーブル定義、worker、shadow 保存、運用SQL（`created_at`/`/v1/search`）は一致。 |
+| index サービス運用ドキュメント | `docs/03_implementation/community_nodes/services_index.md:1`、`kukuri-community-node/crates/cn-index/src/lib.rs:98`, `kukuri-community-node/crates/cn-index/src/lib.rs:2149` | `nl -ba ...`, `rg -n "Meilisearch|SearchWriteMode|backfill"` | **不整合（FAIL）**: `services_index.md` が Meili-only 前提の記述で、Issue #27 後の dual-write/backfill/shadow 運用を反映できていない。 |
+
+## 実行コマンド（抜粋）
+
+- `find . -name 'community-nodes-strict-audit-checklist.md'`
+- `gh api repos/KingYoSun/kukuri/issues/comments/3900483686 | jq '{html_url, created_at, user: .user.login, body}'`
+- `rg -n "search_read_backend|suggest_read_backend|search_write_mode|shadow_sample_rate" ...`
+- `nl -ba docs/01_project/activeContext/search_pg_migration/PR-07_cutover_runbook.md | sed -n '1,360p'`
+- `nl -ba kukuri-community-node/crates/cn-user-api/src/subscriptions.rs | sed -n '400,1740p'`
+- `nl -ba kukuri-community-node/crates/cn-index/src/lib.rs | sed -n '1420,2620p'`
+- `rg -n "/v1/communities/suggest|/v1/search" kukuri-community-node/crates/cn-user-api/src/lib.rs kukuri-community-node/apps/admin-console/openapi/user-api.json docs/03_implementation/community_nodes/user_api.md`
+
+## 残タスク / リスク
+
+1. `docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md` を `(post_id, topic_id)` 主キー前提へ更新する。
+2. `docs/03_implementation/community_nodes/user_api.md` に `/v1/communities/suggest` と search/suggest runtime flag 切替運用を追記する。
+3. `docs/03_implementation/community_nodes/services_index.md` を Meili-only から dual-write/backfill/shadow/cutover 前提へ更新する。
+4. `docs/03_implementation/community_nodes/ops_runbook.md` の cutover 記述を `shadow_sample_rate` 段階カナリア順序に合わせて明確化する。
+
+## 結論
+
+- 最終判定: **NEEDS_FOLLOWUP**
+- 理由: 実装系（runtime flags、suggest、backfill/shadow、migration）は成立しているが、Issue close 判定に必要なドキュメント整合が未完了。

--- a/docs/01_project/progressReports/2026-02-16_issue27_followup_pr02_key_conflict_doc_sync.md
+++ b/docs/01_project/progressReports/2026-02-16_issue27_followup_pr02_key_conflict_doc_sync.md
@@ -1,0 +1,37 @@
+# Issue #27 follow-up: PR-02 key/conflict docs sync
+
+最終更新日: 2026年02月16日
+
+## 概要
+
+Issue #27 最終再監査の residual task #1 に対応し、`PR-02_post_search_pgroonga.md` の主キー/競合ポリシー記述を実装・migration 履歴に一致させた。コード変更はなく docs-only。
+
+## 対応内容
+
+1. PR-02 DDL の主キー記述を修正
+- 変更: `docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md`
+- 修正前: `post_id TEXT PRIMARY KEY`
+- 修正後: `PRIMARY KEY (post_id, topic_id)`
+- 追記: `m7`（初期導入）→ `m8`（複合主キー化）の migration 履歴注記
+
+2. backfill upsert の conflict target を実装値へ同期
+- 変更: `docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md`
+- 修正前: `ON CONFLICT (post_id) DO UPDATE`
+- 修正後: `ON CONFLICT (post_id, topic_id) DO UPDATE`
+
+3. タスク管理更新
+- `docs/01_project/activeContext/tasks/status/in_progress.md` に residual task #1 完了メモを追記し、残タスクを 3件へ更新。
+- `docs/01_project/activeContext/tasks/completed/2026-02-16.md` に本フォローアップ完了ログを追記。
+
+## 検証
+
+- `git diff --check`（pass）
+- `rg -n "post_id TEXT PRIMARY KEY|ON CONFLICT \\(post_id\\)" docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md`（pass: 一致なし）
+- `rg -n "PRIMARY KEY \\(post_id, topic_id\\)|ON CONFLICT \\(post_id, topic_id\\)|20260216040000_m8_post_search_documents_topic_key.sql" docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md`（pass）
+
+## 変更ファイル
+
+- `docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md`
+- `docs/01_project/activeContext/tasks/status/in_progress.md`
+- `docs/01_project/activeContext/tasks/completed/2026-02-16.md`
+- `docs/01_project/progressReports/2026-02-16_issue27_followup_pr02_key_conflict_doc_sync.md`


### PR DESCRIPTION
## What changed
- Updated `docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md` to reflect merged implementation:
  - table key is now documented as composite `PRIMARY KEY (post_id, topic_id)`
  - backfill/upsert conflict target is now `ON CONFLICT (post_id, topic_id)`
  - added migration history note (`m7` introduce table, `m8` switch to composite key)
- Updated task tracking docs:
  - `docs/01_project/activeContext/tasks/status/in_progress.md` (mark residual task #1 done, remaining 3 tasks)
  - `docs/01_project/activeContext/tasks/completed/2026-02-16.md` (added completion entry)
- Added follow-up progress report:
  - `docs/01_project/progressReports/2026-02-16_issue27_followup_pr02_key_conflict_doc_sync.md`

## Why
- Final re-audit for Issue #27 reported residual mismatch between PR-02 doc and actual merged implementation for post search key/conflict behavior.
- This PR closes residual task #1 only (docs-only scope).

## Checks
- `git diff --check`
- `rg -n "post_id TEXT PRIMARY KEY|ON CONFLICT \\(post_id\\)" docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md` (no matches)
- `rg -n "PRIMARY KEY \\(post_id, topic_id\\)|ON CONFLICT \\(post_id, topic_id\\)|20260216040000_m8_post_search_documents_topic_key.sql" docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md`

Refs #27