### PR TITLE
docs: sync user API suggest/runtime flag docs for Issue #27 follow-up

### DIFF
--- a/docs/01_project/activeContext/tasks/completed/2026-02-16.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-16.md
@@ -267,6 +267,19 @@
 - [x] docs-only 更新のため、テスト/ビルド/`gh act` は実施不要（`AGENTS.md` の「`./docs` 配下のみ更新では不要」ルールに従う）。
 - [x] `git diff --check`（pass: whitespace/error なし）。
 
+## Issue #27 最終再監査フォローアップ（user_api suggest/runtime flag docs sync）
+
+- [x] `docs/03_implementation/community_nodes/user_api.md` の API 一覧に `GET /v1/communities/suggest` を追記し、`q` 正規化・`limit` clamp・`legacy_fallback` 条件を実装記述へ同期。
+- [x] 同ドキュメントに search/suggest runtime flag 運用メモを追加し、`search_read_backend` / `search_write_mode` / `suggest_read_backend` / `suggest_rerank_mode` / `suggest_relation_weights` / `shadow_sample_rate` の値・fallback・対象サービスを明記。
+- [x] `docs/01_project/activeContext/tasks/status/in_progress.md` の Issue #27 フォローアップ残タスクを 2件へ更新（residual task #2 完了反映）。
+- [x] 進捗レポート `docs/01_project/progressReports/2026-02-16_issue27_followup_user_api_suggest_runtime_flags.md` を追加。
+
+## 検証
+
+- [x] docs-only 更新のため、テスト/ビルド/`gh act` は実施不要（`AGENTS.md` の「`./docs` 配下のみ更新では不要」ルールに従う）。
+- [x] `git diff --check`（pass: whitespace/error なし）。
+- [x] `rg -n "/v1/communities/suggest|search_read_backend|suggest_read_backend|suggest_rerank_mode|suggest_relation_weights|shadow_sample_rate" docs/03_implementation/community_nodes/user_api.md`（pass）。
+
 ## Issue #27 最終再監査フォローアップ（PR-02 key/conflict docs sync）
 
 - [x] `docs/01_project/activeContext/search_pg_migration/PR-02_post_search_pgroonga.md` の DDL を `(post_id, topic_id)` 複合主キーへ更新。

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -90,10 +90,10 @@
 ### 2026年02月16日 Issue #27 最終再監査フォローアップ（ドキュメント整合）
 
 - 目的: Issue #27 クローズ前に、検索PG移行の運用/設計ドキュメントと実装の齟齬を解消する。
-- 状態: 着手（残タスク 3件）。
+- 状態: 着手（残タスク 2件）。
 - 進捗メモ:
   - 2026年02月16日: 残タスク #1（`PR-02_post_search_pgroonga.md` の `(post_id, topic_id)` 主キー・`ON CONFLICT` 記述同期）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_followup_pr02_key_conflict_doc_sync.md` に反映。
+  - 2026年02月16日: 残タスク #2（`user_api.md` の `/v1/communities/suggest` + search/suggest runtime flag 運用追記）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_followup_user_api_suggest_runtime_flags.md` に反映。
 - 残タスク:
-  1. `docs/03_implementation/community_nodes/user_api.md` に `/v1/communities/suggest` と検索ランタイムフラグ運用を追記する。
-  2. `docs/03_implementation/community_nodes/services_index.md` の Meili-only 記述を、Issue #27 後の dual-write/backfill/shadow/cutover 運用へ更新する。
-  3. `docs/03_implementation/community_nodes/ops_runbook.md` の PG cutover 監視説明を、`shadow_sample_rate` カナリア→100% read 切替の順序に合わせて明確化する。
+  1. `docs/03_implementation/community_nodes/services_index.md` の Meili-only 記述を、Issue #27 後の dual-write/backfill/shadow/cutover 運用へ更新する。
+  2. `docs/03_implementation/community_nodes/ops_runbook.md` の PG cutover 監視説明を、`shadow_sample_rate` カナリア→100% read 切替の順序に合わせて明確化する。

--- a/docs/01_project/progressReports/2026-02-16_issue27_followup_user_api_suggest_runtime_flags.md
+++ b/docs/01_project/progressReports/2026-02-16_issue27_followup_user_api_suggest_runtime_flags.md
@@ -1,0 +1,46 @@
+# Issue #27 follow-up: user_api suggest/runtime flag docs sync
+
+最終更新日: 2026年02月16日
+
+## 概要
+
+Issue #27 最終再監査の residual task #2 に対応し、`user_api.md` の公開 API 一覧と search/suggest runtime flag の運用メモを実装挙動へ同期した。コード変更はなく docs-only。
+
+## 対応内容
+
+1. `/v1/communities/suggest` を User API 一覧へ反映
+- 変更: `docs/03_implementation/community_nodes/user_api.md`
+- 追記: `GET /v1/communities/suggest?q=...&limit=...`
+- 実装同期ポイント:
+  - `q` 正規化後が空文字なら `items=[]`
+  - `limit` は `1..50` clamp（既定 20）
+  - `suggest_read_backend=pg` かつ Stage-A 候補 0 件時は `legacy_fallback`
+
+2. search/suggest runtime flag 運用メモを追加
+- 変更: `docs/03_implementation/community_nodes/user_api.md`
+- 追記対象フラグ:
+  - `search_read_backend`
+  - `search_write_mode`
+  - `suggest_read_backend`
+  - `suggest_rerank_mode`
+  - `suggest_relation_weights`
+  - `shadow_sample_rate`
+- 運用同期ポイント:
+  - read backend は二値フラグであり、5/25/50% カナリアは `shadow_sample_rate` で運用
+  - 切替は `INSERT ... ON CONFLICT (flag_name) DO UPDATE` で更新
+
+3. タスク管理更新
+- `docs/01_project/activeContext/tasks/status/in_progress.md` に residual task #2 完了メモを追記し、残タスクを 2 件へ更新。
+- `docs/01_project/activeContext/tasks/completed/2026-02-16.md` に本フォローアップ完了ログを追記。
+
+## 検証
+
+- `git diff --check`（pass）
+- `rg -n "/v1/communities/suggest|search_read_backend|suggest_read_backend|suggest_rerank_mode|suggest_relation_weights|shadow_sample_rate" docs/03_implementation/community_nodes/user_api.md`（pass）
+
+## 変更ファイル
+
+- `docs/03_implementation/community_nodes/user_api.md`
+- `docs/01_project/activeContext/tasks/status/in_progress.md`
+- `docs/01_project/activeContext/tasks/completed/2026-02-16.md`
+- `docs/01_project/progressReports/2026-02-16_issue27_followup_user_api_suggest_runtime_flags.md`

--- a/docs/03_implementation/community_nodes/user_api.md
+++ b/docs/03_implementation/community_nodes/user_api.md
@@ -176,10 +176,16 @@ User API は「ユーザーが何をできるか」を DB の状態で決める�
 
 詳細: `docs/03_implementation/community_nodes/topic_subscription_design.md`
 
-### 検索/トレンド（index）
+### 検索/サジェスト/トレンド（index）
 
+- `GET /v1/communities/suggest?q=...&limit=...`
 - `GET /v1/search?topic=...&q=...`
 - `GET /v1/trending?topic=...`
+
+補足:
+- `/v1/communities/suggest` の `q` は `search_normalizer` で正規化し、空文字になった場合は `items=[]` を返す。
+- `/v1/communities/suggest` と `/v1/search` の `limit` は `1..50` に clamp（未指定は 20）。
+- `/v1/communities/suggest` で `suggest_read_backend=pg` かつ Stage-A 候補が 0 件の場合、`legacy_fallback` へ自動フォールバックする。
 
 ### モデレーション（moderation）
 
@@ -198,6 +204,23 @@ User API は「ユーザーが何をできるか」を DB の状態で決める�
 - `GET /v1/personal-data-export-requests/:export_request_id/download`
 - `POST /v1/personal-data-deletion-requests`
 - `GET /v1/personal-data-deletion-requests/:deletion_request_id`
+
+## 検索/サジェスト runtime flag 運用メモ
+
+正本は `cn_search.runtime_flags`。`cn-user-api` / `cn-index` はこのテーブルを参照して挙動を切り替える。
+
+| flag_name | 値 | 対象 | 実装時挙動 |
+|---|---|---|---|
+| `search_read_backend` | `meili` / `pg` | `/v1/search`（`cn-user-api`） | 主 read backend を切替。未知値・読取失敗時は `meili` フォールバック。 |
+| `search_write_mode` | `meili_only` / `dual` / `pg_only` | 検索索引書込（`cn-index`） | outbox からの書込先を切替。未知値・読取失敗時は `meili_only`。 |
+| `suggest_read_backend` | `legacy` / `pg` | `/v1/communities/suggest`（Stage-A） | 候補生成の backend を切替。未知値・読取失敗時は `legacy`。 |
+| `suggest_rerank_mode` | `shadow` / `enabled` | `/v1/communities/suggest`（Stage-B） | `enabled` で rerank 順を応答順に適用。`shadow` は Stage-A 順を維持しつつ `stage_b_rank` と比較メトリクスを記録。 |
+| `suggest_relation_weights` | JSON | `/v1/communities/suggest`（Stage-B） | relation score 重み。JSON 不正時は既定値へフォールバック。 |
+| `shadow_sample_rate` | `0` - `100` | `/v1/search` と `/v1/communities/suggest` | sampled shadow 比較率。数値以外は `0`、`100` 超は `100` に丸める。 |
+
+運用メモ:
+- read backend（`search_read_backend` / `suggest_read_backend`）は二値フラグであり比率適用しない。5% / 25% / 50% のカナリア段階は `shadow_sample_rate` で実施する。
+- 切替 SQL は `INSERT ... ON CONFLICT (flag_name) DO UPDATE` で更新する（詳細手順: `docs/01_project/activeContext/search_pg_migration/PR-07_cutover_runbook.md`）。
 
 ## 課金/利用量計測（最小モデル）
 


### PR DESCRIPTION
## What changed
- Updated `docs/03_implementation/community_nodes/user_api.md` to include `GET /v1/communities/suggest` in the public API list.
- Added search/suggest runtime flag operation notes for `search_read_backend`, `search_write_mode`, `suggest_read_backend`, `suggest_rerank_mode`, `suggest_relation_weights`, and `shadow_sample_rate`.
- Updated task tracking docs:
  - `docs/01_project/activeContext/tasks/status/in_progress.md`
  - `docs/01_project/activeContext/tasks/completed/2026-02-16.md`
- Added progress report:
  - `docs/01_project/progressReports/2026-02-16_issue27_followup_user_api_suggest_runtime_flags.md`

## Why
- Final re-audit for Issue #27 reported residual task #2 as unresolved: user API doc lacked `/v1/communities/suggest` and runtime flag operation notes.
- This PR closes residual task #2 with docs-only, implementation-aligned wording.

## Checks
- `git diff --check` (pass)
- `rg -n "/v1/communities/suggest|search_read_backend|search_write_mode|suggest_read_backend|suggest_rerank_mode|suggest_relation_weights|shadow_sample_rate" docs/03_implementation/community_nodes/user_api.md` (pass)
- Docs-only change: per `AGENTS.md`, test/build/`gh act` are not required.

Refs #27