### PR TITLE
fix: persist profile data across tauri reload

### DIFF
--- a/kukuri-tauri/src/routeTree.gen.ts
+++ b/kukuri-tauri/src/routeTree.gen.ts
@@ -19,9 +19,9 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as FollowingRouteImport } from './routes/following'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TopicsTopicIdRouteImport } from './routes/topics.$topicId'
+import { Route as ProfileUserIdRouteImport } from './routes/profile.$userId'
 import { Route as TopicsTopicIdThreadsRouteImport } from './routes/topics.$topicId.threads'
 import { Route as TopicsTopicIdThreadsThreadUuidRouteImport } from './routes/topics.$topicId.threads.$threadUuid'
-import { Route as ProfileUserIdRouteImport } from './routes/profile.$userId'
 
 const WelcomeRoute = WelcomeRouteImport.update({
   id: '/welcome',
@@ -73,6 +73,11 @@ const TopicsTopicIdRoute = TopicsTopicIdRouteImport.update({
   path: '/$topicId',
   getParentRoute: () => TopicsRoute,
 } as any)
+const ProfileUserIdRoute = ProfileUserIdRouteImport.update({
+  id: '/profile/$userId',
+  path: '/profile/$userId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const TopicsTopicIdThreadsRoute = TopicsTopicIdThreadsRouteImport.update({
   id: '/threads',
   path: '/threads',
@@ -84,11 +89,6 @@ const TopicsTopicIdThreadsThreadUuidRoute =
     path: '/$threadUuid',
     getParentRoute: () => TopicsTopicIdThreadsRoute,
   } as any)
-const ProfileUserIdRoute = ProfileUserIdRouteImport.update({
-  id: '/profile/$userId',
-  path: '/profile/$userId',
-  getParentRoute: () => rootRouteImport,
-} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -101,8 +101,8 @@ export interface FileRoutesByFullPath {
   '/trending': typeof TrendingRoute
   '/welcome': typeof WelcomeRoute
   '/profile/$userId': typeof ProfileUserIdRoute
-  '/topics/$topicId': typeof TopicsTopicIdRoute
-  '/topics/$topicId/threads': typeof TopicsTopicIdThreadsRoute
+  '/topics/$topicId': typeof TopicsTopicIdRouteWithChildren
+  '/topics/$topicId/threads': typeof TopicsTopicIdThreadsRouteWithChildren
   '/topics/$topicId/threads/$threadUuid': typeof TopicsTopicIdThreadsThreadUuidRoute
 }
 export interface FileRoutesByTo {
@@ -116,8 +116,8 @@ export interface FileRoutesByTo {
   '/trending': typeof TrendingRoute
   '/welcome': typeof WelcomeRoute
   '/profile/$userId': typeof ProfileUserIdRoute
-  '/topics/$topicId': typeof TopicsTopicIdRoute
-  '/topics/$topicId/threads': typeof TopicsTopicIdThreadsRoute
+  '/topics/$topicId': typeof TopicsTopicIdRouteWithChildren
+  '/topics/$topicId/threads': typeof TopicsTopicIdThreadsRouteWithChildren
   '/topics/$topicId/threads/$threadUuid': typeof TopicsTopicIdThreadsThreadUuidRoute
 }
 export interface FileRoutesById {
@@ -132,8 +132,8 @@ export interface FileRoutesById {
   '/trending': typeof TrendingRoute
   '/welcome': typeof WelcomeRoute
   '/profile/$userId': typeof ProfileUserIdRoute
-  '/topics/$topicId': typeof TopicsTopicIdRoute
-  '/topics/$topicId/threads': typeof TopicsTopicIdThreadsRoute
+  '/topics/$topicId': typeof TopicsTopicIdRouteWithChildren
+  '/topics/$topicId/threads': typeof TopicsTopicIdThreadsRouteWithChildren
   '/topics/$topicId/threads/$threadUuid': typeof TopicsTopicIdThreadsThreadUuidRoute
 }
 export interface FileRouteTypes {
@@ -269,6 +269,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TopicsTopicIdRouteImport
       parentRoute: typeof TopicsRoute
     }
+    '/profile/$userId': {
+      id: '/profile/$userId'
+      path: '/profile/$userId'
+      fullPath: '/profile/$userId'
+      preLoaderRoute: typeof ProfileUserIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/topics/$topicId/threads': {
       id: '/topics/$topicId/threads'
       path: '/threads'
@@ -283,22 +290,7 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TopicsTopicIdThreadsThreadUuidRouteImport
       parentRoute: typeof TopicsTopicIdThreadsRoute
     }
-    '/profile/$userId': {
-      id: '/profile/$userId'
-      path: '/profile/$userId'
-      fullPath: '/profile/$userId'
-      preLoaderRoute: typeof ProfileUserIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
   }
-}
-
-interface TopicsRouteChildren {
-  TopicsTopicIdRoute: typeof TopicsTopicIdRouteWithChildren
-}
-
-interface TopicsTopicIdRouteChildren {
-  TopicsTopicIdThreadsRoute: typeof TopicsTopicIdThreadsRouteWithChildren
 }
 
 interface TopicsTopicIdThreadsRouteChildren {
@@ -312,12 +304,21 @@ const TopicsTopicIdThreadsRouteChildren: TopicsTopicIdThreadsRouteChildren = {
 const TopicsTopicIdThreadsRouteWithChildren =
   TopicsTopicIdThreadsRoute._addFileChildren(TopicsTopicIdThreadsRouteChildren)
 
+interface TopicsTopicIdRouteChildren {
+  TopicsTopicIdThreadsRoute: typeof TopicsTopicIdThreadsRouteWithChildren
+}
+
 const TopicsTopicIdRouteChildren: TopicsTopicIdRouteChildren = {
   TopicsTopicIdThreadsRoute: TopicsTopicIdThreadsRouteWithChildren,
 }
 
-const TopicsTopicIdRouteWithChildren =
-  TopicsTopicIdRoute._addFileChildren(TopicsTopicIdRouteChildren)
+const TopicsTopicIdRouteWithChildren = TopicsTopicIdRoute._addFileChildren(
+  TopicsTopicIdRouteChildren,
+)
+
+interface TopicsRouteChildren {
+  TopicsTopicIdRoute: typeof TopicsTopicIdRouteWithChildren
+}
 
 const TopicsRouteChildren: TopicsRouteChildren = {
   TopicsTopicIdRoute: TopicsTopicIdRouteWithChildren,

--- a/kukuri-tauri/src/stores/authStore.ts
+++ b/kukuri-tauri/src/stores/authStore.ts
@@ -117,10 +117,7 @@ const readPersistedCurrentUserFromStorage = (): User | null => {
         : name;
 
     return {
-      id:
-        typeof currentUser.id === 'string' && currentUser.id.length > 0
-          ? currentUser.id
-          : pubkey,
+      id: typeof currentUser.id === 'string' && currentUser.id.length > 0 ? currentUser.id : pubkey,
       pubkey,
       npub,
       name,

--- a/kukuri-tauri/src/stores/authStore.ts
+++ b/kukuri-tauri/src/stores/authStore.ts
@@ -8,7 +8,7 @@ import { errorHandler } from '@/lib/errorHandler';
 import { useTopicStore } from './topicStore';
 import { usePrivacySettingsStore } from './privacySettingsStore';
 import { withPersist } from './utils/persistHelpers';
-import { createAuthPersistConfig } from './config/persist';
+import { createAuthPersistConfig, persistKeys } from './config/persist';
 import { DEFAULT_PUBLIC_TOPIC_ID } from '@/constants/topics';
 import { buildAvatarDataUrl, buildUserAvatarMetadataFromFetch } from '@/lib/profile/avatar';
 import i18n from '@/i18n';
@@ -80,6 +80,64 @@ const persistCurrentUserPubkey = (pubkey: string | null) => {
     window.localStorage?.setItem('currentUserPubkey', pubkey);
   } else {
     window.localStorage?.removeItem('currentUserPubkey');
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const readPersistedCurrentUserFromStorage = (): User | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const rawValue = window.localStorage?.getItem(persistKeys.auth);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (!isRecord(parsed) || !isRecord(parsed.state) || !isRecord(parsed.state.currentUser)) {
+      return null;
+    }
+
+    const currentUser = parsed.state.currentUser;
+    const npub = typeof currentUser.npub === 'string' ? currentUser.npub : '';
+    const pubkey = typeof currentUser.pubkey === 'string' ? currentUser.pubkey : '';
+
+    if (!npub || !pubkey) {
+      return null;
+    }
+
+    const name = typeof currentUser.name === 'string' ? currentUser.name : '';
+    const displayName =
+      typeof currentUser.displayName === 'string' && currentUser.displayName.length > 0
+        ? currentUser.displayName
+        : name;
+
+    return {
+      id:
+        typeof currentUser.id === 'string' && currentUser.id.length > 0
+          ? currentUser.id
+          : pubkey,
+      pubkey,
+      npub,
+      name,
+      displayName,
+      about: typeof currentUser.about === 'string' ? currentUser.about : '',
+      picture: typeof currentUser.picture === 'string' ? currentUser.picture : '',
+      nip05: typeof currentUser.nip05 === 'string' ? currentUser.nip05 : '',
+      avatar: isRecord(currentUser.avatar)
+        ? (currentUser.avatar as unknown as User['avatar'])
+        : null,
+      publicProfile:
+        typeof currentUser.publicProfile === 'boolean' ? currentUser.publicProfile : true,
+      showOnlineStatus:
+        typeof currentUser.showOnlineStatus === 'boolean' ? currentUser.showOnlineStatus : false,
+    };
+  } catch {
+    return null;
   }
 };
 
@@ -624,7 +682,7 @@ export const useAuthStore = create<AuthStore>()(
               typeof currentAccount.metadata?.show_online_status === 'boolean'
                 ? currentAccount.metadata.show_online_status
                 : false;
-            const user: User = {
+            const secureStorageUser: User = {
               id: currentAccount.pubkey,
               pubkey: currentAccount.pubkey,
               npub: currentAccount.npub,
@@ -636,6 +694,26 @@ export const useAuthStore = create<AuthStore>()(
               avatar: null,
               publicProfile,
               showOnlineStatus,
+            };
+            const inMemoryCurrentUser = get().currentUser;
+            const localPersistedUser = readPersistedCurrentUserFromStorage();
+            const persistedCurrentUser =
+              inMemoryCurrentUser &&
+              inMemoryCurrentUser.npub === currentAccount.npub &&
+              inMemoryCurrentUser.pubkey === currentAccount.pubkey
+                ? inMemoryCurrentUser
+                : localPersistedUser &&
+                    localPersistedUser.npub === currentAccount.npub &&
+                    localPersistedUser.pubkey === currentAccount.pubkey
+                  ? localPersistedUser
+                  : null;
+            const mergedUser = applyUserMetadataOverride(
+              secureStorageUser,
+              persistedCurrentUser ?? undefined,
+            );
+            const user: User = {
+              ...mergedUser,
+              avatar: persistedCurrentUser?.avatar ?? mergedUser.avatar ?? null,
             };
 
             set({


### PR DESCRIPTION
## 概要
- Tauriクライアントでプロフィールを変更した後、Ctrl + R で再読み込みすると「新規ユーザー」に戻る問題を修正
- 原因は `initialize()` で SecureStorage の古いメタデータが `currentUser` を上書きしていたこと
- 同一アカウント（npub/pubkey一致）ではローカル永続化済みプロフィールを優先して復元するよう変更
- `routeTree.gen.ts` は `pnpm tauri dev` 実行時の自動更新

## 関連Issue
- Fixes #154

## Codexレビュー依頼（必須）
- [x] bocchan bot で Codex レビュー依頼コメントを投稿済み
- レビュー依頼コメントURL: https://github.com/KingYoSun/kukuri/pull/191#issuecomment-3970452295

## 検証証跡（必須）
- [x] Playwright screenshots upload コメント: https://github.com/KingYoSun/kukuri/pull/191#issuecomment-3970455174
- [x] Playwright Tauri Smoke 実行: https://github.com/KingYoSun/kukuri/actions/runs/22470940754/job/65087505413
- [x] OpenAPI Artifacts Check 実行: https://github.com/KingYoSun/kukuri/actions/runs/22470940754/job/65087505416

## 検証チェックリスト（必須）
- [x] 表示要素（ラベル、ボタン、レイアウト）が期待どおりに表示される
- [x] 画面遷移・トランジションが期待どおりに動作する
- [x] 保存・送信・削除など主要アクションが成功し、結果が反映される
- [x] 影響範囲で回帰がないことを確認した
- [x] CI required checks で format / lint / type-check / tests を確認する

## テスト手順
1. `docker run --rm -v "$PWD":/workspace -w /workspace/kukuri-tauri node:20-bullseye bash -lc "corepack enable && pnpm install --frozen-lockfile --ignore-scripts && pnpm format:check"`
2. `gh pr checks 191` で required checks の状態を確認
3. `gh run view <run_id> --json jobs` で失敗ジョブを特定し、必要時に修正を追加
