### PR TITLE
fix: restore wide desktop shell layout

### DIFF
--- a/apps/desktop/src/components/shell/ShellFrame.tsx
+++ b/apps/desktop/src/components/shell/ShellFrame.tsx
@@ -12,8 +12,6 @@ type ShellFrameProps = {
   mobileFooter?: React.ReactNode;
 };
 
-const DETAIL_PANE_COUNT_VAR = '--shell-detail-pane-count' as const;
-
 function isMobileViewport() {
   if (typeof window === 'undefined') {
     return false;
@@ -31,6 +29,7 @@ export function ShellFrame({
   mobileFooter,
 }: ShellFrameProps) {
   const [showMobileFooter, setShowMobileFooter] = React.useState(() => isMobileViewport());
+  const layoutDetailPaneCount = Math.max(0, Math.min(detailPaneCount, 2));
 
   React.useEffect(() => {
     function handleResize() {
@@ -44,20 +43,19 @@ export function ShellFrame({
     };
   }, []);
 
-  const layoutStyle = {
-    [DETAIL_PANE_COUNT_VAR]: String(detailPaneCount),
-  } as React.CSSProperties;
-
   return (
     <div className='shell-phase1'>
       <a className='shell-skip-link' href={`#${skipTargetId}`}>
         Skip to workspace
       </a>
-      <div className='shell-layout shell-topbar-grid' style={layoutStyle}>
+      <div
+        className='shell-layout shell-topbar-grid'
+        data-detail-pane-count={layoutDetailPaneCount}
+      >
         <div className='shell-topbar-spacer' aria-hidden='true' />
         {topBar}
       </div>
-      <div className='shell-layout' style={layoutStyle}>
+      <div className='shell-layout' data-detail-pane-count={layoutDetailPaneCount}>
         {navRail}
         <main
           id={skipTargetId}

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -121,10 +121,19 @@
   display: grid;
   gap: 1rem;
   align-items: start;
+  grid-template-columns: minmax(260px, 280px) minmax(0, 1fr);
+}
+
+.shell-layout[data-detail-pane-count='1'] {
+  grid-template-columns: minmax(260px, 280px) minmax(0, 1fr) minmax(280px, 320px);
+}
+
+.shell-layout[data-detail-pane-count='2'] {
   grid-template-columns:
     minmax(260px, 280px)
     minmax(0, 1fr)
-    repeat(var(--shell-detail-pane-count, 0), minmax(280px, 320px));
+    minmax(280px, 320px)
+    minmax(280px, 320px);
 }
 
 .shell-main {

--- a/apps/desktop/tests/playwright/shell.smoke.spec.ts
+++ b/apps/desktop/tests/playwright/shell.smoke.spec.ts
@@ -1,5 +1,21 @@
 import { expect, test } from '@playwright/test';
 
+test('browser mock wide shell keeps navigation rail beside the workspace', async ({ page }) => {
+  await page.setViewportSize({ width: 1400, height: 980 });
+  await page.goto('/');
+
+  await expect(page.getByTestId('shell-nav-trigger')).toHaveCount(0);
+
+  const navRail = page.getByRole('complementary', { name: 'Primary navigation' });
+  const workspace = page.locator('main[aria-label="Primary workspace"]');
+  const navBox = await navRail.boundingBox();
+  const workspaceBox = await workspace.boundingBox();
+
+  expect(navBox).not.toBeNull();
+  expect(workspaceBox).not.toBeNull();
+  expect(navBox!.x + navBox!.width).toBeLessThan(workspaceBox!.x);
+});
+
 test('browser mock shell can switch topics, publish, open thread, open author, and update discovery from settings', async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- restore the wide desktop shell grid when no detail pane is open
- replace the invalid repeat(0, ...) layout path with explicit 0/1/2 detail pane variants
- add a Playwright regression test that verifies the nav rail stays beside the workspace at wide widths

## Testing
- npx pnpm@10.16.1 playwright test tests/playwright/shell.smoke.spec.ts
- npx pnpm@10.16.1 vitest run src/App.test.tsx -t "mobile nav trigger is footer-only and desktop omits it"