### PR TITLE
Upgrade iroh to 0.97.0 and stabilize shared-identity scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +765,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1458,6 +1492,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.96.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5236da4d5681f317ec393c8fe2b7e3d360d31c6bb40383991d0b7429ca5ad117"
+checksum = "feb56e7e4b0ec7fba7efa6a236b016a52b5d927d50244aceb9e20566159b1a32"
 dependencies = [
  "axum",
  "backon",
@@ -1997,22 +2041,22 @@ dependencies = [
  "getrandom 0.3.4",
  "hickory-resolver",
  "http",
- "igd-next",
- "iroh-base 0.96.1",
+ "ipnet",
+ "iroh-base",
  "iroh-metrics",
- "iroh-quinn",
- "iroh-quinn-proto",
- "iroh-quinn-udp",
  "iroh-relay",
  "n0-error",
  "n0-future",
  "n0-watcher",
- "netdev",
  "netwatch",
+ "noq",
+ "noq-proto",
+ "noq-udp",
  "papaya",
  "pin-project",
  "pkarr",
  "pkcs8 0.11.0-rc.11",
+ "portable-atomic",
  "portmapper",
  "rand 0.9.2",
  "reqwest",
@@ -2022,7 +2066,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "smallvec",
- "strum 0.27.2",
+ "strum 0.28.0",
  "swarm-discovery",
  "sync_wrapper",
  "time",
@@ -2037,27 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "0.95.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a8c5fb1cc65589f0d7ab44269a76f615a8c4458356952c9b0ef1c93ea45ff8"
-dependencies = [
- "curve25519-dalek",
- "data-encoding",
- "derive_more",
- "ed25519-dalek",
- "n0-error",
- "rand_core 0.9.5",
- "serde",
- "url",
- "zeroize",
- "zeroize_derive",
-]
-
-[[package]]
-name = "iroh-base"
-version = "0.96.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c99d836a1c99e037e98d1bf3ef209c3a4df97555a00ce9510eb78eccdf5567"
+checksum = "55a354e3396b62c14717ee807dfee9a7f43f6dad47e4ac0fd1d49f1ffad14ef0"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -2075,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-blobs"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f253ea06293e51e166a88a3faa019b67e187d12bd7c6a04369a0ec86f53272"
+checksum = "51b06914e77bd07bc1b3600096be66e2a63d391e8f4a901f61771630e20f2116"
 dependencies = [
  "arrayvec",
  "bao-tree",
@@ -2090,15 +2116,15 @@ dependencies = [
  "genawaiter",
  "hex",
  "iroh",
- "iroh-base 0.96.1",
+ "iroh-base",
  "iroh-io",
  "iroh-metrics",
- "iroh-quinn",
- "iroh-tickets 0.3.0",
+ "iroh-tickets",
  "irpc",
  "n0-error",
  "n0-future",
  "nested_enum_utils",
+ "noq",
  "postcard",
  "rand 0.9.2",
  "range-collections",
@@ -2114,14 +2140,15 @@ dependencies = [
 
 [[package]]
 name = "iroh-docs"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42292da17d6be0b73c5897f1ff395ad7c6f858b107ff76a7605867fbdd6c2e72"
+checksum = "57871fef17af23122fd3013719c9d7cacd4ac77d60b2d9463ebc8505dbc3495c"
 dependencies = [
  "anyhow",
  "async-channel",
  "blake3",
  "bytes",
+ "cfg_aliases",
  "derive_more",
  "ed25519-dalek",
  "futures-buffered",
@@ -2132,11 +2159,11 @@ dependencies = [
  "iroh-blobs",
  "iroh-gossip",
  "iroh-metrics",
- "iroh-quinn",
- "iroh-tickets 0.2.0",
+ "iroh-tickets",
  "irpc",
  "n0-error",
  "n0-future",
+ "noq",
  "num_enum",
  "postcard",
  "rand 0.9.2",
@@ -2155,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-gossip"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d04f83254c847ac61a9b2215b95a36d598d87af033ca12a546cd1c6a2e06dab"
+checksum = "4db5b64f3cb0a0c8b68b57888acd4cefcd2f0774f1a132d2a498cbb2a92fbc55"
 dependencies = [
  "blake3",
  "bytes",
@@ -2170,7 +2197,7 @@ dependencies = [
  "hex",
  "indexmap",
  "iroh",
- "iroh-base 0.96.1",
+ "iroh-base",
  "iroh-metrics",
  "irpc",
  "n0-error",
@@ -2229,71 +2256,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-quinn"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034ed21f34c657a123d39525d948c885aacba59508805e4dd67d71f022e7151b"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "iroh-quinn-proto",
- "iroh-quinn-udp",
- "pin-project-lite",
- "rustc-hash",
- "rustls",
- "socket2 0.6.3",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "iroh-quinn-proto"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de99ad8adc878ee0e68509ad256152ce23b8bbe45f5539d04e179630aca40a9"
-dependencies = [
- "bytes",
- "derive_more",
- "enum-assoc",
- "fastbloom",
- "getrandom 0.3.4",
- "identity-hash",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "slab",
- "sorted-index-buffer",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "iroh-quinn-udp"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f981dadd5a072a9e0efcd24bdcc388e570073f7e51b33505ceb1ef4668c80c86"
-dependencies = [
- "cfg_aliases",
- "libc",
- "socket2 0.6.3",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "iroh-relay"
-version = "0.96.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2b63e654b9dec799a73372cdc79b529ca6c7248c0c8de7da78a02e3a46f03c"
+checksum = "d786b260cadfe82ae0b6a9e372e8c78949096a06c857d1c3521355cefced0f55"
 dependencies = [
  "ahash",
  "blake3",
@@ -2309,13 +2275,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "iroh-base 0.96.1",
+ "iroh-base",
  "iroh-metrics",
- "iroh-quinn",
- "iroh-quinn-proto",
  "lru",
  "n0-error",
  "n0-future",
+ "noq",
+ "noq-proto",
  "num_enum",
  "pin-project",
  "pkarr",
@@ -2333,7 +2299,7 @@ dependencies = [
  "serde_json",
  "sha1 0.11.0-rc.4",
  "simdutf8",
- "strum 0.27.2",
+ "strum 0.28.0",
  "time",
  "tokio",
  "tokio-rustls",
@@ -2352,27 +2318,13 @@ dependencies = [
 
 [[package]]
 name = "iroh-tickets"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a322053cacddeca222f0999ce3cf6aa45c64ae5ad8c8911eac9b66008ffbaa5"
+checksum = "ab64bac4bb573b9cfd2142bd2876ed65ca792efbc4398361a4ee51a0f9afbed6"
 dependencies = [
  "data-encoding",
  "derive_more",
- "iroh-base 0.95.1",
- "n0-error",
- "postcard",
- "serde",
-]
-
-[[package]]
-name = "iroh-tickets"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cd580bf680db919cbbce6886a47314acb0e9b4f7b639acebcea5e9f485d183"
-dependencies = [
- "data-encoding",
- "derive_more",
- "iroh-base 0.96.1",
+ "iroh-base",
  "n0-error",
  "postcard",
  "serde",
@@ -2380,16 +2332,16 @@ dependencies = [
 
 [[package]]
 name = "irpc"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bbc84aaeab13a6d7502bae4f40f2517b643924842e0230ea0bf807477cc208"
+checksum = "4f47b7c52662d673df377b5ac40c121c7ff56eb764e520fae6543686132f7957"
 dependencies = [
  "futures-buffered",
  "futures-util",
- "iroh-quinn",
  "irpc-derive",
  "n0-error",
  "n0-future",
+ "noq",
  "postcard",
  "rcgen",
  "rustls",
@@ -2402,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58148196d2230183c9679431ac99b57e172000326d664e8456fa2cd27af6505a"
+checksum = "83c1a4b460634aeed6dc01236a0047867de70e30562d91a0ad031dcb3ac33fb4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3009,7 +2961,7 @@ dependencies = [
  "libc",
  "mac-addr",
  "netlink-packet-core",
- "netlink-packet-route 0.29.0",
+ "netlink-packet-route",
  "netlink-sys",
  "objc2-core-foundation",
  "objc2-system-configuration",
@@ -3025,18 +2977,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
  "paste",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
-dependencies = [
- "bitflags",
- "libc",
- "log",
- "netlink-packet-core",
 ]
 
 [[package]]
@@ -3080,15 +3020,14 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "454b8c0759b2097581f25ed5180b4a1d14c324fde6d0734932a288e044d06232"
+checksum = "3b1b27babe89ef9f2237bc6c028bea24fa84163a1b6f8f17ff93573ebd7d861f"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
  "derive_more",
- "iroh-quinn-udp",
  "js-sys",
  "libc",
  "n0-error",
@@ -3096,9 +3035,10 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.28.0",
+ "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
+ "noq-udp",
  "objc2-core-foundation",
  "objc2-system-configuration",
  "pin-project-lite",
@@ -3122,6 +3062,68 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "noq"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df966fb44ac763bc86da97fa6c811c54ae82ef656575949f93c6dae0c9f09bf"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "noq-proto",
+ "noq-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-proto"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c61b72abd670eebc05b5cf720e077b04a3ef3354bc7bc19f1c3524cb424db7b"
+dependencies = [
+ "aes-gcm",
+ "bytes",
+ "derive_more",
+ "enum-assoc",
+ "fastbloom",
+ "getrandom 0.3.4",
+ "identity-hash",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "slab",
+ "sorted-index-buffer",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-udp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9be4fedd6b98f3ba82ccd3506f4d0219fb723c3f97c67e12fe1494aa020e44"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3552,6 +3554,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3559,9 +3573,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portmapper"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2a8825353ace3285138da3378b1e21860d60351942f7aa3b99b13b41f80318"
+checksum = "74748bc706fa6b6aebac6bbe0bbe0de806b384cb5c557ea974f771360a4e3858"
 dependencies = [
  "base64",
  "bytes",
@@ -4872,11 +4886,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -4894,9 +4908,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5232,26 +5246,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -5270,7 +5275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "winnow",
 ]
@@ -5770,6 +5775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ futures-util = "0.3.32"
 hex = "0.4.3"
 hkdf = "0.12.4"
 httpdate = "1.0.3"
-iroh = { version = "0.96.1", features = ["address-lookup-mdns", "address-lookup-pkarr-dht"] }
-iroh-docs = "0.96.0"
-iroh-blobs = "0.98.0"
-iroh-gossip = "0.96.0"
-iroh-relay = { version = "0.96.1", features = ["server"] }
+iroh = { version = "0.97.0", features = ["address-lookup-mdns", "address-lookup-pkarr-dht"] }
+iroh-docs = "0.97.0"
+iroh-blobs = "0.99.0"
+iroh-gossip = "0.97.0"
+iroh-relay = { version = "0.97.0", features = ["server"] }
 jsonwebtoken = "9.3.1"
 keyring = { version = "3.6.3", default-features = false }
 chacha20poly1305 = "0.10.1"

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -34,6 +34,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +932,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1965,6 +1999,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.96.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5236da4d5681f317ec393c8fe2b7e3d360d31c6bb40383991d0b7429ca5ad117"
+checksum = "feb56e7e4b0ec7fba7efa6a236b016a52b5d927d50244aceb9e20566159b1a32"
 dependencies = [
  "backon",
  "bytes",
@@ -2709,22 +2753,22 @@ dependencies = [
  "getrandom 0.3.4",
  "hickory-resolver",
  "http",
- "igd-next",
- "iroh-base 0.96.1",
+ "ipnet",
+ "iroh-base",
  "iroh-metrics",
- "iroh-quinn",
- "iroh-quinn-proto",
- "iroh-quinn-udp",
  "iroh-relay",
  "n0-error",
  "n0-future",
  "n0-watcher",
- "netdev",
  "netwatch",
+ "noq",
+ "noq-proto",
+ "noq-udp",
  "papaya",
  "pin-project",
  "pkarr",
  "pkcs8 0.11.0-rc.11",
+ "portable-atomic",
  "portmapper",
  "rand 0.9.2",
  "reqwest 0.12.28",
@@ -2734,7 +2778,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "smallvec",
- "strum 0.27.2",
+ "strum 0.28.0",
  "swarm-discovery",
  "sync_wrapper",
  "time",
@@ -2749,27 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "0.95.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a8c5fb1cc65589f0d7ab44269a76f615a8c4458356952c9b0ef1c93ea45ff8"
-dependencies = [
- "curve25519-dalek",
- "data-encoding",
- "derive_more 2.1.1",
- "ed25519-dalek",
- "n0-error",
- "rand_core 0.9.5",
- "serde",
- "url",
- "zeroize",
- "zeroize_derive",
-]
-
-[[package]]
-name = "iroh-base"
-version = "0.96.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c99d836a1c99e037e98d1bf3ef209c3a4df97555a00ce9510eb78eccdf5567"
+checksum = "55a354e3396b62c14717ee807dfee9a7f43f6dad47e4ac0fd1d49f1ffad14ef0"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -2787,9 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-blobs"
-version = "0.98.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f253ea06293e51e166a88a3faa019b67e187d12bd7c6a04369a0ec86f53272"
+checksum = "51b06914e77bd07bc1b3600096be66e2a63d391e8f4a901f61771630e20f2116"
 dependencies = [
  "arrayvec",
  "bao-tree",
@@ -2802,15 +2828,15 @@ dependencies = [
  "genawaiter",
  "hex",
  "iroh",
- "iroh-base 0.96.1",
+ "iroh-base",
  "iroh-io",
  "iroh-metrics",
- "iroh-quinn",
- "iroh-tickets 0.3.0",
+ "iroh-tickets",
  "irpc",
  "n0-error",
  "n0-future",
  "nested_enum_utils",
+ "noq",
  "postcard",
  "rand 0.9.2",
  "range-collections",
@@ -2826,14 +2852,15 @@ dependencies = [
 
 [[package]]
 name = "iroh-docs"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42292da17d6be0b73c5897f1ff395ad7c6f858b107ff76a7605867fbdd6c2e72"
+checksum = "57871fef17af23122fd3013719c9d7cacd4ac77d60b2d9463ebc8505dbc3495c"
 dependencies = [
  "anyhow",
  "async-channel",
  "blake3",
  "bytes",
+ "cfg_aliases",
  "derive_more 2.1.1",
  "ed25519-dalek",
  "futures-buffered",
@@ -2844,11 +2871,11 @@ dependencies = [
  "iroh-blobs",
  "iroh-gossip",
  "iroh-metrics",
- "iroh-quinn",
- "iroh-tickets 0.2.0",
+ "iroh-tickets",
  "irpc",
  "n0-error",
  "n0-future",
+ "noq",
  "num_enum",
  "postcard",
  "rand 0.9.2",
@@ -2867,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-gossip"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d04f83254c847ac61a9b2215b95a36d598d87af033ca12a546cd1c6a2e06dab"
+checksum = "4db5b64f3cb0a0c8b68b57888acd4cefcd2f0774f1a132d2a498cbb2a92fbc55"
 dependencies = [
  "blake3",
  "bytes",
@@ -2882,7 +2909,7 @@ dependencies = [
  "hex",
  "indexmap 2.13.0",
  "iroh",
- "iroh-base 0.96.1",
+ "iroh-base",
  "iroh-metrics",
  "irpc",
  "n0-error",
@@ -2937,71 +2964,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-quinn"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034ed21f34c657a123d39525d948c885aacba59508805e4dd67d71f022e7151b"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "iroh-quinn-proto",
- "iroh-quinn-udp",
- "pin-project-lite",
- "rustc-hash",
- "rustls",
- "socket2 0.6.3",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "iroh-quinn-proto"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de99ad8adc878ee0e68509ad256152ce23b8bbe45f5539d04e179630aca40a9"
-dependencies = [
- "bytes",
- "derive_more 2.1.1",
- "enum-assoc",
- "fastbloom",
- "getrandom 0.3.4",
- "identity-hash",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "slab",
- "sorted-index-buffer",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "iroh-quinn-udp"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f981dadd5a072a9e0efcd24bdcc388e570073f7e51b33505ceb1ef4668c80c86"
-dependencies = [
- "cfg_aliases",
- "libc",
- "socket2 0.6.3",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "iroh-relay"
-version = "0.96.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2b63e654b9dec799a73372cdc79b529ca6c7248c0c8de7da78a02e3a46f03c"
+checksum = "d786b260cadfe82ae0b6a9e372e8c78949096a06c857d1c3521355cefced0f55"
 dependencies = [
  "blake3",
  "bytes",
@@ -3014,13 +2980,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "iroh-base 0.96.1",
+ "iroh-base",
  "iroh-metrics",
- "iroh-quinn",
- "iroh-quinn-proto",
  "lru",
  "n0-error",
  "n0-future",
+ "noq",
+ "noq-proto",
  "num_enum",
  "pin-project",
  "pkarr",
@@ -3031,7 +2997,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_bytes",
- "strum 0.27.2",
+ "strum 0.28.0",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -3046,27 +3012,13 @@ dependencies = [
 
 [[package]]
 name = "iroh-tickets"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a322053cacddeca222f0999ce3cf6aa45c64ae5ad8c8911eac9b66008ffbaa5"
+checksum = "ab64bac4bb573b9cfd2142bd2876ed65ca792efbc4398361a4ee51a0f9afbed6"
 dependencies = [
  "data-encoding",
  "derive_more 2.1.1",
- "iroh-base 0.95.1",
- "n0-error",
- "postcard",
- "serde",
-]
-
-[[package]]
-name = "iroh-tickets"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cd580bf680db919cbbce6886a47314acb0e9b4f7b639acebcea5e9f485d183"
-dependencies = [
- "data-encoding",
- "derive_more 2.1.1",
- "iroh-base 0.96.1",
+ "iroh-base",
  "n0-error",
  "postcard",
  "serde",
@@ -3074,16 +3026,16 @@ dependencies = [
 
 [[package]]
 name = "irpc"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bbc84aaeab13a6d7502bae4f40f2517b643924842e0230ea0bf807477cc208"
+checksum = "4f47b7c52662d673df377b5ac40c121c7ff56eb764e520fae6543686132f7957"
 dependencies = [
  "futures-buffered",
  "futures-util",
- "iroh-quinn",
  "irpc-derive",
  "n0-error",
  "n0-future",
+ "noq",
  "postcard",
  "rcgen",
  "rustls",
@@ -3096,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58148196d2230183c9679431ac99b57e172000326d664e8456fa2cd27af6505a"
+checksum = "83c1a4b460634aeed6dc01236a0047867de70e30562d91a0ad031dcb3ac33fb4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3854,7 +3806,7 @@ dependencies = [
  "libc",
  "mac-addr",
  "netlink-packet-core",
- "netlink-packet-route 0.29.0",
+ "netlink-packet-route",
  "netlink-sys",
  "objc2-core-foundation",
  "objc2-system-configuration",
@@ -3870,18 +3822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
  "paste",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "log",
- "netlink-packet-core",
 ]
 
 [[package]]
@@ -3925,15 +3865,14 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "454b8c0759b2097581f25ed5180b4a1d14c324fde6d0734932a288e044d06232"
+checksum = "3b1b27babe89ef9f2237bc6c028bea24fa84163a1b6f8f17ff93573ebd7d861f"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
  "derive_more 2.1.1",
- "iroh-quinn-udp",
  "js-sys",
  "libc",
  "n0-error",
@@ -3941,9 +3880,10 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.28.0",
+ "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
+ "noq-udp",
  "objc2-core-foundation",
  "objc2-system-configuration",
  "pin-project-lite",
@@ -3979,6 +3919,68 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "noq"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df966fb44ac763bc86da97fa6c811c54ae82ef656575949f93c6dae0c9f09bf"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "noq-proto",
+ "noq-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-proto"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c61b72abd670eebc05b5cf720e077b04a3ef3354bc7bc19f1c3524cb424db7b"
+dependencies = [
+ "aes-gcm",
+ "bytes",
+ "derive_more 2.1.1",
+ "enum-assoc",
+ "fastbloom",
+ "getrandom 0.3.4",
+ "identity-hash",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "slab",
+ "sorted-index-buffer",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-udp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9be4fedd6b98f3ba82ccd3506f4d0219fb723c3f97c67e12fe1494aa020e44"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4731,6 +4733,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4741,9 +4755,9 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2a8825353ace3285138da3378b1e21860d60351942f7aa3b99b13b41f80318"
+checksum = "74748bc706fa6b6aebac6bbe0bbe0de806b384cb5c557ea974f771360a4e3858"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6459,11 +6473,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -6481,9 +6495,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -7791,6 +7805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -25,7 +25,7 @@ const DEFAULT_TRACING_DIRECTIVES: &str =
     "warn,kukuri_desktop_tauri_lib=info,kukuri_app_api=info";
 const DEFAULT_SUPPRESS_DIRECTIVES: &[&str] = &[
     "mainline::rpc::socket=error",
-    "iroh_quinn_proto::connection=error",
+    "noq_proto::connection=error",
     "iroh::socket::remote_map::remote_state=error",
     "iroh_docs::engine::live=error",
     "iroh_gossip::net=error",
@@ -671,7 +671,7 @@ mod tests {
             "expected explicit target override to be preserved"
         );
         assert!(!directives.contains("iroh_docs::engine::live=error"));
-        assert!(directives.contains("iroh_quinn_proto::connection=error"));
+        assert!(directives.contains("noq_proto::connection=error"));
         assert!(directives.contains("mainline::rpc::socket=error"));
     }
 }

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -2627,13 +2627,18 @@ mod tests {
         }
     }
 
-    fn public_replication_retry_schedule(step_timeout: Duration) -> (usize, Duration) {
-        let attempts =
-            if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
-                3
-            } else {
-                1
-            };
+    fn public_replication_retry_schedule(
+        step_timeout: Duration,
+        same_author_shared_identity: bool,
+    ) -> (usize, Duration) {
+        let attempts = if cfg!(target_os = "windows")
+            || std::env::var_os("GITHUB_ACTIONS").is_some()
+            || same_author_shared_identity
+        {
+            3
+        } else {
+            1
+        };
         let per_attempt_timeout = if attempts > 1 {
             Duration::from_millis(
                 (step_timeout.as_millis() / attempts as u128)
@@ -2668,8 +2673,18 @@ mod tests {
         content_prefix: &str,
         timeout_label: &str,
     ) -> String {
-        let (attempts, attempt_timeout) =
-            public_replication_retry_schedule(runtime_replication_timeout());
+        let same_author_shared_identity = publisher
+            .get_sync_status()
+            .await
+            .ok()
+            .zip(subscriber.get_sync_status().await.ok())
+            .is_some_and(|(publisher_status, subscriber_status)| {
+                publisher_status.local_author_pubkey == subscriber_status.local_author_pubkey
+            });
+        let (attempts, attempt_timeout) = public_replication_retry_schedule(
+            runtime_replication_timeout(),
+            same_author_shared_identity,
+        );
         let scope = TimelineScope::Public;
         let mut last_error = None;
 

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -6178,6 +6178,199 @@ mod tests {
             .expect("runtime b shutdown timeout");
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn community_node_connectivity_assist_syncs_public_timeline_with_shared_identity() {
+        let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
+            .await
+            .expect("relay server");
+        let dir = tempdir().expect("tempdir");
+        let db_a = dir.path().join("community-relay-shared-a.db");
+        let db_b = dir.path().join("community-relay-shared-b.db");
+        let shared_keys = KukuriKeys::generate();
+        let shared_secret = shared_keys.export_secret_hex();
+        fs::write(
+            db_a.with_extension("identity-key"),
+            shared_secret.as_bytes(),
+        )
+        .expect("persist shared identity key a");
+        fs::write(db_a.with_extension("identity-store"), b"file")
+            .expect("persist shared identity backend a");
+        fs::write(
+            db_b.with_extension("identity-key"),
+            shared_secret.as_bytes(),
+        )
+        .expect("persist shared identity key b");
+        fs::write(db_b.with_extension("identity-store"), b"file")
+            .expect("persist shared identity backend b");
+
+        let runtime_a = DesktopRuntime::new_with_config_and_identity(
+            &db_a,
+            TransportNetworkConfig::loopback(),
+            IdentityStorageMode::FileOnly,
+        )
+        .await
+        .expect("runtime a");
+        let runtime_b = DesktopRuntime::new_with_config_and_identity(
+            &db_b,
+            TransportNetworkConfig::loopback(),
+            IdentityStorageMode::FileOnly,
+        )
+        .await
+        .expect("runtime b");
+
+        let status_a = runtime_a.get_sync_status().await.expect("status a");
+        let status_b = runtime_b.get_sync_status().await.expect("status b");
+        assert_eq!(status_a.local_author_pubkey, status_b.local_author_pubkey);
+
+        let endpoint_a = status_a.discovery.local_endpoint_id;
+        let endpoint_b = status_b.discovery.local_endpoint_id;
+        let ticket_a = runtime_a
+            .local_peer_ticket()
+            .await
+            .expect("ticket a")
+            .expect("ticket a value");
+        let ticket_b = runtime_b
+            .local_peer_ticket()
+            .await
+            .expect("ticket b")
+            .expect("ticket b value");
+        let addr_hint_a = ticket_a
+            .split_once('@')
+            .map(|(_, addr)| addr.to_string())
+            .expect("addr hint a");
+        let addr_hint_b = ticket_b
+            .split_once('@')
+            .map(|(_, addr)| addr.to_string())
+            .expect("addr hint b");
+        let base_url = "https://community.example.com";
+
+        *runtime_a.community_node_config.lock().await = CommunityNodeConfig {
+            nodes: vec![CommunityNodeNodeConfig {
+                base_url: base_url.to_string(),
+                resolved_urls: Some(
+                    CommunityNodeResolvedUrls::new(
+                        base_url,
+                        vec![relay_url.to_string()],
+                        vec![
+                            CommunityNodeSeedPeer::new(
+                                endpoint_b.as_str(),
+                                Some(addr_hint_b.clone()),
+                            )
+                            .expect("seed peer b"),
+                        ],
+                    )
+                    .expect("resolved urls a"),
+                ),
+            }],
+        };
+        *runtime_b.community_node_config.lock().await = CommunityNodeConfig {
+            nodes: vec![CommunityNodeNodeConfig {
+                base_url: base_url.to_string(),
+                resolved_urls: Some(
+                    CommunityNodeResolvedUrls::new(
+                        base_url,
+                        vec![relay_url.to_string()],
+                        vec![
+                            CommunityNodeSeedPeer::new(
+                                endpoint_a.as_str(),
+                                Some(addr_hint_a.clone()),
+                            )
+                            .expect("seed peer a"),
+                        ],
+                    )
+                    .expect("resolved urls b"),
+                ),
+            }],
+        };
+
+        timeout(
+            Duration::from_secs(15),
+            runtime_a.apply_runtime_connectivity_assist(),
+        )
+        .await
+        .expect("apply assist a timeout")
+        .expect("apply assist a");
+        timeout(
+            Duration::from_secs(15),
+            runtime_a.apply_effective_seed_peers(),
+        )
+        .await
+        .expect("apply seed peers a timeout")
+        .expect("apply seed peers a");
+        timeout(
+            Duration::from_secs(15),
+            runtime_b.apply_runtime_connectivity_assist(),
+        )
+        .await
+        .expect("apply assist b timeout")
+        .expect("apply assist b");
+        timeout(
+            Duration::from_secs(15),
+            runtime_b.apply_effective_seed_peers(),
+        )
+        .await
+        .expect("apply seed peers b timeout")
+        .expect("apply seed peers b");
+
+        let topic = "kukuri:topic:community-node-relay-assist-shared";
+        let scope = TimelineScope::Public;
+        let _ = timeout(
+            Duration::from_secs(15),
+            runtime_a.list_timeline(ListTimelineRequest {
+                topic: topic.to_string(),
+                scope: scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            }),
+        )
+        .await
+        .expect("subscribe a timeout")
+        .expect("subscribe a");
+        let _ = timeout(
+            Duration::from_secs(15),
+            runtime_b.list_timeline(ListTimelineRequest {
+                topic: topic.to_string(),
+                scope: scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            }),
+        )
+        .await
+        .expect("subscribe b timeout")
+        .expect("subscribe b");
+
+        wait_for_connected_topic_peer_count(
+            &runtime_a,
+            topic,
+            1,
+            "community-node assist shared topic readiness timeout a",
+        )
+        .await;
+        wait_for_connected_topic_peer_count(
+            &runtime_b,
+            topic,
+            1,
+            "community-node assist shared topic readiness timeout b",
+        )
+        .await;
+
+        let _object_id = replicate_public_post_with_retry(
+            &runtime_a,
+            &runtime_b,
+            topic,
+            "community relay shared hello",
+            "community-node assist shared identity post sync timeout",
+        )
+        .await;
+
+        timeout(runtime_shutdown_timeout(), runtime_a.shutdown())
+            .await
+            .expect("runtime a shutdown timeout");
+        timeout(runtime_shutdown_timeout(), runtime_b.shutdown())
+            .await
+            .expect("runtime b shutdown timeout");
+    }
+
     #[tokio::test]
     async fn community_node_status_refresh_updates_bootstrap_seed_peers() {
         let dir = tempdir().expect("tempdir");

--- a/crates/docs-sync/src/lib.rs
+++ b/crates/docs-sync/src/lib.rs
@@ -31,6 +31,9 @@ use tokio::time::timeout;
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::{info, warn};
 
+#[cfg(test)]
+use iroh::tls::CaRootsConfig;
+
 pub type DocEventStream = Pin<Box<dyn Stream<Item = Result<DocEvent>> + Send>>;
 type ReplicaRecords = HashMap<String, Vec<u8>>;
 type MemoryReplicaMap = HashMap<String, ReplicaRecords>;
@@ -206,14 +209,15 @@ impl IrohDocsNode {
         let relay_config = relay_config.normalized();
         let relay_urls = Arc::new(StdRwLock::new(relay_config.parsed_relay_urls()?));
         let mut endpoint_builder = build_endpoint_builder(
-            Endpoint::empty_builder(relay_config.relay_mode()?),
+            Endpoint::empty_builder().relay_mode(relay_config.relay_mode()?),
             &discovery,
             Some(&dht_options),
             Arc::clone(&relay_urls),
         )?;
         #[cfg(test)]
         {
-            endpoint_builder = endpoint_builder.insecure_skip_relay_cert_verify(true);
+            endpoint_builder =
+                endpoint_builder.ca_roots_config(CaRootsConfig::insecure_skip_verify());
         }
         if let Some(secret_key) = endpoint_secret {
             endpoint_builder = endpoint_builder.secret_key(secret_key);

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -2276,6 +2276,31 @@ fn private_replication_retry_schedule(step_timeout: Duration) -> (usize, Duratio
     (attempts, per_attempt_timeout)
 }
 
+fn public_replication_retry_schedule(
+    step_timeout: Duration,
+    same_author_shared_identity: bool,
+) -> (usize, Duration) {
+    let attempts = if cfg!(target_os = "windows")
+        || std::env::var_os("GITHUB_ACTIONS").is_some()
+        || same_author_shared_identity
+    {
+        3
+    } else {
+        1
+    };
+    let per_attempt_timeout = if attempts > 1 {
+        Duration::from_millis(
+            (step_timeout.as_millis() / attempts as u128)
+                .max(1)
+                .try_into()
+                .expect("public replication timeout fits in u64"),
+        )
+    } else {
+        step_timeout
+    };
+    (attempts, per_attempt_timeout)
+}
+
 struct PublicReplicationLabels<'a> {
     failure: &'a str,
     publisher: &'a str,
@@ -2290,7 +2315,16 @@ async fn replicate_public_post_with_retry(
     step_timeout: Duration,
     labels: PublicReplicationLabels<'_>,
 ) -> Result<String> {
-    let (attempts, attempt_timeout) = private_replication_retry_schedule(step_timeout);
+    let same_author_shared_identity = publisher
+        .get_sync_status()
+        .await
+        .ok()
+        .zip(subscriber.get_sync_status().await.ok())
+        .is_some_and(|(publisher_status, subscriber_status)| {
+            publisher_status.local_author_pubkey == subscriber_status.local_author_pubkey
+        });
+    let (attempts, attempt_timeout) =
+        public_replication_retry_schedule(step_timeout, same_author_shared_identity);
     let mut last_error = None;
 
     for attempt in 1..=attempts {

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -11,7 +11,8 @@ use async_trait::async_trait;
 use chrono::Utc;
 use futures_util::{Stream, StreamExt};
 use iroh::address_lookup::{
-    AddressLookup, DhtAddressLookup, EndpointInfo, Item as AddressLookupItem, MemoryLookup,
+    AddrFilter, AddressLookup, DhtAddressLookup, EndpointInfo, Item as AddressLookupItem,
+    MemoryLookup,
 };
 use iroh::endpoint::Builder as EndpointBuilder;
 use iroh::protocol::Router;
@@ -29,6 +30,9 @@ use tokio::task::JoinHandle;
 use tokio::time::{sleep, timeout};
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::{debug, warn};
+
+#[cfg(test)]
+use iroh::tls::CaRootsConfig;
 
 pub type HintStream = Pin<Box<dyn Stream<Item = HintEnvelope> + Send>>;
 
@@ -1006,7 +1010,7 @@ async fn bind_endpoint_with_options(
 ) -> Result<(Endpoint, Arc<MemoryLookup>, Option<JoinHandle<()>>)> {
     let discovery = Arc::new(MemoryLookup::new());
     let mut builder = build_endpoint_builder(
-        Endpoint::empty_builder(relay_config.relay_mode()?),
+        Endpoint::empty_builder().relay_mode(relay_config.relay_mode()?),
         &discovery,
         Some(dht_options),
         relay_urls,
@@ -1016,7 +1020,7 @@ async fn bind_endpoint_with_options(
     }
     #[cfg(test)]
     {
-        builder = builder.insecure_skip_relay_cert_verify(true);
+        builder = builder.ca_roots_config(CaRootsConfig::insecure_skip_verify());
     }
     builder = apply_bind(builder, bind_addr)?;
     let endpoint = builder
@@ -1399,7 +1403,7 @@ pub fn build_endpoint_builder(
     builder = builder.address_lookup(RelayFallbackLookup::new(relay_urls));
     if let Some(dht_options) = dht_options.filter(|options| options.enabled) {
         let mut dht_builder = DhtAddressLookup::builder()
-            .include_direct_addresses(true)
+            .addr_filter(AddrFilter::unfiltered())
             .no_publish();
         if let Some(client) = dht_options.client.as_ref() {
             dht_builder = dht_builder.client(client.clone());
@@ -2721,7 +2725,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn gossip_low_level_roundtrip_baseline() {
-        let endpoint_a = Endpoint::empty_builder(RelayMode::Disabled)
+        let endpoint_a = Endpoint::empty_builder()
+            .relay_mode(RelayMode::Disabled)
             .bind_addr(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
             .expect("bind addr a")
             .bind()
@@ -2732,7 +2737,8 @@ mod tests {
             .accept(GOSSIP_ALPN, gossip_a.clone())
             .spawn();
 
-        let endpoint_b = Endpoint::empty_builder(RelayMode::Disabled)
+        let endpoint_b = Endpoint::empty_builder()
+            .relay_mode(RelayMode::Disabled)
             .bind_addr(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
             .expect("bind addr b")
             .bind()
@@ -2746,8 +2752,14 @@ mod tests {
         let discovery = MemoryLookup::new();
         discovery.add_endpoint_info(endpoint_a.addr());
         discovery.add_endpoint_info(endpoint_b.addr());
-        endpoint_a.address_lookup().add(discovery.clone());
-        endpoint_b.address_lookup().add(discovery);
+        endpoint_a
+            .address_lookup()
+            .expect("address lookup a")
+            .add(discovery.clone());
+        endpoint_b
+            .address_lookup()
+            .expect("address lookup b")
+            .add(discovery);
 
         let topic = topic_to_gossip_id(&TopicId::new("kukuri:topic:baseline"));
         let peer_a = endpoint_a.id();
@@ -2812,6 +2824,8 @@ mod tests {
                 text: "hello baseline".into(),
             }
         );
+        endpoint_a.close().await;
+        endpoint_b.close().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/progress/2026-03-10-foundation.md
+++ b/docs/progress/2026-03-10-foundation.md
@@ -67,7 +67,7 @@
 - access token を endpoint-bound にし、community-node bootstrap が same-subscriber でも current endpoint だけ除外して他 endpoint を seed peer に返すようにした
 - discovery diagnostics を `configured seed / community bootstrap seed / manual ticket` に分離し、relay-only community-node path の接続元を UI と app-api status で判別できるようにした
 - community-node bootstrap peer registration を TTL 付き multi-endpoint table へ更新し、authenticated heartbeat で stale peer を prune/refresh できるようにした
-- desktop の Tauri backend で `mainline::rpc::socket`, `iroh_quinn_proto::connection`, `iroh::socket::remote_map::remote_state`, `iroh_docs::engine::live`, `iroh_gossip::net` を既定で `error` へ落とし、community-node connectivity assist 検証時の iroh internal warning noise を抑制した
+- desktop の Tauri backend で `mainline::rpc::socket`, `noq_proto::connection`, `iroh::socket::remote_map::remote_state`, `iroh_docs::engine::live`, `iroh_gossip::net` を既定で `error` へ落とし、community-node connectivity assist 検証時の iroh internal warning noise を抑制した
 - social graph v1 として `author::<pubkey>` replica を正本にした profile / follow-edge / local relationship projection を導入し、desktop で `profile editor`, `follow/unfollow`, `mutual`, `friend of friend` 表示まで通した
 - community-node relay-only path で `seed_peers` が空のまま固まる経路に bootstrap metadata retry を追加し、topic replica docs sync の self-heal と seed update 時の gossip topic 再購読を入れて `0 clients -> 3 clients simultaneous start` の固着を解消した
 - `ADR 0012` を topic-first private channel audience v1 の現状仕様に更新し、`invite_only` / `friend_only` / `friend_plus`、epoch-aware rotate / freeze、`joined via` / `sharing_state` 契約を固定した

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -165,7 +165,7 @@ npx pnpm@10.16.1 tauri:dev
 ```
 
 - `pnpm tauri dev` / `pnpm tauri:dev` は loopback の空き port を自動選択し、5173 が使用中なら次の空き port へ退避する。
-- desktop の Tauri backend は `mainline::rpc::socket`, `iroh_quinn_proto::connection`, `iroh::socket::remote_map::remote_state`, `iroh_docs::engine::live`, `iroh_gossip::net` を既定で `error` へ落としている。community-node connectivity assist / DHT / docs sync の内部 warning を調べたいときだけ `RUST_LOG=warn,mainline::rpc::socket=warn,iroh_quinn_proto::connection=warn,iroh::socket::remote_map::remote_state=warn,iroh_docs::engine::live=warn,iroh_gossip::net=warn` を明示する。
+- desktop の Tauri backend は `mainline::rpc::socket`, `noq_proto::connection`, `iroh::socket::remote_map::remote_state`, `iroh_docs::engine::live`, `iroh_gossip::net` を既定で `error` へ落としている。community-node connectivity assist / DHT / docs sync の内部 warning を調べたいときだけ `RUST_LOG=warn,mainline::rpc::socket=warn,noq_proto::connection=warn,iroh::socket::remote_map::remote_state=warn,iroh_docs::engine::live=warn,iroh_gossip::net=warn` を明示する。
 
 ## Windows 前提
 - Windows prerequisites は Tauri 公式手順を使う: <https://v2.tauri.app/start/prerequisites/#windows>


### PR DESCRIPTION
## Summary
- upgrade workspace iroh crates to iroh 0.97.0 / iroh-blobs 0.99.0 and refresh both lockfiles
- update transport and docs-sync to the new iroh endpoint/address-lookup APIs and switch Tauri tracing suppression to noq_proto::connection
- stabilize the shared-identity community-node scenario and add a focused shared-identity relay-assist regression test

## Testing
- cargo check --workspace --all-targets
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
- cargo fmt --check
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml tracing_directives -- --nocapture
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml explicit_rust_log_keeps_target_specific_override -- --nocapture
- cargo test -p kukuri-desktop-runtime community_node_connectivity_assist_syncs_public_timeline_with_shared_identity -- --nocapture
- ./target/debug/xtask cn-check
- ./target/debug/xtask cn-test
- ./target/debug/xtask e2e-smoke
- ./target/debug/xtask scenario community_node_public_connectivity
- ./target/debug/xtask scenario community_node_multi_device_connectivity
- CI=1 npx pnpm@10.16.1 lint
- CI=1 npx pnpm@10.16.1 typecheck
- CI=1 npx pnpm@10.16.1 test

## Notes
- cargo xtask check reached the frontend lint step, but pnpm lint hung under the WSL + nvm4w execution path, so the equivalent frontend checks were run directly instead.