### PR TITLE
Add desktop theme toggle and solid surfaces

### DIFF
--- a/apps/desktop/.storybook/preview-head.html
+++ b/apps/desktop/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<script src="https://mcp.figma.com/mcp/html-to-design/capture.js" async></script>

--- a/apps/desktop/.storybook/preview.ts
+++ b/apps/desktop/.storybook/preview.ts
@@ -11,6 +11,18 @@ installWindowDesktopMock();
 
 const preview: Preview = {
   globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Desktop shell theme',
+      defaultValue: 'dark',
+      toolbar: {
+        icon: 'mirror',
+        items: [
+          { value: 'dark', title: 'Dark' },
+          { value: 'light', title: 'Light' },
+        ],
+      },
+    },
     shellWidth: {
       name: 'Shell Width',
       description: 'Desktop shell review width',
@@ -32,7 +44,9 @@ const preview: Preview = {
   },
   decorators: [
     (Story, context) => {
+      const theme = context.globals.theme === 'light' ? 'light' : 'dark';
       const shellWidth = context.globals.shellWidth === 'narrow' ? 420 : 960;
+      document.documentElement.dataset.theme = theme;
 
       return createElement(
         'div',
@@ -40,7 +54,7 @@ const preview: Preview = {
           style: {
             minHeight: '100vh',
             padding: '24px',
-            background: 'var(--color-surface-muted)',
+            background: 'var(--shell-background)',
           },
         },
         createElement(

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { createDesktopMockApi } from '@/mocks/desktopApiMock';
+import { DESKTOP_THEME_STORAGE_KEY } from '@/lib/theme';
 
 import { App } from './App';
 import {
@@ -201,7 +202,7 @@ async function openSettingsDrawer(user: ReturnType<typeof userEvent.setup>) {
 
 async function openSettingsSection(
   user: ReturnType<typeof userEvent.setup>,
-  section: 'connectivity' | 'discovery' | 'community-node'
+  section: 'appearance' | 'connectivity' | 'discovery' | 'community-node'
 ) {
   const drawer = await openSettingsDrawer(user);
   await user.click(within(drawer).getByTestId(`settings-section-${section}`));
@@ -483,6 +484,46 @@ test('settings hash route opens the drawer and keeps the selected section in syn
   await waitFor(() => {
     expect(window.location.hash).toContain('settings=connectivity');
   });
+});
+
+test('desktop shell defaults to the dark theme and persists it locally', async () => {
+  render(<App api={createDesktopMockApi()} />);
+
+  await waitFor(() => {
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+  });
+  expect(window.localStorage.getItem(DESKTOP_THEME_STORAGE_KEY)).toBe('dark');
+});
+
+test('desktop shell restores a persisted light theme on boot', async () => {
+  window.localStorage.setItem(DESKTOP_THEME_STORAGE_KEY, 'light');
+
+  render(<App api={createDesktopMockApi()} />);
+
+  await waitFor(() => {
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light');
+  });
+});
+
+test('appearance settings deep link updates the document theme and storage immediately', async () => {
+  const user = userEvent.setup();
+  renderAtHash('#/timeline?topic=kukuri%3Atopic%3Ademo&settings=appearance');
+
+  const drawer = await screen.findByRole('dialog', { name: 'Settings & diagnostics' });
+  await waitFor(() => {
+    expect(within(drawer).getByTestId('settings-section-appearance')).toHaveAttribute(
+      'aria-current',
+      'location'
+    );
+    expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
+  });
+
+  await user.click(within(drawer).getByRole('radio', { name: /Light/i }));
+
+  await waitFor(() => {
+    expect(document.documentElement).toHaveAttribute('data-theme', 'light');
+  });
+  expect(window.localStorage.getItem(DESKTOP_THEME_STORAGE_KEY)).toBe('light');
 });
 
 test('topic and private channel selection sync into the hash route', async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -35,10 +35,12 @@ import {
 } from '@/components/core/types';
 import { ProfileOverviewPanel } from '@/components/extended/ProfileOverviewPanel';
 import { ProfileEditorPanel } from '@/components/extended/ProfileEditorPanel';
+import { AppearancePanel } from '@/components/settings/AppearancePanel';
 import { CommunityNodePanel } from '@/components/settings/CommunityNodePanel';
 import { ConnectivityPanel } from '@/components/settings/ConnectivityPanel';
 import { DiscoveryPanel } from '@/components/settings/DiscoveryPanel';
 import {
+  type AppearancePanelView,
   type CommunityNodePanelView,
   type ConnectivityPanelView,
   type DiscoveryPanelView,
@@ -97,6 +99,7 @@ import {
   runtimeApi,
 } from './lib/api';
 import { blobToCreateAttachment, fileToCreateAttachment } from './lib/attachments';
+import { readDesktopTheme, type DesktopTheme, writeDesktopTheme } from './lib/theme';
 
 type AppProps = {
   api?: DesktopApi;
@@ -217,6 +220,11 @@ type OpenThreadOptions = {
   historyMode?: 'push' | 'replace';
   normalizeOnEmpty?: boolean;
   topic?: string;
+};
+
+type DesktopShellPageProps = AppProps & {
+  theme: DesktopTheme;
+  onThemeChange: (theme: DesktopTheme) => void;
 };
 
 type OpenAuthorOptions = {
@@ -440,6 +448,11 @@ const SETTINGS_SECTION_COPY: Array<{
   description: string;
 }> = [
   {
+    id: 'appearance',
+    label: 'Appearance',
+    description: 'Local light and dark theme selection.',
+  },
+  {
     id: 'connectivity',
     label: 'Connectivity',
     description: 'Sync summary, peer tickets, and global error visibility.',
@@ -455,6 +468,15 @@ const SETTINGS_SECTION_COPY: Array<{
     description: 'Configured community nodes, auth, consent, and refresh actions.',
   },
 ];
+
+function isSettingsSection(value: string | null): value is SettingsSection {
+  return (
+    value === 'appearance' ||
+    value === 'connectivity' ||
+    value === 'discovery' ||
+    value === 'community-node'
+  );
+}
 
 const PRIMARY_SECTION_PATHS: Record<PrimarySection, string> = {
   timeline: '/timeline',
@@ -1201,7 +1223,11 @@ function joinedChannelFromFriendSharePreview(
   };
 }
 
-function DesktopShellPage({ api = runtimeApi }: AppProps) {
+function DesktopShellPage({
+  api = runtimeApi,
+  theme,
+  onThemeChange,
+}: DesktopShellPageProps) {
   const storeApi = useDesktopShellStoreApi();
   const {
     trackedTopics,
@@ -3486,16 +3512,10 @@ function DesktopShellPage({ api = runtimeApi }: AppProps) {
       }));
     }
 
-    const nextSettingsOpen =
-      requestedSettingsSection === 'connectivity' ||
-      requestedSettingsSection === 'discovery' ||
-      requestedSettingsSection === 'community-node';
-    const nextSettingsSection =
-      requestedSettingsSection === 'connectivity' ||
-      requestedSettingsSection === 'discovery' ||
-      requestedSettingsSection === 'community-node'
-        ? requestedSettingsSection
-        : shellChromeState.activeSettingsSection;
+    const nextSettingsOpen = isSettingsSection(requestedSettingsSection);
+    const nextSettingsSection = isSettingsSection(requestedSettingsSection)
+      ? requestedSettingsSection
+      : shellChromeState.activeSettingsSection;
     const nextProfileMode =
       routeSection === 'profile' && requestedProfileMode === 'edit' ? 'edit' : 'overview';
 
@@ -3514,7 +3534,7 @@ function DesktopShellPage({ api = runtimeApi }: AppProps) {
       }));
     }
 
-    if (requestedSettingsSection && !['connectivity', 'discovery', 'community-node'].includes(requestedSettingsSection)) {
+    if (requestedSettingsSection && !isSettingsSection(requestedSettingsSection)) {
       shouldNormalize = true;
     }
     if (requestedProfileMode && requestedProfileMode !== 'edit') {
@@ -4038,6 +4058,24 @@ function DesktopShellPage({ api = runtimeApi }: AppProps) {
       trackedTopics,
     ]
   );
+  const appearancePanelView = useMemo<AppearancePanelView>(
+    () => ({
+      selectedTheme: theme,
+      options: [
+        {
+          value: 'dark',
+          label: 'Dark',
+          description: 'High-contrast solid surfaces for low-light work.',
+        },
+        {
+          value: 'light',
+          label: 'Light',
+          description: 'Brighter solid surfaces for daytime readability.',
+        },
+      ],
+    }),
+    [theme]
+  );
   const discoveryPanelView = useMemo<DiscoveryPanelView>(
     () => ({
       status: 'ready' as const,
@@ -4167,6 +4205,15 @@ function DesktopShellPage({ api = runtimeApi }: AppProps) {
     {
       ...SETTINGS_SECTION_COPY[0],
       content: (
+        <AppearancePanel
+          view={appearancePanelView}
+          onThemeChange={onThemeChange}
+        />
+      ),
+    },
+    {
+      ...SETTINGS_SECTION_COPY[1],
+      content: (
         <ConnectivityPanel
           view={connectivityPanelView}
           onPeerTicketInputChange={setPeerTicket}
@@ -4175,7 +4222,7 @@ function DesktopShellPage({ api = runtimeApi }: AppProps) {
       ),
     },
     {
-      ...SETTINGS_SECTION_COPY[1],
+      ...SETTINGS_SECTION_COPY[2],
       content: (
         <DiscoveryPanel
           view={discoveryPanelView}
@@ -4195,7 +4242,7 @@ function DesktopShellPage({ api = runtimeApi }: AppProps) {
       ),
     },
     {
-      ...SETTINGS_SECTION_COPY[2],
+      ...SETTINGS_SECTION_COPY[3],
       content: (
         <CommunityNodePanel
           view={communityNodePanelView}
@@ -5025,11 +5072,20 @@ function DesktopShellPage({ api = runtimeApi }: AppProps) {
 
 export function App(props: AppProps) {
   const [store] = useState<DesktopShellStoreApi>(() => createDesktopShellStore());
+  const [theme, setTheme] = useState<DesktopTheme>(() => readDesktopTheme());
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  useEffect(() => {
+    writeDesktopTheme(theme);
+  }, [theme]);
 
   return (
     <DesktopShellStoreContext.Provider value={store}>
       <HashRouter>
-        <DesktopShellPage {...props} />
+        <DesktopShellPage {...props} theme={theme} onThemeChange={setTheme} />
       </HashRouter>
     </DesktopShellStoreContext.Provider>
   );

--- a/apps/desktop/src/components/settings/AppearancePanel.stories.tsx
+++ b/apps/desktop/src/components/settings/AppearancePanel.stories.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { type DesktopTheme } from '@/lib/theme';
+
+import { appearancePanelFixture } from './fixtures';
+import { AppearancePanel } from './AppearancePanel';
+import { SettingsStoryFrame } from './SettingsStoryFrame';
+
+const meta = {
+  title: 'Settings/AppearancePanel',
+  component: AppearancePanel,
+  args: {
+    view: appearancePanelFixture,
+    onThemeChange: () => undefined,
+  },
+  render: () => <AppearancePanelStory />,
+} satisfies Meta<typeof AppearancePanel>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function AppearancePanelStory() {
+  const [theme, setTheme] = useState<DesktopTheme>(appearancePanelFixture.selectedTheme);
+
+  return (
+    <SettingsStoryFrame width='narrow'>
+      <AppearancePanel
+        view={{ ...appearancePanelFixture, selectedTheme: theme }}
+        onThemeChange={setTheme}
+      />
+    </SettingsStoryFrame>
+  );
+}
+
+export const Default: Story = {};

--- a/apps/desktop/src/components/settings/AppearancePanel.tsx
+++ b/apps/desktop/src/components/settings/AppearancePanel.tsx
@@ -1,0 +1,70 @@
+import { cn } from '@/lib/utils';
+
+import { Card, CardHeader } from '@/components/ui/card';
+import { Notice } from '@/components/ui/notice';
+
+import { type AppearancePanelView } from './types';
+
+type AppearancePanelProps = {
+  view: AppearancePanelView;
+  onThemeChange: (theme: AppearancePanelView['selectedTheme']) => void;
+};
+
+export function AppearancePanel({ view, onThemeChange }: AppearancePanelProps) {
+  return (
+    <Card className='space-y-4'>
+      <CardHeader>
+        <h3>Appearance</h3>
+        <small>{view.selectedTheme === 'dark' ? 'dark theme selected' : 'light theme selected'}</small>
+      </CardHeader>
+
+      <Notice>Theme changes apply immediately on this device and stay local to this desktop.</Notice>
+
+      <div
+        role='radiogroup'
+        aria-label='Theme mode'
+        className='gap-3'
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(14rem, 1fr))',
+        }}
+      >
+        {view.options.map((option) => {
+          const selected = option.value === view.selectedTheme;
+
+          return (
+            <button
+              key={option.value}
+              type='button'
+              role='radio'
+              aria-label={option.label}
+              aria-checked={selected}
+              className={cn(
+                'min-w-0 rounded-[20px] border p-4 text-left transition-colors',
+                selected
+                  ? 'border-[var(--border-accent)] bg-[var(--surface-active)]'
+                  : 'border-[var(--border-subtle)] bg-[var(--surface-panel-muted)] hover:bg-[var(--surface-button-ghost-hover)]'
+              )}
+              onClick={() => onThemeChange(option.value)}
+            >
+              <span className='block text-base font-semibold text-foreground'>{option.label}</span>
+              <span className='mt-2 block text-sm leading-6 text-[var(--muted-foreground)]'>
+                {option.description}
+              </span>
+              <span
+                className={cn(
+                  'mt-4 inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.08em]',
+                  selected
+                    ? 'border-[var(--border-accent)] bg-[var(--surface-panel-soft)] text-[var(--accent-foreground)]'
+                    : 'border-[var(--border-subtle)] bg-[var(--surface-badge-neutral)] text-[var(--muted-foreground)]'
+                )}
+              >
+                {selected ? 'Active' : 'Available'}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/apps/desktop/src/components/settings/CommunityNodePanel.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.tsx
@@ -82,7 +82,7 @@ export function CommunityNodePanel({
         {view.nodes.map((node) => (
           <section
             key={node.baseUrl}
-            className='min-w-0 rounded-[20px] border border-[var(--border-subtle)] bg-white/3 p-4 shadow-[0_12px_32px_rgba(2,7,15,0.1)]'
+            className='min-w-0 rounded-[20px] border border-[var(--border-subtle)] bg-[var(--surface-panel-soft)] p-4 shadow-[0_12px_32px_rgba(2,7,15,0.1)]'
           >
             <div className='flex flex-wrap items-start justify-between gap-3'>
               <div className='min-w-0'>

--- a/apps/desktop/src/components/settings/ConnectivityPanel.tsx
+++ b/apps/desktop/src/components/settings/ConnectivityPanel.tsx
@@ -82,7 +82,7 @@ export function ConnectivityPanel({
           {view.topics.map((topic) => (
             <section
               key={topic.topic}
-              className='rounded-[20px] border border-[var(--border-subtle)] bg-white/3 p-4 shadow-[0_12px_32px_rgba(2,7,15,0.1)]'
+              className='rounded-[20px] border border-[var(--border-subtle)] bg-[var(--surface-panel-soft)] p-4 shadow-[0_12px_32px_rgba(2,7,15,0.1)]'
             >
               <div className='flex flex-wrap items-start justify-between gap-3'>
                 <div className='min-w-0'>

--- a/apps/desktop/src/components/settings/SettingsDiagnosticList.tsx
+++ b/apps/desktop/src/components/settings/SettingsDiagnosticList.tsx
@@ -26,7 +26,7 @@ export function SettingsDiagnosticList({
       {items.map((item) => (
         <div
           key={item.label}
-          className='min-w-0 rounded-[18px] border border-[var(--border-subtle)] bg-white/3 px-4 py-3 shadow-[0_12px_32px_rgba(2,7,15,0.1)]'
+          className='min-w-0 rounded-[18px] border border-[var(--border-subtle)] bg-[var(--surface-panel-soft)] px-4 py-3 shadow-[0_12px_32px_rgba(2,7,15,0.1)]'
         >
           <dt className='text-[0.74rem] uppercase tracking-[0.08em] text-[var(--muted-foreground)]'>
             {item.label}

--- a/apps/desktop/src/components/settings/SettingsMetricGrid.tsx
+++ b/apps/desktop/src/components/settings/SettingsMetricGrid.tsx
@@ -20,12 +20,13 @@ export function SettingsMetricGrid({ items }: SettingsMetricGridProps) {
           key={item.label}
           className={cn(
             'min-w-0 rounded-[18px] border px-4 py-3 shadow-[0_12px_32px_rgba(2,7,15,0.12)]',
-            item.tone === 'accent' && 'border-[rgba(0,179,164,0.28)] bg-[var(--surface-active)]',
-            item.tone === 'warning' && 'border-[rgba(245,157,98,0.28)] bg-[rgba(245,157,98,0.1)]',
+            item.tone === 'accent' && 'border-[var(--border-accent)] bg-[var(--surface-active)]',
+            item.tone === 'warning' &&
+              'border-[var(--border-warning)] bg-[var(--surface-warning-soft)]',
             item.tone === 'danger' &&
-              'border-[rgba(255,180,138,0.24)] bg-[rgba(255,180,138,0.08)]',
+              'border-[var(--border-destructive)] bg-[var(--surface-destructive-soft)]',
             (!item.tone || item.tone === 'default') &&
-              'border-[var(--border-subtle)] bg-white/4'
+              'border-[var(--border-subtle)] bg-[var(--surface-panel-muted)]'
           )}
         >
           <dt className='text-[0.74rem] uppercase tracking-[0.08em] text-[var(--muted-foreground)]'>

--- a/apps/desktop/src/components/settings/SettingsPanels.test.tsx
+++ b/apps/desktop/src/components/settings/SettingsPanels.test.tsx
@@ -2,10 +2,12 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
+import { AppearancePanel } from './AppearancePanel';
 import { CommunityNodePanel } from './CommunityNodePanel';
 import { ConnectivityPanel } from './ConnectivityPanel';
 import { DiscoveryPanel } from './DiscoveryPanel';
 import {
+  appearancePanelFixture,
   communityNodePanelFixture,
   connectivityPanelFixture,
   discoveryPanelFixture,
@@ -13,6 +15,22 @@ import {
 import { SettingsActionRow } from './SettingsActionRow';
 import { SettingsDiagnosticList } from './SettingsDiagnosticList';
 import { SettingsMetricGrid } from './SettingsMetricGrid';
+
+test('appearance panel switches the selected theme immediately', async () => {
+  const user = userEvent.setup();
+  const onThemeChange = vi.fn();
+
+  render(
+    <AppearancePanel
+      view={appearancePanelFixture}
+      onThemeChange={onThemeChange}
+    />
+  );
+
+  await user.click(screen.getByRole('radio', { name: /Light/i }));
+  expect(onThemeChange).toHaveBeenCalledWith('light');
+  expect(screen.getByRole('radio', { name: /Dark/i })).toHaveAttribute('aria-checked', 'true');
+});
 
 test('connectivity panel renders loading and topic detail states', async () => {
   const user = userEvent.setup();
@@ -95,6 +113,7 @@ test('community node panel renders ready and error states', async () => {
 test('settings panels avoid the legacy grid classname collision', () => {
   const { container } = render(
     <div>
+      <AppearancePanel view={appearancePanelFixture} onThemeChange={() => {}} />
       <ConnectivityPanel
         view={connectivityPanelFixture}
         onPeerTicketInputChange={() => {}}

--- a/apps/desktop/src/components/settings/fixtures.ts
+++ b/apps/desktop/src/components/settings/fixtures.ts
@@ -1,8 +1,25 @@
 import type {
+  AppearancePanelView,
   CommunityNodePanelView,
   ConnectivityPanelView,
   DiscoveryPanelView,
 } from './types';
+
+export const appearancePanelFixture: AppearancePanelView = {
+  selectedTheme: 'dark',
+  options: [
+    {
+      value: 'dark',
+      label: 'Dark',
+      description: 'High-contrast solid surfaces for low-light work.',
+    },
+    {
+      value: 'light',
+      label: 'Light',
+      description: 'Brighter solid surfaces for daytime readability.',
+    },
+  ],
+};
 
 export const connectivityPanelFixture: ConnectivityPanelView = {
   status: 'ready',

--- a/apps/desktop/src/components/settings/types.ts
+++ b/apps/desktop/src/components/settings/types.ts
@@ -1,3 +1,5 @@
+import { type DesktopTheme } from '@/lib/theme';
+
 export type SettingsPanelStatus = 'loading' | 'ready' | 'error';
 
 export type SettingsMetricView = {
@@ -64,4 +66,15 @@ export type CommunityNodePanelView = {
   editorMessage?: string;
   editorMessageTone?: 'default' | 'danger';
   nodes: CommunityNodeEntryView[];
+};
+
+export type AppearanceOptionView = {
+  value: DesktopTheme;
+  label: string;
+  description: string;
+};
+
+export type AppearancePanelView = {
+  selectedTheme: DesktopTheme;
+  options: AppearanceOptionView[];
 };

--- a/apps/desktop/src/components/shell/SettingsDrawer.stories.tsx
+++ b/apps/desktop/src/components/shell/SettingsDrawer.stories.tsx
@@ -2,14 +2,17 @@ import { useMemo, useState } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import { AppearancePanel } from '@/components/settings/AppearancePanel';
 import { CommunityNodePanel } from '@/components/settings/CommunityNodePanel';
 import { ConnectivityPanel } from '@/components/settings/ConnectivityPanel';
 import { DiscoveryPanel } from '@/components/settings/DiscoveryPanel';
 import {
+  appearancePanelFixture,
   communityNodePanelFixture,
   connectivityPanelFixture,
   discoveryPanelFixture,
 } from '@/components/settings/fixtures';
+import type { DesktopTheme } from '@/lib/theme';
 import type { SettingsSection } from '@/components/shell/types';
 
 import { SettingsDrawer } from './SettingsDrawer';
@@ -17,12 +20,24 @@ import { SettingsDrawer } from './SettingsDrawer';
 function SettingsDrawerStory({ initialSection = 'connectivity' }: { initialSection?: SettingsSection }) {
   const [open, setOpen] = useState(true);
   const [activeSection, setActiveSection] = useState<SettingsSection>(initialSection);
+  const [theme, setTheme] = useState<DesktopTheme>(appearancePanelFixture.selectedTheme);
   const [peerTicketInput, setPeerTicketInput] = useState(connectivityPanelFixture.peerTicketInput);
   const [seedPeersInput, setSeedPeersInput] = useState(discoveryPanelFixture.seedPeersInput);
   const [baseUrlsInput, setBaseUrlsInput] = useState(communityNodePanelFixture.baseUrlsInput);
 
   const sections = useMemo(
     () => [
+      {
+        id: 'appearance' as const,
+        label: 'Appearance',
+        description: 'Local light and dark theme selection.',
+        content: (
+          <AppearancePanel
+            view={{ ...appearancePanelFixture, selectedTheme: theme }}
+            onThemeChange={setTheme}
+          />
+        ),
+      },
       {
         id: 'connectivity' as const,
         label: 'Connectivity',
@@ -73,7 +88,7 @@ function SettingsDrawerStory({ initialSection = 'connectivity' }: { initialSecti
         ),
       },
     ],
-    [baseUrlsInput, peerTicketInput, seedPeersInput]
+    [baseUrlsInput, peerTicketInput, seedPeersInput, theme]
   );
 
   return (
@@ -110,6 +125,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const ConnectivityOpen: Story = {};
+
+export const AppearanceOpen: Story = {
+  render: () => <SettingsDrawerStory initialSection='appearance' />,
+};
 
 export const DiscoveryOpen: Story = {
   render: () => <SettingsDrawerStory initialSection='discovery' />,

--- a/apps/desktop/src/components/shell/types.ts
+++ b/apps/desktop/src/components/shell/types.ts
@@ -1,6 +1,6 @@
 export type PrimarySection = 'timeline' | 'channels' | 'live' | 'game' | 'profile';
 
-export type SettingsSection = 'connectivity' | 'discovery' | 'community-node';
+export type SettingsSection = 'appearance' | 'connectivity' | 'discovery' | 'community-node';
 
 export type ProfileWorkspaceMode = 'overview' | 'edit';
 

--- a/apps/desktop/src/components/ui/badge.tsx
+++ b/apps/desktop/src/components/ui/badge.tsx
@@ -10,13 +10,13 @@ const badgeVariants = cva(
     variants: {
       tone: {
         neutral:
-          'border-[var(--border-subtle)] bg-white/5 text-[var(--muted-foreground)]',
+          'border-[var(--border-subtle)] bg-[var(--surface-badge-neutral)] text-[var(--muted-foreground)]',
         accent:
-          'border-[rgba(0,179,164,0.32)] bg-[rgba(0,179,164,0.14)] text-[var(--accent-foreground)]',
+          'border-[var(--border-accent)] bg-[var(--surface-accent-soft)] text-[var(--accent-foreground)]',
         warning:
-          'border-[rgba(245,157,98,0.28)] bg-[rgba(245,157,98,0.16)] text-[var(--foreground)]',
+          'border-[var(--border-warning)] bg-[var(--surface-warning-soft)] text-[var(--foreground)]',
         destructive:
-          'border-[rgba(255,180,138,0.24)] bg-[rgba(255,180,138,0.12)] text-[var(--destructive)]',
+          'border-[var(--border-destructive)] bg-[var(--surface-destructive-soft)] text-[var(--destructive)]',
       },
     },
     defaultVariants: {

--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -10,10 +10,9 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        primary: 'shadow-[0_10px_28px_rgba(245,157,98,0.16)]',
+        primary: 'shadow-[var(--shadow-button-primary)]',
         secondary: 'button-secondary',
-        ghost:
-          'button-ghost border border-[var(--border-subtle)] bg-transparent text-foreground shadow-none hover:bg-white/5',
+        ghost: 'button-ghost text-foreground shadow-none hover:bg-[var(--surface-button-ghost-hover)]',
       },
       size: {
         default: 'min-h-11 px-4 py-3',

--- a/apps/desktop/src/components/ui/notice.tsx
+++ b/apps/desktop/src/components/ui/notice.tsx
@@ -9,13 +9,13 @@ const noticeVariants = cva(
   {
     variants: {
       tone: {
-        neutral: 'border-[var(--border-subtle)] bg-white/5 text-foreground',
+        neutral: 'border-[var(--border-subtle)] bg-[var(--surface-panel-muted)] text-foreground',
         accent:
-          'border-[rgba(0,179,164,0.24)] bg-[rgba(0,179,164,0.12)] text-[var(--accent-foreground)]',
+          'border-[var(--border-accent)] bg-[var(--surface-accent-soft)] text-[var(--accent-foreground)]',
         warning:
-          'border-[rgba(245,157,98,0.24)] bg-[rgba(245,157,98,0.1)] text-foreground',
+          'border-[var(--border-warning)] bg-[var(--surface-warning-soft)] text-foreground',
         destructive:
-          'border-[rgba(255,180,138,0.2)] bg-[rgba(255,180,138,0.08)] text-[var(--destructive)]',
+          'border-[var(--border-destructive)] bg-[var(--surface-destructive-soft)] text-[var(--destructive)]',
       },
     },
     defaultVariants: {

--- a/apps/desktop/src/lib/theme.ts
+++ b/apps/desktop/src/lib/theme.ts
@@ -1,0 +1,24 @@
+export type DesktopTheme = 'dark' | 'light';
+
+export const DESKTOP_THEME_STORAGE_KEY = 'kukuri.desktop.theme';
+
+export function isDesktopTheme(value: string | null | undefined): value is DesktopTheme {
+  return value === 'dark' || value === 'light';
+}
+
+export function readDesktopTheme(): DesktopTheme {
+  if (typeof window === 'undefined') {
+    return 'dark';
+  }
+
+  const storedTheme = window.localStorage.getItem(DESKTOP_THEME_STORAGE_KEY);
+  return isDesktopTheme(storedTheme) ? storedTheme : 'dark';
+}
+
+export function writeDesktopTheme(theme: DesktopTheme) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(DESKTOP_THEME_STORAGE_KEY, theme);
+}

--- a/apps/desktop/src/stories/foundations/Tokens.stories.tsx
+++ b/apps/desktop/src/stories/foundations/Tokens.stories.tsx
@@ -15,9 +15,9 @@ const swatches = [
   { name: 'Background', value: 'var(--background)' },
   { name: 'Panel', value: 'var(--surface-panel)' },
   { name: 'Panel Accent', value: 'var(--surface-panel-accent)' },
+  { name: 'Panel Muted', value: 'var(--surface-panel-muted)' },
   { name: 'Input', value: 'var(--surface-input)' },
-  { name: 'Primary Start', value: 'var(--primary-start)' },
-  { name: 'Primary End', value: 'var(--primary-end)' },
+  { name: 'Primary Surface', value: 'var(--surface-button-primary)' },
   { name: 'Accent', value: 'var(--accent)' },
   { name: 'Destructive', value: 'var(--destructive)' },
 ];
@@ -34,17 +34,17 @@ function TokensPreview({ width }: { width: number }) {
           <h1 className='text-3xl font-semibold tracking-[-0.03em]'>kukuri shell foundation</h1>
           <p className='max-w-[60ch] text-sm text-[var(--muted-foreground)]'>
             Phase 0 keeps the existing shell intact while standardizing color, spacing, radius,
-            and primitive styling around shared CSS variables.
+            and primitive styling around shared CSS variables for both light and dark themes.
           </p>
         </div>
         <div className='grid gap-4 sm:grid-cols-2 xl:grid-cols-4'>
           {swatches.map((swatch) => (
             <div
               key={swatch.name}
-              className='flex flex-col gap-3 rounded-[var(--radius-input)] border border-[var(--border-subtle)] bg-black/10 p-4'
+              className='flex flex-col gap-3 rounded-[var(--radius-input)] border border-[var(--border-subtle)] bg-[var(--surface-panel-muted)] p-4'
             >
               <div
-                className='h-20 rounded-[calc(var(--radius-input)-2px)] border border-white/10'
+                className='h-20 rounded-[calc(var(--radius-input)-2px)] border border-[var(--border-subtle)]'
                 style={{ background: swatch.value }}
               />
               <div className='flex flex-col gap-1'>
@@ -55,17 +55,17 @@ function TokensPreview({ width }: { width: number }) {
           ))}
         </div>
         <div className='grid gap-3 text-sm text-[var(--muted-foreground)] md:grid-cols-3'>
-          <div className='rounded-[var(--radius-input)] border border-[var(--border-subtle)] bg-black/10 p-4'>
+          <div className='rounded-[var(--radius-input)] border border-[var(--border-subtle)] bg-[var(--surface-panel-muted)] p-4'>
             <strong className='block text-foreground'>Typography</strong>
             <p>IBM Plex Sans is the shared shell font, with muted copy and strong headline states.</p>
           </div>
-          <div className='rounded-[var(--radius-input)] border border-[var(--border-subtle)] bg-black/10 p-4'>
+          <div className='rounded-[var(--radius-input)] border border-[var(--border-subtle)] bg-[var(--surface-panel-muted)] p-4'>
             <strong className='block text-foreground'>Radius</strong>
             <p>Panels keep a 22px frame radius. Inputs and field surfaces use a 14px inner radius.</p>
           </div>
-          <div className='rounded-[var(--radius-input)] border border-[var(--border-subtle)] bg-black/10 p-4'>
-            <strong className='block text-foreground'>Motion + focus</strong>
-            <p>Reduced decoration, visible focus rings, and deliberate gradients remain the default.</p>
+          <div className='rounded-[var(--radius-input)] border border-[var(--border-subtle)] bg-[var(--surface-panel-muted)] p-4'>
+            <strong className='block text-foreground'>Theme + focus</strong>
+            <p>Solid surfaces, persistent light/dark themes, and visible focus rings stay consistent.</p>
           </div>
         </div>
       </div>

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -35,5 +35,5 @@ button:disabled {
 }
 
 ::selection {
-  background: rgba(245, 157, 98, 0.32);
+  background: var(--surface-selection);
 }

--- a/apps/desktop/src/styles/shell-phase1-legacy.css
+++ b/apps/desktop/src/styles/shell-phase1-legacy.css
@@ -16,7 +16,7 @@
   margin: 0 0 0.5rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: #f59d62;
+  color: var(--primary-start);
 }
 
 .shell-phase1 .hero h1 {
@@ -27,7 +27,7 @@
 
 .shell-phase1 .lede {
   max-width: 56ch;
-  color: rgba(246, 241, 232, 0.78);
+  color: var(--muted-foreground);
 }
 
 .shell-phase1 .grid {
@@ -41,7 +41,7 @@
   border-radius: var(--radius-panel);
   padding: 1rem;
   background: var(--surface-panel);
-  backdrop-filter: blur(10px);
+  backdrop-filter: none;
   box-shadow: var(--shadow-panel);
 }
 
@@ -92,7 +92,7 @@
   height: auto;
   padding: 0.1rem 0 0;
   border: 0;
-  background: transparent;
+  background: var(--surface-panel);
   line-height: 1.2;
 }
 
@@ -116,7 +116,7 @@
   align-items: center;
   padding: 0.8rem 0.9rem;
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-panel-muted);
 }
 
 .shell-phase1 .draft-attachment-content {
@@ -145,7 +145,7 @@
 .shell-phase1 .draft-attachment-item small {
   display: block;
   margin-top: 0.35rem;
-  color: rgba(246, 241, 232, 0.58);
+  color: var(--muted-foreground-soft);
 }
 
 .shell-phase1 .composer {
@@ -181,7 +181,7 @@
   align-items: center;
   padding: 0.75rem 0.9rem;
   border-radius: 16px;
-  background: rgba(0, 179, 164, 0.12);
+  background: var(--surface-accent-soft);
 }
 
 .shell-phase1 .reply-banner strong {
@@ -208,7 +208,7 @@
   border-radius: 999px;
   padding: 0.75rem 1.1rem;
   color: var(--primary-foreground);
-  background: linear-gradient(120deg, var(--primary-start), var(--primary-end));
+  background: var(--surface-button-primary);
   font-weight: 700;
   cursor: pointer;
 }
@@ -220,7 +220,7 @@
 
 .shell-phase1 .button-ghost {
   color: inherit;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-button-ghost);
   border: 1px solid var(--border-subtle);
   box-shadow: none;
 }
@@ -247,12 +247,12 @@
 .shell-phase1 .status-grid div {
   padding: 0.85rem;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-panel-muted);
 }
 
 .shell-phase1 .status-grid dt {
   font-size: 0.75rem;
-  color: rgba(246, 241, 232, 0.66);
+  color: var(--muted-foreground);
 }
 
 .shell-phase1 .status-grid dd {
@@ -279,7 +279,7 @@
   align-items: center;
   padding: 0.45rem;
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-panel-soft);
 }
 
 .shell-phase1 .topic-item-active {
@@ -288,7 +288,7 @@
 
 .shell-phase1 .topic-link, .shell-phase1 .topic-remove {
   border: 0;
-  background: transparent;
+  background: none;
   color: inherit;
   cursor: pointer;
 }
@@ -361,10 +361,10 @@
 }
 
 .shell-phase1 .post-card {
-  border: 1px solid rgba(246, 241, 232, 0.08);
+  border: 1px solid var(--border-subtle);
   border-radius: 18px;
   padding: 0.95rem;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-panel-soft);
 }
 
 .shell-phase1 .author-avatar {
@@ -372,9 +372,9 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  border: 1px solid rgba(246, 241, 232, 0.12);
-  background: linear-gradient(145deg, rgba(245, 157, 98, 0.24), rgba(0, 179, 164, 0.2));
-  color: rgba(246, 241, 232, 0.94);
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-avatar);
+  color: var(--foreground-strong);
   font-weight: 700;
   flex: none;
 }
@@ -404,14 +404,14 @@
 }
 
 .shell-phase1 .post-card-thread {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--surface-panel-muted);
 }
 
 .shell-phase1 .post-link {
   width: 100%;
   text-align: left;
   color: inherit;
-  background: transparent;
+  background: none;
   border: 0;
   cursor: pointer;
 }
@@ -431,16 +431,16 @@
   aspect-ratio: 16 / 9;
   margin: 0.4rem 0 0.75rem;
   border-radius: 16px;
-  border: 1px solid rgba(246, 241, 232, 0.08);
-  background: rgba(8, 15, 23, 0.72);
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-panel-muted);
 }
 
 .shell-phase1 .media-frame-loading {
-  background: linear-gradient(135deg, rgba(15, 29, 41, 0.96), rgba(11, 24, 36, 0.82));
+  background: var(--surface-media-loading);
 }
 
 .shell-phase1 .media-frame-ready {
-  background: linear-gradient(135deg, rgba(0, 179, 164, 0.18), rgba(10, 20, 28, 0.88));
+  background: var(--surface-media-ready);
 }
 
 .shell-phase1 .media-badges {
@@ -462,23 +462,23 @@
   font-size: 0.72rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  backdrop-filter: blur(6px);
+  border: 1px solid var(--border-subtle);
 }
 
 .shell-phase1 .media-status-badge {
-  color: #e9f7f6;
-  background: rgba(12, 28, 39, 0.78);
+  color: var(--foreground-strong);
+  background: var(--surface-contrast);
 }
 
 .shell-phase1 .media-type-badge {
-  color: rgba(246, 241, 232, 0.9);
-  background: rgba(0, 179, 164, 0.18);
+  color: var(--accent-foreground);
+  background: var(--surface-accent-soft);
 }
 
 .shell-phase1 .media-count-badge {
   margin-left: auto;
-  color: rgba(246, 241, 232, 0.92);
-  background: rgba(245, 157, 98, 0.22);
+  color: var(--foreground-strong);
+  background: var(--surface-warning-soft);
 }
 
 .shell-phase1 .media-skeleton, .shell-phase1 .media-ready-placeholder {
@@ -489,28 +489,12 @@
 }
 
 .shell-phase1 .media-skeleton {
-  position: relative;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.04)),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
-}
-
-.shell-phase1 .media-skeleton::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 0.12) 50%,
-    rgba(255, 255, 255, 0) 100%
-  );
-  transform: translateX(-100%);
-  animation: media-shimmer 1.8s ease-in-out infinite;
+  background: var(--surface-skeleton);
+  animation: skeleton-pulse 1.8s ease-in-out infinite;
 }
 
 .shell-phase1 .media-ready-placeholder {
-  color: rgba(246, 241, 232, 0.78);
+  color: var(--muted-foreground);
   font-size: 0.88rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -526,7 +510,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  background: rgba(6, 12, 18, 0.9);
+  background: var(--surface-panel);
 }
 
 .shell-phase1 .media-meta {
@@ -535,7 +519,7 @@
   gap: 0.75rem;
   margin-top: -0.15rem;
   margin-bottom: 0.65rem;
-  color: rgba(246, 241, 232, 0.6);
+  color: var(--muted-foreground-soft);
   font-size: 0.76rem;
 }
 
@@ -548,13 +532,8 @@
   display: block;
   height: 0.95rem;
   border-radius: 999px;
-  background: linear-gradient(
-    90deg,
-    rgba(255, 255, 255, 0.08),
-    rgba(255, 255, 255, 0.18),
-    rgba(255, 255, 255, 0.08)
-  );
-  animation: media-shimmer 1.8s ease-in-out infinite;
+  background: var(--surface-skeleton);
+  animation: skeleton-pulse 1.8s ease-in-out infinite;
 }
 
 .shell-phase1 .text-skeleton-line {
@@ -572,7 +551,7 @@
 }
 
 .shell-phase1 .active-topic-label {
-  color: rgba(246, 241, 232, 0.72);
+  color: var(--muted-foreground);
   font-size: 0.8rem;
 }
 
@@ -584,7 +563,7 @@
   gap: 1rem;
   margin-bottom: 0.55rem;
   font-size: 0.8rem;
-  color: rgba(246, 241, 232, 0.68);
+  color: var(--muted-foreground);
 }
 
 .shell-phase1 .post-meta-author {
@@ -606,8 +585,8 @@
   align-items: center;
   border-radius: 999px;
   padding: 0.18rem 0.55rem;
-  color: rgba(246, 241, 232, 0.9);
-  background: rgba(0, 179, 164, 0.16);
+  color: var(--accent-foreground);
+  background: var(--surface-accent-soft);
   line-height: 1.1;
 }
 
@@ -615,14 +594,14 @@
   display: inline-block;
   margin-top: 0.55rem;
   font-style: normal;
-  color: #8ce0d6;
+  color: var(--accent);
 }
 
 .shell-phase1 .author-link {
   padding: 0;
   border: 0;
-  color: #f6f1e8;
-  background: transparent;
+  color: var(--foreground);
+  background: none;
   font-weight: 700;
   text-align: left;
   cursor: pointer;
@@ -633,23 +612,23 @@
   align-items: center;
   border-radius: 999px;
   padding: 0.2rem 0.55rem;
-  color: rgba(246, 241, 232, 0.9);
-  background: rgba(246, 241, 232, 0.08);
+  color: var(--foreground);
+  background: var(--surface-badge-neutral);
 }
 
 .shell-phase1 .relationship-badge-direct {
-  background: rgba(0, 179, 164, 0.2);
-  color: #b9f2ea;
+  background: var(--surface-accent-soft);
+  color: var(--accent-foreground);
 }
 
 .shell-phase1 .relationship-badge-mutual {
-  background: rgba(245, 157, 98, 0.22);
-  color: #ffd6b9;
+  background: var(--surface-warning-soft);
+  color: var(--foreground);
 }
 
 .shell-phase1 .relationship-badge-fof {
-  background: rgba(110, 180, 255, 0.18);
-  color: #c9e1ff;
+  background: var(--surface-info-soft);
+  color: var(--foreground);
 }
 
 .shell-phase1 .author-detail {
@@ -696,7 +675,7 @@
 .shell-phase1 .author-detail-copy {
   margin: 0;
   line-height: 1.45;
-  color: rgba(246, 241, 232, 0.78);
+  color: var(--muted-foreground);
 }
 
 .shell-phase1 .author-detail-copy-stack {
@@ -727,7 +706,7 @@
   margin: 0;
   font-size: 0.72rem;
   line-height: 1.45;
-  color: rgba(246, 241, 232, 0.54);
+  color: var(--muted-foreground-soft);
 }
 
 .shell-phase1 .shell-icon-button {
@@ -736,8 +715,8 @@
   min-inline-size: 2.1rem;
   padding: 0;
   border-radius: 14px;
-  color: rgba(246, 241, 232, 0.92);
-  background: rgba(255, 255, 255, 0.06);
+  color: var(--foreground);
+  background: var(--surface-button-ghost);
   border: 1px solid var(--border-subtle);
   box-shadow: none;
 }
@@ -750,7 +729,7 @@
 
 .shell-phase1 .shell-icon-button:hover,
 .shell-phase1 .shell-icon-button:focus-visible {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--surface-button-ghost-hover);
 }
 
 .shell-phase1 .shell-icon-button svg {
@@ -768,33 +747,33 @@
   display: block;
   margin-top: 0.5rem;
   word-break: break-all;
-  color: rgba(246, 241, 232, 0.54);
+  color: var(--muted-foreground-soft);
 }
 
 .shell-phase1 .thread-item {
-  border-left: 3px solid rgba(0, 179, 164, 0.72);
+  border-left: 3px solid var(--border-accent);
   padding-left: 0.85rem;
 }
 
 .shell-phase1 .empty, .shell-phase1 .error {
-  color: rgba(246, 241, 232, 0.72);
+  color: var(--muted-foreground);
 }
 
 .shell-phase1 .error {
   margin-top: 1rem;
-  color: #ffb58c;
+  color: var(--destructive);
 }
 
 .shell-phase1 .error-inline {
   margin-top: 0;
 }
 
-@keyframes media-shimmer {
+@keyframes skeleton-pulse {
   0% {
-    transform: translateX(-100%);
+    opacity: 0.62;
   }
   100% {
-    transform: translateX(100%);
+    opacity: 1;
   }
 }
 

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -14,7 +14,7 @@
   border-radius: 999px;
   padding: 0.7rem 1rem;
   color: var(--primary-foreground);
-  background: linear-gradient(120deg, var(--primary-start), var(--primary-end));
+  background: var(--surface-button-primary);
   transform: translateY(-220%);
   transition: transform 180ms ease;
 }
@@ -152,7 +152,7 @@
 }
 
 .extended-channel-card-active {
-  border-color: rgba(0, 179, 164, 0.32);
+  border-color: var(--border-accent);
   background: var(--surface-active);
 }
 
@@ -218,7 +218,7 @@
   border-radius: 18px;
   padding: 0.9rem 1rem;
   color: inherit;
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--surface-panel-muted);
   text-align: left;
   cursor: pointer;
 }
@@ -235,7 +235,7 @@
 .shell-primary-nav-item-active,
 .shell-settings-nav-item-active,
 .shell-tab-active {
-  border-color: rgba(0, 179, 164, 0.32);
+  border-color: var(--border-accent);
   background: var(--surface-active);
 }
 
@@ -360,7 +360,7 @@
   overflow: hidden;
   border: 1px solid var(--border-subtle);
   border-radius: 20px;
-  background: linear-gradient(145deg, rgba(245, 157, 98, 0.22), rgba(0, 179, 164, 0.18));
+  background: var(--surface-avatar);
   font-size: 1.4rem;
   font-weight: 700;
   color: var(--foreground-strong);
@@ -427,7 +427,7 @@
   position: fixed;
   inset: 0;
   z-index: 60;
-  background: rgba(3, 7, 12, 0.68);
+  background: var(--surface-overlay);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -1,34 +1,105 @@
 :root {
   --font-sans: "IBM Plex Sans", "Segoe UI", sans-serif;
+  --radius: 1rem;
+  --radius-panel: 22px;
+  --radius-input: 14px;
+}
+
+:root,
+:root[data-theme='dark'] {
   --background: #101923;
+  --shell-background: #101923;
   --foreground: #f6f1e8;
   --foreground-strong: #fff7ef;
-  --muted-foreground: rgba(246, 241, 232, 0.72);
-  --muted-foreground-soft: rgba(246, 241, 232, 0.58);
-  --surface-panel: rgba(6, 12, 18, 0.48);
+  --muted-foreground: #cbbdae;
+  --muted-foreground-soft: #a89b8f;
+  --surface-panel: #0c1721;
   --surface-panel-solid: #0c1721;
-  --surface-panel-accent: linear-gradient(160deg, rgba(255, 132, 74, 0.14), rgba(8, 17, 26, 0.55));
-  --surface-input: rgba(10, 16, 24, 0.8);
-  --surface-raised: rgba(8, 15, 23, 0.72);
-  --surface-button-secondary: rgba(246, 241, 232, 0.08);
-  --surface-active: rgba(0, 179, 164, 0.16);
-  --border-subtle: rgba(246, 241, 232, 0.12);
-  --border-subtle-strong: rgba(246, 241, 232, 0.08);
+  --surface-panel-accent: #162231;
+  --surface-panel-muted: #13202c;
+  --surface-panel-soft: #182632;
+  --surface-input: #101b26;
+  --surface-raised: #1b2a36;
+  --surface-button-primary: #f59d62;
+  --surface-button-primary-hover: #ee8f4e;
+  --surface-button-secondary: #233241;
+  --surface-button-ghost: #1a2734;
+  --surface-button-ghost-hover: #223241;
+  --surface-active: #17393c;
+  --surface-overlay: #071019;
+  --surface-avatar: #21303d;
+  --surface-media-loading: #1a2734;
+  --surface-media-ready: #173439;
+  --surface-skeleton: #243442;
+  --surface-selection: #d98b55;
+  --surface-accent-soft: #17393c;
+  --surface-warning-soft: #463423;
+  --surface-destructive-soft: #4a2b22;
+  --surface-info-soft: #203449;
+  --surface-badge-neutral: #1a2734;
+  --surface-contrast: #20303c;
+  --border-subtle: #2a3a4a;
+  --border-subtle-strong: #39495a;
+  --border-accent: #2d7b76;
+  --border-warning: #a36b40;
+  --border-destructive: #a35e49;
   --primary-start: #f59d62;
-  --primary-end: #ffd36e;
+  --primary-end: #f59d62;
   --primary-foreground: #0e1b26;
   --accent: #00b3a4;
   --accent-foreground: #eafffb;
   --destructive: #ffb48a;
-  --ring: rgba(0, 179, 164, 0.48);
+  --ring: rgba(0, 179, 164, 0.45);
   --shadow-panel: 0 18px 60px rgba(2, 7, 15, 0.22);
-  --shell-background:
-    radial-gradient(circle at top left, rgba(255, 132, 74, 0.22), transparent 28%),
-    radial-gradient(circle at top right, rgba(0, 179, 164, 0.18), transparent 22%),
-    linear-gradient(135deg, #101923 0%, #0f2231 48%, #132c3d 100%);
-  --radius: 1rem;
-  --radius-panel: 22px;
-  --radius-input: 14px;
+  --shadow-button-primary: 0 10px 28px rgba(245, 157, 98, 0.16);
+}
+
+:root[data-theme='light'] {
+  --background: #f4efe6;
+  --shell-background: #f4efe6;
+  --foreground: #21303b;
+  --foreground-strong: #15202a;
+  --muted-foreground: #5f6c76;
+  --muted-foreground-soft: #74818a;
+  --surface-panel: #ffffff;
+  --surface-panel-solid: #ffffff;
+  --surface-panel-accent: #f5ede2;
+  --surface-panel-muted: #edf2f6;
+  --surface-panel-soft: #e6edf2;
+  --surface-input: #f8f4ee;
+  --surface-raised: #dde5ec;
+  --surface-button-primary: #d77d45;
+  --surface-button-primary-hover: #c86f38;
+  --surface-button-secondary: #dfe6ec;
+  --surface-button-ghost: #edf2f6;
+  --surface-button-ghost-hover: #e3ebf1;
+  --surface-active: #d8eee9;
+  --surface-overlay: #d7dfe7;
+  --surface-avatar: #dfe8ee;
+  --surface-media-loading: #dde5ec;
+  --surface-media-ready: #d8eee9;
+  --surface-skeleton: #e8eef3;
+  --surface-selection: #e9b28c;
+  --surface-accent-soft: #d8eee9;
+  --surface-warning-soft: #f6e7d9;
+  --surface-destructive-soft: #f6dfd4;
+  --surface-info-soft: #dce7f4;
+  --surface-badge-neutral: #edf2f6;
+  --surface-contrast: #dde5ec;
+  --border-subtle: #cad3db;
+  --border-subtle-strong: #b7c2cb;
+  --border-accent: #78a8a2;
+  --border-warning: #d1a06d;
+  --border-destructive: #d89b86;
+  --primary-start: #d77d45;
+  --primary-end: #d77d45;
+  --primary-foreground: #fff7ef;
+  --accent: #0f8c82;
+  --accent-foreground: #143633;
+  --destructive: #b35f46;
+  --ring: rgba(15, 140, 130, 0.32);
+  --shadow-panel: 0 18px 48px rgba(33, 48, 59, 0.12);
+  --shadow-button-primary: 0 10px 24px rgba(215, 125, 69, 0.18);
 }
 
 @theme inline {

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -5,5 +5,11 @@ import { afterEach, vi } from 'vitest';
 afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
+  if (typeof window !== 'undefined') {
+    window.localStorage.clear();
+  }
+  if (typeof document !== 'undefined') {
+    delete document.documentElement.dataset.theme;
+  }
   cleanup();
 });

--- a/apps/desktop/tests/playwright/hash-routing.spec.ts
+++ b/apps/desktop/tests/playwright/hash-routing.spec.ts
@@ -13,13 +13,14 @@ test('browser mock hash routes deep link profile, channels, and settings surface
   await expect(page.getByPlaceholder('core contributors')).toBeVisible();
   await expect(page).toHaveURL(/#\/channels\?topic=/);
 
-  await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ademo&settings=discovery');
+  await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ademo&settings=appearance');
   const settingsDialog = page.getByRole('dialog', { name: 'Settings & diagnostics' });
   await expect(settingsDialog).toBeVisible();
-  await expect(settingsDialog.getByTestId('settings-section-discovery')).toHaveAttribute(
+  await expect(settingsDialog.getByTestId('settings-section-appearance')).toHaveAttribute(
     'aria-current',
     'location'
   );
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
 
   await settingsDialog.getByTestId('settings-section-connectivity').click();
   await expect(page).toHaveURL(/settings=connectivity/);

--- a/apps/desktop/tests/playwright/shell.smoke.spec.ts
+++ b/apps/desktop/tests/playwright/shell.smoke.spec.ts
@@ -69,6 +69,24 @@ test('browser mock shell can switch topics, publish, open thread, open author, a
   await expect(nodeCard).toBeVisible();
 });
 
+test('browser mock shell persists appearance theme changes across reloads', async ({ page }) => {
+  await page.setViewportSize({ width: 1400, height: 980 });
+  await page.goto('/');
+
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+  await page.getByTestId('shell-settings-trigger').click();
+  const settingsDialog = page.getByRole('dialog', { name: 'Settings & diagnostics' });
+  await settingsDialog.getByTestId('settings-section-appearance').click();
+  await settingsDialog.getByRole('radio', { name: /Light/i }).click();
+
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+
+  await page.reload();
+
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+});
+
 test('browser mock narrow shell keeps nav, context, and settings flows reachable without overflow', async ({
   page,
 }) => {

--- a/docs/ui-reviews/2026-03-27-desktop-theme-solidification.md
+++ b/docs/ui-reviews/2026-03-27-desktop-theme-solidification.md
@@ -1,0 +1,9 @@
+# 2026-03-27 desktop theme solidification
+
+- Figma: なし。既存 shell surface の theme token と settings drawer を更新する visual refinement として扱い、standalone Figma proposal は作成していない。例外として記録する。
+- Storybook review surface: `Foundations/Tokens/DesktopWidth`, `UI/Button/Default`, `UI/Card/Default`, `Settings/AppearancePanel/Default`, `Shell/SettingsDrawer/AppearanceOpen`
+- Summary: `apps/desktop` の shell token を `dark` / `light` の 2 系統へ再編し、panel・button・badge・notice・settings card・post/media chrome の背景を solid surface に統一した。settings drawer に `Appearance` section を追加し、theme 切り替えを local storage に保存するようにした。`DesktopApi` / Tauri invoke / Rust contract は変更していない。
+- User flow summary: 初回起動時は dark theme を使い、settings drawer の `Appearance` から `Light` / `Dark` を即時切り替えできる。選択はこの desktop に保存され、reload 後も維持される。settings deep-link は `?settings=appearance` を受け付ける。
+- Review result: shell background、accent panel、ghost/secondary button、settings diagnostics card、post/media placeholder の translucent or gradient background は廃止し、theme ごとの solid token へ置き換えた。Storybook preview には theme toolbar を追加し、light/dark を同じ review surface で確認できるようにした。
+- Shneiderman: 一貫性は shared token layer と settings drawer への切り替え導線集約で担保した。informative feedback は active theme の selected state と即時反映で維持した。internal locus of control は automatic system override を入れず、明示的な local choice を保存することで高めた。short-term memory load は settings deep-link と persistent local choice で下げた。
+- Validation: `cd apps/desktop && npx pnpm@10.16.1 test`; `cd apps/desktop && npx pnpm@10.16.1 typecheck`; `cd apps/desktop && npx pnpm@10.16.1 lint`; `cd apps/desktop && npx pnpm@10.16.1 storybook:build`; `cd apps/desktop && npx pnpm@10.16.1 test:e2e:browser`


### PR DESCRIPTION
## Summary
- split desktop theme tokens into explicit dark and light solid surface palettes
- add an Appearance settings section with persisted light/dark switching and `settings=appearance` routing support
- update stories, tests, and UI review artifacts, including a Storybook capture hook for the Figma artifact

## Testing
- `cd apps/desktop && npx pnpm@10.16.1 test`
- `cd apps/desktop && npx pnpm@10.16.1 storybook:build`

## Artifact
- [Figma artifact](https://www.figma.com/design/KV3nSFq5F4suYO4RH3ozkx)