### PR TITLE
fix(tauri): Windows での cargo test リンクとテスト用データディレクトリを整理

### DIFF
--- a/docs/03_implementation/bugfix_windows_msvc_duplicate_version_resource.md
+++ b/docs/03_implementation/bugfix_windows_msvc_duplicate_version_resource.md
@@ -1,0 +1,52 @@
+# Windows MSVC: VERSION リソース重複（CVT1100 / LNK1123）と `crate-type` 調整
+
+**最終更新**: 2026年03月19日
+
+## 概要（事象）
+
+Windows（MSVC）で `kukuri-tauri` の `cargo test` / 各種バイナリをリンクする際、次のようなエラーが出る場合がある。
+
+- `CVTRES : fatal error CVT1100`（`VERSION` リソースの重複）
+- `LINK : fatal error LNK1123`（COFF 変換失敗として続くことがある）
+
+## 原因
+
+1. **`tauri-build`（Windows）** は内部で `tauri_winres` を用い、**一度** `resource.lib` を生成し、`cargo:rustc-link-lib=dylib=resource` を出力する。ここには **VERSION** と **RT_MANIFEST**（既定で Common Controls v6 依存の記述を含む）が含まれる。
+2. 同じ `build.rs` で **`winres::WindowsResource::compile()` をもう一度**呼ぶと、同じ種類の **VERSION** が再度リンク対象となり、MSVC のリソースマージで **重複** と判定される。
+
+※ `origin/main`（調査時点）の `build.rs` には上記の「二重 `winres`」コードは**含まれていなかった**。再現した環境では、ローカル変更や別ブランチで `winres` が追加されていた可能性がある。**再発防止**のため `build.rs` に短い注意コメントを残す。
+
+## 実施した修正（本件のスコープ）
+
+| 対象 | 内容 | `main` からの実質的な挙動差 |
+|------|------|-----------------------------|
+| `kukuri-tauri/src-tauri/Cargo.toml` | `[lib] crate-type` から `staticlib` を削除し `["cdylib", "rlib"]` とする | **あり**（Windows での `staticlib` リンク負荷・テスト時の扱いが変わる） |
+| `kukuri-tauri/src-tauri/build.rs` | `tauri_build::build()` のみ。二重 `winres` を足さない旨の短いコメント | `main` では元々 `winres` なし → **コメント追加が主** |
+| `docs/03_implementation/testing_guide.md` | Windows 節に CVT1100 と `STATUS_ENTRYPOINT_NOT_FOUND` の注記を追加 | ドキュメントのみ |
+
+### `crate-type` から `staticlib` を外す理由（要約）
+
+- Tauri デスクトップ向けには `cdylib` が必要。
+- 単体テスト・他クレートからの利用には `rlib` が使われる。
+- `staticlib` は C 静的リンク用途が主で、Windows で裸 `cargo test` 時に余計なリンク経路を踏みやすい。**静的 FFI を本プロジェクトが要求しない限り**外してよい、という整理。
+
+## 本件とは別の変更（混在時の整理）
+
+次は **CVT1100 修正とは独立**した変更として、別コミット / 別 PR に分けることを推奨する。
+
+| パス / 要素 | 内容 |
+|-------------|------|
+| `presentation/handlers/community_node_handler.rs`（テストモジュール） | Windows では `dirs::data_dir()` が `APPDATA` を参照するため、テスト用環境変数を `XDG_DATA_HOME` ではなく **`APPDATA`** に切り替える `cfg` 対応。**データディレクトリまわりのテスト正しさ**向け。 |
+| `tauri-win-link-test/`（リポジトリ直下） | 最小 Tauri でリンク・`cargo test` を切り分け検証するための**サンプル**。本番修正の**必須構成ではない**。コミットする場合は目的を README に明記するか、`.gitignore` するか方針を決める。 |
+| `todo.md` | 作業メモならコミット対象外が無難。 |
+| `Cargo.lock` | `crate-type` のみの変更では通常パッケージ解決は変わらない。**改行 CRLF/LF のみの差分**になっていないか、コミット前に `git diff` で確認すること。 |
+
+## 検証
+
+- **リンクまで**: `cd kukuri-tauri/src-tauri && cargo build --lib` が MSVC で成功すること。
+- **テスト実行（Windows ホスト）**: Tauri / ネイティブ依存により `STATUS_ENTRYPOINT_NOT_FOUND` が出る場合がある。リポジトリ方針どおり **`./scripts/test-docker.ps1 rust`** 等での検証を推奨（`AGENTS.md` / `testing_guide.md` 参照）。
+
+## 参考
+
+- `tauri-build` 既定の Windows マニフェスト（Common Controls v6）: クレート内 `windows-app-manifest.xml`（`tauri-build` ソース参照）
+- 本リポジトリのテスト方針: `docs/03_implementation/testing_guide.md`（「Windows環境特有の問題」）

--- a/docs/03_implementation/testing_guide.md
+++ b/docs/03_implementation/testing_guide.md
@@ -227,6 +227,16 @@ pnpm tauri build --runner cargo-xwin --target x86_64-pc-windows-msvc
    - Windows環境では`\`が使用されるが、テストでは`/`を期待する場合がある
    - 必要に応じてパスを正規化
 
+3. **`link.exe` / `CVT1100` / `LNK1123`（VERSION リソース重複）**
+   - 症状: `CVTRES : fatal error CVT1100`（`VERSION` 重複）、`LNK1123` など。
+   - 原因: `tauri-build` が既に `tauri_winres` で `resource.lib` を生成し `cargo:rustc-link-lib=dylib=resource` を出力しているのに、`build.rs` でさらに `winres::WindowsResource::compile()` を呼ぶと、同じ `VERSION` が二重にリンクされる。
+   - 対処: `build.rs` では二重の `winres` コンパイルを行わない（Common Controls v6 は `tauri-build` 既定の `windows-app-manifest.xml` に含まれる）。
+   - 詳細: [bugfix_windows_msvc_duplicate_version_resource.md](./bugfix_windows_msvc_duplicate_version_resource.md)
+
+4. **Rust テストを Windows ホストで直接実行したときの `STATUS_ENTRYPOINT_NOT_FOUND`**
+   - Tauri / WebView2 / ネイティブ依存を引き込むクレートでは、ホスト上の `cargo test` がリンクまでは通っても実行時に失敗することがある。
+   - 本リポジトリの方針どおり、Windows では `./scripts/test-docker.ps1 rust`（など）で Docker 経由の実行を推奨する。
+
 ## トラブルシューティング
 
 ### よくある問題

--- a/kukuri-tauri/src-tauri/Cargo.toml
+++ b/kukuri-tauri/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ default-run = "kukuri-tauri"
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
 name = "kukuri_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2.5.5", features = [] }

--- a/kukuri-tauri/src-tauri/build.rs
+++ b/kukuri-tauri/src-tauri/build.rs
@@ -1,3 +1,5 @@
 fn main() {
     tauri_build::build();
+    // Windows: 二重の `winres` / `WindowsResource::compile()` を足さないこと（`tauri-build` が既に
+    // `resource.lib` をリンクする）。詳細は `docs/03_implementation/bugfix_windows_msvc_duplicate_version_resource.md`。
 }

--- a/kukuri-tauri/src-tauri/src/presentation/handlers/community_node_handler.rs
+++ b/kukuri-tauri/src-tauri/src/presentation/handlers/community_node_handler.rs
@@ -2938,7 +2938,11 @@ mod community_node_handler_tests {
     use tokio::time::timeout;
 
     const MOCK_SERVER_RECV_TIMEOUT: Duration = Duration::from_secs(2);
-    const XDG_DATA_HOME_ENV: &str = "XDG_DATA_HOME";
+    // On Windows, dirs::data_dir() reads APPDATA (not XDG_DATA_HOME which is Linux-only).
+    #[cfg(target_os = "windows")]
+    const DATA_HOME_ENV: &str = "APPDATA";
+    #[cfg(not(target_os = "windows"))]
+    const DATA_HOME_ENV: &str = "XDG_DATA_HOME";
     const KUKURI_BOOTSTRAP_PEERS_ENV: &str = "KUKURI_BOOTSTRAP_PEERS";
     static BOOTSTRAP_ENV_GUARD: OnceLock<StdMutex<()>> = OnceLock::new();
 
@@ -3417,7 +3421,7 @@ mod community_node_handler_tests {
     async fn set_config_appends_resolved_bootstrap_nodes_on_add() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("add");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let existing =
@@ -3468,7 +3472,7 @@ mod community_node_handler_tests {
     async fn set_config_appends_resolved_bootstrap_nodes_on_update() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("update");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let resolved1 =
@@ -3533,7 +3537,7 @@ mod community_node_handler_tests {
     async fn set_config_deduplicates_bootstrap_nodes_with_existing_entries() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("dedup");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let existing =
@@ -3583,7 +3587,7 @@ mod community_node_handler_tests {
     async fn set_config_replaces_existing_bootstrap_nodes_for_same_node_id() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("replace-same-node-id");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let node_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -3637,7 +3641,7 @@ mod community_node_handler_tests {
     async fn set_config_uses_runtime_bootstrap_nodes_when_descriptor_has_no_p2p() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("runtime-fallback");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let descriptor = build_bootstrap_descriptor_event("https://node.example", &[]);
@@ -3698,7 +3702,7 @@ mod community_node_handler_tests {
     async fn resolve_nostr_relay_urls_prefers_matching_descriptor_ws_over_base_url_fallback() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("nostr-relays");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let response = json!({
@@ -3752,7 +3756,7 @@ mod community_node_handler_tests {
     async fn resolve_nostr_relay_urls_refreshes_live_bootstrap_descriptors_before_fallback() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("nostr-relays-live-refresh");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let (base_url, rx, handle) = spawn_json_sequence_server_with_builder(|base_url| {
@@ -3811,7 +3815,7 @@ mod community_node_handler_tests {
     async fn resolve_nostr_relay_urls_errors_when_live_bootstrap_refresh_fails() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("nostr-relays-live-failure");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let bootstrap_without_descriptor = json!({
@@ -3856,7 +3860,7 @@ mod community_node_handler_tests {
     async fn resolve_nostr_relay_urls_returns_empty_when_bootstrap_descriptor_has_no_ws() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("nostr-relays-fallback");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let response = json!({
@@ -3907,7 +3911,7 @@ mod community_node_handler_tests {
      {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("nostr-relays-multi-node");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let (bootstrap_base_url, rx, handle) =
@@ -3980,7 +3984,7 @@ mod community_node_handler_tests {
     async fn resolve_nostr_relay_urls_uses_bootstrap_descriptor_ws_when_http_endpoint_differs() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("nostr-relays-bootstrap-http-mismatch");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let descriptor_http_url = "https://relay.example.com".to_string();
@@ -4042,7 +4046,7 @@ mod community_node_handler_tests {
     async fn resolve_nostr_relay_urls_falls_back_to_base_url_for_single_non_bootstrap_node() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("nostr-relays-single-node-fallback");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let base_url = "https://api.example.com".to_string();
@@ -4079,7 +4083,7 @@ mod community_node_handler_tests {
      {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("nostr-relays-ignore-loopback");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let base_url = "https://api.example.com".to_string();
@@ -4128,7 +4132,7 @@ mod community_node_handler_tests {
     async fn resolve_nostr_relay_urls_keeps_loopback_descriptor_ws_for_loopback_base_url() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("nostr-relays-keep-loopback");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let descriptor_ws_url = "ws://localhost:8082/relay".to_string();
@@ -4177,7 +4181,7 @@ mod community_node_handler_tests {
     async fn set_config_treats_localhost_bootstrap_nodes_as_loopback() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("localhost");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let existing =
@@ -4236,7 +4240,7 @@ mod community_node_handler_tests {
     async fn authenticate_refreshes_bootstrap_nodes_with_new_token() {
         let _env_guard = lock_bootstrap_env();
         let data_dir = temp_bootstrap_data_dir("auth-refresh");
-        let _xdg_guard = ScopedEnvVar::set(XDG_DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
+        let _xdg_guard = ScopedEnvVar::set(DATA_HOME_ENV, data_dir.to_string_lossy().as_ref());
         let _bootstrap_peers_guard = ScopedEnvVar::unset(KUKURI_BOOTSTRAP_PEERS_ENV);
 
         let resolved =


### PR DESCRIPTION
## 概要

Windows（MSVC）で `cargo test` / 各バイナリをリンクする際に発生し得る **VERSION リソース重複（CVT1100 / LNK1123）** を避けるための整理と、**Windows と Linux でテスト用データディレクトリの環境変数が異なる**点への対応です。

## 変更内容

### 1. Tauri ビルド経路と `cargo test` のリンク（二重注入の回避）

- `tauri-build` は Windows 上で既に `tauri_winres` により `resource.lib` を生成し、`cargo:rustc-link-lib=dylib=resource` を出力します（VERSION + RT_MANIFEST。既定 manifest には Common Controls v6 が含まれます）。
- 同一 `build.rs` で **さらに** `winres::WindowsResource::compile()` 等を呼ぶと、**同じ VERSION が二重にリンク**され、MSVC で `CVT1100` / `LNK1123` となることがあります。
- **対策**: `build.rs` では二重の winres を足さない旨を短いコメントで明示し、詳細を `docs/03_implementation/bugfix_windows_msvc_duplicate_version_resource.md` に記載しました。
- `[lib] crate-type` から `staticlib` を外し `cdylib` + `rlib` のみとし、Windows での裸 `cargo test` 時のリンク負荷を抑えます（静的 FFI が不要な前提）。

### 2. Windows と Linux で「データディレクトリ」を指す環境変数の不一致（テスト）

- `dirs::data_dir()` は Windows では **`APPDATA`** を参照し、Linux 等では **`XDG_DATA_HOME`** が効きます。
- `community_node_handler` のテストで一括 `XDG_DATA_HOME` のみをセットしていたため、Windows では意図したテンポラリデータディレクトリに誘導できていませんでした。
- **`#[cfg(target_os = "windows")]`** で `APPDATA`、それ以外で `XDG_DATA_HOME` を使う定数に切り替えました。

### 3. ドキュメント

- `docs/03_implementation/testing_guide.md` に CVT1100 / LNK1123 と `STATUS_ENTRYPOINT_NOT_FOUND` の注記を追加。
- 上記 bugfix ドキュメントへのリンクを追加。

## 確認したこと

- `kukuri-tauri/src-tauri` で `cargo test --no-run` が通ることを確認（ローカル Windows）。

## 関連

- 本リポジトリ方針どおり、Windows 上の実行検証の主経路は引き続き `./scripts/test-docker.ps1 rust` を推奨します。
```

## プッシュ後に upstream へ PR を開く例（フォーク `qiuliw/kukuri` → `KingYoSun/kukuri` の場合）

```bash
git push -u origin fix/windows-cargo-test-tauri-linking
gh pr create --repo KingYoSun/kukuri --base main --head qiuliw:fix/windows-cargo-test-tauri-linking --title "fix(tauri): Windows での cargo test リンクとテスト用データディレクトリを整理" --body-file docs/01_project/activeContext/pr-draft-windows-tauri-build-ja.md
```