### PR TITLE
Fix Windows migration checksum mismatches

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 
 # Ensure bash scripts stay executable on Linux
 *.sh text eol=lf
+*.sql text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2745,7 +2745,9 @@ dependencies = [
  "kukuri-core",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "sqlx",
+ "tempfile",
  "tokio",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -273,6 +273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -3241,6 +3242,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
@@ -3428,6 +3430,7 @@ dependencies = [
  "kukuri-core",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "sqlx",
  "tokio",
 ]
@@ -5473,7 +5476,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5608,7 +5611,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -7582,6 +7585,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -9,7 +9,11 @@ anyhow.workspace = true
 async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
 kukuri-core = { path = "../core" }
+
+[dev-dependencies]
+tempfile.workspace = true
 

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -11,9 +11,12 @@ use kukuri_core::{
     parse_follow_edge, parse_profile,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha384};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Pool, Row, Sqlite};
 use tokio::sync::RwLock;
+
+static STORE_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TimelineCursor {
@@ -197,7 +200,7 @@ impl SqliteStore {
             .await
             .with_context(|| format!("failed to connect sqlite database: {database_url}"))?;
 
-        sqlx::migrate!("./migrations").run(&pool).await?;
+        run_store_migrations(&pool).await?;
 
         Ok(Self { pool })
     }
@@ -212,7 +215,7 @@ impl SqliteStore {
             .await
             .with_context(|| format!("failed to connect sqlite database: {}", path.display()))?;
 
-        sqlx::migrate!("./migrations").run(&pool).await?;
+        run_store_migrations(&pool).await?;
 
         Ok(Self { pool })
     }
@@ -228,6 +231,108 @@ impl SqliteStore {
     pub async fn close(&self) {
         self.pool.close().await;
     }
+}
+
+async fn run_store_migrations(pool: &Pool<Sqlite>) -> Result<()> {
+    repair_line_ending_only_migration_checksums(pool).await?;
+    STORE_MIGRATOR.run(pool).await?;
+    Ok(())
+}
+
+async fn repair_line_ending_only_migration_checksums(pool: &Pool<Sqlite>) -> Result<()> {
+    if !sqlite_table_exists(pool, "_sqlx_migrations").await? {
+        return Ok(());
+    }
+
+    let applied_migrations = sqlx::query_as::<_, (i64, Vec<u8>)>(
+        "SELECT version, checksum FROM _sqlx_migrations ORDER BY version",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for (version, applied_checksum) in applied_migrations {
+        let Some(migration) = STORE_MIGRATOR.iter().find(|migration| {
+            migration.version == version && !migration.migration_type.is_down_migration()
+        }) else {
+            continue;
+        };
+
+        if applied_checksum.as_slice() == migration.checksum.as_ref() {
+            continue;
+        }
+
+        if checksum_matches_line_ending_variant(&applied_checksum, migration.sql.as_ref()) {
+            repair_migration_checksum(pool, version).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn repair_migration_checksum(pool: &Pool<Sqlite>, version: i64) -> Result<()> {
+    let migration = STORE_MIGRATOR
+        .iter()
+        .find(|migration| {
+            migration.version == version && !migration.migration_type.is_down_migration()
+        })
+        .with_context(|| format!("embedded migration {version} is missing"))?;
+    let result = sqlx::query("UPDATE _sqlx_migrations SET checksum = ?1 WHERE version = ?2")
+        .bind(migration.checksum.as_ref())
+        .bind(version)
+        .execute(pool)
+        .await?;
+    if result.rows_affected() != 1 {
+        anyhow::bail!("expected to repair one migration row for version {version}");
+    }
+    Ok(())
+}
+
+async fn sqlite_table_exists(pool: &Pool<Sqlite>, name: &str) -> Result<bool> {
+    let exists = sqlx::query_scalar::<_, i64>(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1 LIMIT 1",
+    )
+    .bind(name)
+    .fetch_optional(pool)
+    .await?
+    .is_some();
+    Ok(exists)
+}
+
+fn checksum_matches_line_ending_variant(applied_checksum: &[u8], sql: &str) -> bool {
+    let lf_sql = normalize_sql_line_endings(sql);
+    let lf_checksum = migration_checksum(lf_sql.as_str());
+    if applied_checksum == lf_checksum {
+        return true;
+    }
+
+    let crlf_sql = lf_sql.replace('\n', "\r\n");
+    let crlf_checksum = migration_checksum(crlf_sql.as_str());
+    applied_checksum == crlf_checksum
+}
+
+#[cfg(test)]
+fn alternate_line_ending_checksum(sql: &str, current_checksum: &[u8]) -> Option<Vec<u8>> {
+    let lf_sql = normalize_sql_line_endings(sql);
+    let lf_checksum = migration_checksum(lf_sql.as_str());
+    if lf_checksum != current_checksum {
+        return Some(lf_checksum);
+    }
+
+    let crlf_sql = lf_sql.replace('\n', "\r\n");
+    let crlf_checksum = migration_checksum(crlf_sql.as_str());
+    if crlf_checksum != current_checksum {
+        return Some(crlf_checksum);
+    }
+
+    None
+}
+
+fn normalize_sql_line_endings(sql: &str) -> String {
+    sql.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn migration_checksum(sql: &str) -> Vec<u8> {
+    Vec::from(Sha384::digest(sql.as_bytes()).as_slice())
 }
 
 #[async_trait]
@@ -1785,6 +1890,7 @@ mod tests {
         BlobHash, FollowEdgeStatus, PayloadRef, ReplicaId, TopicId, build_follow_edge_envelope,
         build_post_envelope, generate_keys,
     };
+    use tempfile::tempdir;
 
     #[tokio::test]
     async fn store_timeline_cursor_stable() {
@@ -2032,5 +2138,63 @@ mod tests {
             vec!["c".repeat(64)]
         );
         assert!(relationship.followed_by);
+    }
+
+    #[tokio::test]
+    async fn connect_file_repairs_line_ending_only_migration_checksum_mismatches() {
+        let tempdir = tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("store.db");
+        let store = SqliteStore::connect_file(&db_path)
+            .await
+            .expect("initialize sqlite store");
+        store.close().await;
+
+        let database_url = format!("sqlite://{}", db_path.display());
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await
+            .expect("reopen sqlite db");
+        for version in [20260319000000_i64, 20260319010000_i64] {
+            let migration = STORE_MIGRATOR
+                .iter()
+                .find(|migration| {
+                    migration.version == version && !migration.migration_type.is_down_migration()
+                })
+                .expect("embedded store migration");
+            let alternate_checksum =
+                alternate_line_ending_checksum(migration.sql.as_ref(), migration.checksum.as_ref())
+                    .expect("alternate line-ending checksum");
+            sqlx::query("UPDATE _sqlx_migrations SET checksum = ?1 WHERE version = ?2")
+                .bind(alternate_checksum)
+                .bind(version)
+                .execute(&pool)
+                .await
+                .expect("rewrite migration checksum to alternate line ending");
+        }
+        pool.close().await;
+
+        let reopened = SqliteStore::connect_file(&db_path)
+            .await
+            .expect("reopen store after repairing line-ending-only migration checksum mismatch");
+        for version in [20260319000000_i64, 20260319010000_i64] {
+            let stored_checksum = sqlx::query_scalar::<_, Vec<u8>>(
+                "SELECT checksum FROM _sqlx_migrations WHERE version = ?1",
+            )
+            .bind(version)
+            .fetch_one(reopened.pool())
+            .await
+            .expect("load repaired checksum");
+            let expected_checksum = STORE_MIGRATOR
+                .iter()
+                .find(|migration| {
+                    migration.version == version && !migration.migration_type.is_down_migration()
+                })
+                .expect("embedded store migration")
+                .checksum
+                .to_vec();
+
+            assert_eq!(stored_checksum, expected_checksum);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- repair SQLite migration checksums when the only mismatch is LF/CRLF line endings so Windows `tauri dev` can reopen existing app data
- reuse a shared store migrator and cover the checksum repair path with a regression test
- pin `*.sql` files to LF in `.gitattributes` and update lockfiles for the added checksum/test dependencies

## Testing
- cargo test -p kukuri-store --lib
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml