### PR TITLE
Implement desktop Phase 1 shell frame

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -177,6 +177,22 @@ function installFailedPosterGenerationMocks() {
   });
 }
 
+async function openSettingsDrawer(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByTestId('shell-settings-trigger'));
+  return await screen.findByRole('dialog', { name: 'Settings & diagnostics' });
+}
+
+async function openSettingsSection(
+  user: ReturnType<typeof userEvent.setup>,
+  section: 'profile' | 'connectivity' | 'discovery' | 'community-node'
+) {
+  const drawer = await openSettingsDrawer(user);
+  if (section !== 'profile') {
+    await user.click(within(drawer).getByTestId(`settings-section-${section}`));
+  }
+  return drawer;
+}
+
 test('desktop shell can publish and render a post', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
@@ -188,11 +204,13 @@ test('desktop shell can publish and render a post', async () => {
     expect(screen.getByText('hello desktop')).toBeInTheDocument();
   });
   expect(screen.getByText('Seeded DHT + direct peers')).toBeInTheDocument();
-  expect(screen.getByDisplayValue('peer1@127.0.0.1:7777')).toBeInTheDocument();
-  expect(screen.getByText('Configured Peers')).toBeInTheDocument();
-  expect(screen.getByText('Connected to all configured peers')).toBeInTheDocument();
-  expect(screen.getAllByText('peer-a').length).toBeGreaterThan(0);
   expect(screen.getByText('joined / peers: 1')).toBeInTheDocument();
+
+  const drawer = await openSettingsSection(user, 'connectivity');
+  expect(within(drawer).getByDisplayValue('peer1@127.0.0.1:7777')).toBeInTheDocument();
+  expect(within(drawer).getByText('Configured Peers')).toBeInTheDocument();
+  expect(within(drawer).getByText('Connected to all configured peers')).toBeInTheDocument();
+  expect(within(drawer).getAllByText('peer-a').length).toBeGreaterThan(0);
 });
 
 test('desktop shell can update discovery seeds', async () => {
@@ -203,14 +221,15 @@ test('desktop shell can update discovery seeds', async () => {
 
   render(<App api={api} />);
 
-  const seedEditor = screen.getByPlaceholderText('node_id or node_id@host:port');
+  const drawer = await openSettingsSection(user, 'discovery');
+  const seedEditor = within(drawer).getByPlaceholderText('node_id or node_id@host:port');
   await user.type(seedEditor, 'seed-peer-1');
-  await user.click(screen.getByRole('button', { name: 'Save Seeds' }));
+  await user.click(within(drawer).getByRole('button', { name: 'Save Seeds' }));
 
   await waitFor(() => {
     expect(setDiscoverySeeds).toHaveBeenCalledWith(['seed-peer-1']);
   });
-  expect(screen.getAllByText('seed-peer-1').length).toBeGreaterThan(0);
+  expect(within(drawer).getAllByText('seed-peer-1').length).toBeGreaterThan(0);
 });
 
 test('desktop shell can enter reply mode and render reply state', async () => {
@@ -321,9 +340,10 @@ test('desktop shell surfaces relay-assisted topic connectivity in diagnostics', 
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi({ assistPeerIds: ['relay-peer'] })} />);
 
+  const drawer = await openSettingsSection(user, 'discovery');
   await waitFor(() => {
-    expect(screen.getByText('Relay-assisted Peers')).toBeInTheDocument();
-    expect(screen.getByText('relay-peer')).toBeInTheDocument();
+    expect(within(drawer).getByText('Relay-assisted Peers')).toBeInTheDocument();
+    expect(within(drawer).getByText('relay-peer')).toBeInTheDocument();
   });
 
   await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:relay');
@@ -338,6 +358,7 @@ test('desktop shell surfaces relay-assisted topic connectivity in diagnostics', 
 });
 
 test('desktop shell renders diagnostics error reasons', async () => {
+  const user = userEvent.setup();
   render(
     <App
       api={createDesktopMockApi({
@@ -347,15 +368,47 @@ test('desktop shell renders diagnostics error reasons', async () => {
     />
   );
 
+  const drawer = await openSettingsSection(user, 'connectivity');
   await waitFor(() => {
-    expect(screen.getByText('Last Error')).toBeInTheDocument();
+    expect(within(drawer).getByText('Last Error')).toBeInTheDocument();
     expect(
-      screen.getByText('failed to import peer ticket: invalid endpoint id')
+      within(drawer).getByText('failed to import peer ticket: invalid endpoint id')
     ).toBeInTheDocument();
     expect(
       screen.getByText('error: timed out waiting for gossip topic join')
     ).toBeInTheDocument();
   });
+});
+
+test('desktop shell primary nav jumps focus and settings drawer restores trigger focus on escape', async () => {
+  const user = userEvent.setup();
+  render(<App api={createDesktopMockApi()} />);
+
+  const gameNav = screen.getByRole('button', { name: /Game/i });
+  await user.click(gameNav);
+
+  const gameSection = screen.getByPlaceholderText('Top 8 Finals').closest('.shell-section');
+  if (!(gameSection instanceof HTMLElement)) {
+    throw new Error('game section not found');
+  }
+
+  await waitFor(() => {
+    expect(gameNav).toHaveAttribute('aria-current', 'location');
+    expect(gameSection).toHaveFocus();
+  });
+
+  const settingsTrigger = screen.getByTestId('shell-settings-trigger');
+  await user.click(settingsTrigger);
+  await screen.findByRole('dialog', { name: 'Settings & diagnostics' });
+
+  fireEvent.keyDown(window, { key: 'Escape' });
+
+  await waitFor(() => {
+    expect(
+      screen.queryByRole('dialog', { name: 'Settings & diagnostics' })
+    ).not.toBeInTheDocument();
+  });
+  expect(settingsTrigger).toHaveFocus();
 });
 
 test('desktop shell can create, join, leave, and end a live session', async () => {
@@ -794,10 +847,7 @@ test('thread pane reuses the same image placeholder renderer', async () => {
     expect(screen.getByText('envelope-image-post')).toBeInTheDocument();
   });
   await user.click(screen.getByText('envelope-image-post'));
-  const threadPanel = screen.getByRole('heading', { name: 'Thread' }).closest('section');
-  if (!threadPanel) {
-    throw new Error('thread panel not found');
-  }
+  const threadPanel = await screen.findByRole('tabpanel', { name: 'Thread' });
 
   await waitFor(() => {
     expect(within(threadPanel).getByText('syncing image')).toBeInTheDocument();
@@ -1120,10 +1170,14 @@ test('community node panel activates relay connectivity on the current session a
 
   render(<App api={api} />);
 
-  await user.type(screen.getByPlaceholderText('https://community.example.com'), 'https://api.kukuri.app');
-  await user.click(screen.getByRole('button', { name: 'Save Nodes' }));
+  const drawer = await openSettingsSection(user, 'community-node');
+  await user.type(
+    within(drawer).getByPlaceholderText('https://community.example.com'),
+    'https://api.kukuri.app'
+  );
+  await user.click(within(drawer).getByRole('button', { name: 'Save Nodes' }));
 
-  const nodeHeading = await screen.findByText(
+  const nodeHeading = await within(drawer).findByText(
     (_content, element) =>
       element?.tagName === 'STRONG' && element.textContent === 'https://api.kukuri.app'
   );
@@ -1155,6 +1209,66 @@ test('community node panel activates relay connectivity on the current session a
       'connectivity urls active on current session'
     );
   });
+});
+
+test('context pane auto-switches between author and thread and keeps manual tab selection', async () => {
+  const user = userEvent.setup();
+  const authorPubkey = 'a'.repeat(64);
+
+  render(
+    <App
+      api={createDesktopMockApi({
+        seedPosts: {
+          'kukuri:topic:demo': [
+            {
+              object_id: 'context-post',
+              envelope_id: 'envelope-context-post',
+              author_pubkey: authorPubkey,
+              author_name: 'alice',
+              author_display_name: null,
+              following: false,
+              followed_by: false,
+              mutual: false,
+              friend_of_friend: false,
+              object_kind: 'post',
+              content: 'context body',
+              content_status: 'Available',
+              attachments: [],
+              created_at: 1,
+              reply_to: null,
+              root_id: 'context-post',
+              audience_label: 'Public',
+            },
+          ],
+        },
+        authorSocialViews: {
+          [authorPubkey]: {
+            name: 'alice',
+          },
+        },
+      })}
+    />
+  );
+
+  await user.click(await screen.findByRole('button', { name: 'alice' }));
+  await waitFor(() => {
+    expect(screen.getByRole('tab', { name: 'Author' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  await user.click(screen.getByText('envelope-context-post'));
+  await waitFor(() => {
+    expect(screen.getByRole('tab', { name: 'Thread' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  await user.click(screen.getByRole('tab', { name: 'Author' }));
+  expect(screen.getByRole('tab', { name: 'Author' })).toHaveAttribute('aria-selected', 'true');
+
+  await user.click(screen.getByRole('button', { name: 'Clear Author' }));
+  const authorPanel = screen.getByRole('tabpanel', { name: 'Author' });
+  expect(screen.getByRole('tab', { name: 'Author' })).toHaveAttribute('aria-selected', 'true');
+  expect(
+    within(authorPanel).getByText('Select an author to inspect profile and relationship.')
+  ).toBeInTheDocument();
 });
 
 test('post card shows friend of friend badge and author name fallback', async () => {
@@ -1252,9 +1366,10 @@ test('local profile editor saves profile draft', async () => {
 
   render(<App api={api} />);
 
-  const displayNameInput = await screen.findByPlaceholderText('Visible label');
+  const drawer = await openSettingsSection(user, 'profile');
+  const displayNameInput = within(drawer).getByPlaceholderText('Visible label');
   await user.type(displayNameInput, 'Local Author');
-  await user.click(screen.getByRole('button', { name: 'Save Profile' }));
+  await user.click(within(drawer).getByRole('button', { name: 'Save Profile' }));
 
   await waitFor(() => {
     expect(screen.getByText('Local Author')).toBeInTheDocument();
@@ -1262,9 +1377,11 @@ test('local profile editor saves profile draft', async () => {
 });
 
 test('keeps local peer ticket visible when profile loading fails', async () => {
+  const user = userEvent.setup();
   render(<App api={createDesktopMockApi({ myProfileError: 'profile load failed' })} />);
 
+  const drawer = await openSettingsSection(user, 'connectivity');
   await waitFor(() => {
-    expect(screen.getByDisplayValue('peer1@127.0.0.1:7777')).toBeInTheDocument();
+    expect(within(drawer).getByDisplayValue('peer1@127.0.0.1:7777')).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -10,10 +10,23 @@ import {
   useState,
 } from 'react';
 
+import { ContextPane } from '@/components/shell/ContextPane';
+import { ShellFrame } from '@/components/shell/ShellFrame';
+import { ShellNavRail } from '@/components/shell/ShellNavRail';
+import { SettingsDrawer } from '@/components/shell/SettingsDrawer';
+import { ShellTopBar } from '@/components/shell/ShellTopBar';
+import {
+  type ContextPaneMode,
+  type PrimarySection,
+  type SettingsSection,
+  type ShellChromeState,
+} from '@/components/shell/types';
+import { StatusBadge } from '@/components/StatusBadge';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Notice } from '@/components/ui/notice';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 
@@ -69,6 +82,10 @@ const PUBLIC_TIMELINE_SCOPE: TimelineScope = { kind: 'public' };
 const REFRESH_INTERVAL_MS = 2000;
 const VIDEO_POSTER_TIMEOUT_MS = 5000;
 const MEDIA_DEBUG_STORAGE_KEY = 'kukuri:media-debug';
+const SHELL_WORKSPACE_ID = 'shell-primary-workspace';
+const SHELL_NAV_ID = 'shell-nav-rail';
+const SHELL_CONTEXT_ID = 'shell-context-pane';
+const SHELL_SETTINGS_ID = 'shell-settings-drawer';
 const DEFAULT_DISCOVERY_CONFIG: DiscoveryConfig = {
   mode: 'seeded_dht',
   connect_mode: 'direct_only',
@@ -101,6 +118,60 @@ const DEFAULT_SYNC_STATUS: SyncStatus = {
     last_discovery_error: null,
   },
 };
+
+const PRIMARY_SECTION_ITEMS: Array<{
+  id: PrimarySection;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: 'timeline',
+    label: 'Timeline',
+    description: 'Jump to the main feed, scope, and refresh controls.',
+  },
+  {
+    id: 'channels',
+    label: 'Channels',
+    description: 'Private channel controls, invite import, and composer.',
+  },
+  {
+    id: 'live',
+    label: 'Live',
+    description: 'Live session creation and active session status.',
+  },
+  {
+    id: 'game',
+    label: 'Game',
+    description: 'Game room creation, score editing, and room status.',
+  },
+];
+
+const SETTINGS_SECTION_COPY: Array<{
+  id: SettingsSection;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: 'profile',
+    label: 'Profile',
+    description: 'Edit your local profile without leaving the workspace.',
+  },
+  {
+    id: 'connectivity',
+    label: 'Connectivity',
+    description: 'Sync summary, peer tickets, and global error visibility.',
+  },
+  {
+    id: 'discovery',
+    label: 'Discovery',
+    description: 'Seeded DHT configuration and discovery diagnostics.',
+  },
+  {
+    id: 'community-node',
+    label: 'Community Node',
+    description: 'Configured community nodes, auth, consent, and refresh actions.',
+  },
+];
 
 function selectPrimaryImage(post: PostView): AttachmentView | null {
   return post.attachments.find((attachment) => attachment.role === 'image_original') ?? null;
@@ -257,6 +328,33 @@ function seedPeersToEditorValue(config: DiscoveryConfig): string {
 
 function communityNodesToEditorValue(config: CommunityNodeConfig): string {
   return config.nodes.map((node) => node.base_url).join('\n');
+}
+
+function syncStatusBadgeTone(syncStatus: SyncStatus): 'accent' | 'destructive' | 'warning' {
+  if (syncStatus.last_error) {
+    return 'destructive';
+  }
+  return syncStatus.connected ? 'accent' : 'warning';
+}
+
+function syncStatusBadgeLabel(syncStatus: SyncStatus): string {
+  if (syncStatus.last_error) {
+    return 'error';
+  }
+  return syncStatus.connected ? 'connected' : 'waiting';
+}
+
+function topicConnectionLabel(diagnostic?: TopicSyncStatus): string {
+  if (!diagnostic) {
+    return 'idle';
+  }
+  if (diagnostic.connected_peers.length > 0) {
+    return 'joined';
+  }
+  if (diagnostic.assist_peer_ids.length > 0) {
+    return 'relay-assisted';
+  }
+  return diagnostic.joined ? 'joined' : 'idle';
 }
 
 function communityNodeConnectivityUrlsLabel(status?: CommunityNodeNodeStatus): string {
@@ -771,10 +869,27 @@ export function App({ api = runtimeApi }: AppProps) {
   const [gameError, setGameError] = useState<string | null>(null);
   const [gameDrafts, setGameDrafts] = useState<Record<string, GameEditorDraft>>({});
   const [error, setError] = useState<string | null>(null);
+  const [shellChromeState, setShellChromeState] = useState<ShellChromeState>({
+    activePrimarySection: 'timeline',
+    activeContextPaneMode: 'thread',
+    activeSettingsSection: 'profile',
+    navOpen: false,
+    contextOpen: false,
+    settingsOpen: false,
+  });
   const draftSequenceRef = useRef(0);
   const mediaFetchAttemptRef = useRef(new Map<string, number>());
   const remoteObjectUrlRef = useRef(new Map<string, string>());
   const draftPreviewUrlRef = useRef(new Map<string, string>());
+  const navTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const settingsTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const contextTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const primarySectionRefs = useRef<Record<PrimarySection, HTMLElement | null>>({
+    timeline: null,
+    channels: null,
+    live: null,
+    game: null,
+  });
 
   const headline = useMemo(
     () => {
@@ -1147,6 +1262,115 @@ export function App({ api = runtimeApi }: AppProps) {
     };
   }, [api, mediaObjectUrls, previewableMediaAttachments]);
 
+  useEffect(() => {
+    if (!selectedThread) {
+      return;
+    }
+    setShellChromeState((current) => ({
+      ...current,
+      activeContextPaneMode: 'thread',
+      contextOpen: true,
+    }));
+  }, [selectedThread]);
+
+  useEffect(() => {
+    if (!selectedAuthorPubkey) {
+      return;
+    }
+    setShellChromeState((current) => ({
+      ...current,
+      activeContextPaneMode: 'author',
+      contextOpen: true,
+    }));
+  }, [selectedAuthorPubkey]);
+
+  const setNavOpen = useCallback((open: boolean, restoreToTrigger = false) => {
+    setShellChromeState((current) => ({
+      ...current,
+      navOpen: open,
+    }));
+    if (!open && restoreToTrigger) {
+      window.requestAnimationFrame(() => {
+        navTriggerRef.current?.focus();
+      });
+    }
+  }, []);
+
+  const setContextOpen = useCallback((open: boolean, restoreToTrigger = false) => {
+    setShellChromeState((current) => ({
+      ...current,
+      contextOpen: open,
+    }));
+    if (!open && restoreToTrigger) {
+      window.requestAnimationFrame(() => {
+        contextTriggerRef.current?.focus();
+      });
+    }
+  }, []);
+
+  const setSettingsOpen = useCallback((open: boolean, restoreToTrigger = false) => {
+    setShellChromeState((current) => ({
+      ...current,
+      settingsOpen: open,
+    }));
+    if (!open && restoreToTrigger) {
+      window.requestAnimationFrame(() => {
+        settingsTriggerRef.current?.focus();
+      });
+    }
+  }, []);
+
+  function setPrimarySectionRef(section: PrimarySection) {
+    return (element: HTMLElement | null) => {
+      primarySectionRefs.current[section] = element;
+    };
+  }
+
+  function focusPrimarySection(section: PrimarySection) {
+    setShellChromeState((current) => ({
+      ...current,
+      activePrimarySection: section,
+      navOpen: false,
+    }));
+    window.requestAnimationFrame(() => {
+      primarySectionRefs.current[section]?.focus();
+    });
+  }
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      if (shellChromeState.settingsOpen) {
+        event.preventDefault();
+        setSettingsOpen(false, true);
+        return;
+      }
+      if (shellChromeState.contextOpen) {
+        event.preventDefault();
+        setContextOpen(false, true);
+        return;
+      }
+      if (shellChromeState.navOpen) {
+        event.preventDefault();
+        setNavOpen(false, true);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [
+    setContextOpen,
+    setNavOpen,
+    setSettingsOpen,
+    shellChromeState.contextOpen,
+    shellChromeState.navOpen,
+    shellChromeState.settingsOpen,
+  ]);
+
   function nextDraftId(): string {
     draftSequenceRef.current += 1;
     return `draft-${draftSequenceRef.current}`;
@@ -1226,12 +1450,21 @@ export function App({ api = runtimeApi }: AppProps) {
     setTrackedTopics(nextTopics);
     setActiveTopic(nextTopic);
     setTopicInput('');
+    setShellChromeState((current) => ({
+      ...current,
+      activePrimarySection: 'timeline',
+      navOpen: false,
+    }));
     clearThreadContext();
     await loadTopics(nextTopics, nextTopic, null);
   }
 
   async function handleSelectTopic(topic: string) {
     setActiveTopic(topic);
+    setShellChromeState((current) => ({
+      ...current,
+      navOpen: false,
+    }));
     clearThreadContext();
     await loadTopics(trackedTopics, topic, null);
   }
@@ -1245,6 +1478,10 @@ export function App({ api = runtimeApi }: AppProps) {
     await api.unsubscribeTopic(topic);
     setTrackedTopics(nextTopics);
     setActiveTopic(nextActiveTopic);
+    setShellChromeState((current) => ({
+      ...current,
+      navOpen: false,
+    }));
     clearThreadContext();
     await loadTopics(nextTopics, nextActiveTopic, null);
   }
@@ -1254,6 +1491,10 @@ export function App({ api = runtimeApi }: AppProps) {
     setTimelineScopeByTopic((current) => ({
       ...current,
       [activeTopic]: nextScope,
+    }));
+    setShellChromeState((current) => ({
+      ...current,
+      activePrimarySection: 'timeline',
     }));
     await loadTopics(trackedTopics, activeTopic, selectedThread);
   }
@@ -1293,6 +1534,10 @@ export function App({ api = runtimeApi }: AppProps) {
           kind: 'private_channel',
           channel_id: channel.channel_id,
         },
+      }));
+      setShellChromeState((current) => ({
+        ...current,
+        activePrimarySection: 'channels',
       }));
       await loadTopics(trackedTopics, activeTopic, selectedThread);
     } catch (channelCreateError) {
@@ -1388,6 +1633,10 @@ export function App({ api = runtimeApi }: AppProps) {
     setInviteTokenInput('');
     setInviteOutput(null);
     setChannelError(null);
+    setShellChromeState((current) => ({
+      ...current,
+      activePrimarySection: 'channels',
+    }));
     clearThreadContext();
     await loadTopics(nextTopics, topicId, null);
   }
@@ -1492,6 +1741,10 @@ export function App({ api = runtimeApi }: AppProps) {
       setDraftMediaItems([]);
       setAttachmentInputKey((value) => value + 1);
       setComposerError(null);
+      setShellChromeState((current) => ({
+        ...current,
+        activePrimarySection: 'channels',
+      }));
       await loadTopics(trackedTopics, activeTopic, selectedThread);
       setReplyTarget(null);
     } catch (publishError) {
@@ -1550,6 +1803,11 @@ export function App({ api = runtimeApi }: AppProps) {
       startTransition(() => {
         setSelectedThread(threadId);
         setThread(threadView.items);
+        setShellChromeState((current) => ({
+          ...current,
+          activeContextPaneMode: 'thread',
+          contextOpen: true,
+        }));
       });
     } catch (threadError) {
       setError(threadError instanceof Error ? threadError.message : 'failed to load thread');
@@ -1577,6 +1835,11 @@ export function App({ api = runtimeApi }: AppProps) {
       setSelectedAuthorPubkey(authorPubkey);
       setSelectedAuthor(socialView);
       setAuthorError(null);
+      setShellChromeState((current) => ({
+        ...current,
+        activeContextPaneMode: 'author',
+        contextOpen: true,
+      }));
     } catch (detailError) {
       setAuthorError(detailError instanceof Error ? detailError.message : 'failed to load author');
     }
@@ -1753,6 +2016,10 @@ export function App({ api = runtimeApi }: AppProps) {
       setLiveTitle('');
       setLiveDescription('');
       setLiveError(null);
+      setShellChromeState((current) => ({
+        ...current,
+        activePrimarySection: 'live',
+      }));
       await loadTopics(trackedTopics, activeTopic, selectedThread);
     } catch (liveCreateError) {
       setLiveError(
@@ -1821,6 +2088,10 @@ export function App({ api = runtimeApi }: AppProps) {
       setGameDescription('');
       setGameParticipantsInput('');
       setGameError(null);
+      setShellChromeState((current) => ({
+        ...current,
+        activePrimarySection: 'game',
+      }));
       await loadTopics(trackedTopics, activeTopic, selectedThread);
     } catch (createError) {
       setGameError(createError instanceof Error ? createError.message : 'failed to create game room');
@@ -2069,974 +2340,536 @@ export function App({ api = runtimeApi }: AppProps) {
     );
   }
 
-  return (
-    <main className='shell'>
-      <section className='hero'>
-        <div>
-          <p className='eyebrow'>kukuri rebuild</p>
-          <h1>{headline}</h1>
-          <p className='lede'>
-            topic, timeline, composer, thread, sync status の5要素だけで Linux MVP を成立させる
-            desktop shell
-          </p>
-        </div>
-        <Label>
-          <span>Add Topic</span>
-          <div className='topic-input-row'>
-            <Input
-              value={topicInput}
-              onChange={(e) => setTopicInput(e.target.value)}
-              placeholder='kukuri:topic:demo'
-            />
-            <Button variant='secondary' onClick={() => void handleAddTopic()}>
-              Add
-            </Button>
-          </div>
-        </Label>
-      </section>
+  const statusBadges = (
+    <div className='shell-status-badges'>
+      <StatusBadge
+        label={syncStatusBadgeLabel(syncStatus)}
+        tone={syncStatusBadgeTone(syncStatus)}
+      />
+      <StatusBadge label={`${syncStatus.peer_count} peers`} />
+      <StatusBadge
+        label={syncStatus.discovery.mode === 'seeded_dht' ? 'seeded dht' : 'static peers'}
+      />
+      {syncStatus.pending_events > 0 ? (
+        <StatusBadge label={`${syncStatus.pending_events} pending`} tone='warning' />
+      ) : null}
+    </div>
+  );
 
-      <section className='grid'>
-        <Card as='aside' tone='accent'>
-          <h2>Sync Status</h2>
-          <dl className='status-grid'>
-            <div>
-              <dt>Connected</dt>
-              <dd>{syncStatus.connected ? 'yes' : 'no'}</dd>
+  const topicList = (
+    <ul>
+      {trackedTopics.map((topic) => (
+        <li
+          key={topic}
+          className={topic === activeTopic ? 'topic-item topic-item-active' : 'topic-item'}
+        >
+          <button className='topic-link' type='button' onClick={() => void handleSelectTopic(topic)}>
+            <span className='shell-topic-link-label' title={topic}>
+              {topic}
+            </span>
+          </button>
+          {trackedTopics.length > 1 ? (
+            <button
+              className='topic-remove'
+              type='button'
+              aria-label={`Remove ${topic}`}
+              onClick={() => void handleRemoveTopic(topic)}
+            >
+              x
+            </button>
+          ) : null}
+          <div className='topic-diagnostic'>
+            <span>
+              {topicConnectionLabel(topicDiagnostics[topic])} / peers:{' '}
+              {topicDiagnostics[topic]?.peer_count ?? 0}
+            </span>
+            <small>
+              {topicDiagnostics[topic]?.last_received_at
+                ? new Date(topicDiagnostics[topic].last_received_at!).toLocaleTimeString('ja-JP')
+                : 'no events'}
+            </small>
+          </div>
+          <div className='topic-diagnostic topic-diagnostic-secondary'>
+            <span>expected: {topicDiagnostics[topic]?.configured_peer_ids.length ?? 0}</span>
+            <span>missing: {topicDiagnostics[topic]?.missing_peer_ids.length ?? 0}</span>
+          </div>
+          <div className='topic-diagnostic topic-diagnostic-secondary'>
+            <span>{topicDiagnostics[topic]?.status_detail ?? 'No topic diagnostics yet'}</span>
+          </div>
+          {topicDiagnostics[topic]?.last_error ? (
+            <div className='topic-diagnostic topic-diagnostic-error'>
+              <span>error: {topicDiagnostics[topic].last_error}</span>
             </div>
-            <div>
-              <dt>Peers</dt>
-              <dd>{syncStatus.peer_count}</dd>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+
+  const settingsSections = [
+    {
+      ...SETTINGS_SECTION_COPY[0],
+      content: (
+        <Card>
+          <CardHeader>
+            <h3>My Profile</h3>
+            <small>
+              {authorDisplayLabel(
+                syncStatus.local_author_pubkey,
+                localProfile?.display_name,
+                localProfile?.name
+              )}
+            </small>
+          </CardHeader>
+          <form className='composer composer-compact' onSubmit={handleSaveProfile}>
+            <Label>
+              <span>Display Name</span>
+              <Input
+                value={profileDraft.display_name ?? ''}
+                onChange={(event) => {
+                  setProfileDraft((current) => ({
+                    ...current,
+                    display_name: event.target.value,
+                  }));
+                  setProfileDirty(true);
+                }}
+                placeholder='Visible label'
+              />
+            </Label>
+            <Label>
+              <span>Name</span>
+              <Input
+                value={profileDraft.name ?? ''}
+                onChange={(event) => {
+                  setProfileDraft((current) => ({
+                    ...current,
+                    name: event.target.value,
+                  }));
+                  setProfileDirty(true);
+                }}
+                placeholder='Canonical name'
+              />
+            </Label>
+            <Label>
+              <span>About</span>
+              <Textarea
+                value={profileDraft.about ?? ''}
+                onChange={(event) => {
+                  setProfileDraft((current) => ({
+                    ...current,
+                    about: event.target.value,
+                  }));
+                  setProfileDirty(true);
+                }}
+                className='ticket-output'
+                placeholder='Short bio'
+              />
+            </Label>
+            <Label>
+              <span>Picture URL</span>
+              <Input
+                value={profileDraft.picture ?? ''}
+                onChange={(event) => {
+                  setProfileDraft((current) => ({
+                    ...current,
+                    picture: event.target.value,
+                  }));
+                  setProfileDirty(true);
+                }}
+                placeholder='https://...'
+              />
+            </Label>
+            {profileError ? <p className='error error-inline'>{profileError}</p> : null}
+            <div className='discovery-actions'>
+              <Button variant='secondary' type='submit' disabled={!profileDirty}>
+                Save Profile
+              </Button>
+              <Button
+                variant='secondary'
+                type='button'
+                disabled={!profileDirty}
+                onClick={() => {
+                  if (!localProfile) {
+                    return;
+                  }
+                  setProfileDraft(profileInputFromProfile(localProfile));
+                  setProfileDirty(false);
+                  setProfileError(null);
+                }}
+              >
+                Reset
+              </Button>
             </div>
-            <div>
-              <dt>Pending</dt>
-              <dd>{syncStatus.pending_events}</dd>
-            </div>
-          </dl>
-          <div className='diagnostic-block'>
-            <strong>Configured Peers</strong>
-            <p>{syncStatus.configured_peers.length > 0 ? syncStatus.configured_peers.join(', ') : 'none'}</p>
-          </div>
-          <div className='diagnostic-block'>
-            <strong>Connection Detail</strong>
-            <p>{syncStatus.status_detail}</p>
-          </div>
-          <div className='diagnostic-block'>
-            <strong>Effective Peers</strong>
-            <p>{effectivePeerIds.join(', ') || 'none'}</p>
-          </div>
-          <div className='diagnostic-block'>
-            <strong>Last Error</strong>
-            <p className={syncStatus.last_error ? 'diagnostic-error' : undefined}>
-              {syncStatus.last_error ?? 'none'}
-            </p>
-          </div>
-          <Card className='panel-subsection'>
+          </form>
+        </Card>
+      ),
+    },
+    {
+      ...SETTINGS_SECTION_COPY[1],
+      content: (
+        <div className='shell-main-stack'>
+          <Card>
             <CardHeader>
-              <h3>My Profile</h3>
-              <small>{authorDisplayLabel(syncStatus.local_author_pubkey, localProfile?.display_name, localProfile?.name)}</small>
+              <h3>Sync Status</h3>
+              <small>{syncStatus.connected ? 'connected' : 'waiting'}</small>
             </CardHeader>
-            <form className='composer composer-compact' onSubmit={handleSaveProfile}>
-              <Label>
-                <span>Display Name</span>
-                <Input
-                  value={profileDraft.display_name ?? ''}
-                  onChange={(event) => {
-                    setProfileDraft((current) => ({
-                      ...current,
-                      display_name: event.target.value,
-                    }));
-                    setProfileDirty(true);
-                  }}
-                  placeholder='Visible label'
-                />
-              </Label>
-              <Label>
-                <span>Name</span>
-                <Input
-                  value={profileDraft.name ?? ''}
-                  onChange={(event) => {
-                    setProfileDraft((current) => ({
-                      ...current,
-                      name: event.target.value,
-                    }));
-                    setProfileDirty(true);
-                  }}
-                  placeholder='Canonical name'
-                />
-              </Label>
-              <Label>
-                <span>About</span>
-                <Textarea
-                  value={profileDraft.about ?? ''}
-                  onChange={(event) => {
-                    setProfileDraft((current) => ({
-                      ...current,
-                      about: event.target.value,
-                    }));
-                    setProfileDirty(true);
-                  }}
-                  className='ticket-output'
-                  placeholder='Short bio'
-                />
-              </Label>
-              <Label>
-                <span>Picture URL</span>
-                <Input
-                  value={profileDraft.picture ?? ''}
-                  onChange={(event) => {
-                    setProfileDraft((current) => ({
-                      ...current,
-                      picture: event.target.value,
-                    }));
-                    setProfileDirty(true);
-                  }}
-                  placeholder='https://...'
-                />
-              </Label>
-              {profileError ? <p className='error error-inline'>{profileError}</p> : null}
-              <div className='discovery-actions'>
-                <Button variant='secondary' type='submit' disabled={!profileDirty}>
-                  Save Profile
-                </Button>
-                <Button
-                  variant='secondary'
-                  type='button'
-                  disabled={!profileDirty}
-                  onClick={() => {
-                    if (!localProfile) {
-                      return;
-                    }
-                    setProfileDraft(profileInputFromProfile(localProfile));
-                    setProfileDirty(false);
-                    setProfileError(null);
-                  }}
-                >
-                  Reset
-                </Button>
-              </div>
-            </form>
-          </Card>
-          <Card className='panel-subsection discovery-panel'>
-            <CardHeader>
-              <h3>Discovery</h3>
-              <small>{syncStatus.discovery.mode}</small>
-            </CardHeader>
-            <dl className='status-grid status-grid-compact'>
+            <dl className='status-grid'>
               <div>
-                <dt>Mode</dt>
-                <dd>{syncStatus.discovery.mode}</dd>
+                <dt>Connected</dt>
+                <dd>{syncStatus.connected ? 'yes' : 'no'}</dd>
               </div>
               <div>
-                <dt>Connect</dt>
-                <dd>{syncStatus.discovery.connect_mode}</dd>
+                <dt>Peers</dt>
+                <dd>{syncStatus.peer_count}</dd>
               </div>
               <div>
-                <dt>Env Lock</dt>
-                <dd>{discoveryConfig.env_locked ? 'yes' : 'no'}</dd>
+                <dt>Pending</dt>
+                <dd>{syncStatus.pending_events}</dd>
               </div>
             </dl>
             <div className='diagnostic-block'>
-              <strong>Local Endpoint ID</strong>
-              <p>{syncStatus.discovery.local_endpoint_id || 'unknown'}</p>
-            </div>
-            <div className='diagnostic-block'>
-              <strong>Connected Peers</strong>
-              <p>{syncStatus.discovery.connected_peer_ids.join(', ') || 'none'}</p>
-            </div>
-            <div className='diagnostic-block'>
-              <strong>Relay-assisted Peers</strong>
-              <p>{syncStatus.discovery.assist_peer_ids.join(', ') || 'none'}</p>
-            </div>
-            <div className='diagnostic-block'>
-              <strong>Manual Ticket Peers</strong>
-              <p>{syncStatus.discovery.manual_ticket_peer_ids.join(', ') || 'none'}</p>
-            </div>
-            <div className='diagnostic-block'>
-              <strong>Community Bootstrap Peers</strong>
-              <p>{syncStatus.discovery.bootstrap_seed_peer_ids.join(', ') || 'none'}</p>
-            </div>
-            <div className='diagnostic-block'>
-              <strong>Configured Seed IDs</strong>
-              <p>{syncStatus.discovery.configured_seed_peer_ids.join(', ') || 'none'}</p>
-            </div>
-            <Label>
-              <span>Seed Peers</span>
-              <Textarea
-                value={discoverySeedInput}
-                onChange={(event) => {
-                  setDiscoverySeedInput(event.target.value);
-                  setDiscoveryEditorDirty(true);
-                }}
-                readOnly={discoveryConfig.env_locked}
-                className='ticket-output discovery-editor'
-                placeholder='node_id or node_id@host:port'
-              />
-            </Label>
-            <div className='diagnostic-block'>
-              <strong>Discovery Error</strong>
-              <p
-                className={
-                  discoveryError || syncStatus.discovery.last_discovery_error
-                    ? 'diagnostic-error'
-                    : undefined
-                }
-              >
-                {discoveryError ?? syncStatus.discovery.last_discovery_error ?? 'none'}
+              <strong>Configured Peers</strong>
+              <p>
+                {syncStatus.configured_peers.length > 0
+                  ? syncStatus.configured_peers.join(', ')
+                  : 'none'}
               </p>
             </div>
-            <div className='discovery-actions'>
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={discoveryConfig.env_locked || !discoveryEditorDirty}
-                onClick={() => void handleSaveDiscoverySeeds()}
-              >
-                Save Seeds
-              </Button>
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={!discoveryEditorDirty}
-                onClick={() => {
-                  setDiscoverySeedInput(seedPeersToEditorValue(discoveryConfig));
-                  setDiscoveryEditorDirty(false);
-                  setDiscoveryError(null);
-                }}
-              >
-                Reset
-              </Button>
+            <div className='diagnostic-block'>
+              <strong>Connection Detail</strong>
+              <p>{syncStatus.status_detail}</p>
             </div>
+            <div className='diagnostic-block'>
+              <strong>Effective Peers</strong>
+              <p>{effectivePeerIds.join(', ') || 'none'}</p>
+            </div>
+            <div className='diagnostic-block'>
+              <strong>Last Error</strong>
+              <p className={syncStatus.last_error ? 'diagnostic-error' : undefined}>
+                {syncStatus.last_error ?? 'none'}
+              </p>
+            </div>
+            {error ? (
+              <Notice tone='destructive' className='mt-4'>
+                {error}
+              </Notice>
+            ) : null}
           </Card>
-          <Card className='panel-subsection discovery-panel'>
+
+          <Card>
             <CardHeader>
-              <h3>Community Node</h3>
-              <small>{communityNodeStatuses.length} configured</small>
+              <h3>Peer Tickets</h3>
+              <small>manual connectivity</small>
             </CardHeader>
             <Label>
-              <span>Base URLs</span>
-              <Textarea
-                value={communityNodeInput}
-                onChange={(event) => {
-                  setCommunityNodeInput(event.target.value);
-                  setCommunityNodeEditorDirty(true);
-                }}
-                className='ticket-output discovery-editor'
-                placeholder='https://community.example.com'
+              <span>Your Ticket</span>
+              <Textarea readOnly value={localPeerTicket ?? ''} className='ticket-output' />
+            </Label>
+            <Label>
+              <span>Peer Ticket</span>
+              <Input
+                value={peerTicket}
+                onChange={(event) => setPeerTicket(event.target.value)}
+                placeholder='nodeid@127.0.0.1:7777'
               />
             </Label>
-            <div className='diagnostic-block'>
-              <strong>Community Node Error</strong>
-              <p className={communityNodeError ? 'diagnostic-error' : undefined}>
-                {communityNodeError ?? 'none'}
-              </p>
-            </div>
-            <div className='discovery-actions'>
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={!communityNodeEditorDirty}
-                onClick={() => void handleSaveCommunityNodes()}
-              >
-                Save Nodes
-              </Button>
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={!communityNodeEditorDirty}
-                onClick={() => {
-                  setCommunityNodeInput(communityNodesToEditorValue(communityNodeConfig));
-                  setCommunityNodeEditorDirty(false);
-                  setCommunityNodeError(null);
-                }}
-              >
-                Reset
-              </Button>
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={communityNodeConfig.nodes.length === 0}
-                onClick={() => void handleClearCommunityNodes()}
-              >
-                Clear
-              </Button>
-            </div>
-            {communityNodeConfig.nodes.map((node) => {
-              const status = communityNodeStatusByBaseUrl[node.base_url];
-              return (
-                <div key={node.base_url} className='diagnostic-block'>
-                  <strong>{node.base_url}</strong>
-                  <p>
-                    auth:{' '}
-                    {status?.auth_state.authenticated
-                      ? `yes (${status.auth_state.expires_at ?? 'unknown'})`
-                      : 'no'}
-                  </p>
-                  <p>
-                    consent:{' '}
-                    {status?.consent_state
-                      ? status.consent_state.all_required_accepted
-                        ? 'accepted'
-                        : 'required'
-                      : 'unknown'}
-                  </p>
-                  <p>
-                    connectivity urls:{' '}
-                    {communityNodeConnectivityUrlsLabel(status)}
-                  </p>
-                  <p>session activation: {communityNodeSessionActivationLabel(status)}</p>
-                  <p>next step: {communityNodeNextStepLabel(status)}</p>
-                  <div className='discovery-actions'>
-                    <Button
-                      variant='secondary'
-                      type='button'
-                      onClick={() => void handleAuthenticateCommunityNode(node.base_url)}
-                    >
-                      Authenticate
-                    </Button>
-                    <Button
-                      variant='secondary'
-                      type='button'
-                      onClick={() => void handleFetchCommunityNodeConsents(node.base_url)}
-                    >
-                      Consents
-                    </Button>
-                    <Button
-                      variant='secondary'
-                      type='button'
-                      onClick={() => void handleAcceptCommunityNodeConsents(node.base_url)}
-                    >
-                      Accept
-                    </Button>
-                    <Button
-                      variant='secondary'
-                      type='button'
-                      onClick={() => void handleRefreshCommunityNode(node.base_url)}
-                    >
-                      Refresh
-                    </Button>
-                    <Button
-                      variant='secondary'
-                      type='button'
-                      onClick={() => void handleClearCommunityNodeToken(node.base_url)}
-                    >
-                      Clear Token
-                    </Button>
-                  </div>
-                </div>
-              );
-            })}
+            <Button variant='secondary' onClick={() => void handleImportPeer()}>
+              Import Peer
+            </Button>
           </Card>
+        </div>
+      ),
+    },
+    {
+      ...SETTINGS_SECTION_COPY[2],
+      content: (
+        <Card className='discovery-panel'>
+          <CardHeader>
+            <h3>Discovery</h3>
+            <small>{syncStatus.discovery.mode}</small>
+          </CardHeader>
+          <dl className='status-grid status-grid-compact'>
+            <div>
+              <dt>Mode</dt>
+              <dd>{syncStatus.discovery.mode}</dd>
+            </div>
+            <div>
+              <dt>Connect</dt>
+              <dd>{syncStatus.discovery.connect_mode}</dd>
+            </div>
+            <div>
+              <dt>Env Lock</dt>
+              <dd>{discoveryConfig.env_locked ? 'yes' : 'no'}</dd>
+            </div>
+          </dl>
+          <div className='diagnostic-block'>
+            <strong>Local Endpoint ID</strong>
+            <p>{syncStatus.discovery.local_endpoint_id || 'unknown'}</p>
+          </div>
+          <div className='diagnostic-block'>
+            <strong>Connected Peers</strong>
+            <p>{syncStatus.discovery.connected_peer_ids.join(', ') || 'none'}</p>
+          </div>
+          <div className='diagnostic-block'>
+            <strong>Relay-assisted Peers</strong>
+            <p>{syncStatus.discovery.assist_peer_ids.join(', ') || 'none'}</p>
+          </div>
+          <div className='diagnostic-block'>
+            <strong>Manual Ticket Peers</strong>
+            <p>{syncStatus.discovery.manual_ticket_peer_ids.join(', ') || 'none'}</p>
+          </div>
+          <div className='diagnostic-block'>
+            <strong>Community Bootstrap Peers</strong>
+            <p>{syncStatus.discovery.bootstrap_seed_peer_ids.join(', ') || 'none'}</p>
+          </div>
+          <div className='diagnostic-block'>
+            <strong>Configured Seed IDs</strong>
+            <p>{syncStatus.discovery.configured_seed_peer_ids.join(', ') || 'none'}</p>
+          </div>
           <Label>
-            <span>Your Ticket</span>
-            <Textarea readOnly value={localPeerTicket ?? ''} className='ticket-output' />
-          </Label>
-          <Label>
-            <span>Peer Ticket</span>
-            <Input
-              value={peerTicket}
-              onChange={(e) => setPeerTicket(e.target.value)}
-              placeholder='nodeid@127.0.0.1:7777'
+            <span>Seed Peers</span>
+            <Textarea
+              value={discoverySeedInput}
+              onChange={(event) => {
+                setDiscoverySeedInput(event.target.value);
+                setDiscoveryEditorDirty(true);
+              }}
+              readOnly={discoveryConfig.env_locked}
+              className='ticket-output discovery-editor'
+              placeholder='node_id or node_id@host:port'
             />
           </Label>
-          <Button variant='secondary' onClick={() => void handleImportPeer()}>
-            Import Peer
-          </Button>
-          <section className='topic-list'>
-            <div className='panel-header'>
-              <h3>Tracked Topics</h3>
-              <small>{syncStatus.subscribed_topics.length} active</small>
-            </div>
-            <ul>
-              {trackedTopics.map((topic) => (
-                <li
-                  key={topic}
-                  className={topic === activeTopic ? 'topic-item topic-item-active' : 'topic-item'}
-                >
-                  <button className='topic-link' type='button' onClick={() => void handleSelectTopic(topic)}>
-                    {topic}
-                  </button>
-                  {trackedTopics.length > 1 ? (
-                    <button
-                      className='topic-remove'
-                      type='button'
-                      onClick={() => void handleRemoveTopic(topic)}
-                    >
-                      x
-                    </button>
-                  ) : null}
-                  <div className='topic-diagnostic'>
-                    <span>
-                      {topicDiagnostics[topic]?.connected_peers.length
-                        ? 'joined'
-                        : topicDiagnostics[topic]?.assist_peer_ids.length
-                          ? 'relay-assisted'
-                          : topicDiagnostics[topic]?.joined
-                            ? 'joined'
-                            : 'idle'} / peers:{' '}
-                      {topicDiagnostics[topic]?.peer_count ?? 0}
-                    </span>
-                    <small>
-                      {topicDiagnostics[topic]?.last_received_at
-                        ? new Date(topicDiagnostics[topic].last_received_at!).toLocaleTimeString('ja-JP')
-                        : 'no events'}
-                    </small>
-                  </div>
-                  <div className='topic-diagnostic topic-diagnostic-secondary'>
-                    <span>expected: {topicDiagnostics[topic]?.configured_peer_ids.length ?? 0}</span>
-                    <span>missing: {topicDiagnostics[topic]?.missing_peer_ids.length ?? 0}</span>
-                  </div>
-                  <div className='topic-diagnostic topic-diagnostic-secondary'>
-                    <span>{topicDiagnostics[topic]?.status_detail ?? 'No topic diagnostics yet'}</span>
-                  </div>
-                  {topicDiagnostics[topic]?.last_error ? (
-                    <div className='topic-diagnostic topic-diagnostic-error'>
-                      <span>error: {topicDiagnostics[topic].last_error}</span>
-                    </div>
-                  ) : null}
-                </li>
-                ))}
-              </ul>
-            </section>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <h2>Timeline</h2>
-            <span className='active-topic-label'>{activeTopic}</span>
+          <div className='diagnostic-block'>
+            <strong>Discovery Error</strong>
+            <p
+              className={
+                discoveryError || syncStatus.discovery.last_discovery_error
+                  ? 'diagnostic-error'
+                  : undefined
+              }
+            >
+              {discoveryError ?? syncStatus.discovery.last_discovery_error ?? 'none'}
+            </p>
+          </div>
+          <div className='discovery-actions'>
             <Button
               variant='secondary'
-              onClick={() => void loadTopics(trackedTopics, activeTopic, selectedThread)}
+              type='button'
+              disabled={discoveryConfig.env_locked || !discoveryEditorDirty}
+              onClick={() => void handleSaveDiscoverySeeds()}
             >
-              Refresh
+              Save Seeds
             </Button>
+            <Button
+              variant='secondary'
+              type='button'
+              disabled={!discoveryEditorDirty}
+              onClick={() => {
+                setDiscoverySeedInput(seedPeersToEditorValue(discoveryConfig));
+                setDiscoveryEditorDirty(false);
+                setDiscoveryError(null);
+              }}
+            >
+              Reset
+            </Button>
+          </div>
+        </Card>
+      ),
+    },
+    {
+      ...SETTINGS_SECTION_COPY[3],
+      content: (
+        <Card className='discovery-panel'>
+          <CardHeader>
+            <h3>Community Node</h3>
+            <small>{communityNodeStatuses.length} configured</small>
           </CardHeader>
-          <div className='topic-diagnostic'>
-            <Label>
-              <span>View Scope</span>
-              <Select
-                aria-label='View Scope'
-                value={timelineScopeValue(activeTimelineScope)}
-                onChange={(event) => {
-                  void handleTimelineScopeChange(event.target.value);
-                }}
-              >
-                <option value='public'>Public</option>
-                <option value='all_joined'>All joined</option>
-                {activeJoinedChannels.map((channel) => (
-                  <option key={channel.channel_id} value={`channel:${channel.channel_id}`}>
-                    {channel.label}
-                  </option>
-                ))}
-              </Select>
-            </Label>
-            <Label>
-              <span>Compose Target</span>
-              <Select
-                aria-label='Compose Target'
-                value={channelRefValue(activeComposeChannel)}
-                disabled={Boolean(replyTarget)}
-                onChange={(event) => handleComposeChannelChange(event.target.value)}
-              >
-                <option value='public'>Public</option>
-                {activeJoinedChannels.map((channel) => (
-                  <option key={channel.channel_id} value={`channel:${channel.channel_id}`}>
-                    {channel.label}
-                  </option>
-                ))}
-              </Select>
-            </Label>
-          </div>
-          <div className='topic-diagnostic topic-diagnostic-secondary'>
-            <span>Viewing: {audienceLabelForTimelineScope(activeTimelineScope, activeJoinedChannels)}</span>
-            <span>Posting to: {activeComposeAudienceLabel}</span>
-          </div>
-          <form className='composer composer-compact' onSubmit={handleCreatePrivateChannel}>
-            <Label>
-              <span>Create Channel</span>
-              <Input
-                value={channelLabelInput}
-                onChange={(event) => setChannelLabelInput(event.target.value)}
-                placeholder='core contributors'
-              />
-            </Label>
-            <Label>
-              <span>Audience</span>
-              <Select
-                aria-label='Channel Audience'
-                value={channelAudienceInput}
-                onChange={(event) =>
-                  setChannelAudienceInput(event.target.value as ChannelAudienceKind)
-                }
-              >
-                <option value='invite_only'>Invite only</option>
-                <option value='friend_only'>Friends</option>
-                <option value='friend_plus'>Friends+</option>
-              </Select>
-            </Label>
-            <Button variant='secondary' type='submit'>
-              Create Channel
-            </Button>
-            {activePrivateChannel?.audience_kind === 'invite_only' ? (
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={activeComposeChannel.kind !== 'private_channel'}
-                onClick={() => void handleCreateInvite()}
-              >
-                Create Invite
-              </Button>
-            ) : null}
-            {activePrivateChannel?.audience_kind === 'friend_only' ? (
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={!activePrivateChannel.is_owner}
-                onClick={() => void handleCreateGrant()}
-              >
-                Create Grant
-              </Button>
-            ) : null}
-            {activePrivateChannel?.audience_kind === 'friend_plus' ? (
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={activeComposeChannel.kind !== 'private_channel'}
-                onClick={() => void handleCreateShare()}
-              >
-                Create Share
-              </Button>
-            ) : null}
-            {activePrivateChannel?.audience_kind === 'friend_plus' ? (
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={!activePrivateChannel.is_owner}
-                onClick={() => void handleFreezePrivateChannel()}
-              >
-                Freeze
-              </Button>
-            ) : null}
-            {activePrivateChannel?.audience_kind === 'friend_only' ? (
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={!activePrivateChannel.is_owner}
-                onClick={() => void handleRotatePrivateChannel()}
-              >
-                Rotate
-              </Button>
-            ) : null}
-            {activePrivateChannel?.audience_kind === 'friend_plus' ? (
-              <Button
-                variant='secondary'
-                type='button'
-                disabled={!activePrivateChannel.is_owner}
-                onClick={() => void handleRotatePrivateChannel()}
-              >
-                Rotate
-              </Button>
-            ) : null}
-          </form>
-          <form className='composer composer-compact' onSubmit={handleJoinInvite}>
-            <Label>
-              <span>Join via Invite</span>
-              <Textarea
-                value={inviteTokenInput}
-                onChange={(event) => setInviteTokenInput(event.target.value)}
-                placeholder='paste private channel invite, friend grant, or friends+ share'
-              />
-            </Label>
-            <Button variant='secondary' type='submit'>
-              Join Invite
-            </Button>
-            <Button variant='secondary' type='button' onClick={() => void handleJoinGrant()}>
-              Join Grant
-            </Button>
-            <Button variant='secondary' type='button' onClick={() => void handleJoinShare()}>
-              Join Share
-            </Button>
-          </form>
-          {inviteOutput ? (
-            <div className='topic-diagnostic topic-diagnostic-secondary'>
-              <span>
-                {inviteOutputLabel === 'grant'
-                  ? 'Latest grant'
-                  : inviteOutputLabel === 'share'
-                    ? 'Latest share'
-                    : 'Latest invite'}
-              </span>
-              <code>{inviteOutput}</code>
-            </div>
-          ) : null}
-          {activePrivateChannel ? (
-            <div className='topic-diagnostic topic-diagnostic-secondary'>
-              <span>
-                Policy:{' '}
-                {activePrivateChannel.audience_kind === 'friend_only'
-                  ? 'Friends: only mutual followers can join'
-                  : activePrivateChannel.audience_kind === 'friend_plus'
-                    ? 'Friends+: participants can share to their mutuals'
-                    : 'Invite only'}
-              </span>
-              <span>epoch: {activePrivateChannel.current_epoch_id}</span>
-              <span>sharing: {activePrivateChannel.sharing_state}</span>
-              {activePrivateChannel.joined_via_pubkey ? (
-                <span>joined via {shortPubkey(activePrivateChannel.joined_via_pubkey)}</span>
-              ) : null}
-            </div>
-          ) : null}
-          {activePrivateChannel &&
-          (activePrivateChannel.audience_kind === 'friend_only' ||
-            activePrivateChannel.audience_kind === 'friend_plus') ? (
-            <div className='topic-diagnostic topic-diagnostic-secondary'>
-              <span>participants: {activePrivateChannel.participant_count}</span>
-              <span>stale: {activePrivateChannel.stale_participant_count}</span>
-              <span>owner: {activePrivateChannel.is_owner ? 'yes' : 'no'}</span>
-            </div>
-          ) : null}
-          {activePrivateChannel?.audience_kind === 'friend_only' &&
-          activePrivateChannel.rotation_required ? (
-            <div className='topic-diagnostic topic-diagnostic-error'>
-              <span>rotation required: current participants include non-mutual followers</span>
-            </div>
-          ) : null}
-          {channelError ? <p className='error error-inline'>{channelError}</p> : null}
-          <form className='composer' onSubmit={handlePublish}>
-            {replyTarget ? (
-              <div className='reply-banner'>
-                <div>
-                  <strong>Replying</strong>
-                  <p>{replyTarget.content}</p>
-                  <small>Audience: {replyTarget.audience_label}</small>
-                </div>
-                <Button variant='secondary' type='button' onClick={clearReply}>
-                  Clear
-                </Button>
-              </div>
-            ) : null}
+          <Label>
+            <span>Base URLs</span>
             <Textarea
-              value={composer}
-              onChange={(e) => setComposer(e.target.value)}
-              placeholder={replyTarget ? 'Write a reply' : 'Write a post'}
+              value={communityNodeInput}
+              onChange={(event) => {
+                setCommunityNodeInput(event.target.value);
+                setCommunityNodeEditorDirty(true);
+              }}
+              className='ticket-output discovery-editor'
+              placeholder='https://community.example.com'
             />
-            <Label className='file-field'>
-              <span>Attach</span>
-              <Input
-                key={attachmentInputKey}
-                aria-label='Attach'
-                type='file'
-                accept='image/*,video/*'
-                multiple
-                onChange={(event) => {
-                  void handleAttachmentSelection(event);
-                }}
-              />
-            </Label>
-            {composerError ? <p className='error error-inline'>{composerError}</p> : null}
-            {draftMediaItems.length > 0 ? (
-              <ul className='draft-attachment-list'>
-                {draftMediaItems.map((item) => (
-                  <li key={item.id} className='draft-attachment-item'>
-                    <div className='draft-attachment-content'>
-                      <div className='draft-preview-frame'>
-                        <img
-                          className='draft-preview-image'
-                          src={item.preview_url}
-                          alt={`draft preview ${item.source_name}`}
-                        />
-                      </div>
-                      <div>
-                        <strong>{item.source_name}</strong>
-                        {item.attachments.map((attachment) => (
-                          <small key={`${attachment.role ?? attachment.mime}-${attachment.file_name ?? item.source_name}`}>
-                            {attachment.role ?? 'attachment'} · {attachment.mime} ·{' '}
-                            {formatBytes(attachment.byte_size)}
-                          </small>
-                        ))}
-                      </div>
-                    </div>
-                    <Button variant='secondary' type='button' onClick={() => handleRemoveDraftAttachment(item.id)}>
-                      Remove
-                    </Button>
+          </Label>
+          <div className='diagnostic-block'>
+            <strong>Community Node Error</strong>
+            <p className={communityNodeError ? 'diagnostic-error' : undefined}>
+              {communityNodeError ?? 'none'}
+            </p>
+          </div>
+          <div className='discovery-actions'>
+            <Button
+              variant='secondary'
+              type='button'
+              disabled={!communityNodeEditorDirty}
+              onClick={() => void handleSaveCommunityNodes()}
+            >
+              Save Nodes
+            </Button>
+            <Button
+              variant='secondary'
+              type='button'
+              disabled={!communityNodeEditorDirty}
+              onClick={() => {
+                setCommunityNodeInput(communityNodesToEditorValue(communityNodeConfig));
+                setCommunityNodeEditorDirty(false);
+                setCommunityNodeError(null);
+              }}
+            >
+              Reset
+            </Button>
+            <Button
+              variant='secondary'
+              type='button'
+              disabled={communityNodeConfig.nodes.length === 0}
+              onClick={() => void handleClearCommunityNodes()}
+            >
+              Clear
+            </Button>
+          </div>
+          {communityNodeConfig.nodes.map((node) => {
+            const status = communityNodeStatusByBaseUrl[node.base_url];
+            return (
+              <div key={node.base_url} className='diagnostic-block'>
+                <strong>{node.base_url}</strong>
+                <p>
+                  auth:{' '}
+                  {status?.auth_state.authenticated
+                    ? `yes (${status.auth_state.expires_at ?? 'unknown'})`
+                    : 'no'}
+                </p>
+                <p>
+                  consent:{' '}
+                  {status?.consent_state
+                    ? status.consent_state.all_required_accepted
+                      ? 'accepted'
+                      : 'required'
+                    : 'unknown'}
+                </p>
+                <p>connectivity urls: {communityNodeConnectivityUrlsLabel(status)}</p>
+                <p>session activation: {communityNodeSessionActivationLabel(status)}</p>
+                <p>next step: {communityNodeNextStepLabel(status)}</p>
+                <div className='discovery-actions'>
+                  <Button
+                    variant='secondary'
+                    type='button'
+                    onClick={() => void handleAuthenticateCommunityNode(node.base_url)}
+                  >
+                    Authenticate
+                  </Button>
+                  <Button
+                    variant='secondary'
+                    type='button'
+                    onClick={() => void handleFetchCommunityNodeConsents(node.base_url)}
+                  >
+                    Consents
+                  </Button>
+                  <Button
+                    variant='secondary'
+                    type='button'
+                    onClick={() => void handleAcceptCommunityNodeConsents(node.base_url)}
+                  >
+                    Accept
+                  </Button>
+                  <Button
+                    variant='secondary'
+                    type='button'
+                    onClick={() => void handleRefreshCommunityNode(node.base_url)}
+                  >
+                    Refresh
+                  </Button>
+                  <Button
+                    variant='secondary'
+                    type='button'
+                    onClick={() => void handleClearCommunityNodeToken(node.base_url)}
+                  >
+                    Clear Token
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </Card>
+      ),
+    },
+  ];
+
+  const contextTabs = [
+    {
+      id: 'thread' as ContextPaneMode,
+      label: 'Thread',
+      summary: selectedThread ? `${thread.length} posts in thread` : 'Select a post to inspect the thread.',
+      content: (
+        <div className='shell-main-stack'>
+          <Card>
+            <CardHeader>
+              <h3>Thread</h3>
+              <div className='post-actions-inline'>
+                {selectedThread ? (
+                  <Button
+                    variant='secondary'
+                    type='button'
+                    onClick={() => {
+                      setSelectedThread(null);
+                      setThread([]);
+                      clearReply();
+                    }}
+                  >
+                    Close
+                  </Button>
+                ) : null}
+              </div>
+            </CardHeader>
+            {selectedThread ? (
+              <ul className='thread-list'>
+                {thread.map((post) => (
+                  <li key={post.object_id} className='thread-item'>
+                    {renderPostCard(post, 'thread')}
                   </li>
                 ))}
               </ul>
-            ) : null}
-            <div className='topic-diagnostic topic-diagnostic-secondary'>
-              <span>Audience: {activeComposeAudienceLabel}</span>
-            </div>
-            <Button type='submit'>
-              {replyTarget ? 'Reply' : 'Publish'}
-            </Button>
-          </form>
-          <Card className='panel-subsection'>
-            <CardHeader>
-              <h3>Live Sessions</h3>
-              <small>{activeLiveSessions.length} active</small>
-            </CardHeader>
-            <form className='composer composer-compact' onSubmit={handleCreateLiveSession}>
-              <Label>
-                <span>Live Title</span>
-                <Input
-                  value={liveTitle}
-                  onChange={(event) => setLiveTitle(event.target.value)}
-                  placeholder='Friday stream'
-                />
-              </Label>
-              <Label>
-                <span>Live Description</span>
-                <Textarea
-                  value={liveDescription}
-                  onChange={(event) => setLiveDescription(event.target.value)}
-                  placeholder='short session summary'
-                />
-              </Label>
-              {liveError ? <p className='error error-inline'>{liveError}</p> : null}
-              <div className='topic-diagnostic topic-diagnostic-secondary'>
-                <span>Audience: {activeComposeAudienceLabel}</span>
-              </div>
-              <Button type='submit'>
-                Start Live
-              </Button>
-            </form>
-            {activeLiveSessions.length === 0 ? <p className='empty-state'>No live sessions</p> : null}
-            <ul className='post-list'>
-              {activeLiveSessions.map((session) => {
-                const isOwner = session.host_pubkey === syncStatus.local_author_pubkey;
-                return (
-                  <li key={session.session_id}>
-                    <article className='post-card'>
-                      <div className='post-meta'>
-                        <span>{session.title}</span>
-                        <span>{session.status}</span>
-                        <span className='reply-chip'>{session.audience_label}</span>
-                      </div>
-                      <div className='post-body'>
-                        <strong className='post-title'>{session.description || 'no description'}</strong>
-                      </div>
-                      <small>{session.session_id}</small>
-                      <div className='topic-diagnostic topic-diagnostic-secondary'>
-                        <span>viewers: {session.viewer_count}</span>
-                        <span>
-                          started:{' '}
-                          {new Date(session.started_at).toLocaleTimeString('ja-JP')}
-                        </span>
-                      </div>
-                      {session.ended_at ? (
-                        <div className='topic-diagnostic topic-diagnostic-secondary'>
-                          <span>ended: {new Date(session.ended_at).toLocaleTimeString('ja-JP')}</span>
-                        </div>
-                      ) : null}
-                      <div className='post-actions'>
-                        {session.joined_by_me ? (
-                          <Button
-                            variant='secondary'
-                            type='button'
-                            onClick={() => void handleLeaveLiveSession(session.session_id)}
-                          >
-                            Leave
-                          </Button>
-                        ) : (
-                          <Button
-                            variant='secondary'
-                            type='button'
-                            disabled={session.status === 'Ended'}
-                            onClick={() => void handleJoinLiveSession(session.session_id)}
-                          >
-                            Join
-                          </Button>
-                        )}
-                        {isOwner ? (
-                          <Button
-                            variant='secondary'
-                            type='button'
-                            disabled={session.status === 'Ended'}
-                            onClick={() => void handleEndLiveSession(session.session_id)}
-                          >
-                            End
-                          </Button>
-                        ) : null}
-                      </div>
-                    </article>
-                  </li>
-                );
-              })}
-            </ul>
+            ) : (
+              <p className='empty'>Select a post to inspect the thread.</p>
+            )}
           </Card>
-          <Card className='panel-subsection'>
-            <CardHeader>
-              <h3>Game Rooms</h3>
-              <small>{activeGameRooms.length} tracked</small>
-            </CardHeader>
-            <form className='composer composer-compact' onSubmit={handleCreateGameRoom}>
-              <Label>
-                <span>Game Title</span>
-                <Input
-                  value={gameTitle}
-                  onChange={(event) => setGameTitle(event.target.value)}
-                  placeholder='Top 8 Finals'
-                />
-              </Label>
-              <Label>
-                <span>Game Description</span>
-                <Textarea
-                  value={gameDescription}
-                  onChange={(event) => setGameDescription(event.target.value)}
-                  placeholder='match summary'
-                />
-              </Label>
-              <Label>
-                <span>Participants</span>
-                <Input
-                  value={gameParticipantsInput}
-                  onChange={(event) => setGameParticipantsInput(event.target.value)}
-                  placeholder='Alice, Bob'
-                />
-              </Label>
-              {gameError ? <p className='error error-inline'>{gameError}</p> : null}
-              <div className='topic-diagnostic topic-diagnostic-secondary'>
-                <span>Audience: {activeComposeAudienceLabel}</span>
-              </div>
-              <Button type='submit'>
-                Create Room
-              </Button>
-            </form>
-            {activeGameRooms.length === 0 ? <p className='empty-state'>No game rooms</p> : null}
-            <ul className='post-list'>
-              {activeGameRooms.map((room) => {
-                const draft = gameDrafts[room.room_id] ?? createGameEditorDraft(room);
-                const isOwner = room.host_pubkey === syncStatus.local_author_pubkey;
-                return (
-                  <li key={room.room_id}>
-                    <article className='post-card'>
-                      <div className='post-meta'>
-                        <span>{room.title}</span>
-                        <span>{room.status}</span>
-                        <span className='reply-chip'>{room.audience_label}</span>
-                      </div>
-                      <div className='post-body'>
-                        <strong className='post-title'>{room.description || 'no description'}</strong>
-                      </div>
-                      <small>{room.room_id}</small>
-                      <div className='topic-diagnostic topic-diagnostic-secondary'>
-                        <span>phase: {room.phase_label ?? 'none'}</span>
-                        <span>
-                          updated: {new Date(room.updated_at).toLocaleTimeString('ja-JP')}
-                        </span>
-                      </div>
-                      <ul className='draft-attachment-list'>
-                        {room.scores.map((score) => (
-                          <li key={score.participant_id} className='draft-attachment-item score-row'>
-                            <div className='draft-attachment-content'>
-                              <strong>{score.label}</strong>
-                            </div>
-                            {isOwner ? (
-                              <Input
-                                aria-label={`${room.room_id}-${score.label}-score`}
-                                value={draft.scores[score.participant_id] ?? String(score.score)}
-                                onChange={(event) =>
-                                  updateGameDraft(room.room_id, (current) => ({
-                                    ...current,
-                                    scores: {
-                                      ...current.scores,
-                                      [score.participant_id]: event.target.value,
-                                    },
-                                  }))
-                                }
-                              />
-                            ) : (
-                              <span>{score.score}</span>
-                            )}
-                          </li>
-                        ))}
-                      </ul>
-                      {isOwner ? (
-                        <div className='composer composer-compact'>
-                          <Label>
-                            <span>Status</span>
-                            <Select
-                              aria-label={`${room.room_id}-status`}
-                              value={draft.status}
-                              onChange={(event) =>
-                                updateGameDraft(room.room_id, (current) => ({
-                                  ...current,
-                                  status: event.target.value as GameRoomStatus,
-                                }))
-                              }
-                            >
-                              <option value='Waiting'>Waiting</option>
-                              <option value='Running'>Running</option>
-                              <option value='Paused'>Paused</option>
-                              <option value='Ended'>Ended</option>
-                            </Select>
-                          </Label>
-                          <Label>
-                            <span>Phase</span>
-                            <Input
-                              aria-label={`${room.room_id}-phase`}
-                              value={draft.phase_label}
-                              onChange={(event) =>
-                                updateGameDraft(room.room_id, (current) => ({
-                                  ...current,
-                                  phase_label: event.target.value,
-                                }))
-                              }
-                            />
-                          </Label>
-                          <Button variant='secondary' type='button' onClick={() => void handleUpdateGameRoom(room)}>
-                            Save Room
-                          </Button>
-                        </div>
-                      ) : null}
-                    </article>
-                  </li>
-                );
-              })}
-            </ul>
-          </Card>
-          <ul className='post-list'>
-            {activeTimeline.map((post) => (
-              <li key={post.object_id}>{renderPostCard(post, 'timeline')}</li>
-            ))}
-          </ul>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <h2>Thread</h2>
-            <div className='post-actions-inline'>
-              {selectedAuthor ? (
-                <Button
-                  variant='secondary'
-                  type='button'
-                  onClick={() => {
-                    setSelectedAuthorPubkey(null);
-                    setSelectedAuthor(null);
-                    setAuthorError(null);
-                  }}
-                >
-                  Clear Author
-                </Button>
-              ) : null}
-              {selectedThread ? (
-                <Button
-                  variant='secondary'
-                  type='button'
-                  onClick={() => {
-                    setSelectedThread(null);
-                    setThread([]);
-                    clearReply();
-                  }}
-                >
-                  Close
-                </Button>
-              ) : null}
-            </div>
-          </CardHeader>
-          <Card className='panel-subsection'>
+        </div>
+      ),
+    },
+    {
+      id: 'author' as ContextPaneMode,
+      label: 'Author',
+      summary: selectedAuthor
+        ? authorDisplayLabel(
+            selectedAuthor.author_pubkey,
+            selectedAuthor.display_name,
+            selectedAuthor.name
+          )
+        : 'Select an author to inspect profile and relationship.',
+      content: (
+        <div className='shell-main-stack'>
+          <Card>
             <CardHeader>
               <h3>Author Detail</h3>
-              <small>{selectedAuthor ? selectedAuthor.author_pubkey.slice(0, 12) : 'none'}</small>
+              <div className='post-actions-inline'>
+                {selectedAuthor ? (
+                  <Button
+                    variant='secondary'
+                    type='button'
+                    onClick={() => {
+                      setSelectedAuthorPubkey(null);
+                      setSelectedAuthor(null);
+                      setAuthorError(null);
+                    }}
+                  >
+                    Clear Author
+                  </Button>
+                ) : null}
+              </div>
             </CardHeader>
             {selectedAuthor ? (
               <div className='author-detail'>
@@ -3100,21 +2933,695 @@ export function App({ api = runtimeApi }: AppProps) {
               <p className='empty'>Select an author to inspect profile and relationship.</p>
             )}
           </Card>
-          {selectedThread ? (
-            <ul className='thread-list'>
-              {thread.map((post) => (
-                <li key={post.object_id} className='thread-item'>
-                  {renderPostCard(post, 'thread')}
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className='empty'>Select a post to inspect the thread.</p>
-          )}
-        </Card>
-      </section>
+        </div>
+      ),
+    },
+  ];
 
-      {error ? <p className='error'>{error}</p> : null}
-    </main>
+  return (
+    <>
+      <ShellFrame
+        skipTargetId={SHELL_WORKSPACE_ID}
+        topBar={
+          <ShellTopBar
+            headline={headline}
+            activeTopic={activeTopic}
+            statusBadges={statusBadges}
+            navOpen={shellChromeState.navOpen}
+            settingsOpen={shellChromeState.settingsOpen}
+            navControlsId={SHELL_NAV_ID}
+            settingsControlsId={SHELL_SETTINGS_ID}
+            navButtonRef={navTriggerRef}
+            settingsButtonRef={settingsTriggerRef}
+            onToggleNav={() => setNavOpen(!shellChromeState.navOpen)}
+            onToggleSettings={() => setSettingsOpen(!shellChromeState.settingsOpen)}
+          />
+        }
+        navRail={
+          <ShellNavRail
+            railId={SHELL_NAV_ID}
+            open={shellChromeState.navOpen}
+            onOpenChange={(open) => setNavOpen(open, !open)}
+            primaryItems={PRIMARY_SECTION_ITEMS}
+            activePrimarySection={shellChromeState.activePrimarySection}
+            onSelectPrimarySection={focusPrimarySection}
+            addTopicControl={
+              <Label>
+                <span>Add Topic</span>
+                <div className='topic-input-row'>
+                  <Input
+                    value={topicInput}
+                    onChange={(event) => setTopicInput(event.target.value)}
+                    placeholder='kukuri:topic:demo'
+                  />
+                  <Button variant='secondary' onClick={() => void handleAddTopic()}>
+                    Add
+                  </Button>
+                </div>
+              </Label>
+            }
+            topicList={topicList}
+            topicCount={syncStatus.subscribed_topics.length}
+          />
+        }
+        workspace={
+          <div className='shell-main-stack'>
+            <Card className='shell-workspace-card'>
+              <div
+                className='shell-section'
+                ref={setPrimarySectionRef('timeline')}
+                tabIndex={-1}
+                onFocusCapture={() =>
+                  setShellChromeState((current) => ({
+                    ...current,
+                    activePrimarySection: 'timeline',
+                  }))
+                }
+              >
+                <div className='shell-workspace-header'>
+                  <div>
+                    <h2>Timeline</h2>
+                    <span className='active-topic-label'>{activeTopic}</span>
+                  </div>
+                  <div className='shell-inline-actions'>
+                    <div className='shell-workspace-summary'>
+                      <StatusBadge
+                        label={`viewing ${audienceLabelForTimelineScope(
+                          activeTimelineScope,
+                          activeJoinedChannels
+                        ).toLowerCase()}`}
+                      />
+                      <StatusBadge
+                        label={`posting ${activeComposeAudienceLabel.toLowerCase()}`}
+                      />
+                    </div>
+                    <Button
+                      ref={contextTriggerRef}
+                      className='shell-context-trigger'
+                      variant='ghost'
+                      type='button'
+                      aria-label='Open context pane'
+                      aria-controls={SHELL_CONTEXT_ID}
+                      aria-expanded={shellChromeState.contextOpen}
+                      data-testid='shell-context-trigger'
+                      onClick={() => setContextOpen(true)}
+                    >
+                      Open Context
+                    </Button>
+                    <Button
+                      variant='secondary'
+                      onClick={() => void loadTopics(trackedTopics, activeTopic, selectedThread)}
+                    >
+                      Refresh
+                    </Button>
+                  </div>
+                </div>
+                <div className='topic-diagnostic'>
+                  <Label>
+                    <span>View Scope</span>
+                    <Select
+                      aria-label='View Scope'
+                      value={timelineScopeValue(activeTimelineScope)}
+                      onChange={(event) => {
+                        void handleTimelineScopeChange(event.target.value);
+                      }}
+                    >
+                      <option value='public'>Public</option>
+                      <option value='all_joined'>All joined</option>
+                      {activeJoinedChannels.map((channel) => (
+                        <option key={channel.channel_id} value={`channel:${channel.channel_id}`}>
+                          {channel.label}
+                        </option>
+                      ))}
+                    </Select>
+                  </Label>
+                  <Label>
+                    <span>Compose Target</span>
+                    <Select
+                      aria-label='Compose Target'
+                      value={channelRefValue(activeComposeChannel)}
+                      disabled={Boolean(replyTarget)}
+                      onChange={(event) => handleComposeChannelChange(event.target.value)}
+                    >
+                      <option value='public'>Public</option>
+                      {activeJoinedChannels.map((channel) => (
+                        <option key={channel.channel_id} value={`channel:${channel.channel_id}`}>
+                          {channel.label}
+                        </option>
+                      ))}
+                    </Select>
+                  </Label>
+                </div>
+                <div className='topic-diagnostic topic-diagnostic-secondary'>
+                  <span>
+                    Viewing:{' '}
+                    {audienceLabelForTimelineScope(activeTimelineScope, activeJoinedChannels)}
+                  </span>
+                  <span>Posting to: {activeComposeAudienceLabel}</span>
+                </div>
+              </div>
+
+              <section
+                className='shell-section'
+                ref={setPrimarySectionRef('channels')}
+                tabIndex={-1}
+                onFocusCapture={() =>
+                  setShellChromeState((current) => ({
+                    ...current,
+                    activePrimarySection: 'channels',
+                  }))
+                }
+              >
+                <form className='composer composer-compact' onSubmit={handleCreatePrivateChannel}>
+                  <Label>
+                    <span>Create Channel</span>
+                    <Input
+                      value={channelLabelInput}
+                      onChange={(event) => setChannelLabelInput(event.target.value)}
+                      placeholder='core contributors'
+                    />
+                  </Label>
+                  <Label>
+                    <span>Audience</span>
+                    <Select
+                      aria-label='Channel Audience'
+                      value={channelAudienceInput}
+                      onChange={(event) =>
+                        setChannelAudienceInput(event.target.value as ChannelAudienceKind)
+                      }
+                    >
+                      <option value='invite_only'>Invite only</option>
+                      <option value='friend_only'>Friends</option>
+                      <option value='friend_plus'>Friends+</option>
+                    </Select>
+                  </Label>
+                  <Button variant='secondary' type='submit'>
+                    Create Channel
+                  </Button>
+                  {activePrivateChannel?.audience_kind === 'invite_only' ? (
+                    <Button
+                      variant='secondary'
+                      type='button'
+                      disabled={activeComposeChannel.kind !== 'private_channel'}
+                      onClick={() => void handleCreateInvite()}
+                    >
+                      Create Invite
+                    </Button>
+                  ) : null}
+                  {activePrivateChannel?.audience_kind === 'friend_only' ? (
+                    <Button
+                      variant='secondary'
+                      type='button'
+                      disabled={!activePrivateChannel.is_owner}
+                      onClick={() => void handleCreateGrant()}
+                    >
+                      Create Grant
+                    </Button>
+                  ) : null}
+                  {activePrivateChannel?.audience_kind === 'friend_plus' ? (
+                    <Button
+                      variant='secondary'
+                      type='button'
+                      disabled={activeComposeChannel.kind !== 'private_channel'}
+                      onClick={() => void handleCreateShare()}
+                    >
+                      Create Share
+                    </Button>
+                  ) : null}
+                  {activePrivateChannel?.audience_kind === 'friend_plus' ? (
+                    <Button
+                      variant='secondary'
+                      type='button'
+                      disabled={!activePrivateChannel.is_owner}
+                      onClick={() => void handleFreezePrivateChannel()}
+                    >
+                      Freeze
+                    </Button>
+                  ) : null}
+                  {activePrivateChannel?.audience_kind === 'friend_only' ? (
+                    <Button
+                      variant='secondary'
+                      type='button'
+                      disabled={!activePrivateChannel.is_owner}
+                      onClick={() => void handleRotatePrivateChannel()}
+                    >
+                      Rotate
+                    </Button>
+                  ) : null}
+                  {activePrivateChannel?.audience_kind === 'friend_plus' ? (
+                    <Button
+                      variant='secondary'
+                      type='button'
+                      disabled={!activePrivateChannel.is_owner}
+                      onClick={() => void handleRotatePrivateChannel()}
+                    >
+                      Rotate
+                    </Button>
+                  ) : null}
+                </form>
+                <form className='composer composer-compact' onSubmit={handleJoinInvite}>
+                  <Label>
+                    <span>Join via Invite</span>
+                    <Textarea
+                      value={inviteTokenInput}
+                      onChange={(event) => setInviteTokenInput(event.target.value)}
+                      placeholder='paste private channel invite, friend grant, or friends+ share'
+                    />
+                  </Label>
+                  <Button variant='secondary' type='submit'>
+                    Join Invite
+                  </Button>
+                  <Button variant='secondary' type='button' onClick={() => void handleJoinGrant()}>
+                    Join Grant
+                  </Button>
+                  <Button variant='secondary' type='button' onClick={() => void handleJoinShare()}>
+                    Join Share
+                  </Button>
+                </form>
+                {inviteOutput ? (
+                  <div className='topic-diagnostic topic-diagnostic-secondary'>
+                    <span>
+                      {inviteOutputLabel === 'grant'
+                        ? 'Latest grant'
+                        : inviteOutputLabel === 'share'
+                          ? 'Latest share'
+                          : 'Latest invite'}
+                    </span>
+                    <code>{inviteOutput}</code>
+                  </div>
+                ) : null}
+                {activePrivateChannel ? (
+                  <div className='topic-diagnostic topic-diagnostic-secondary'>
+                    <span>
+                      Policy:{' '}
+                      {activePrivateChannel.audience_kind === 'friend_only'
+                        ? 'Friends: only mutual followers can join'
+                        : activePrivateChannel.audience_kind === 'friend_plus'
+                          ? 'Friends+: participants can share to their mutuals'
+                          : 'Invite only'}
+                    </span>
+                    <span>epoch: {activePrivateChannel.current_epoch_id}</span>
+                    <span>sharing: {activePrivateChannel.sharing_state}</span>
+                    {activePrivateChannel.joined_via_pubkey ? (
+                      <span>joined via {shortPubkey(activePrivateChannel.joined_via_pubkey)}</span>
+                    ) : null}
+                  </div>
+                ) : null}
+                {activePrivateChannel &&
+                (activePrivateChannel.audience_kind === 'friend_only' ||
+                  activePrivateChannel.audience_kind === 'friend_plus') ? (
+                  <div className='topic-diagnostic topic-diagnostic-secondary'>
+                    <span>participants: {activePrivateChannel.participant_count}</span>
+                    <span>stale: {activePrivateChannel.stale_participant_count}</span>
+                    <span>owner: {activePrivateChannel.is_owner ? 'yes' : 'no'}</span>
+                  </div>
+                ) : null}
+                {activePrivateChannel?.audience_kind === 'friend_only' &&
+                activePrivateChannel.rotation_required ? (
+                  <div className='topic-diagnostic topic-diagnostic-error'>
+                    <span>rotation required: current participants include non-mutual followers</span>
+                  </div>
+                ) : null}
+                {channelError ? <p className='error error-inline'>{channelError}</p> : null}
+                <form className='composer' onSubmit={handlePublish}>
+                  {replyTarget ? (
+                    <div className='reply-banner'>
+                      <div>
+                        <strong>Replying</strong>
+                        <p>{replyTarget.content}</p>
+                        <small>Audience: {replyTarget.audience_label}</small>
+                      </div>
+                      <Button variant='secondary' type='button' onClick={clearReply}>
+                        Clear
+                      </Button>
+                    </div>
+                  ) : null}
+                  <Textarea
+                    value={composer}
+                    onChange={(event) => setComposer(event.target.value)}
+                    placeholder={replyTarget ? 'Write a reply' : 'Write a post'}
+                  />
+                  <Label className='file-field'>
+                    <span>Attach</span>
+                    <Input
+                      key={attachmentInputKey}
+                      aria-label='Attach'
+                      type='file'
+                      accept='image/*,video/*'
+                      multiple
+                      onChange={(event) => {
+                        void handleAttachmentSelection(event);
+                      }}
+                    />
+                  </Label>
+                  {composerError ? <p className='error error-inline'>{composerError}</p> : null}
+                  {draftMediaItems.length > 0 ? (
+                    <ul className='draft-attachment-list'>
+                      {draftMediaItems.map((item) => (
+                        <li key={item.id} className='draft-attachment-item'>
+                          <div className='draft-attachment-content'>
+                            <div className='draft-preview-frame'>
+                              <img
+                                className='draft-preview-image'
+                                src={item.preview_url}
+                                alt={`draft preview ${item.source_name}`}
+                              />
+                            </div>
+                            <div>
+                              <strong>{item.source_name}</strong>
+                              {item.attachments.map((attachment) => (
+                                <small
+                                  key={`${
+                                    attachment.role ?? attachment.mime
+                                  }-${attachment.file_name ?? item.source_name}`}
+                                >
+                                  {attachment.role ?? 'attachment'} · {attachment.mime} ·{' '}
+                                  {formatBytes(attachment.byte_size)}
+                                </small>
+                              ))}
+                            </div>
+                          </div>
+                          <Button
+                            variant='secondary'
+                            type='button'
+                            onClick={() => handleRemoveDraftAttachment(item.id)}
+                          >
+                            Remove
+                          </Button>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                  <div className='topic-diagnostic topic-diagnostic-secondary'>
+                    <span>Audience: {activeComposeAudienceLabel}</span>
+                  </div>
+                  <Button type='submit'>{replyTarget ? 'Reply' : 'Publish'}</Button>
+                </form>
+              </section>
+
+              <section
+                className='shell-section'
+                ref={setPrimarySectionRef('live')}
+                tabIndex={-1}
+                onFocusCapture={() =>
+                  setShellChromeState((current) => ({
+                    ...current,
+                    activePrimarySection: 'live',
+                  }))
+                }
+              >
+                <Card className='panel-subsection'>
+                  <CardHeader>
+                    <h3>Live Sessions</h3>
+                    <small>{activeLiveSessions.length} active</small>
+                  </CardHeader>
+                  <form className='composer composer-compact' onSubmit={handleCreateLiveSession}>
+                    <Label>
+                      <span>Live Title</span>
+                      <Input
+                        value={liveTitle}
+                        onChange={(event) => setLiveTitle(event.target.value)}
+                        placeholder='Friday stream'
+                      />
+                    </Label>
+                    <Label>
+                      <span>Live Description</span>
+                      <Textarea
+                        value={liveDescription}
+                        onChange={(event) => setLiveDescription(event.target.value)}
+                        placeholder='short session summary'
+                      />
+                    </Label>
+                    {liveError ? <p className='error error-inline'>{liveError}</p> : null}
+                    <div className='topic-diagnostic topic-diagnostic-secondary'>
+                      <span>Audience: {activeComposeAudienceLabel}</span>
+                    </div>
+                    <Button type='submit'>Start Live</Button>
+                  </form>
+                  {activeLiveSessions.length === 0 ? (
+                    <p className='empty-state'>No live sessions</p>
+                  ) : null}
+                  <ul className='post-list'>
+                    {activeLiveSessions.map((session) => {
+                      const isOwner = session.host_pubkey === syncStatus.local_author_pubkey;
+                      return (
+                        <li key={session.session_id}>
+                          <article className='post-card'>
+                            <div className='post-meta'>
+                              <span>{session.title}</span>
+                              <span>{session.status}</span>
+                              <span className='reply-chip'>{session.audience_label}</span>
+                            </div>
+                            <div className='post-body'>
+                              <strong className='post-title'>
+                                {session.description || 'no description'}
+                              </strong>
+                            </div>
+                            <small>{session.session_id}</small>
+                            <div className='topic-diagnostic topic-diagnostic-secondary'>
+                              <span>viewers: {session.viewer_count}</span>
+                              <span>
+                                started:{' '}
+                                {new Date(session.started_at).toLocaleTimeString('ja-JP')}
+                              </span>
+                            </div>
+                            {session.ended_at ? (
+                              <div className='topic-diagnostic topic-diagnostic-secondary'>
+                                <span>
+                                  ended: {new Date(session.ended_at).toLocaleTimeString('ja-JP')}
+                                </span>
+                              </div>
+                            ) : null}
+                            <div className='post-actions'>
+                              {session.joined_by_me ? (
+                                <Button
+                                  variant='secondary'
+                                  type='button'
+                                  onClick={() => void handleLeaveLiveSession(session.session_id)}
+                                >
+                                  Leave
+                                </Button>
+                              ) : (
+                                <Button
+                                  variant='secondary'
+                                  type='button'
+                                  disabled={session.status === 'Ended'}
+                                  onClick={() => void handleJoinLiveSession(session.session_id)}
+                                >
+                                  Join
+                                </Button>
+                              )}
+                              {isOwner ? (
+                                <Button
+                                  variant='secondary'
+                                  type='button'
+                                  disabled={session.status === 'Ended'}
+                                  onClick={() => void handleEndLiveSession(session.session_id)}
+                                >
+                                  End
+                                </Button>
+                              ) : null}
+                            </div>
+                          </article>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </Card>
+              </section>
+
+              <section
+                className='shell-section'
+                ref={setPrimarySectionRef('game')}
+                tabIndex={-1}
+                onFocusCapture={() =>
+                  setShellChromeState((current) => ({
+                    ...current,
+                    activePrimarySection: 'game',
+                  }))
+                }
+              >
+                <Card className='panel-subsection'>
+                  <CardHeader>
+                    <h3>Game Rooms</h3>
+                    <small>{activeGameRooms.length} tracked</small>
+                  </CardHeader>
+                  <form className='composer composer-compact' onSubmit={handleCreateGameRoom}>
+                    <Label>
+                      <span>Game Title</span>
+                      <Input
+                        value={gameTitle}
+                        onChange={(event) => setGameTitle(event.target.value)}
+                        placeholder='Top 8 Finals'
+                      />
+                    </Label>
+                    <Label>
+                      <span>Game Description</span>
+                      <Textarea
+                        value={gameDescription}
+                        onChange={(event) => setGameDescription(event.target.value)}
+                        placeholder='match summary'
+                      />
+                    </Label>
+                    <Label>
+                      <span>Participants</span>
+                      <Input
+                        value={gameParticipantsInput}
+                        onChange={(event) => setGameParticipantsInput(event.target.value)}
+                        placeholder='Alice, Bob'
+                      />
+                    </Label>
+                    {gameError ? <p className='error error-inline'>{gameError}</p> : null}
+                    <div className='topic-diagnostic topic-diagnostic-secondary'>
+                      <span>Audience: {activeComposeAudienceLabel}</span>
+                    </div>
+                    <Button type='submit'>Create Room</Button>
+                  </form>
+                  {activeGameRooms.length === 0 ? <p className='empty-state'>No game rooms</p> : null}
+                  <ul className='post-list'>
+                    {activeGameRooms.map((room) => {
+                      const draft = gameDrafts[room.room_id] ?? createGameEditorDraft(room);
+                      const isOwner = room.host_pubkey === syncStatus.local_author_pubkey;
+                      return (
+                        <li key={room.room_id}>
+                          <article className='post-card'>
+                            <div className='post-meta'>
+                              <span>{room.title}</span>
+                              <span>{room.status}</span>
+                              <span className='reply-chip'>{room.audience_label}</span>
+                            </div>
+                            <div className='post-body'>
+                              <strong className='post-title'>
+                                {room.description || 'no description'}
+                              </strong>
+                            </div>
+                            <small>{room.room_id}</small>
+                            <div className='topic-diagnostic topic-diagnostic-secondary'>
+                              <span>phase: {room.phase_label ?? 'none'}</span>
+                              <span>
+                                updated: {new Date(room.updated_at).toLocaleTimeString('ja-JP')}
+                              </span>
+                            </div>
+                            <ul className='draft-attachment-list'>
+                              {room.scores.map((score) => (
+                                <li
+                                  key={score.participant_id}
+                                  className='draft-attachment-item score-row'
+                                >
+                                  <div className='draft-attachment-content'>
+                                    <strong>{score.label}</strong>
+                                  </div>
+                                  {isOwner ? (
+                                    <Input
+                                      aria-label={`${room.room_id}-${score.label}-score`}
+                                      value={
+                                        draft.scores[score.participant_id] ?? String(score.score)
+                                      }
+                                      onChange={(event) =>
+                                        updateGameDraft(room.room_id, (current) => ({
+                                          ...current,
+                                          scores: {
+                                            ...current.scores,
+                                            [score.participant_id]: event.target.value,
+                                          },
+                                        }))
+                                      }
+                                    />
+                                  ) : (
+                                    <span>{score.score}</span>
+                                  )}
+                                </li>
+                              ))}
+                            </ul>
+                            {isOwner ? (
+                              <div className='composer composer-compact'>
+                                <Label>
+                                  <span>Status</span>
+                                  <Select
+                                    aria-label={`${room.room_id}-status`}
+                                    value={draft.status}
+                                    onChange={(event) =>
+                                      updateGameDraft(room.room_id, (current) => ({
+                                        ...current,
+                                        status: event.target.value as GameRoomStatus,
+                                      }))
+                                    }
+                                  >
+                                    <option value='Waiting'>Waiting</option>
+                                    <option value='Running'>Running</option>
+                                    <option value='Paused'>Paused</option>
+                                    <option value='Ended'>Ended</option>
+                                  </Select>
+                                </Label>
+                                <Label>
+                                  <span>Phase</span>
+                                  <Input
+                                    aria-label={`${room.room_id}-phase`}
+                                    value={draft.phase_label}
+                                    onChange={(event) =>
+                                      updateGameDraft(room.room_id, (current) => ({
+                                        ...current,
+                                        phase_label: event.target.value,
+                                      }))
+                                    }
+                                  />
+                                </Label>
+                                <Button
+                                  variant='secondary'
+                                  type='button'
+                                  onClick={() => void handleUpdateGameRoom(room)}
+                                >
+                                  Save Room
+                                </Button>
+                              </div>
+                            ) : null}
+                          </article>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </Card>
+              </section>
+
+              <ul className='post-list'>
+                {activeTimeline.map((post) => (
+                  <li key={post.object_id}>{renderPostCard(post, 'timeline')}</li>
+                ))}
+              </ul>
+            </Card>
+          </div>
+        }
+        contextPane={
+          <ContextPane
+            paneId={SHELL_CONTEXT_ID}
+            open={shellChromeState.contextOpen}
+            onOpenChange={(open) => setContextOpen(open, !open)}
+            activeMode={shellChromeState.activeContextPaneMode}
+            onModeChange={(mode) =>
+              setShellChromeState((current) => ({
+                ...current,
+                activeContextPaneMode: mode,
+                contextOpen: true,
+              }))
+            }
+            tabs={contextTabs}
+          />
+        }
+      />
+
+      <SettingsDrawer
+        drawerId={SHELL_SETTINGS_ID}
+        open={shellChromeState.settingsOpen}
+        onOpenChange={(open) => setSettingsOpen(open, !open)}
+        activeSection={shellChromeState.activeSettingsSection}
+        onSectionChange={(section) =>
+          setShellChromeState((current) => ({
+            ...current,
+            activeSettingsSection: section,
+          }))
+        }
+        sections={settingsSections}
+      />
+    </>
   );
 }

--- a/apps/desktop/src/components/shell/ContextPane.tsx
+++ b/apps/desktop/src/components/shell/ContextPane.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+
+import { X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+import { type ContextPaneMode } from './types';
+
+type ContextTab = {
+  id: ContextPaneMode;
+  label: string;
+  summary: string;
+  content: React.ReactNode;
+};
+
+type ContextPaneProps = {
+  paneId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  activeMode: ContextPaneMode;
+  onModeChange: (mode: ContextPaneMode) => void;
+  tabs: ContextTab[];
+};
+
+export function ContextPane({
+  paneId,
+  open,
+  onOpenChange,
+  activeMode,
+  onModeChange,
+  tabs,
+}: ContextPaneProps) {
+  const activeTab = tabs.find((tab) => tab.id === activeMode) ?? tabs[0];
+
+  return (
+    <>
+      <div
+        className='shell-overlay-backdrop shell-context-backdrop'
+        data-open={open}
+        onClick={() => onOpenChange(false)}
+        aria-hidden='true'
+      />
+      <Card
+        as='aside'
+        id={paneId}
+        className='shell-context'
+        data-open={open}
+        aria-label='Context pane'
+      >
+        <div className='shell-pane-header'>
+          <div>
+            <p className='eyebrow'>Context</p>
+            <h2 className='shell-pane-heading'>{activeTab.label}</h2>
+            <p className='shell-pane-copy'>{activeTab.summary}</p>
+          </div>
+          <Button
+            className='shell-context-close'
+            variant='ghost'
+            size='icon'
+            type='button'
+            aria-label='Close context pane'
+            onClick={() => onOpenChange(false)}
+          >
+            <X className='size-4' aria-hidden='true' />
+          </Button>
+        </div>
+
+        <div className='shell-tab-list' role='tablist' aria-label='Context tabs'>
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              className={cn('shell-tab', activeMode === tab.id && 'shell-tab-active')}
+              id={`${paneId}-tab-${tab.id}`}
+              role='tab'
+              type='button'
+              aria-selected={activeMode === tab.id}
+              aria-controls={`${paneId}-panel-${tab.id}`}
+              tabIndex={activeMode === tab.id ? 0 : -1}
+              onClick={() => onModeChange(tab.id)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {tabs.map((tab) => (
+          <section
+            key={tab.id}
+            id={`${paneId}-panel-${tab.id}`}
+            className='shell-context-panel'
+            role='tabpanel'
+            aria-labelledby={`${paneId}-tab-${tab.id}`}
+            hidden={activeMode !== tab.id}
+          >
+            {tab.content}
+          </section>
+        ))}
+      </Card>
+    </>
+  );
+}

--- a/apps/desktop/src/components/shell/SettingsDrawer.tsx
+++ b/apps/desktop/src/components/shell/SettingsDrawer.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+
+import { X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+import { type SettingsSection } from './types';
+
+type SettingsDrawerSection = {
+  id: SettingsSection;
+  label: string;
+  description: string;
+  content: React.ReactNode;
+};
+
+type SettingsDrawerProps = {
+  drawerId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  activeSection: SettingsSection;
+  onSectionChange: (section: SettingsSection) => void;
+  sections: SettingsDrawerSection[];
+};
+
+export function SettingsDrawer({
+  drawerId,
+  open,
+  onOpenChange,
+  activeSection,
+  onSectionChange,
+  sections,
+}: SettingsDrawerProps) {
+  const currentSection = sections.find((section) => section.id === activeSection) ?? sections[0];
+
+  return (
+    <>
+      <div
+        className='shell-overlay-backdrop shell-settings-backdrop'
+        data-open={open}
+        onClick={() => onOpenChange(false)}
+        aria-hidden='true'
+      />
+      <Card
+        as='section'
+        id={drawerId}
+        className='shell-settings-drawer'
+        data-open={open}
+        role='dialog'
+        aria-modal='true'
+        aria-hidden={!open}
+        aria-labelledby={`${drawerId}-title`}
+      >
+        <div className='shell-settings-nav'>
+          <div className='shell-pane-header shell-pane-header-compact'>
+            <div>
+              <p className='eyebrow'>Settings</p>
+              <h2 id={`${drawerId}-title`} className='shell-pane-heading'>
+                Settings & diagnostics
+              </h2>
+            </div>
+            <Button
+              variant='ghost'
+              size='icon'
+              type='button'
+              aria-label='Close settings and diagnostics'
+              onClick={() => onOpenChange(false)}
+            >
+              <X className='size-4' aria-hidden='true' />
+            </Button>
+          </div>
+          <nav aria-label='Settings sections' className='shell-settings-nav-list'>
+            {sections.map((section) => (
+              <button
+                key={section.id}
+                className={cn(
+                  'shell-settings-nav-item',
+                  activeSection === section.id && 'shell-settings-nav-item-active'
+                )}
+                type='button'
+                aria-current={activeSection === section.id ? 'location' : undefined}
+                data-testid={`settings-section-${section.id}`}
+                onClick={() => onSectionChange(section.id)}
+              >
+                <span className='shell-primary-nav-label'>{section.label}</span>
+                <span className='shell-primary-nav-copy'>{section.description}</span>
+              </button>
+            ))}
+          </nav>
+        </div>
+
+        <div className='shell-settings-body'>
+          <div className='shell-settings-current'>
+            <p className='eyebrow'>Current section</p>
+            <h3 className='shell-pane-heading'>{currentSection.label}</h3>
+            <p className='shell-pane-copy'>{currentSection.description}</p>
+          </div>
+          <div className='shell-settings-content'>{currentSection.content}</div>
+        </div>
+      </Card>
+    </>
+  );
+}

--- a/apps/desktop/src/components/shell/ShellFrame.stories.tsx
+++ b/apps/desktop/src/components/shell/ShellFrame.stories.tsx
@@ -1,0 +1,364 @@
+import { useMemo, useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { StatusBadge } from '@/components/StatusBadge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Notice } from '@/components/ui/notice';
+
+import { ContextPane } from './ContextPane';
+import { ShellFrame } from './ShellFrame';
+import { ShellNavRail } from './ShellNavRail';
+import { SettingsDrawer } from './SettingsDrawer';
+import { ShellTopBar } from './ShellTopBar';
+import {
+  type ContextPaneMode,
+  type PrimarySection,
+  type SettingsSection,
+  type ShellChromeState,
+} from './types';
+
+const meta = {
+  title: 'Shell/ShellFrame',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+type ShellStoryFixtureProps = {
+  width: number;
+  initialChromeState?: Partial<ShellChromeState>;
+};
+
+const PRIMARY_ITEMS: Array<{
+  id: PrimarySection;
+  label: string;
+  description: string;
+}> = [
+  { id: 'timeline', label: 'Timeline', description: 'Feed and scope controls' },
+  { id: 'channels', label: 'Channels', description: 'Private channel entry and composer' },
+  { id: 'live', label: 'Live', description: 'Live sessions and status' },
+  { id: 'game', label: 'Game', description: 'Scoreboards and room editing' },
+];
+
+const SETTINGS_ITEMS: Array<{
+  id: SettingsSection;
+  label: string;
+  description: string;
+}> = [
+  { id: 'profile', label: 'Profile', description: 'Edit author identity' },
+  { id: 'connectivity', label: 'Connectivity', description: 'Peer status and tickets' },
+  { id: 'discovery', label: 'Discovery', description: 'Seed configuration and diagnostics' },
+  {
+    id: 'community-node',
+    label: 'Community Node',
+    description: 'Auth, consent, and community metadata',
+  },
+];
+
+function ShellStoryFixture({ width, initialChromeState }: ShellStoryFixtureProps) {
+  const [chromeState, setChromeState] = useState<ShellChromeState>({
+    activePrimarySection: 'timeline',
+    activeContextPaneMode: 'thread',
+    activeSettingsSection: 'profile',
+    navOpen: false,
+    contextOpen: false,
+    settingsOpen: false,
+    ...initialChromeState,
+  });
+
+  const contextTabs = useMemo(
+    () => [
+      {
+        id: 'thread' as ContextPaneMode,
+        label: 'Thread',
+        summary: '3 replies in the active thread',
+        content: (
+          <div className='shell-main-stack'>
+            <Card>
+              <h3>Thread</h3>
+              <p className='lede'>Keep the reading context visible without taking over the workspace.</p>
+            </Card>
+          </div>
+        ),
+      },
+      {
+        id: 'author' as ContextPaneMode,
+        label: 'Author',
+        summary: 'alice',
+        content: (
+          <div className='shell-main-stack'>
+            <Card>
+              <h3>Author Detail</h3>
+              <p className='lede'>Profile, relationship badges, and follow actions live here.</p>
+            </Card>
+          </div>
+        ),
+      },
+    ],
+    []
+  );
+
+  const settingsSections = useMemo(
+    () =>
+      SETTINGS_ITEMS.map((section) => ({
+        ...section,
+        content: (
+          <div className='shell-main-stack'>
+            <Card>
+              <h3>{section.label}</h3>
+              <p className='lede'>{section.description}</p>
+              <Notice tone={section.id === 'connectivity' ? 'accent' : 'neutral'}>
+                Review surface for {section.label.toLowerCase()}.
+              </Notice>
+            </Card>
+          </div>
+        ),
+      })),
+    []
+  );
+
+  return (
+    <div style={{ maxWidth: `${width}px`, margin: '0 auto' }}>
+      <ShellFrame
+        skipTargetId='story-shell-workspace'
+        topBar={
+          <ShellTopBar
+            headline='Seeded DHT + direct peers'
+            activeTopic='kukuri:topic:demo'
+            statusBadges={
+              <>
+                <StatusBadge label='connected' tone='accent' />
+                <StatusBadge label='1 peers' />
+                <StatusBadge label='seeded dht' />
+              </>
+            }
+            navOpen={chromeState.navOpen}
+            settingsOpen={chromeState.settingsOpen}
+            navControlsId='story-shell-nav'
+            settingsControlsId='story-shell-settings'
+            onToggleNav={() =>
+              setChromeState((current) => ({
+                ...current,
+                navOpen: !current.navOpen,
+              }))
+            }
+            onToggleSettings={() =>
+              setChromeState((current) => ({
+                ...current,
+                settingsOpen: !current.settingsOpen,
+              }))
+            }
+          />
+        }
+        navRail={
+          <ShellNavRail
+            railId='story-shell-nav'
+            open={chromeState.navOpen}
+            onOpenChange={(open) =>
+              setChromeState((current) => ({
+                ...current,
+                navOpen: open,
+              }))
+            }
+            primaryItems={PRIMARY_ITEMS}
+            activePrimarySection={chromeState.activePrimarySection}
+            onSelectPrimarySection={(section) =>
+              setChromeState((current) => ({
+                ...current,
+                activePrimarySection: section,
+              }))
+            }
+            addTopicControl={
+              <div className='composer composer-compact'>
+                <label className='field flex flex-col gap-2'>
+                  <span>Add Topic</span>
+                  <input
+                    className='h-11 w-full rounded-[var(--radius-input)] border border-[var(--border-subtle)] bg-[var(--surface-input)] px-4 py-3 text-sm text-foreground'
+                    placeholder='kukuri:topic:demo'
+                    readOnly
+                    value='kukuri:topic:design'
+                  />
+                </label>
+                <Button variant='secondary'>Add</Button>
+              </div>
+            }
+            topicList={
+              <ul>
+                <li className='topic-item topic-item-active'>
+                  <button className='topic-link' type='button'>
+                    <span className='shell-topic-link-label'>kukuri:topic:demo</span>
+                  </button>
+                  <div className='topic-diagnostic'>
+                    <span>joined / peers: 1</span>
+                    <small>12:45:11</small>
+                  </div>
+                </li>
+                <li className='topic-item'>
+                  <button className='topic-link' type='button'>
+                    <span className='shell-topic-link-label'>kukuri:topic:staging-preview</span>
+                  </button>
+                  <div className='topic-diagnostic topic-diagnostic-secondary'>
+                    <span>relay-assisted / peers: 1</span>
+                    <small>no events</small>
+                  </div>
+                </li>
+              </ul>
+            }
+            topicCount={2}
+          />
+        }
+        workspace={
+          <div className='shell-main-stack'>
+            <Card className='shell-workspace-card'>
+              <section className='shell-section' tabIndex={-1}>
+                <div className='shell-workspace-header'>
+                  <div>
+                    <h2>Timeline</h2>
+                    <span className='active-topic-label'>kukuri:topic:demo</span>
+                  </div>
+                  <div className='shell-inline-actions'>
+                    <StatusBadge label='viewing public' />
+                    <StatusBadge label='posting public' />
+                    <Button
+                      className='shell-context-trigger'
+                      variant='ghost'
+                      onClick={() =>
+                        setChromeState((current) => ({
+                          ...current,
+                          contextOpen: true,
+                        }))
+                      }
+                    >
+                      Open Context
+                    </Button>
+                    <Button variant='secondary'>Refresh</Button>
+                  </div>
+                </div>
+                <Notice tone='accent'>
+                  Timeline header, scope selectors, and refresh remain in the primary workspace.
+                </Notice>
+              </section>
+
+              <section className='shell-section' tabIndex={-1}>
+                <Card className='panel-subsection'>
+                  <h3>Channels & Composer</h3>
+                  <p className='lede'>
+                    Private channel controls, invite import, and the main composer stay together.
+                  </p>
+                </Card>
+              </section>
+
+              <section className='shell-section' tabIndex={-1}>
+                <Card className='panel-subsection'>
+                  <h3>Live</h3>
+                  <p className='lede'>Live session entry remains in the workspace stack.</p>
+                </Card>
+              </section>
+
+              <section className='shell-section' tabIndex={-1}>
+                <Card className='panel-subsection'>
+                  <h3>Game</h3>
+                  <p className='lede'>Game room entry and score editing live below live sessions.</p>
+                </Card>
+              </section>
+
+              <Card className='panel-subsection'>
+                <h3>Timeline Feed</h3>
+                <p className='lede'>Posts render last so composer-heavy flows stay above the fold.</p>
+              </Card>
+            </Card>
+          </div>
+        }
+        contextPane={
+          <ContextPane
+            paneId='story-shell-context'
+            open={chromeState.contextOpen}
+            onOpenChange={(open) =>
+              setChromeState((current) => ({
+                ...current,
+                contextOpen: open,
+              }))
+            }
+            activeMode={chromeState.activeContextPaneMode}
+            onModeChange={(mode) =>
+              setChromeState((current) => ({
+                ...current,
+                activeContextPaneMode: mode,
+              }))
+            }
+            tabs={contextTabs}
+          />
+        }
+      />
+
+      <SettingsDrawer
+        drawerId='story-shell-settings'
+        open={chromeState.settingsOpen}
+        onOpenChange={(open) =>
+          setChromeState((current) => ({
+            ...current,
+            settingsOpen: open,
+          }))
+        }
+        activeSection={chromeState.activeSettingsSection}
+        onSectionChange={(section) =>
+          setChromeState((current) => ({
+            ...current,
+            activeSettingsSection: section,
+          }))
+        }
+        sections={settingsSections}
+      />
+    </div>
+  );
+}
+
+export const Wide: Story = {
+  render: () => <ShellStoryFixture width={1360} />,
+};
+
+export const Narrow: Story = {
+  render: () => <ShellStoryFixture width={700} />,
+};
+
+export const SettingsDrawerOpen: Story = {
+  render: () => (
+    <ShellStoryFixture
+      width={1360}
+      initialChromeState={{
+        settingsOpen: true,
+        activeSettingsSection: 'community-node',
+      }}
+    />
+  ),
+};
+
+export const ContextThread: Story = {
+  render: () => (
+    <ShellStoryFixture
+      width={1360}
+      initialChromeState={{
+        contextOpen: true,
+        activeContextPaneMode: 'thread',
+      }}
+    />
+  ),
+};
+
+export const ContextAuthor: Story = {
+  render: () => (
+    <ShellStoryFixture
+      width={1360}
+      initialChromeState={{
+        contextOpen: true,
+        activeContextPaneMode: 'author',
+      }}
+    />
+  ),
+};

--- a/apps/desktop/src/components/shell/ShellFrame.tsx
+++ b/apps/desktop/src/components/shell/ShellFrame.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+type ShellFrameProps = {
+  skipTargetId: string;
+  topBar: React.ReactNode;
+  navRail: React.ReactNode;
+  workspace: React.ReactNode;
+  contextPane: React.ReactNode;
+};
+
+export function ShellFrame({
+  skipTargetId,
+  topBar,
+  navRail,
+  workspace,
+  contextPane,
+}: ShellFrameProps) {
+  return (
+    <div className='shell-phase1'>
+      <a className='shell-skip-link' href={`#${skipTargetId}`}>
+        Skip to workspace
+      </a>
+      {topBar}
+      <div className='shell-layout'>
+        {navRail}
+        <main
+          id={skipTargetId}
+          className={cn('shell-main')}
+          tabIndex={-1}
+          aria-label='Primary workspace'
+        >
+          {workspace}
+        </main>
+        {contextPane}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/shell/ShellNavRail.tsx
+++ b/apps/desktop/src/components/shell/ShellNavRail.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+
+import { X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+import { type PrimarySection } from './types';
+
+type PrimaryNavItem = {
+  id: PrimarySection;
+  label: string;
+  description: string;
+};
+
+type ShellNavRailProps = {
+  railId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  primaryItems: PrimaryNavItem[];
+  activePrimarySection: PrimarySection;
+  onSelectPrimarySection: (section: PrimarySection) => void;
+  addTopicControl: React.ReactNode;
+  topicList: React.ReactNode;
+  topicCount: number;
+};
+
+export function ShellNavRail({
+  railId,
+  open,
+  onOpenChange,
+  primaryItems,
+  activePrimarySection,
+  onSelectPrimarySection,
+  addTopicControl,
+  topicList,
+  topicCount,
+}: ShellNavRailProps) {
+  return (
+    <>
+      <div
+        className='shell-overlay-backdrop shell-nav-backdrop'
+        data-open={open}
+        onClick={() => onOpenChange(false)}
+        aria-hidden='true'
+      />
+      <Card
+        as='aside'
+        tone='accent'
+        id={railId}
+        className='shell-nav'
+        data-open={open}
+        aria-label='Primary navigation'
+      >
+        <div className='shell-pane-header shell-pane-header-compact'>
+          <div>
+            <p className='eyebrow'>Navigate</p>
+            <h2 className='shell-pane-heading'>Workspace</h2>
+          </div>
+          <Button
+            className='shell-mobile-close'
+            variant='ghost'
+            size='icon'
+            type='button'
+            aria-label='Close navigation'
+            onClick={() => onOpenChange(false)}
+          >
+            <X className='size-4' aria-hidden='true' />
+          </Button>
+        </div>
+
+        <nav className='shell-primary-nav' aria-label='Primary sections'>
+          {primaryItems.map((item) => (
+            <button
+              key={item.id}
+              className={cn(
+                'shell-primary-nav-item',
+                activePrimarySection === item.id && 'shell-primary-nav-item-active'
+              )}
+              type='button'
+              aria-current={activePrimarySection === item.id ? 'location' : undefined}
+              onClick={() => onSelectPrimarySection(item.id)}
+            >
+              <span className='shell-primary-nav-label'>{item.label}</span>
+              <span className='shell-primary-nav-copy'>{item.description}</span>
+            </button>
+          ))}
+        </nav>
+
+        <div className='shell-nav-topic-entry'>{addTopicControl}</div>
+
+        <section className='topic-list shell-nav-topic-list'>
+          <div className='panel-header'>
+            <h3>Tracked Topics</h3>
+            <small>{topicCount} active</small>
+          </div>
+          {topicList}
+        </section>
+      </Card>
+    </>
+  );
+}

--- a/apps/desktop/src/components/shell/ShellTopBar.tsx
+++ b/apps/desktop/src/components/shell/ShellTopBar.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+
+import { PanelLeftOpen, Settings2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+type ShellTopBarProps = {
+  headline: string;
+  activeTopic: string;
+  statusBadges: React.ReactNode;
+  navOpen: boolean;
+  settingsOpen: boolean;
+  navControlsId: string;
+  settingsControlsId: string;
+  navButtonRef?: React.RefObject<HTMLButtonElement | null>;
+  settingsButtonRef?: React.RefObject<HTMLButtonElement | null>;
+  onToggleNav: () => void;
+  onToggleSettings: () => void;
+};
+
+export function ShellTopBar({
+  headline,
+  activeTopic,
+  statusBadges,
+  navOpen,
+  settingsOpen,
+  navControlsId,
+  settingsControlsId,
+  navButtonRef,
+  settingsButtonRef,
+  onToggleNav,
+  onToggleSettings,
+}: ShellTopBarProps) {
+  return (
+    <header className='shell-topbar panel panel-accent'>
+      <div className='shell-topbar-copy'>
+        <p className='eyebrow'>kukuri rebuild</p>
+        <h1 className='shell-topbar-heading'>{headline}</h1>
+        <p className='shell-topbar-topic' title={activeTopic}>
+          Active topic: {activeTopic}
+        </p>
+      </div>
+      <div className='shell-topbar-meta'>{statusBadges}</div>
+      <div className='shell-topbar-actions'>
+        <Button
+          ref={navButtonRef}
+          variant='ghost'
+          size='icon'
+          type='button'
+          aria-label={navOpen ? 'Close navigation' : 'Open navigation'}
+          aria-controls={navControlsId}
+          aria-expanded={navOpen}
+          data-testid='shell-nav-trigger'
+          onClick={onToggleNav}
+        >
+          <PanelLeftOpen className='size-4' aria-hidden='true' />
+        </Button>
+        <Button
+          ref={settingsButtonRef}
+          variant='ghost'
+          size='icon'
+          type='button'
+          aria-label={settingsOpen ? 'Close settings and diagnostics' : 'Open settings and diagnostics'}
+          aria-controls={settingsControlsId}
+          aria-expanded={settingsOpen}
+          data-testid='shell-settings-trigger'
+          onClick={onToggleSettings}
+        >
+          <Settings2 className='size-4' aria-hidden='true' />
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/apps/desktop/src/components/shell/types.ts
+++ b/apps/desktop/src/components/shell/types.ts
@@ -1,0 +1,14 @@
+export type PrimarySection = 'timeline' | 'channels' | 'live' | 'game';
+
+export type ContextPaneMode = 'thread' | 'author';
+
+export type SettingsSection = 'profile' | 'connectivity' | 'discovery' | 'community-node';
+
+export type ShellChromeState = {
+  activePrimarySection: PrimarySection;
+  activeContextPaneMode: ContextPaneMode;
+  activeSettingsSection: SettingsSection;
+  navOpen: boolean;
+  contextOpen: boolean;
+  settingsOpen: boolean;
+};

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
 @import "./tokens.css";
 @import "./base.css";
+@import "./shell-phase1.css";
 @import "./legacy-shell.css";

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -1,0 +1,415 @@
+.shell-phase1 {
+  display: grid;
+  gap: 1rem;
+  max-width: 1560px;
+  margin: 0 auto;
+  padding: 1rem 1rem 2rem;
+}
+
+.shell-skip-link {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  z-index: 100;
+  border-radius: 999px;
+  padding: 0.7rem 1rem;
+  color: var(--primary-foreground);
+  background: linear-gradient(120deg, var(--primary-start), var(--primary-end));
+  transform: translateY(-220%);
+  transition: transform 180ms ease;
+}
+
+.shell-skip-link:focus-visible {
+  transform: translateY(0);
+}
+
+.shell-topbar {
+  position: sticky;
+  top: 1rem;
+  z-index: 20;
+  display: grid;
+  gap: 1rem;
+}
+
+.shell-topbar-copy,
+.shell-main,
+.shell-pane-heading,
+.shell-pane-copy,
+.shell-topbar-topic {
+  min-width: 0;
+}
+
+.shell-topbar-heading {
+  margin: 0;
+  font-size: clamp(1.9rem, 4vw, 3.5rem);
+  line-height: 0.94;
+}
+
+.shell-topbar-topic {
+  margin: 0.4rem 0 0;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shell-topbar-meta,
+.shell-topbar-actions,
+.shell-status-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.shell-topbar-actions {
+  justify-content: flex-end;
+}
+
+.shell-layout {
+  display: grid;
+  gap: 1rem;
+  align-items: start;
+  grid-template-columns: minmax(260px, 280px) minmax(0, 1fr) minmax(280px, 320px);
+}
+
+.shell-main {
+  min-width: 0;
+}
+
+.shell-main-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.shell-pane-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+}
+
+.shell-pane-header-compact {
+  align-items: center;
+}
+
+.shell-pane-heading {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.shell-pane-copy {
+  margin: 0.35rem 0 0;
+  color: var(--muted-foreground);
+}
+
+.shell-nav,
+.shell-context {
+  min-width: 0;
+  display: grid;
+  gap: 1rem;
+  position: sticky;
+  top: 6.5rem;
+  max-height: calc(100vh - 7.5rem);
+  overflow: auto;
+}
+
+.shell-primary-nav,
+.shell-settings-nav-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.shell-primary-nav-item,
+.shell-settings-nav-item,
+.shell-tab {
+  width: 100%;
+  border: 1px solid var(--border-subtle);
+  border-radius: 18px;
+  padding: 0.9rem 1rem;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.02);
+  text-align: left;
+  cursor: pointer;
+}
+
+.shell-primary-nav-item-active,
+.shell-settings-nav-item-active,
+.shell-tab-active {
+  border-color: rgba(0, 179, 164, 0.32);
+  background: var(--surface-active);
+}
+
+.shell-primary-nav-label {
+  display: block;
+  font-weight: 700;
+}
+
+.shell-primary-nav-copy {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.shell-nav-topic-entry {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shell-nav-topic-list {
+  margin-top: 0;
+}
+
+.shell-topic-link-label {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shell-workspace-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.shell-workspace-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.shell-workspace-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.shell-context-trigger {
+  display: none;
+}
+
+.shell-section {
+  min-width: 0;
+  display: grid;
+  gap: 0.8rem;
+  scroll-margin-top: 6rem;
+  outline: none;
+}
+
+.shell-inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.shell-context {
+  gap: 0.9rem;
+}
+
+.shell-tab-list {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.shell-context-panel {
+  min-width: 0;
+}
+
+.shell-settings-drawer {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 70;
+  width: min(920px, calc(100vw - 2rem));
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+  gap: 1rem;
+  overflow: hidden;
+  transform: translateX(calc(100% + 2rem));
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    transform 180ms ease,
+    visibility 180ms ease;
+}
+
+.shell-settings-drawer[data-open='true'] {
+  transform: translateX(0);
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.shell-settings-nav {
+  display: grid;
+  align-content: start;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.shell-settings-body {
+  min-width: 0;
+  display: grid;
+  gap: 1rem;
+  overflow: hidden;
+}
+
+.shell-settings-current {
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.shell-settings-content {
+  min-width: 0;
+  overflow: auto;
+  padding-right: 0.35rem;
+}
+
+.shell-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgba(3, 7, 12, 0.68);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 180ms ease,
+    visibility 180ms ease;
+}
+
+.shell-overlay-backdrop[data-open='true'] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.shell-mobile-close {
+  display: none;
+}
+
+.shell-context-close {
+  display: none;
+}
+
+@media (min-width: 900px) {
+  .shell-topbar {
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) auto;
+    align-items: end;
+  }
+}
+
+@media (max-width: 1099px) {
+  .shell-layout {
+    grid-template-columns: minmax(260px, 280px) minmax(0, 1fr);
+  }
+
+  .shell-context {
+    position: fixed;
+    right: 1rem;
+    top: 1rem;
+    bottom: 1rem;
+    z-index: 65;
+    width: min(380px, calc(100vw - 2rem));
+    max-height: none;
+    transform: translateX(calc(100% + 2rem));
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+      transform 180ms ease,
+      visibility 180ms ease;
+  }
+
+  .shell-context[data-open='true'] {
+    transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .shell-context-close {
+    display: inline-flex;
+  }
+
+  .shell-context-trigger {
+    display: inline-flex;
+  }
+}
+
+@media (min-width: 1100px) {
+  .shell-context-backdrop {
+    display: none;
+  }
+}
+
+@media (max-width: 899px) {
+  .shell-topbar-actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 759px) {
+  .shell-phase1 {
+    padding-inline: 0.75rem;
+  }
+
+  .shell-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .shell-nav {
+    position: fixed;
+    left: 0.75rem;
+    top: 0.75rem;
+    bottom: 0.75rem;
+    z-index: 65;
+    width: min(92vw, 360px);
+    max-height: none;
+    transform: translateX(calc(-100% - 2rem));
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+      transform 180ms ease,
+      visibility 180ms ease;
+  }
+
+  .shell-nav[data-open='true'] {
+    transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .shell-context {
+    right: 0.75rem;
+    top: 0.75rem;
+    bottom: 0.75rem;
+    width: min(92vw, 360px);
+  }
+
+  .shell-settings-drawer {
+    top: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    width: calc(100vw - 1.5rem);
+    grid-template-columns: 1fr;
+  }
+
+  .shell-mobile-close {
+    display: inline-flex;
+  }
+
+  .shell-workspace-header {
+    align-items: stretch;
+  }
+}
+
+@media (min-width: 760px) {
+  .shell-nav-backdrop {
+    display: none;
+  }
+}

--- a/apps/desktop/tests/playwright/shell.smoke.spec.ts
+++ b/apps/desktop/tests/playwright/shell.smoke.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from '@playwright/test';
 
-test('browser mock shell can publish and render a post', async ({ page }) => {
+test('browser mock shell can publish, open thread, and update discovery from settings', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1400, height: 980 });
   await page.goto('/');
 
   await expect(page.getByRole('heading', { name: /Seeded DHT/i })).toBeVisible();
@@ -9,5 +12,56 @@ test('browser mock shell can publish and render a post', async ({ page }) => {
   await page.getByRole('button', { name: 'Publish' }).click();
 
   await expect(page.getByText('hello browser mock')).toBeVisible();
-  await expect(page.getByText('Configured Peers', { exact: true })).toBeVisible();
+
+  await page.getByText('hello browser mock').click();
+  await expect(page.getByRole('tab', { name: 'Thread' })).toHaveAttribute('aria-selected', 'true');
+
+  await page.getByTestId('shell-settings-trigger').click();
+  await expect(page.getByRole('dialog', { name: 'Settings & diagnostics' })).toBeVisible();
+  await page.getByTestId('settings-section-discovery').click();
+  await page.getByPlaceholder('node_id or node_id@host:port').fill('seed-peer-1');
+  await page.getByRole('button', { name: 'Save Seeds' }).click();
+
+  await expect(page.getByRole('textbox', { name: 'Seed Peers' })).toHaveValue('seed-peer-1');
+});
+
+test('browser mock narrow shell keeps nav, context, and settings flows reachable without overflow', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 700, height: 980 });
+  await page.goto('/');
+
+  await page.getByTestId('shell-nav-trigger').click();
+  await page.getByPlaceholder('kukuri:topic:demo').fill('kukuri:topic:narrow');
+  await page.getByRole('button', { name: 'Add' }).click();
+
+  await page.getByTestId('shell-nav-trigger').click();
+  await page.getByRole('button', { name: /^kukuri:topic:demo$/ }).click();
+  await expect(page.getByText('Active topic: kukuri:topic:demo')).toBeVisible();
+
+  await page.getByPlaceholder('Write a post').fill('narrow browser mock');
+  await page.getByRole('button', { name: 'Publish' }).click();
+  await expect(page.getByText('narrow browser mock')).toBeVisible();
+
+  await page.getByText('narrow browser mock').click();
+  await expect(page.getByRole('tabpanel', { name: 'Thread' })).toBeVisible();
+
+  await page
+    .getByRole('tabpanel', { name: 'Thread' })
+    .getByRole('button', { name: 'ffffffffffff' })
+    .first()
+    .click();
+  await expect(page.getByRole('tab', { name: 'Author' })).toHaveAttribute('aria-selected', 'true');
+
+  await page.keyboard.press('Escape');
+  await page.getByTestId('shell-settings-trigger').click();
+  await page.getByTestId('settings-section-connectivity').click();
+  await page.getByPlaceholder('nodeid@127.0.0.1:7777').fill('peer-b@127.0.0.1:8888');
+  await page.getByRole('button', { name: 'Import Peer' }).click();
+  await expect(page.getByPlaceholder('nodeid@127.0.0.1:7777')).toHaveValue('');
+
+  const noOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth <= window.innerWidth
+  );
+  expect(noOverflow).toBeTruthy();
 });

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -10,26 +10,30 @@
 - Codex が implementation patch と Figma review data を同時に生成する UI proposal
 
 ## Required Workflow
-1. Codex が UI を新規提案または大きく改修する場合、先に Figma で proposal を作る。
-2. 一次レビューは Figma で行う。
-3. code review に耐える方向性が固まってから実装する。
-4. 変更の大きさとリスクに応じて Storybook、Vitest、Playwright、`cargo xtask` で検証する。
-5. merge された変更が user-facing behavior または design rule を変える場合は、`docs/ui-reviews/` に記録を残す。
+1. Codex が UI を新規提案または大きく改修する場合、先に local HTML / React draft を作る。
+2. `generate_figma_design` の HTML capture で Figma design を生成または更新する。
+3. 一次レビューは、その HTML capture で作った Figma design を基準に行う。
+4. code review に耐える方向性が固まってから実装を詰める。
+5. 変更の大きさとリスクに応じて Storybook、Vitest、Playwright、`cargo xtask` で検証する。
+6. merge された変更が user-facing behavior または design rule を変える場合は、`docs/ui-reviews/` に記録を残す。
 
 ## Tooling Policy
 - Figma MCP は Codex-assisted UI proposal で required とする。Figma を primary review artifact にする。
+- Codex-assisted UI proposal の既定 artifact は HTML capture で生成した Figma design とする。自然言語だけで作った Figma draft を workflow の前提にしない。
 - 新規 UI と大きく触る既存 UI の標準 stack は Tailwind + shadcn/ui + Storybook にする。
 - Playwright は top-level user flow を変える変更、または複数 component をまたぐ回帰リスクが高い変更で required とする。
 - shadcn MCP は optional とする。対象 surface に標準 stack が入ってから使う。
 - shadcn MCP は implementation aid であり、review system でも Figma MCP の代替でもない。
 - Code Connect は optional とし、workflow の blocker にしない。
+- FigJam は IA 整理や flow 説明の補助 artifact として使ってよいが、primary review artifact の代替にはしない。
 
 ## Review Artifacts
-- すべての UI proposal PR は Figma link を含む。
+- すべての UI proposal PR は Figma link を含む。既定値は HTML capture で生成した Figma design URL とする。
 - すべての UI proposal PR は、PR 上で直接 review できる preview image または short video を含む。
 - すべての UI proposal PR は、変更する user flow の短い summary を含む。
 - すべての UI proposal PR は、Shneiderman checklist の結果または例外理由を含む。
 - public PR reader が Figma edit 権限なしでも proposal を理解できる状態を必須にする。
+- capture 用に一時挿入した script、query、hash parameter は review artifact 生成後に戻し、product code へ常駐させない。
 
 ## Design System Rules
 - token から始める。color、typography、spacing、radius、border、shadow、motion は one-off hard-code ではなく shared token layer から取る。

--- a/docs/adr/0014-uiux-dev-flow.md
+++ b/docs/adr/0014-uiux-dev-flow.md
@@ -7,12 +7,19 @@ Accepted
 - 現行 desktop frontend は、依然として `apps/desktop/src/App.tsx` と `apps/desktop/src/styles.css` を中心に構成されている。
 - repo は public で、外部 contributor からの review も想定する。UI proposal は local 実装差分だけでなく、PR 上で読める review artifact を持つ必要がある。
 - Codex が UI を提案する場合、code review より前に人間が一次レビューできる面が必要であり、その正本は Figma に置く。
+- 現状の official Figma MCP では、自然言語だけから自由度の高い高忠実度 UI を安定生成するより、local HTML / React draft を `generate_figma_design` で capture する方が再現性が高い。
 - 現在の検証基盤は Vitest、`cargo xtask`、GitHub Actions が中心であり、新しい frontend tooling はこの品質ゲートを置き換えずに補完する必要がある。
 - 今後の UI 実装は Tailwind + shadcn/ui + Storybook へ寄せるが、現行 app はまだ全面移行されていない。
 - Figma MCP は review 用 design data の生成に使える。shadcn MCP と Code Connect は将来的な支援手段だが、workflow の前提条件にはしない。
 
 ## Decision
 - Codex が作る UI proposal は、実装パッチに加えて Figma data を作成または更新しなければならない。人間の一次レビューは Figma 上で行う。
+- Codex-assisted UI proposal の標準フローは次に固定する。
+  - text instruction から local HTML / React draft を作る
+  - `generate_figma_design` の HTML capture で Figma design を生成または更新する
+  - 人間が Figma 上で一次レビューし、必要なら Figma 側で修正する
+  - Codex は修正版 Figma を再取り込みして code へ反映する
+- Figma link は、原則として HTML capture で生成した Figma design URL を使う。FigJam は IA 補助 artifact としては許容するが、primary review artifact の代替にはしない。
 - UI proposal PR には次を必須にする。
   - Figma link
   - PR 上で読める preview image または short video
@@ -31,6 +38,8 @@ Accepted
 
 ## Consequences
 - code だけ、または文章だけの UI proposal は不十分になる。Figma review data と PR-visible preview が必須になる。
+- text-only の Figma 生成を前提にしない。Codex は review 用の HTML / React draft を先に作る責務を持つ。
+- local capture のために一時的に挿入した script や URL hook は、product requirement でない限り capture 後に戻す必要がある。
 - Figma edit 権限を持たない contributor でも、PR に summary と preview があれば public repo 上で UI review に参加できる。
 - reusable component と major UI refactor には Storybook story が必要になる。one-off の glue UI は、再利用を想定せず既存 test で十分守られている場合に限って Storybook を省略できる。
 - shadcn MCP は component 探索や registry 作業の加速には使えるが、registry から入れた component をそのまま採用せず、local token、命名、variant、state、accessibility へ合わせる必要がある。

--- a/docs/progress/2026-03-24-shell-ui-production-migration.md
+++ b/docs/progress/2026-03-24-shell-ui-production-migration.md
@@ -14,7 +14,7 @@
 - product UI と diagnostics UI を分離し、`ADR 0014` と `docs/DESIGN.md` に整合する reviewable な移行パスを用意する。
 
 ### Non-goals
-- この文書自体で新しい visual spec、token 値、layout pixel、component API を確定しない。これらは各 phase の Figma proposal と implementation review で決める。
+- この文書自体で新しい visual spec、token 値、layout pixel、component API を確定しない。これらは各 phase の Figma design artifact と implementation review で決める。
 - backend、runtime、Tauri invoke surface、data contract、domain model の変更計画を持ち込まない。
 - `legacy/` からの wholesale 移植や、全面 rewrite を 1 PR で完了する前提を置かない。
 
@@ -29,6 +29,7 @@
 
 ## Applicable Rules
 - workflow の正本は `docs/adr/0014-uiux-dev-flow.md` とし、Codex-assisted UI proposal では Figma を primary review artifact にする。
+- Codex-assisted UI proposal の既定 path は `local HTML / React draft -> generate_figma_design による HTML capture -> human review in Figma` とする。
 - design-system / review / exception policy の正本は `docs/DESIGN.md` とする。
 - merge 済みで user-facing behavior または design rule を変えた UI 変更は `docs/ui-reviews/` に record を残す。
 - 新規 UI と大きく触る既存 UI の標準 stack は Tailwind + shadcn/ui + Storybook とし、Playwright は top-level flow 変更または component 境界をまたぐ高リスク変更で required にする。
@@ -224,6 +225,7 @@
 - diagnostics を後景へ移す際に observability を失うと、current scope の connectivity / auth / audience troubleshooting が困難になる。
 - Windows / Linux 両方で resize、focus、packaged app behavior を崩さない前提で進める必要がある。
 - UI proposal workflow では Figma link と PR-visible preview が required になるため、各 phase の PR は review artifact を先に揃える必要がある。
+- Figma link の既定値は HTML capture で生成した Figma design URL とし、FigJam は補助 artifact として扱う。
 
 ## Exit Criteria
 - 現行 shell の primary / secondary surface が新しい shell boundary に載り替わっている。
@@ -233,5 +235,5 @@
 - user-facing behavior または reusable design rule を変えた採用済み UI 変更について、必要な `docs/ui-reviews/` record が残っている。
 
 ## Notes
-- この planning-doc PR 自体では Figma proposal や UI review record を新規作成しない。これらは implementation phase の成果物として扱う。
+- この planning-doc PR 自体では Figma design artifact や UI review record を新規作成しない。これらは implementation phase の成果物として扱う。
 - 本文書は roadmap / sequencing の正本であり、実装時の具体的な token 値、component prop、layout detail は各 phase の proposal で確定する。

--- a/docs/ui-reviews/2026-03-24-desktop-phase1-shell-frame.md
+++ b/docs/ui-reviews/2026-03-24-desktop-phase1-shell-frame.md
@@ -1,0 +1,10 @@
+# 2026-03-24 desktop phase1 shell frame
+
+- PR: local workspace change for shell UI production migration Phase 1. PR identifier is pending.
+- Figma: [Phase 1 shell HTML capture](https://www.figma.com/design/4AbJxI5rOI91h9WLPtD3NQ)
+- Summary: `apps/desktop` の shell を 3-pane 基準の frame へ差し替え、left nav rail、workspace、thread/author context、settings drawer を分離した。main workspace から diagnostics / connectivity / discovery / profile editor を退避し、topic navigation、composer、timeline、live、game は既存 contract のまま中央 pane に残した。
+- User flow summary: 起動後の初期 focus path は `Skip to workspace` から始まり、top bar actions、topic nav、workspace controls、context trigger / tabs、settings drawer contents の順で辿れる。wide では thread / author context を右 pane に常設し、medium / narrow では drawer に切り替える。settings hub から `Save Seeds`、`Save Nodes`、`Authenticate`、`Consents`、`Accept`、`Refresh`、`Clear Token`、`Import Peer` へ既存順序のまま到達できる。
+- Review result: shell UI production migration の Phase 1 slice として採用。router や backend contract を増やさずに shell boundary と information architecture を先行固定する方針を承認した。
+- Shneiderman: 一貫性は section / drawer / context tab の命名と操作順維持で担保した。頻出操作のショートカットは focus jump と persistent context tab で補強した。情報量の圧縮は diagnostics を hub へ退避し、workspace には summary badge のみ残す方針で評価した。`Esc` で overlay を閉じて trigger へ focus を戻すこと、active nav に `aria-current`、tabs に tab semantics、drawer trigger に `aria-expanded` / `aria-controls` を持たせることを review 条件として確認した。
+- Exceptions: 一次 review では HTML capture の Figma design と local Storybook stories を基準に進めた。初期 IA の検討には FigJam proposal も併用した。PR-visible preview image / short video はこの local 実装時点では未作成のため、PR 作成時に補完する前提で記録する。
+- Validation: `cd apps/desktop && npx pnpm@10.16.1 build`; `cd apps/desktop && npx pnpm@10.16.1 test`; `cd apps/desktop && npx pnpm@10.16.1 storybook:build`; `cd apps/desktop && npx pnpm@10.16.1 test:e2e:browser`; `cargo xtask check`; `cargo xtask test`; `cargo xtask e2e-smoke`。

--- a/docs/ui-reviews/README.md
+++ b/docs/ui-reviews/README.md
@@ -13,6 +13,8 @@
 ## 必須項目
 - PR link または identifier
 - 一次 review に使った Figma link
+  - 既定値は HTML capture で生成した Figma design URL
+  - FigJam link だけで済ませる場合は例外理由を record に書く
 - 採用された変更の short summary
 - review result
 - 承認された例外


### PR DESCRIPTION
## Summary
- replace the desktop shell with a Phase 1 frame that splits nav, workspace, context, and settings surfaces
- add shell component stories, Vitest/Playwright coverage, and a UI review record for the Phase 1 rollout
- update the UI/UX docs so Codex-assisted review uses HTML capture -> Figma design as the default flow

## Figma
- HTML capture: https://www.figma.com/design/4AbJxI5rOI91h9WLPtD3NQ
- accepted record: docs/ui-reviews/2026-03-24-desktop-phase1-shell-frame.md

## Testing
- `cd apps/desktop && npx pnpm@10.16.1 lint`
- `cd apps/desktop && npx pnpm@10.16.1 typecheck`
- `cd apps/desktop && npx pnpm@10.16.1 test`
- `cd apps/desktop && npx pnpm@10.16.1 storybook:build`
- `cd apps/desktop && npx pnpm@10.16.1 test:e2e:browser`

## Not completed
- `cargo xtask check`
- `cargo xtask test`
- `cargo xtask e2e-smoke`

`cargo xtask check` previously reached the frontend lint step and failed only on a `react-hooks/exhaustive-deps` warning in `apps/desktop/src/App.tsx`; that warning is fixed in this branch, but the full workspace rerun was not carried to completion because the Rust relink/test cycle is long.
