### PR TITLE
docs: refresh UI/UX workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,13 @@
 - `docs/README.md`
 - `docs/runbooks/dev.md`
 - `docs/progress/2026-03-10-foundation.md`
+- `docs/DESIGN.md`（UI/UX 作業時）
 
 ## 作業対象
 - 新規実装・修正は原則 root workspace の現行実装のみ。
 - `legacy/` は参照専用。移植かユーザー明示依頼がない限り編集しない。
-- Phase6 着手前の現行スコープでは Windows 対応、DHT discovery、community-node 連携を追加しない。
+- 現行スコープの最新状態は `docs/progress/2026-03-10-foundation.md` を優先する。
+- Windows desktop support、seeded DHT discovery、community-node connectivity/auth、social graph v1、private channel audience v1 は current scope に含まれる。
 
 ## 実行入口
 - `cargo xtask doctor`
@@ -23,6 +25,8 @@
 - 仕様: `docs/adr/`
 - 実行手順: `docs/runbooks/`
 - 現状: `docs/progress/`
+- デザインルール: `docs/DESIGN.md`
+- UI review record: `docs/ui-reviews/`
 - 振る舞い: `crates/*` のテストと `harness/scenarios/`
 
 ## ガードレール

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,14 +35,17 @@ npx pnpm@10.16.1 dev
 
 - root workspace が実装対象です。
 - `legacy/` は参照専用です。
-- MVP 中は Linux だけを required target にします。
-- Windows、DHT、community-node 連携は後続フェーズです。
+- 現在の desktop target は Linux / Windows です。
+- 現在の network scope には static-peer、seeded DHT、community-node connectivity/auth が含まれます。
+- UI/UX 作業は `docs/adr/0014-uiux-dev-flow.md` と `docs/DESIGN.md` に従います。
 - 新規参加者は `AGENTS.md -> docs/*` だけで着手できます。
 
 ## ドキュメント
 
 - overview: `docs/README.md`
 - decision: `docs/adr/0001-linux-first-mvp.md`
+- ui/ux flow: `docs/adr/0014-uiux-dev-flow.md`
+- design rules: `docs/DESIGN.md`
 - runbook: `docs/runbooks/dev.md`
 - progress: `docs/progress/2026-03-10-foundation.md`
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,17 @@ npx pnpm@10.16.1 dev
 
 - root workspace is the active implementation surface.
 - `legacy/` is reference-only.
-- Linux is the only required target during MVP.
-- Windows, DHT discovery, and community-node integration are deferred.
+- current desktop targets are Linux and Windows.
+- current networking scope includes static-peer, seeded DHT, and community-node connectivity/auth.
+- UI/UX work should follow `docs/adr/0014-uiux-dev-flow.md` and `docs/DESIGN.md`.
 - `AGENTS.md -> docs/*` is sufficient for new contributors.
 
 ## Docs
 
 - overview: `docs/README.md`
 - decision: `docs/adr/0001-linux-first-mvp.md`
+- ui/ux flow: `docs/adr/0014-uiux-dev-flow.md`
+- design rules: `docs/DESIGN.md`
 - runbook: `docs/runbooks/dev.md`
 - progress: `docs/progress/2026-03-10-foundation.md`
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,70 @@
+# kukuri UI/UX Design Rules
+
+## Purpose
+- この文書は、現行 kukuri workspace における UI proposal、review、implementation の既定ルールを定義する。
+- workflow 自体は `docs/adr/0014-uiux-dev-flow.md` が定義し、この文書はその中で使う design-system rule と review rule を定義する。
+
+## Applies To
+- `apps/desktop` の user-facing UI
+- Storybook story と UI review artifact
+- Codex が implementation patch と Figma review data を同時に生成する UI proposal
+
+## Required Workflow
+1. Codex が UI を新規提案または大きく改修する場合、先に Figma で proposal を作る。
+2. 一次レビューは Figma で行う。
+3. code review に耐える方向性が固まってから実装する。
+4. 変更の大きさとリスクに応じて Storybook、Vitest、Playwright、`cargo xtask` で検証する。
+5. merge された変更が user-facing behavior または design rule を変える場合は、`docs/ui-reviews/` に記録を残す。
+
+## Tooling Policy
+- Figma MCP は Codex-assisted UI proposal で required とする。Figma を primary review artifact にする。
+- 新規 UI と大きく触る既存 UI の標準 stack は Tailwind + shadcn/ui + Storybook にする。
+- Playwright は top-level user flow を変える変更、または複数 component をまたぐ回帰リスクが高い変更で required とする。
+- shadcn MCP は optional とする。対象 surface に標準 stack が入ってから使う。
+- shadcn MCP は implementation aid であり、review system でも Figma MCP の代替でもない。
+- Code Connect は optional とし、workflow の blocker にしない。
+
+## Review Artifacts
+- すべての UI proposal PR は Figma link を含む。
+- すべての UI proposal PR は、PR 上で直接 review できる preview image または short video を含む。
+- すべての UI proposal PR は、変更する user flow の短い summary を含む。
+- すべての UI proposal PR は、Shneiderman checklist の結果または例外理由を含む。
+- public PR reader が Figma edit 権限なしでも proposal を理解できる状態を必須にする。
+
+## Design System Rules
+- token から始める。color、typography、spacing、radius、border、shadow、motion は one-off hard-code ではなく shared token layer から取る。
+- primitive を再利用する。同じ pattern が 2 回以上出たら、markup と style を複製せず reusable component に昇格させる。
+- naming を安定させる。component 名、variant 名、prop 名は一時的な実装都合ではなく product 上の意味を表す。
+- product UI と diagnostics UI を分離する。discovery、sync、community-node などの observability panel は、primary user flow よりも視覚的・構造的に後景へ置く。
+- state を設計し切る。意味のある surface には loading、empty、error、success または interactive state を定義する。
+- desktop window resize に耐える。最大化 window だけを前提にせず、狭い desktop 幅でも unreadable overflow を起こさない。
+- keyboard access を守る。primary action、navigation、dialog、menu、form は mouse なしでも到達・理解できるようにする。
+- visible feedback を残す。focus、hover、selected、disabled、pending、error は識別できるようにする。
+- motion は意図的に使う。state 変化や hierarchy を説明するために使い、過剰にせず reduced motion も考慮する。
+
+## shadcn Usage Rules
+- shadcn/ui は base layer として扱い、完成済み design system と見なさない。
+- registry component を追加するときは、merge 前に token、命名、variant、state handling、accessibility を kukuri に合わせる。
+- kukuri の terminology、layout、state model と衝突する registry default はそのまま採用しない。
+- 新しい reusable component と、大きく改修した reusable component には Storybook story を付ける。
+- one-off の glue UI は、再利用を想定せず既存 test で十分守られている場合に限って Storybook を省略できる。
+
+## Shneiderman Checklist
+- Consistency: topic、thread、channel、settings をまたいでも、似た action、label、layout は同じように振る舞うこと。
+- Shortcuts for frequent users: 繰り返し操作は click 数削減、context 維持、keyboard-friendly flow により高速化できること。
+- Informative feedback: save、publish、load、sync wait、consent state、failure を UI が明確に伝えること。
+- Dialog closure: multi-step flow は、完了状態または次に取るべき action を明示して終わること。
+- Error prevention: 危険または無効な操作は commit 前に防止または明確化すること。
+- Easy reversal: user が transient action を取り消すか、mistake から recovery できること。
+- Internal locus of control: unexplained reset、forced context jump、hidden mode switch で user を驚かせないこと。
+- Reduce short-term memory load: panel をまたいでも identifier、前の選択、隠れた前提条件を user に覚えさせ過ぎないこと。
+
+## Validation Expectations
+- Storybook は、実装開始後の reusable component review surface の既定値とする。
+- Vitest は component と UI logic の既定 frontend regression layer として維持する。
+- Playwright は、Storybook と Vitest だけでは守りにくい component 境界越えの変更に追加する。
+- `cargo xtask` は workspace 全体の integration gate として維持し、frontend-only tooling で置き換えない。
+
+## Exceptions
+- この文書からの例外は PR description に明記する。
+- 例外が受け入れ済み product direction を変える場合は、`docs/ui-reviews/` に短い record を追加する。

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,16 +6,27 @@
 - `legacy/docs` は参照専用の履歴として扱う。
 
 ## 優先参照順
-1. `docs/adr/0001-linux-first-mvp.md`
-2. `docs/adr/0007-windows-desktop-support.md`
-3. `docs/runbooks/dev.md`
-4. `docs/progress/2026-03-10-foundation.md`
-5. `harness/scenarios/`
-6. `docs/adr/0003-image-post-data-classification.md`
-7. `docs/adr/0004-video-post-data-classification.md`
+1. `docs/progress/2026-03-10-foundation.md`
+2. `docs/runbooks/dev.md`
+3. `docs/adr/0001-linux-first-mvp.md`
+4. `docs/adr/0007-windows-desktop-support.md`
+5. `docs/adr/0008-dht-discovery-data-classification.md`
+6. `docs/adr/0009-community-node-relay-auth-data-classification.md`
+7. `docs/adr/0014-uiux-dev-flow.md`
+8. `docs/DESIGN.md`
+9. `harness/scenarios/`
+10. `docs/adr/0003-image-post-data-classification.md`
+11. `docs/adr/0004-video-post-data-classification.md`
 
 ## 現在の対象
-- `desktop + core + store + static-peer transport + harness`
+- `desktop + core + store + docs-sync + blob-service + desktop-runtime + cn-* + harness`
 - desktop target は Linux / Windows
+- current connectivity scope は `static-peer + seeded DHT + community-node connectivity/auth`
+- current product scope には `social graph v1 + private channel audience v1` を含む
 - root 実行入口は `cargo xtask ...`
 - 新 feature 着手前に `docs/adr/0002-feature-data-classification-template.md` を埋める。
+
+## UI/UX
+- flow: `docs/adr/0014-uiux-dev-flow.md`
+- rules: `docs/DESIGN.md`
+- accepted review records: `docs/ui-reviews/`

--- a/docs/adr/0014-uiux-dev-flow.md
+++ b/docs/adr/0014-uiux-dev-flow.md
@@ -1,0 +1,37 @@
+# ADR 0014: 本番向け UI/UX 開発フロー
+
+## Status
+Accepted
+
+## Context
+- 現行 desktop frontend は、依然として `apps/desktop/src/App.tsx` と `apps/desktop/src/styles.css` を中心に構成されている。
+- repo は public で、外部 contributor からの review も想定する。UI proposal は local 実装差分だけでなく、PR 上で読める review artifact を持つ必要がある。
+- Codex が UI を提案する場合、code review より前に人間が一次レビューできる面が必要であり、その正本は Figma に置く。
+- 現在の検証基盤は Vitest、`cargo xtask`、GitHub Actions が中心であり、新しい frontend tooling はこの品質ゲートを置き換えずに補完する必要がある。
+- 今後の UI 実装は Tailwind + shadcn/ui + Storybook へ寄せるが、現行 app はまだ全面移行されていない。
+- Figma MCP は review 用 design data の生成に使える。shadcn MCP と Code Connect は将来的な支援手段だが、workflow の前提条件にはしない。
+
+## Decision
+- Codex が作る UI proposal は、実装パッチに加えて Figma data を作成または更新しなければならない。人間の一次レビューは Figma 上で行う。
+- UI proposal PR には次を必須にする。
+  - Figma link
+  - PR 上で読める preview image または short video
+  - 変更する user flow の短い summary
+  - Shneiderman の 8 つの黄金律に対する checklist 結果、または例外理由
+- 新規 UI と大きく触る既存 UI の標準 stack は Tailwind + shadcn/ui + Storybook にする。
+- 未着手の既存 UI は、対象 surface を触るまで現行の `App.tsx` / `styles.css` path に残してよい。全面移行は前提条件にしない。
+- Playwright は、top-level user flow を変える変更、または複数 component をまたぐ回帰リスクが高い変更に限って required にする。Vitest と既存 `cargo xtask` lane は baseline gate として維持する。
+- 製品 UI と diagnostics UI は、設計と review の両方で分離する。discovery、community-node、sync などの observability surface を primary product flow として扱わない。
+- tool の優先順位は次に固定する。
+  - Figma MCP: required
+  - shadcn MCP: 標準 stack 導入後の optional implementation aid
+  - Code Connect: optional future accelerator。前提条件にしない
+- UI/UX の guardrail、review checklist、例外ポリシーは `docs/DESIGN.md` に置く。
+- 採用済み UI review record は `docs/ui-reviews/` に残す。
+
+## Consequences
+- code だけ、または文章だけの UI proposal は不十分になる。Figma review data と PR-visible preview が必須になる。
+- Figma edit 権限を持たない contributor でも、PR に summary と preview があれば public repo 上で UI review に参加できる。
+- reusable component と major UI refactor には Storybook story が必要になる。one-off の glue UI は、再利用を想定せず既存 test で十分守られている場合に限って Storybook を省略できる。
+- shadcn MCP は component 探索や registry 作業の加速には使えるが、registry から入れた component をそのまま採用せず、local token、命名、variant、state、accessibility へ合わせる必要がある。
+- Code Connect は plan と permission 条件が満たされた後に追加できるが、これがなくても workflow は成立し続けなければならない。

--- a/docs/ui-reviews/README.md
+++ b/docs/ui-reviews/README.md
@@ -1,0 +1,33 @@
+# UI Review Records
+
+この directory は、採用済み UI review decision の短い record を保存する。
+
+## Record を追加する条件
+- merge された PR が user-facing UI behavior または layout を大きく変える。
+- merge された PR が reusable design rule を追加または変更する。
+- merge された PR が `docs/DESIGN.md` の例外付きで承認される。
+
+## File Naming
+- `YYYY-MM-DD-slug.md` を使う。
+
+## 必須項目
+- PR link または identifier
+- 一次 review に使った Figma link
+- 採用された変更の short summary
+- review result
+- 承認された例外
+- Storybook、Vitest、Playwright、`cargo xtask` などの validation note
+
+## Minimal Template
+```md
+# YYYY-MM-DD slug
+
+- PR:
+- Figma:
+- Summary:
+- Review result:
+- Exceptions:
+- Validation:
+```
+
+preview image は原則 PR に置く。この directory は media archive ではなく durable な decision record を置く。


### PR DESCRIPTION
## Summary
- rewrite ADR 0014 into a current ADR for production UI/UX workflow
- add docs/DESIGN.md and docs/ui-reviews/README.md for design rules and review records
- update AGENTS and README pointers to reflect current scope and the new UI/UX docs

## Testing
- git diff --check
