### PR TITLE
fix: stabilize Community Node Tests consent/quota metrics contract

### DIFF
--- a/docs/01_project/activeContext/tasks/completed/2026-02-16.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-16.md
@@ -2,6 +2,21 @@
 
 最終更新日: 2026年02月16日
 
+## Main branch Community Node Tests fix loop（Run `22060340981`）
+
+- [x] GitHub Actions Run `22060340981` / Job `63738742754` の失敗ログを解析し、`cn-user-api` 契約テスト `auth_consent_quota_metrics_regression_counters_increment` の `428` vs `402` 競合を根因として特定。
+- [x] `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs` で、該当テストの2回目 `topic-subscription-requests` を `post_json_with_consent_retry` に置換し、consent競合時の再試行を追加。
+- [x] 進捗レポート `docs/01_project/progressReports/2026-02-16_main_branch_community_node_tests_run22060340981_fix_loop.md` を追加。
+
+## 検証
+
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`（pass）
+- [x] `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`（pass）
+- [x] `NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check --action-cache-path /tmp/act-cache --cache-server-path /tmp/actcache`（pass）
+- [x] `NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux --action-cache-path /tmp/act-cache --cache-server-path /tmp/actcache`（pass）
+- [x] `NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests --action-cache-path /tmp/act-cache --cache-server-path /tmp/actcache`（pass）
+
 ## Issue #27 検索PG移行計画の初期監査
 
 - [x] `docs/01_project/activeContext/search_pg_migration/` の PR-01..PR-07 計画を現行実装へ突合し、`implemented / missing / risky` を整理。

--- a/docs/01_project/progressReports/2026-02-16_main_branch_community_node_tests_run22060340981_fix_loop.md
+++ b/docs/01_project/progressReports/2026-02-16_main_branch_community_node_tests_run22060340981_fix_loop.md
@@ -1,0 +1,38 @@
+# Main branch Community Node Tests fix loop（Run `22060340981`）
+
+最終更新日: 2026年02月16日
+
+## 概要
+
+GitHub Actions Run `22060340981` の `Community Node Tests`（Job `63738742754`）失敗を triage し、`cn-user-api` 契約テストの不安定失敗（`428` vs `402`）を最小修正で安定化した。
+
+## 原因
+
+- 失敗テスト: `subscriptions::api_contract_tests::auth_consent_quota_metrics_regression_counters_increment`
+- 失敗箇所: `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs`（CIログでは `assert_eq!(status, StatusCode::PAYMENT_REQUIRED)`）
+- CIログの実値: `left: 428` / `right: 402`
+- テスト並列実行中に `current policy` が増減するタイミング競合で、2回目の購読リクエストが一時的に `CONSENT_REQUIRED(428)` へ戻ることがある。
+
+## 実装内容
+
+1. 契約テストの2回目リクエストを consent retry 付きに変更
+- 変更: `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs`
+- `post_json(...)` を `post_json_with_consent_retry(...)` に差し替え、競合時に `ensure_consents` 後リトライするようにした。
+- プロダクトコードは変更せず、テスト安定化のみを実施。
+
+## 検証
+
+- `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml up -d community-node-postgres community-node-meilisearch`（pass）
+- `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml build test-runner`（pass）
+- `DOCKER_CONFIG=/tmp/docker-config docker run --rm --network kukuri_community-node-network -e DATABASE_URL=postgres://cn:cn_password@community-node-postgres:5432/cn -e MEILI_URL=http://community-node-meilisearch:7700 -e MEILI_MASTER_KEY=change-me -v "$(git rev-parse --show-toplevel):/workspace" -w /workspace/kukuri-community-node kukuri-test-runner bash -lc "set -euo pipefail; source /usr/local/cargo/env; cargo test --workspace --all-features; cargo build --release -p cn-cli"`（pass）
+- `DOCKER_CONFIG=/tmp/docker-config docker compose -f docker-compose.test.yml down --remove-orphans --volumes`（pass）
+- `NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job format-check --action-cache-path /tmp/act-cache --cache-server-path /tmp/actcache`（pass）
+- `NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job native-test-linux --action-cache-path /tmp/act-cache --cache-server-path /tmp/actcache`（pass）
+- `NPM_CONFIG_PREFIX=/tmp/npm-global DOCKER_CONFIG=/tmp/docker-config gh act --workflows .github/workflows/test.yml --job community-node-tests --action-cache-path /tmp/act-cache --cache-server-path /tmp/actcache`（pass）
+
+## 変更ファイル
+
+- `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs`
+- `docs/01_project/activeContext/tasks/status/in_progress.md`
+- `docs/01_project/activeContext/tasks/completed/2026-02-16.md`
+- `docs/01_project/progressReports/2026-02-16_main_branch_community_node_tests_run22060340981_fix_loop.md`

--- a/kukuri-community-node/crates/cn-user-api/src/subscriptions.rs
+++ b/kukuri-community-node/crates/cn-user-api/src/subscriptions.rs
@@ -3822,7 +3822,7 @@ mod api_contract_tests {
         insert_topic_subscription(&pool, &existing_topic_id, &subscriber_pubkey).await;
         assign_active_plan_limit(&pool, &subscriber_pubkey, "max_topics", "limit", 1).await;
 
-        let (status, payload) = post_json(
+        let (status, payload) = post_json_with_consent_retry(
             app.clone(),
             "/v1/topic-subscription-requests",
             &token,
@@ -3830,6 +3830,8 @@ mod api_contract_tests {
                 "topic_id": quota_topic_id,
                 "requested_services": ["relay", "index"]
             }),
+            &pool,
+            &subscriber_pubkey,
         )
         .await;
         assert_eq!(status, StatusCode::PAYMENT_REQUIRED);


### PR DESCRIPTION
## 概要
- Main branch workflow failure（Run `22060340981` / Job `63738742754`）を triage し、`Community Node Tests` の失敗根因を特定しました。
- 失敗していた `subscriptions::api_contract_tests::auth_consent_quota_metrics_regression_counters_increment` の不安定性を最小修正で安定化しました。

## 根因
- CIログ上で `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs` の `assert_eq!(status, StatusCode::PAYMENT_REQUIRED)` が失敗し、`left: 428` / `right: 402` が観測されました。
- 契約テスト並列実行時の consent policy 競合により、2回目の subscription request が一時的に `CONSENT_REQUIRED (428)` を返すことがあり、`PAYMENT_REQUIRED (402)` 固定アサートが崩れていました。

## 変更内容
- `kukuri-community-node/crates/cn-user-api/src/subscriptions.rs`
  - 該当テストの2回目リクエストを `post_json(...)` から `post_json_with_consent_retry(...)` に変更し、consent競合時の再試行を追加。

## 検証
- Community Node コンテナ経路で full pass
  - `cargo test --workspace --all-features`
  - `cargo build --release -p cn-cli`
- `gh act` 必須ジョブ
  - `format-check` pass
  - `native-test-linux` pass
  - `community-node-tests` pass

## 補足
- 進捗レポート: `docs/01_project/progressReports/2026-02-16_main_branch_community_node_tests_run22060340981_fix_loop.md`
- タスク完了記録: `docs/01_project/activeContext/tasks/completed/2026-02-16.md`
