### PR TITLE
docs: sync services_index with issue27 cutover model

### DIFF
--- a/docs/01_project/activeContext/tasks/completed/2026-02-16.md
+++ b/docs/01_project/activeContext/tasks/completed/2026-02-16.md
@@ -282,6 +282,19 @@
 - [x] docs-only 更新のため、テスト/ビルド/`gh act` は実施不要（`AGENTS.md` の「`./docs` 配下のみ更新では不要」ルールに従う）。
 - [x] `git diff --check`（pass: whitespace/error なし）。
 
+## Issue #27 最終再監査フォローアップ（services_index cutover sync）
+
+- [x] `docs/03_implementation/community_nodes/services_index.md` を Meili-only 記述から、`search_write_mode` / dual-write 片系失敗再送 / backfill checkpoint / shadow-read 連携 / cutover 順序を含む運用モデルへ更新。
+- [x] 同ドキュメントに責務境界（shadow-read 実行主体は `cn-user-api`）と、`cn-index` `GET /healthz` の Meili readiness 依存を注記。
+- [x] `docs/01_project/activeContext/tasks/status/in_progress.md` の Issue #27 フォローアップ残タスクを 1件へ更新（residual task #3 完了反映）。
+- [x] 進捗レポート `docs/01_project/progressReports/2026-02-16_issue27_followup_services_index_cutover_sync.md` を追加。
+
+## 検証
+
+- [x] docs-only 更新のため、テスト/ビルド/`gh act` は実施不要（`AGENTS.md` の「`./docs` 配下のみ更新では不要」ルールに従う）。
+- [x] `git diff --check`（pass: whitespace/error なし）。
+- [x] `rg -n "search_write_mode|backfill_jobs|shadow_sample_rate|search_read_backend=pg|healthz" docs/03_implementation/community_nodes/services_index.md`（pass）。
+
 ## Issue #27 最終再監査フォローアップ（user_api suggest/runtime flag docs sync）
 
 - [x] `docs/03_implementation/community_nodes/user_api.md` の API 一覧に `GET /v1/communities/suggest` を追記し、`q` 正規化・`limit` clamp・`legacy_fallback` 条件を実装記述へ同期。

--- a/docs/01_project/activeContext/tasks/status/in_progress.md
+++ b/docs/01_project/activeContext/tasks/status/in_progress.md
@@ -90,10 +90,10 @@
 ### 2026年02月16日 Issue #27 最終再監査フォローアップ（ドキュメント整合）
 
 - 目的: Issue #27 クローズ前に、検索PG移行の運用/設計ドキュメントと実装の齟齬を解消する。
-- 状態: 着手（残タスク 2件）。
+- 状態: 着手（残タスク 1件）。
 - 進捗メモ:
   - 2026年02月16日: 残タスク #1（`PR-02_post_search_pgroonga.md` の `(post_id, topic_id)` 主キー・`ON CONFLICT` 記述同期）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_followup_pr02_key_conflict_doc_sync.md` に反映。
   - 2026年02月16日: 残タスク #2（`user_api.md` の `/v1/communities/suggest` + search/suggest runtime flag 運用追記）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_followup_user_api_suggest_runtime_flags.md` に反映。
+  - 2026年02月16日: 残タスク #3（`services_index.md` の Meili-only 記述を dual-write/backfill/shadow/cutover 運用へ同期）を完了し、`tasks/completed/2026-02-16.md` と `progressReports/2026-02-16_issue27_followup_services_index_cutover_sync.md` に反映。
 - 残タスク:
-  1. `docs/03_implementation/community_nodes/services_index.md` の Meili-only 記述を、Issue #27 後の dual-write/backfill/shadow/cutover 運用へ更新する。
-  2. `docs/03_implementation/community_nodes/ops_runbook.md` の PG cutover 監視説明を、`shadow_sample_rate` カナリア→100% read 切替の順序に合わせて明確化する。
+  1. `docs/03_implementation/community_nodes/ops_runbook.md` の PG cutover 監視説明を、`shadow_sample_rate` カナリア→100% read 切替の順序に合わせて明確化する。

--- a/docs/01_project/progressReports/2026-02-16_issue27_followup_services_index_cutover_sync.md
+++ b/docs/01_project/progressReports/2026-02-16_issue27_followup_services_index_cutover_sync.md
@@ -1,0 +1,35 @@
+# Issue #27 follow-up: services_index dual-write/backfill/shadow/cutover sync
+
+最終更新日: 2026年02月16日
+
+## 概要
+
+Issue #27 最終再監査の residual task #3 に対応し、`services_index.md` を Meili-only 記述から実装準拠の検索移行運用モデルへ更新した。コード変更はなく docs-only。
+
+## 対応内容
+
+1. `services_index.md` を運用実態へ同期
+- 変更: `docs/03_implementation/community_nodes/services_index.md`
+- 同期した要点:
+  - `search_write_mode`（`meili_only` / `dual` / `pg_only`）と outbox dual-write の責務
+  - 片系失敗時の再送（outbox replay）と関連メトリクス
+  - `cn_search.backfill_jobs` / `cn_search.backfill_checkpoints` による checkpoint 再開可能 backfill
+  - `shadow_sample_rate` カナリア（5/25/50%）から 100% read cutover までの段階順序
+  - `shadow_read_logs` の保存主体は `cn-user-api` である責務境界
+  - `cn-index` `GET /healthz` が Meili readiness を必須とする現状注記
+
+2. タスク管理更新
+- `docs/01_project/activeContext/tasks/status/in_progress.md` の residual task #3 完了メモを追記し、残タスクを 1 件へ更新。
+- `docs/01_project/activeContext/tasks/completed/2026-02-16.md` に本フォローアップ完了ログを追記。
+
+## 検証
+
+- `git diff --check`（pass）
+- `rg -n "search_write_mode|backfill_jobs|shadow_sample_rate|search_read_backend=pg|healthz" docs/03_implementation/community_nodes/services_index.md`（pass）
+
+## 変更ファイル
+
+- `docs/03_implementation/community_nodes/services_index.md`
+- `docs/01_project/activeContext/tasks/status/in_progress.md`
+- `docs/01_project/activeContext/tasks/completed/2026-02-16.md`
+- `docs/01_project/progressReports/2026-02-16_issue27_followup_services_index_cutover_sync.md`

--- a/docs/03_implementation/community_nodes/services_index.md
+++ b/docs/03_implementation/community_nodes/services_index.md
@@ -1,37 +1,65 @@
-# Index サービス（Meilisearch）実装計画
+# Index サービス（検索移行運用対応）
 
-**作成日**: 2026年01月22日  
-**役割**: topic 別の検索・ランキング（発見体験の核）
+**作成日**: 2026年01月22日
+**最終更新日**: 2026年02月16日
+**役割**: relay outbox から検索派生データを同期し、検索基盤の段階移行（dual-write/backfill/shadow/cutover）を支える
 
 ## 責務
 
-- relay が保存した取込レコード（Postgres）を購読し、正規化/検索用ドキュメントへ変換する
-- Meilisearch への同期（検索/ランキング用のドキュメント生成）
-- イベント種別（置換/削除/期限切れ等）の反映（正規化結果の整合性を保つ）
-- topic 別の検索 API / trending API の提供
-- 再索引（reindex）とインデックス設定（synonyms/stopwords 等）の管理
+- outbox consumer `index-v1` で `cn_relay.events_outbox` を順次処理し、`cn_relay.consumer_offsets` を更新する
+- `cn_search.runtime_flags.search_write_mode` に応じて検索書込先を切り替える
+  - `meili_only`: Meilisearch のみ
+  - `dual`: Meili + `cn_search.post_search_documents` 両系
+  - `pg_only`: `cn_search.post_search_documents` のみ
+- dual-write 中の片系失敗を検知し、outbox 再処理で整合回復する（error/retry メトリクスを記録）
+- `cn_search.backfill_jobs` / `cn_search.backfill_checkpoints` を使い、PG 側検索ドキュメントを checkpoint 再開可能で backfill する
+- stale `running` ジョブの lease reclaim（5分）と `started_at` フェンシングで backfill の多重実行を防止する
+- outbox 差分を AGE suggest graph へ同期し、`cn_search.user_community_affinity` を定期再計算する
+- reindex job（`cn_index.reindex_jobs`）を処理する（現行は Meili インデックス再構築が中心）
 
-## 外部インタフェース（提案）
+## 外部インタフェース
 
-- 外部公開は User API に集約する
+- Index service endpoint
+  - `GET /healthz`
+  - `GET /metrics`
+- 外部公開 API（User/Admin API 経由）
   - `GET /v1/search?topic=...&q=...`
+  - `GET /v1/communities/suggest?q=...&limit=...`
   - `GET /v1/trending?topic=...`
-  - `POST /v1/reindex`（Admin API 経由で実行）
+  - `POST /v1/reindex`（Admin API）
+- 役割分離
+  - shadow-read 比較の実行主体は `cn-user-api`（`cn_search.shadow_read_logs` へ保存）
+  - `cn-index` は dual-write/backfill と outbox 同期の責務を持つ
 
-## Meilisearch 設計（最小）
+## 段階移行モデル（Issue #27 実装後）
 
-- インデックスは topic 単位（`topic_<id>`）を基本とし、必要に応じて統合インデックスも用意する
-- `document` は「検索に必要な最小情報 + 検索結果表示に必要な要約」を保持する
-- 生イベントは Postgres に保存し、Meilisearch は検索用の派生ストアとして扱う
+1. `search_write_mode=meili_only` で稼働し、PG 側 schema/migration を準備する
+2. `search_write_mode=dual` に変更し、Meili + PG の並行書込を開始する
+3. `cn_search.backfill_jobs` に `target='post_search_documents'` ジョブを登録し、high-watermark 以前を backfill する
+4. `cn-user-api` の `shadow_sample_rate` を `5% -> 25% -> 50%` へ段階拡大し、shadow 比較を収集する
+5. 品質/性能ゲート達成後に `search_read_backend=pg` / `suggest_read_backend=pg` で 100% read cutover する
+6. 安定観測後に `search_write_mode=pg_only` と Meili 段階撤去へ進む（障害時は read/write flag を rollback）
 
-## 実装手順（v1）
+## 主要テーブル・メトリクス
 
-1. relay の取込レコードを追従（outbox を正として `seq` 追従 + `consumer_offsets` で offset 管理）
-   - 詳細: `docs/03_implementation/community_nodes/outbox_notify_semantics.md`
-2. 正規化（検索対象フィールドの抽出、topic_id 抽出、置換/削除/期限切れの反映）
-   - `upsert`: ドキュメントを更新（replaceable/addressable の effective view 更新も含む）
-   - `delete`: ドキュメントを削除（deletion request 適用、expiration 到来 等）
-   - 詳細: `docs/03_implementation/community_nodes/event_treatment_policy.md`
-3. Meilisearch 同期（upsert/delete）
-4. trending（簡易: 期間内の反応数/投稿数 + 重み付け）
-5. reindex ジョブ（キュー/進捗を Postgres に記録）
+- テーブル
+  - `cn_search.runtime_flags`
+  - `cn_search.post_search_documents`
+  - `cn_search.backfill_jobs`
+  - `cn_search.backfill_checkpoints`
+  - `cn_search.shadow_read_logs`（writer: `cn-user-api`）
+  - `cn_relay.consumer_offsets`（consumer: `index-v1`）
+- 主要メトリクス
+  - `search_dual_write_errors_total`
+  - `search_dual_write_retries_total`
+  - `backfill_processed_rows`
+  - `backfill_eta_seconds`
+  - `outbox_backlog{consumer="index-v1"}`
+
+## 運用上の注意
+
+- 現行実装の `cn-index` `GET /healthz` は Meili readiness を必須チェックする。`pg_only` 運用中も Meili 接続設定を残す前提で運用する。
+- cutover 手順・監視 SQL・rollback は以下を正本として運用する。
+  - `docs/01_project/activeContext/search_pg_migration/PR-07_cutover_runbook.md`
+  - `docs/03_implementation/community_nodes/ops_runbook.md`
+  - `docs/03_implementation/community_nodes/user_api.md`


### PR DESCRIPTION
## What changed
- Updated `docs/03_implementation/community_nodes/services_index.md` from Meili-only plan to merged operational model.
- Added explicit flow for `search_write_mode` (`meili_only`/`dual`/`pg_only`), backfill (`cn_search.backfill_jobs`/`cn_search.backfill_checkpoints`), shadow sampling (`shadow_sample_rate`), and 100% read cutover.
- Clarified responsibility boundary: shadow-read execution/persistence is handled by `cn-user-api`, while `cn-index` handles dual-write and backfill.
- Synced task tracking docs:
  - `docs/01_project/activeContext/tasks/status/in_progress.md`
  - `docs/01_project/activeContext/tasks/completed/2026-02-16.md`
- Added progress report:
  - `docs/01_project/progressReports/2026-02-16_issue27_followup_services_index_cutover_sync.md`

## Why
- Issue #27 final re-audit marked residual task #3 as NEEDS_FOLLOWUP: `services_index.md` still described Meili-only operations and did not reflect merged dual-write/backfill/shadow/cutover implementation.

## Checks
- `git diff --check` (pass)
- `rg -n "search_write_mode|backfill_jobs|shadow_sample_rate|search_read_backend=pg|healthz" docs/03_implementation/community_nodes/services_index.md` (pass)

Refs #27