### PR TITLE
Add author profile topic feed

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,10 +8,11 @@ use kukuri_desktop_runtime::{
     ExportPrivateChannelInviteRequest, FreezePrivateChannelRequest, GetBlobMediaRequest,
     GetBlobPreviewRequest, ImportFriendOnlyGrantRequest, ImportFriendPlusShareRequest,
     ImportPeerTicketRequest, ImportPrivateChannelInviteRequest, ListGameRoomsRequest,
-    ListJoinedPrivateChannelsRequest, ListLiveSessionsRequest, ListThreadRequest,
-    ListTimelineRequest, LiveSessionCommandRequest, RotatePrivateChannelRequest,
-    SetCommunityNodeConfigRequest, SetDiscoverySeedsRequest, SetMyProfileRequest,
-    UnsubscribeTopicRequest, UpdateGameRoomRequest, AuthorRequest, resolve_db_path_from_env,
+    ListJoinedPrivateChannelsRequest, ListLiveSessionsRequest, ListProfileTimelineRequest,
+    ListThreadRequest, ListTimelineRequest, LiveSessionCommandRequest,
+    RotatePrivateChannelRequest, SetCommunityNodeConfigRequest, SetDiscoverySeedsRequest,
+    SetMyProfileRequest, UnsubscribeTopicRequest, UpdateGameRoomRequest, AuthorRequest,
+    resolve_db_path_from_env,
 };
 use tauri::Manager;
 use tracing::{info, warn};
@@ -231,6 +232,18 @@ async fn list_thread(
     request: ListThreadRequest,
 ) -> Result<kukuri_app_api::TimelineView, String> {
     state.runtime.list_thread(request).await.map_err(map_error)
+}
+
+#[tauri::command]
+async fn list_profile_timeline(
+    state: tauri::State<'_, DesktopState>,
+    request: ListProfileTimelineRequest,
+) -> Result<kukuri_app_api::TimelineView, String> {
+    state
+        .runtime
+        .list_profile_timeline(request)
+        .await
+        .map_err(map_error)
 }
 
 #[tauri::command]
@@ -610,6 +623,7 @@ pub fn run() {
             list_joined_private_channels,
             list_timeline,
             list_thread,
+            list_profile_timeline,
             get_my_profile,
             set_my_profile,
             follow_author,

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -671,7 +671,7 @@ test('desktop shell can track multiple topics at once', async () => {
   expect(demoTopic).not.toHaveTextContent('Connected to all configured peers for this topic');
 });
 
-test('profile overview follows the active topic public timeline, not the current compose or channel scope', async () => {
+test('profile overview aggregates public posts across topics and excludes private channel posts', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
@@ -701,6 +701,7 @@ test('profile overview follows the active topic public timeline, not the current
   await selectWorkspace(user, 'Profile');
   expect(screen.getByText('demo public post')).toBeInTheDocument();
   expect(screen.queryByText('demo private post')).not.toBeInTheDocument();
+  expect(screen.getAllByText('kukuri:topic:demo').length).toBeGreaterThan(0);
 
   await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:second');
   await user.click(screen.getByRole('button', { name: 'Add' }));
@@ -717,8 +718,15 @@ test('profile overview follows the active topic public timeline, not the current
   });
 
   await selectWorkspace(user, 'Profile');
+  expect(screen.getByText('demo public post')).toBeInTheDocument();
   expect(screen.getByText('second public post')).toBeInTheDocument();
-  expect(screen.queryByText('demo public post')).not.toBeInTheDocument();
+  expect(screen.queryByText('demo private post')).not.toBeInTheDocument();
+  const profileSection = screen.getByText('second public post').closest('.shell-section');
+  if (!(profileSection instanceof HTMLElement)) {
+    throw new Error('profile section not found');
+  }
+  expect(within(profileSection).queryByRole('button', { name: 'Reply' })).not.toBeInTheDocument();
+  expect(within(profileSection).getAllByRole('button', { name: 'Open original topic' }).length).toBe(2);
 });
 
 test('removing the active topic falls back to the remaining tracked topic', async () => {
@@ -1831,6 +1839,85 @@ test('author detail shows via authors and follow action updates relationship', a
     expect(screen.getByRole('button', { name: 'Unfollow' })).toBeInTheDocument();
   });
   expect(screen.getAllByText('following').length).toBeGreaterThan(0);
+});
+
+test('author detail shows profile topic posts and can open an untracked origin topic', async () => {
+  const authorPubkey = 'b'.repeat(64);
+  const user = userEvent.setup();
+
+  render(
+    <App
+      api={createDesktopMockApi({
+        seedPosts: {
+          'kukuri:topic:demo': [
+            {
+              object_id: 'post-author-demo',
+              envelope_id: 'envelope-author-demo',
+              author_pubkey: authorPubkey,
+              author_name: 'bob',
+              author_display_name: null,
+              following: false,
+              followed_by: false,
+              mutual: false,
+              friend_of_friend: false,
+              object_kind: 'post',
+              content: 'post from demo topic',
+              content_status: 'Available',
+              attachments: [],
+              created_at: 1,
+              reply_to: null,
+              root_id: 'post-author-demo',
+              audience_label: 'Public',
+            },
+          ],
+          'kukuri:topic:relay': [
+            {
+              object_id: 'post-author-relay',
+              envelope_id: 'envelope-author-relay',
+              author_pubkey: authorPubkey,
+              author_name: 'bob',
+              author_display_name: null,
+              following: false,
+              followed_by: false,
+              mutual: false,
+              friend_of_friend: false,
+              object_kind: 'post',
+              content: 'post from relay topic',
+              content_status: 'Available',
+              attachments: [],
+              created_at: 2,
+              reply_to: null,
+              root_id: 'post-author-relay',
+              audience_label: 'Public',
+            },
+          ],
+        },
+        authorSocialViews: {
+          [authorPubkey]: {
+            name: 'bob',
+            about: 'author detail profile feed',
+          },
+        },
+      })}
+    />
+  );
+
+  await user.click(await screen.findByRole('button', { name: 'bob' }));
+
+  const authorPane = await screen.findByRole('complementary', { name: 'Author' });
+  expect(within(authorPane).getByText('post from demo topic')).toBeInTheDocument();
+  expect(within(authorPane).getByText('post from relay topic')).toBeInTheDocument();
+  expect(within(authorPane).getByText('kukuri:topic:relay')).toBeInTheDocument();
+  expect(within(authorPane).queryByRole('button', { name: 'Reply' })).not.toBeInTheDocument();
+
+  await user.click(within(authorPane).getAllByRole('button', { name: 'Open original topic' })[0]);
+
+  await waitFor(() => {
+    expectActiveTopicBar('kukuri:topic:relay');
+    expect(screen.queryByRole('complementary', { name: 'Author' })).not.toBeInTheDocument();
+  });
+  expect(screen.getByText('post from relay topic')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'kukuri:topic:relay' })).toBeInTheDocument();
 });
 
 test('local profile editor saves profile draft from primary navigation and settings stays diagnostics-only', async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -164,6 +164,7 @@ type DesktopShellState = {
   unsupportedVideoManifests: Record<string, true>;
   syncStatus: SyncStatus;
   localProfile: Profile | null;
+  profileTimeline: PostView[];
   profileDraft: ProfileInput;
   profileDirty: boolean;
   profileError: string | null;
@@ -171,6 +172,7 @@ type DesktopShellState = {
   profileSaving: boolean;
   selectedAuthorPubkey: string | null;
   selectedAuthor: AuthorSocialView | null;
+  selectedAuthorTimeline: PostView[];
   authorError: string | null;
   composerError: string | null;
   liveTitle: string;
@@ -344,6 +346,7 @@ function createInitialShellState(): DesktopShellState {
     unsupportedVideoManifests: {},
     syncStatus: DEFAULT_SYNC_STATUS,
     localProfile: null,
+    profileTimeline: [],
     profileDraft: {},
     profileDirty: false,
     profileError: null,
@@ -351,6 +354,7 @@ function createInitialShellState(): DesktopShellState {
     profileSaving: false,
     selectedAuthorPubkey: null,
     selectedAuthor: null,
+    selectedAuthorTimeline: [],
     authorError: null,
     composerError: null,
     liveTitle: '',
@@ -1330,6 +1334,7 @@ function DesktopShellPage({
     unsupportedVideoManifests,
     syncStatus,
     localProfile,
+    profileTimeline,
     profileDraft,
     profileDirty,
     profileError,
@@ -1337,6 +1342,7 @@ function DesktopShellPage({
     profileSaving,
     selectedAuthorPubkey,
     selectedAuthor,
+    selectedAuthorTimeline,
     authorError,
     composerError,
     liveTitle,
@@ -1453,6 +1459,7 @@ function DesktopShellPage({
   );
   const setSyncStatus = useMemo(() => makeFieldSetter('syncStatus'), [makeFieldSetter]);
   const setLocalProfile = useMemo(() => makeFieldSetter('localProfile'), [makeFieldSetter]);
+  const setProfileTimeline = useMemo(() => makeFieldSetter('profileTimeline'), [makeFieldSetter]);
   const setProfileDraft = useMemo(() => makeFieldSetter('profileDraft'), [makeFieldSetter]);
   const setProfileDirty = useMemo(() => makeFieldSetter('profileDirty'), [makeFieldSetter]);
   const setProfileError = useMemo(() => makeFieldSetter('profileError'), [makeFieldSetter]);
@@ -1466,6 +1473,10 @@ function DesktopShellPage({
     [makeFieldSetter]
   );
   const setSelectedAuthor = useMemo(() => makeFieldSetter('selectedAuthor'), [makeFieldSetter]);
+  const setSelectedAuthorTimeline = useMemo(
+    () => makeFieldSetter('selectedAuthorTimeline'),
+    [makeFieldSetter]
+  );
   const setAuthorError = useMemo(() => makeFieldSetter('authorError'), [makeFieldSetter]);
   const setComposerError = useMemo(() => makeFieldSetter('composerError'), [makeFieldSetter]);
   const setLiveTitle = useMemo(() => makeFieldSetter('liveTitle'), [makeFieldSetter]);
@@ -1627,16 +1638,23 @@ function DesktopShellPage({
     mode: 'push' | 'replace' = 'replace',
     overrides?: DesktopShellRouteOverrides
   ) => {
+    const hasOverride = <K extends keyof DesktopShellRouteOverrides>(key: K) =>
+      overrides ? Object.prototype.hasOwnProperty.call(overrides, key) : false;
     const search = new URLSearchParams();
     const nextTopic = overrides?.activeTopic ?? activeTopic;
     const nextTimelineScope = overrides?.timelineScope ?? activeTimelineScope;
     const nextComposeTarget = overrides?.composeTarget ?? activeComposeChannel;
     const nextPrimarySection = overrides?.primarySection ?? shellChromeState.activePrimarySection;
     const nextProfileMode = overrides?.profileMode ?? shellChromeState.profileMode;
-    const nextSelectedThread = overrides?.selectedThread ?? selectedThread;
-    const nextSelectedAuthorPubkey =
-      overrides?.selectedAuthorPubkey ?? selectedAuthorPubkey;
-    const nextSettingsOpen = overrides?.settingsOpen ?? shellChromeState.settingsOpen;
+    const nextSelectedThread = hasOverride('selectedThread')
+      ? overrides?.selectedThread ?? null
+      : selectedThread;
+    const nextSelectedAuthorPubkey = hasOverride('selectedAuthorPubkey')
+      ? overrides?.selectedAuthorPubkey ?? null
+      : selectedAuthorPubkey;
+    const nextSettingsOpen = hasOverride('settingsOpen')
+      ? overrides?.settingsOpen ?? false
+      : shellChromeState.settingsOpen;
     const nextSettingsSection =
       overrides?.settingsSection ?? shellChromeState.activeSettingsSection;
 
@@ -1760,7 +1778,13 @@ function DesktopShellPage({
   );
   const previewableMediaAttachments = useMemo(() => {
     const attachments = new Map<string, AttachmentView>();
-    for (const post of [...activeTimeline, ...activePublicTimeline, ...thread]) {
+    for (const post of [
+      ...activeTimeline,
+      ...activePublicTimeline,
+      ...profileTimeline,
+      ...selectedAuthorTimeline,
+      ...thread,
+    ]) {
       for (const attachment of [
         selectPrimaryImage(post),
         selectVideoPoster(post),
@@ -1772,7 +1796,7 @@ function DesktopShellPage({
       }
     }
     return [...attachments.values()];
-  }, [activePublicTimeline, activeTimeline, thread]);
+  }, [activePublicTimeline, activeTimeline, profileTimeline, selectedAuthorTimeline, thread]);
 
   const loadTopics = useCallback(
     async (currentTopics: string[], currentActiveTopic: string, currentThread: string | null) => {
@@ -1848,6 +1872,8 @@ function DesktopShellPage({
           ticketResult,
           profileResult,
           authorViewResult,
+          profileTimelineResult,
+          authorTimelineResult,
         ] = await Promise.allSettled([
           api.getDiscoveryConfig(),
           api.getCommunityNodeConfig(),
@@ -1856,6 +1882,10 @@ function DesktopShellPage({
           api.getMyProfile(),
           currentSelectedAuthorPubkey
             ? api.getAuthorSocialView(currentSelectedAuthorPubkey)
+            : Promise.resolve(null),
+          api.listProfileTimeline(status.local_author_pubkey, null, 50),
+          currentSelectedAuthorPubkey
+            ? api.listProfileTimeline(currentSelectedAuthorPubkey, null, 50)
             : Promise.resolve(null),
         ]);
         if (requestId !== loadTopicsRequestRef.current) {
@@ -1983,16 +2013,31 @@ function DesktopShellPage({
             if (!currentProfileDirty) {
               setProfileDraft(profileInputFromProfile(profileResult.value));
             }
-            setProfileError(null);
-            setProfilePanelState({
-              status: 'ready',
-              error: null,
-            });
+            if (profileTimelineResult.status === 'fulfilled') {
+              setProfileTimeline(profileTimelineResult.value.items);
+              setProfileError(null);
+              setProfilePanelState({
+                status: 'ready',
+                error: null,
+              });
+            } else {
+              const nextProfileError = messageFromError(
+                profileTimelineResult.reason,
+                translate('common:errors.failedToLoadProfile')
+              );
+              setProfileTimeline([]);
+              setProfileError(nextProfileError);
+              setProfilePanelState({
+                status: 'error',
+                error: nextProfileError,
+              });
+            }
           } else {
             const nextProfileError = messageFromError(
               profileResult.reason,
               translate('common:errors.failedToLoadProfile')
             );
+            setProfileTimeline([]);
             setProfileError(nextProfileError);
             setProfilePanelState({
               status: 'error',
@@ -2001,15 +2046,26 @@ function DesktopShellPage({
           }
           if (!currentSelectedAuthorPubkey) {
             setSelectedAuthor(null);
+            setSelectedAuthorTimeline([]);
             setAuthorError(null);
-          } else if (authorViewResult.status === 'fulfilled') {
+          } else if (
+            authorViewResult.status === 'fulfilled' &&
+            authorTimelineResult.status === 'fulfilled'
+          ) {
             setSelectedAuthor(authorViewResult.value);
+            setSelectedAuthorTimeline(authorTimelineResult.value?.items ?? []);
             setAuthorError(null);
           } else {
+            setSelectedAuthorTimeline([]);
             setAuthorError(
-              authorViewResult.reason instanceof Error
-                ? authorViewResult.reason.message
-                : translate('common:errors.failedToLoadAuthor')
+              messageFromError(
+                authorViewResult.status === 'rejected'
+                  ? authorViewResult.reason
+                  : authorTimelineResult.status === 'rejected'
+                    ? authorTimelineResult.reason
+                    : null,
+                translate('common:errors.failedToLoadAuthor')
+              )
             );
           }
           if (threadView) {
@@ -2047,10 +2103,12 @@ function DesktopShellPage({
       setLiveSessionsByTopic,
       setLocalPeerTicket,
       setLocalProfile,
+      setProfileTimeline,
       setProfileDraft,
       setProfileError,
       setProfilePanelState,
       setSelectedAuthor,
+      setSelectedAuthorTimeline,
       setSyncStatus,
       setThread,
       setTimelinesByTopic,
@@ -2078,7 +2136,7 @@ function DesktopShellPage({
       disposed = true;
       window.clearInterval(intervalId);
     };
-  }, [activeTopic, loadTopics, selectedThread, trackedTopics]);
+  }, [activeTopic, loadTopics, selectedAuthorPubkey, selectedThread, trackedTopics]);
 
   useEffect(() => {
     const remoteObjectUrls = remoteObjectUrlRef.current;
@@ -2293,11 +2351,12 @@ function DesktopShellPage({
   const closeAuthorPane = useCallback(() => {
     setSelectedAuthorPubkey(null);
     setSelectedAuthor(null);
+    setSelectedAuthorTimeline([]);
     setAuthorError(null);
     syncRoute('replace', {
       selectedAuthorPubkey: null,
     });
-  }, [setAuthorError, setSelectedAuthor, setSelectedAuthorPubkey, syncRoute]);
+  }, [setAuthorError, setSelectedAuthor, setSelectedAuthorTimeline, setSelectedAuthorPubkey, syncRoute]);
 
   const closeThreadPane = useCallback(() => {
     setSelectedThread(null);
@@ -2305,6 +2364,7 @@ function DesktopShellPage({
     setReplyTarget(null);
     setSelectedAuthorPubkey(null);
     setSelectedAuthor(null);
+    setSelectedAuthorTimeline([]);
     setAuthorError(null);
     syncRoute('replace', {
       selectedThread: null,
@@ -2314,6 +2374,7 @@ function DesktopShellPage({
     setAuthorError,
     setReplyTarget,
     setSelectedAuthor,
+    setSelectedAuthorTimeline,
     setSelectedAuthorPubkey,
     setSelectedThread,
     setThread,
@@ -2434,6 +2495,7 @@ function DesktopShellPage({
     setReplyTarget(null);
     setSelectedAuthorPubkey(null);
     setSelectedAuthor(null);
+    setSelectedAuthorTimeline([]);
     setAuthorError(null);
   }
 
@@ -2591,6 +2653,27 @@ function DesktopShellPage({
       activeTopic: topic,
     });
     await loadTopics(trackedTopics, topic, null);
+  }
+
+  async function handleOpenOriginalTopic(topicId: string) {
+    const nextTopics = trackedTopics.includes(topicId) ? trackedTopics : [...trackedTopics, topicId];
+    setTrackedTopics(nextTopics);
+    setActiveTopic(topicId);
+    setShellChromeState((current) => ({
+      ...current,
+      activePrimarySection: 'timeline',
+      navOpen: false,
+    }));
+    clearThreadContext();
+    syncRoute('replace', {
+      activeTopic: topicId,
+      primarySection: 'timeline',
+      timelineScope: timelineScopeByTopic[topicId] ?? PUBLIC_TIMELINE_SCOPE,
+      composeTarget: composeChannelByTopic[topicId] ?? PUBLIC_CHANNEL_REF,
+      selectedAuthorPubkey: null,
+      selectedThread: null,
+    });
+    await loadTopics(nextTopics, topicId, null);
   }
 
   async function handleRemoveTopic(topic: string) {
@@ -3122,6 +3205,7 @@ function DesktopShellPage({
       const nextThreadId = options?.fromThread ? (options.threadId ?? selectedThread) : null;
       setSelectedAuthorPubkey(authorPubkey);
       setSelectedAuthor(socialView);
+      setSelectedAuthorTimeline([]);
       setAuthorError(null);
       if (!options?.fromThread) {
         setSelectedThread(null);
@@ -3140,6 +3224,7 @@ function DesktopShellPage({
       if (options?.normalizeOnError) {
         setSelectedAuthorPubkey(null);
         setSelectedAuthor(null);
+        setSelectedAuthorTimeline([]);
         if (!options?.fromThread) {
           setSelectedThread(null);
           setThread([]);
@@ -3154,6 +3239,7 @@ function DesktopShellPage({
     api,
     setAuthorError,
     setSelectedAuthor,
+    setSelectedAuthorTimeline,
     setSelectedAuthorPubkey,
     setSelectedThread,
     setThread,
@@ -3983,15 +4069,12 @@ function DesktopShellPage({
     [activeTimeline, buildPostCardView]
   );
   const profileTimelinePostViews = useMemo(
-    () =>
-      activePublicTimeline
-        .filter(
-          (post) =>
-            !post.channel_id &&
-            post.author_pubkey === syncStatus.local_author_pubkey
-        )
-        .map((post) => buildPostCardView(post, 'timeline')),
-    [activePublicTimeline, buildPostCardView, syncStatus.local_author_pubkey]
+    () => profileTimeline.map((post) => buildPostCardView(post, 'timeline')),
+    [buildPostCardView, profileTimeline]
+  );
+  const selectedAuthorTimelinePostViews = useMemo(
+    () => selectedAuthorTimeline.map((post) => buildPostCardView(post, 'timeline')),
+    [buildPostCardView, selectedAuthorTimeline]
   );
   const threadPostViews = useMemo(
     () => thread.map((post) => buildPostCardView(post, 'thread')),
@@ -4523,6 +4606,17 @@ function DesktopShellPage({
                 void handleRelationshipAction(authorPubkey, following)
               }
             />
+            <Card className='shell-workspace-card'>
+              <TimelineFeed
+                posts={selectedAuthorTimelinePostViews}
+                emptyCopy={t('profile:feed.noAuthorPosts')}
+                onOpenAuthor={(authorPubkey) => void openAuthorDetail(authorPubkey)}
+                onOpenThread={(threadId) => void openThread(threadId)}
+                onReply={beginReply}
+                readOnly={true}
+                onOpenOriginalTopic={(topicId) => void handleOpenOriginalTopic(topicId)}
+              />
+            </Card>
           </div>
         </ContextPane>
       ) : null}
@@ -5220,10 +5314,12 @@ function DesktopShellPage({
                   <Card className='shell-workspace-card'>
                     <TimelineFeed
                       posts={profileTimelinePostViews}
-                      emptyCopy={t('shell:workspace.noPublicPosts')}
+                      emptyCopy={t('profile:feed.noOwnPosts')}
                       onOpenAuthor={(authorPubkey) => void openAuthorDetail(authorPubkey)}
                       onOpenThread={(threadId) => void openThread(threadId)}
                       onReply={beginReply}
+                      readOnly={true}
+                      onOpenOriginalTopic={(topicId) => void handleOpenOriginalTopic(topicId)}
                     />
                   </Card>
                 </>

--- a/apps/desktop/src/components/core/PostCard.tsx
+++ b/apps/desktop/src/components/core/PostCard.tsx
@@ -14,13 +14,23 @@ type PostCardProps = {
   onOpenAuthor: (authorPubkey: string) => void;
   onOpenThread: (threadId: string) => void;
   onReply: (post: PostCardView['post']) => void;
+  readOnly?: boolean;
+  onOpenOriginalTopic?: (topicId: string) => void;
 };
 
-export function PostCard({ view, onOpenAuthor, onOpenThread, onReply }: PostCardProps) {
-  const { t } = useTranslation(['common']);
+export function PostCard({
+  view,
+  onOpenAuthor,
+  onOpenThread,
+  onReply,
+  readOnly = false,
+  onOpenOriginalTopic,
+}: PostCardProps) {
+  const { t } = useTranslation(['common', 'profile']);
   const { post, context } = view;
   const isPendingText = post.content_status === 'Missing' && post.content === '[blob pending]';
   const audienceChipLabel = view.audienceChipLabel ?? post.audience_label;
+  const originTopicId = post.origin_topic_id?.trim() || null;
 
   return (
     <article className={context === 'thread' ? 'post-card post-card-thread' : 'post-card'}>
@@ -47,32 +57,76 @@ export function PostCard({ view, onOpenAuthor, onOpenThread, onReply }: PostCard
         </div>
       </div>
 
-      <button className='post-link' type='button' onClick={() => onOpenThread(view.threadTargetId)}>
-        <PostMedia media={view.media} />
+      {readOnly ? (
+        <div className='post-link'>
+          <PostMedia media={view.media} />
 
-        <div className='post-body'>
-          {isPendingText ? (
-            <div
-              className='text-skeleton-group'
-              data-testid={`text-skeleton-${post.object_id}`}
-              aria-hidden='true'
-            >
-              <span className='text-skeleton text-skeleton-line' />
-              <span className='text-skeleton text-skeleton-line text-skeleton-line-short' />
+          <div className='post-body'>
+            {isPendingText ? (
+              <div
+                className='text-skeleton-group'
+                data-testid={`text-skeleton-${post.object_id}`}
+                aria-hidden='true'
+              >
+                <span className='text-skeleton text-skeleton-line' />
+                <span className='text-skeleton text-skeleton-line text-skeleton-line-short' />
+              </div>
+            ) : (
+              <strong className='post-title'>{post.content}</strong>
+            )}
+          </div>
+
+          <small>{post.envelope_id}</small>
+          {post.reply_to ? <em className='post-reply-flag'>{t('actions.reply')}</em> : null}
+          {originTopicId ? (
+            <div className='topic-diagnostic topic-diagnostic-secondary'>
+              <span>{t('feed.originTopic', { ns: 'profile' })}</span>
+              <span className='shell-topic-link-label' title={originTopicId}>
+                {originTopicId}
+              </span>
             </div>
-          ) : (
-            <strong className='post-title'>{post.content}</strong>
-          )}
+          ) : null}
         </div>
+      ) : (
+        <button className='post-link' type='button' onClick={() => onOpenThread(view.threadTargetId)}>
+          <PostMedia media={view.media} />
 
-        <small>{post.envelope_id}</small>
-        {post.reply_to ? <em className='post-reply-flag'>{t('actions.reply')}</em> : null}
-      </button>
+          <div className='post-body'>
+            {isPendingText ? (
+              <div
+                className='text-skeleton-group'
+                data-testid={`text-skeleton-${post.object_id}`}
+                aria-hidden='true'
+              >
+                <span className='text-skeleton text-skeleton-line' />
+                <span className='text-skeleton text-skeleton-line text-skeleton-line-short' />
+              </div>
+            ) : (
+              <strong className='post-title'>{post.content}</strong>
+            )}
+          </div>
+
+          <small>{post.envelope_id}</small>
+          {post.reply_to ? <em className='post-reply-flag'>{t('actions.reply')}</em> : null}
+        </button>
+      )}
 
       <div className='post-actions'>
-        <Button variant='secondary' type='button' onClick={() => onReply(post)}>
-          {t('actions.reply')}
-        </Button>
+        {readOnly ? (
+          originTopicId ? (
+            <Button
+              variant='secondary'
+              type='button'
+              onClick={() => onOpenOriginalTopic?.(originTopicId)}
+            >
+              {t('feed.openOriginalTopic', { ns: 'profile' })}
+            </Button>
+          ) : null
+        ) : (
+          <Button variant='secondary' type='button' onClick={() => onReply(post)}>
+            {t('actions.reply')}
+          </Button>
+        )}
       </div>
     </article>
   );

--- a/apps/desktop/src/components/core/TimelineFeed.tsx
+++ b/apps/desktop/src/components/core/TimelineFeed.tsx
@@ -9,6 +9,8 @@ type TimelineFeedProps = {
   onOpenAuthor: (authorPubkey: string) => void;
   onOpenThread: (threadId: string) => void;
   onReply: (post: PostCardView['post']) => void;
+  readOnly?: boolean;
+  onOpenOriginalTopic?: (topicId: string) => void;
 };
 
 export function TimelineFeed({
@@ -19,6 +21,8 @@ export function TimelineFeed({
   onOpenAuthor,
   onOpenThread,
   onReply,
+  readOnly = false,
+  onOpenOriginalTopic,
 }: TimelineFeedProps) {
   if (posts.length === 0) {
     return <p className='empty'>{emptyCopy}</p>;
@@ -33,6 +37,8 @@ export function TimelineFeed({
             onOpenAuthor={onOpenAuthor}
             onOpenThread={onOpenThread}
             onReply={onReply}
+            readOnly={readOnly}
+            onOpenOriginalTopic={onOpenOriginalTopic}
           />
         </li>
       ))}

--- a/apps/desktop/src/i18n/locales/en/profile.json
+++ b/apps/desktop/src/i18n/locales/en/profile.json
@@ -20,7 +20,13 @@
     "edit": "Edit Profile",
     "loading": "Loading profile…",
     "noBio": "No profile bio published yet.",
-    "postCount": "Public posts in active topic",
+    "postCount": "Public posts",
     "title": "Profile"
+  },
+  "feed": {
+    "noAuthorPosts": "No public posts from this author yet.",
+    "noOwnPosts": "No public posts published yet.",
+    "openOriginalTopic": "Open original topic",
+    "originTopic": "Origin topic"
   }
 }

--- a/apps/desktop/src/i18n/locales/ja/profile.json
+++ b/apps/desktop/src/i18n/locales/ja/profile.json
@@ -20,7 +20,13 @@
     "edit": "プロフィールを編集",
     "loading": "プロフィールを読み込み中…",
     "noBio": "まだプロフィール文が公開されていません。",
-    "postCount": "現在のトピックでの公開投稿",
+    "postCount": "公開投稿",
     "title": "プロフィール"
+  },
+  "feed": {
+    "noAuthorPosts": "この著者にはまだ公開投稿がありません。",
+    "noOwnPosts": "まだ公開投稿がありません。",
+    "openOriginalTopic": "元のトピックを開く",
+    "originTopic": "元のトピック"
   }
 }

--- a/apps/desktop/src/i18n/locales/zh-CN/profile.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/profile.json
@@ -20,7 +20,13 @@
     "edit": "编辑资料",
     "loading": "正在加载资料…",
     "noBio": "尚未发布个人简介。",
-    "postCount": "当前主题下的公开帖子",
+    "postCount": "公开帖子",
     "title": "资料"
+  },
+  "feed": {
+    "noAuthorPosts": "这位作者还没有公开帖子。",
+    "noOwnPosts": "还没有公开帖子。",
+    "openOriginalTopic": "打开原始主题",
+    "originTopic": "原始主题"
   }
 }

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -34,6 +34,7 @@ export type PostView = {
   created_at: number;
   reply_to?: string | null;
   root_id?: string | null;
+  origin_topic_id?: string | null;
   channel_id?: string | null;
   audience_label: string;
 };
@@ -299,6 +300,11 @@ export interface DesktopApi {
     cursor?: TimelineCursor | null,
     limit?: number
   ): Promise<TimelineView>;
+  listProfileTimeline(
+    pubkey: string,
+    cursor?: TimelineCursor | null,
+    limit?: number
+  ): Promise<TimelineView>;
   getMyProfile(): Promise<Profile>;
   setMyProfile(input: ProfileInput): Promise<Profile>;
   followAuthor(pubkey: string): Promise<AuthorSocialView>;
@@ -453,6 +459,18 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         thread_id: threadId,
+        cursor,
+        limit,
+      },
+    });
+  },
+  listProfileTimeline: async (pubkey, cursor, limit) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.listProfileTimeline(pubkey, cursor, limit);
+    }
+    return invokeDesktop<TimelineView>('list_profile_timeline', {
+      request: {
+        pubkey,
         cursor,
         limit,
       },

--- a/apps/desktop/src/mocks/desktopApiMock.ts
+++ b/apps/desktop/src/mocks/desktopApiMock.ts
@@ -26,6 +26,7 @@ export type DesktopMockApiOptions = {
   topicLastError?: string | null;
   assistPeerIds?: string[];
   seedPosts?: Record<string, TimelineView['items']>;
+  authorProfileTimelines?: Record<string, TimelineView['items']>;
   seedLiveSessions?: Record<string, LiveSessionView[]>;
   seedGameRooms?: Record<string, GameRoomView[]>;
   myProfile?: Partial<Profile>;
@@ -43,6 +44,7 @@ function withSocialPostDefaults(post: PostView): PostView {
     followed_by: post.followed_by ?? false,
     mutual: post.mutual ?? false,
     friend_of_friend: post.friend_of_friend ?? false,
+    origin_topic_id: post.origin_topic_id ?? null,
     channel_id: post.channel_id ?? null,
     audience_label: post.audience_label ?? (post.channel_id ? 'Private channel' : 'Public'),
     attachments: [...post.attachments],
@@ -146,9 +148,35 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
   const postsByTopic: Record<string, TimelineView['items']> = Object.fromEntries(
     Object.entries(options?.seedPosts ?? {}).map(([topic, posts]) => [
       topic,
+      posts.map((post) => withSocialPostDefaults({ ...post, origin_topic_id: post.origin_topic_id ?? topic })),
+    ])
+  );
+  const authorProfileTimelines: Record<string, TimelineView['items']> = Object.fromEntries(
+    Object.entries(options?.authorProfileTimelines ?? {}).map(([pubkey, posts]) => [
+      pubkey,
       posts.map((post) => withSocialPostDefaults(post)),
     ])
   );
+  for (const [topic, posts] of Object.entries(postsByTopic)) {
+    for (const post of posts) {
+      if (post.channel_id) {
+        continue;
+      }
+      const current = authorProfileTimelines[post.author_pubkey] ?? [];
+      if (current.some((item) => item.object_id === post.object_id)) {
+        continue;
+      }
+      authorProfileTimelines[post.author_pubkey] = [
+        withSocialPostDefaults({
+          ...post,
+          origin_topic_id: post.origin_topic_id ?? topic,
+          channel_id: null,
+          audience_label: 'Public',
+        }),
+        ...current,
+      ].sort((left, right) => right.created_at - left.created_at || right.object_id.localeCompare(left.object_id));
+    }
+  }
   const liveSessionsByTopic: Record<string, LiveSessionView[]> = Object.fromEntries(
     Object.entries(options?.seedLiveSessions ?? {}).map(([topic, sessions]) => [
       topic,
@@ -256,11 +284,38 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
           created_at: sequence,
           reply_to: replyTo ?? null,
           root_id: rootId,
+          origin_topic_id: topic,
           channel_id: channelId,
           audience_label: channelId ? 'Private channel' : 'Public',
         }),
         ...posts,
       ];
+      if (!channelId) {
+        authorProfileTimelines[syncStatus.local_author_pubkey] = [
+          withSocialPostDefaults({
+            object_id: objectId,
+            envelope_id: objectId,
+            author_pubkey: syncStatus.local_author_pubkey,
+            following: false,
+            followed_by: false,
+            mutual: false,
+            friend_of_friend: false,
+            object_kind: replyTo ? 'comment' : 'post',
+            content,
+            content_status: 'Available',
+            attachments: postAttachments,
+            created_at: sequence,
+            reply_to: replyTo ?? null,
+            root_id: rootId,
+            origin_topic_id: topic,
+            channel_id: null,
+            audience_label: 'Public',
+          }),
+          ...(authorProfileTimelines[syncStatus.local_author_pubkey] ?? []).filter(
+            (post) => post.object_id !== objectId
+          ),
+        ];
+      }
       syncStatus.subscribed_topics = Array.from(new Set([...syncStatus.subscribed_topics, topic]));
       if (!syncStatus.topic_diagnostics.some((entry) => entry.topic === topic)) {
         syncStatus.topic_diagnostics.push({
@@ -310,6 +365,12 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       const posts = postsByTopic[topic] ?? [];
       return {
         items: posts.filter((post) => post.root_id === threadId || post.object_id === threadId),
+        next_cursor: null,
+      };
+    },
+    async listProfileTimeline(pubkey) {
+      return {
+        items: [...(authorProfileTimelines[pubkey] ?? [])],
         next_cursor: null,
       };
     },

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -8,26 +8,28 @@ use chrono::Utc;
 use futures_util::StreamExt;
 use kukuri_blob_service::{BlobService, BlobStatus, MemoryBlobService, StoredBlob};
 use kukuri_core::{
-    AssetRole, AuthorProfileDocV1, CanonicalPostHeader, ChannelAudienceKind, ChannelId, ChannelRef,
-    ChannelSharingState, CreatePrivateChannelInput, EnvelopeId, FollowEdge, FollowEdgeDocV1,
-    FollowEdgeStatus, FriendOnlyGrantPreview, FriendPlusSharePreview, GAME_MANIFEST_MIME,
-    GameParticipant, GameRoomManifestBlobV1, GameRoomStateDocV1, GameRoomStatus, GameScoreEntry,
-    GossipHint, HintObjectRef, KukuriEnvelope, KukuriKeys, KukuriMediaManifestV1,
-    KukuriProfileEnvelopeContentV1, LIVE_MANIFEST_MIME, LiveSessionManifestBlobV1,
+    AssetRole, AuthorProfileDocV1, AuthorProfilePostDocV1, CanonicalPostHeader,
+    ChannelAudienceKind, ChannelId, ChannelRef, ChannelSharingState, CreatePrivateChannelInput,
+    EnvelopeId, FollowEdge, FollowEdgeDocV1, FollowEdgeStatus, FriendOnlyGrantPreview,
+    FriendPlusSharePreview, GAME_MANIFEST_MIME, GameParticipant, GameRoomManifestBlobV1,
+    GameRoomStateDocV1, GameRoomStatus, GameScoreEntry, GossipHint, HintObjectRef, KukuriEnvelope,
+    KukuriKeys, KukuriMediaManifestV1, KukuriProfileEnvelopeContentV1,
+    KukuriProfilePostEnvelopeContentV1, LIVE_MANIFEST_MIME, LiveSessionManifestBlobV1,
     LiveSessionStateDocV1, LiveSessionStatus, ManifestBlobRef, MediaManifestItem, ObjectVisibility,
     PayloadRef, PrivateChannelInvitePreview, PrivateChannelJoinMode, PrivateChannelMetadataDocV1,
     PrivateChannelParticipantDocV1, PrivateChannelPolicyDocV1, PrivateChannelRotationGrantDocV1,
-    PrivateChannelRotationGrantPayloadV1, Profile, Pubkey, ReplicaId, TimelineScope, TopicId,
-    build_follow_edge_envelope, build_friend_only_grant_token, build_friend_plus_share_token,
-    build_game_session_envelope, build_live_session_envelope, build_media_manifest_envelope,
-    build_post_envelope_with_payload_in_channel, build_private_channel_invite_token,
-    build_private_channel_participant_envelope, build_private_channel_policy_envelope,
-    build_private_channel_rotation_grant_envelope, build_profile_envelope,
-    decrypt_private_channel_rotation_grant, encrypt_private_channel_rotation_grant, generate_keys,
-    parse_follow_edge, parse_friend_only_grant_token, parse_friend_plus_share_token,
+    PrivateChannelRotationGrantPayloadV1, Profile, ProfilePost, Pubkey, ReplicaId, TimelineScope,
+    TopicId, author_profile_topic_id, build_follow_edge_envelope, build_friend_only_grant_token,
+    build_friend_plus_share_token, build_game_session_envelope, build_live_session_envelope,
+    build_media_manifest_envelope, build_post_envelope_with_payload_in_channel,
+    build_private_channel_invite_token, build_private_channel_participant_envelope,
+    build_private_channel_policy_envelope, build_private_channel_rotation_grant_envelope,
+    build_profile_envelope, build_profile_post_envelope, decrypt_private_channel_rotation_grant,
+    encrypt_private_channel_rotation_grant, generate_keys, parse_follow_edge,
+    parse_friend_only_grant_token, parse_friend_plus_share_token,
     parse_private_channel_invite_token, parse_private_channel_participant,
     parse_private_channel_policy, parse_private_channel_rotation_grant, parse_profile,
-    timeline_sort_key,
+    parse_profile_post, timeline_sort_key,
 };
 use kukuri_docs_sync::{
     DocOp, DocQuery, DocsSync, MemoryDocsSync, author_replica_id, private_channel_epoch_replica_id,
@@ -67,6 +69,7 @@ pub struct PostView {
     pub reply_to: Option<String>,
     pub root_id: Option<String>,
     pub object_kind: String,
+    pub origin_topic_id: Option<String>,
     pub channel_id: Option<String>,
     pub audience_label: String,
 }
@@ -465,6 +468,36 @@ impl AppService {
         self.build_author_social_view(author_pubkey.as_str()).await
     }
 
+    pub async fn list_profile_timeline(
+        &self,
+        author_pubkey: &str,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<TimelineView> {
+        let author_pubkey = normalize_author_pubkey(author_pubkey)?;
+        self.ensure_author_subscription(author_pubkey.as_str())
+            .await?;
+        self.rebuild_author_relationships().await?;
+        let mut posts =
+            load_profile_posts_from_author_replica(self.docs_sync.as_ref(), author_pubkey.as_str())
+                .await?;
+        posts.sort_by(|left, right| {
+            right
+                .created_at
+                .cmp(&left.created_at)
+                .then_with(|| right.object_id.cmp(&left.object_id))
+        });
+        let page = profile_post_page(posts, cursor, limit);
+        let mut items = Vec::with_capacity(page.items.len());
+        for post in page.items {
+            items.push(self.profile_post_to_view(post).await?);
+        }
+        Ok(TimelineView {
+            items,
+            next_cursor: page.next_cursor,
+        })
+    }
+
     pub async fn create_post(
         &self,
         topic_id: &str,
@@ -634,6 +667,9 @@ impl AppService {
             },
             effective_channel_id.as_ref(),
         )?;
+        let post_object = envelope
+            .to_post_object()?
+            .ok_or_else(|| anyhow::anyhow!("failed to parse post object for profile topic"))?;
         self.ingest_event(
             &write_replica,
             envelope.clone(),
@@ -641,6 +677,32 @@ impl AppService {
             stored_attachments,
         )
         .await?;
+        if effective_channel_id.is_none() {
+            let local_author_pubkey = self.current_author_pubkey();
+            let profile_post_envelope = build_profile_post_envelope(
+                self.keys.as_ref(),
+                &KukuriProfilePostEnvelopeContentV1 {
+                    author_pubkey: Pubkey::from(local_author_pubkey.as_str()),
+                    profile_topic_id: author_profile_topic_id(local_author_pubkey.as_str()),
+                    origin_topic_id: topic.clone(),
+                    object_id: post_object.object_id.clone(),
+                    created_at: post_object.created_at,
+                    object_kind: post_object.object_kind.clone(),
+                    content: content.to_string(),
+                    attachments: post_object.attachments.clone(),
+                    reply_to_object_id: post_object.reply_to.clone(),
+                    root_id: post_object.root.clone(),
+                },
+            )?;
+            let profile_post = parse_profile_post(&profile_post_envelope)?
+                .ok_or_else(|| anyhow::anyhow!("failed to parse profile post envelope"))?;
+            persist_profile_post_doc(
+                self.docs_sync.as_ref(),
+                &profile_post,
+                &profile_post_envelope,
+            )
+            .await?;
+        }
         self.hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, effective_channel_id.as_ref()),
@@ -3689,8 +3751,53 @@ impl AppService {
             } else {
                 "post".into()
             },
+            origin_topic_id: Some(row.topic_id.clone()),
             channel_id: channel_id_for_view(row.channel_id.as_str()),
             audience_label,
+        })
+    }
+
+    async fn profile_post_to_view(&self, profile_post: ProfilePost) -> Result<PostView> {
+        let profile = self
+            .store
+            .get_profile(profile_post.author_pubkey.as_str())
+            .await?;
+        let relationship = self
+            .projection_store
+            .get_author_relationship(
+                self.current_author_pubkey().as_str(),
+                profile_post.author_pubkey.as_str(),
+            )
+            .await?;
+
+        Ok(PostView {
+            object_id: profile_post.object_id.0.clone(),
+            envelope_id: profile_post.object_id.0.clone(),
+            author_pubkey: profile_post.author_pubkey.as_str().to_string(),
+            author_name: profile.as_ref().and_then(|value| value.name.clone()),
+            author_display_name: profile
+                .as_ref()
+                .and_then(|value| value.display_name.clone()),
+            following: relationship.as_ref().is_some_and(|value| value.following),
+            followed_by: relationship.as_ref().is_some_and(|value| value.followed_by),
+            mutual: relationship.as_ref().is_some_and(|value| value.mutual),
+            friend_of_friend: relationship
+                .as_ref()
+                .is_some_and(|value| value.friend_of_friend),
+            object_kind: profile_post.object_kind,
+            content: profile_post.content,
+            content_status: BlobViewStatus::Available,
+            attachments: attachment_views_from_refs(
+                self.blob_service.as_ref(),
+                &profile_post.attachments,
+            )
+            .await?,
+            created_at: profile_post.created_at,
+            reply_to: profile_post.reply_to_object_id.map(|id| id.0),
+            root_id: profile_post.root_id.map(|id| id.0),
+            origin_topic_id: Some(profile_post.origin_topic_id.as_str().to_string()),
+            channel_id: None,
+            audience_label: "Public".into(),
         })
     }
 }
@@ -3847,6 +3954,45 @@ async fn persist_profile_doc(
         .await
 }
 
+async fn persist_profile_post_doc(
+    docs_sync: &dyn DocsSync,
+    profile_post: &ProfilePost,
+    envelope: &KukuriEnvelope,
+) -> Result<()> {
+    let replica = author_replica_id(profile_post.author_pubkey.as_str());
+    docs_sync.open_replica(&replica).await?;
+    docs_sync
+        .apply_doc_op(
+            &replica,
+            DocOp::SetJson {
+                key: stable_key("profile/posts", profile_post.object_id.as_str()),
+                value: serde_json::to_value(AuthorProfilePostDocV1 {
+                    author_pubkey: profile_post.author_pubkey.clone(),
+                    profile_topic_id: profile_post.profile_topic_id.clone(),
+                    origin_topic_id: profile_post.origin_topic_id.clone(),
+                    object_id: profile_post.object_id.clone(),
+                    created_at: profile_post.created_at,
+                    object_kind: profile_post.object_kind.clone(),
+                    content: profile_post.content.clone(),
+                    attachments: profile_post.attachments.clone(),
+                    reply_to_object_id: profile_post.reply_to_object_id.clone(),
+                    root_id: profile_post.root_id.clone(),
+                    envelope_id: envelope.id.clone(),
+                })?,
+            },
+        )
+        .await?;
+    docs_sync
+        .apply_doc_op(
+            &replica,
+            DocOp::SetJson {
+                key: stable_key("envelopes", envelope.id.as_str()),
+                value: serde_json::to_value(envelope)?,
+            },
+        )
+        .await
+}
+
 async fn persist_follow_edge_doc(
     docs_sync: &dyn DocsSync,
     edge: &FollowEdge,
@@ -3983,6 +4129,79 @@ async fn fetch_author_envelope_by_id(
     let envelope: KukuriEnvelope = serde_json::from_slice(record.value.as_slice())?;
     envelope.verify()?;
     Ok(Some(envelope))
+}
+
+async fn load_profile_posts_from_author_replica(
+    docs_sync: &dyn DocsSync,
+    author_pubkey: &str,
+) -> Result<Vec<ProfilePost>> {
+    let author_pubkey = normalize_author_pubkey(author_pubkey)?;
+    let replica = author_replica_id(author_pubkey.as_str());
+    let expected_profile_topic_id = author_profile_topic_id(author_pubkey.as_str());
+    let mut items = Vec::new();
+    let mut seen_object_ids = BTreeSet::new();
+
+    for record in docs_sync
+        .query_replica(&replica, DocQuery::Prefix("profile/posts/".into()))
+        .await?
+    {
+        match serde_json::from_slice::<AuthorProfilePostDocV1>(record.value.as_slice()) {
+            Ok(doc)
+                if doc.author_pubkey.as_str() == author_pubkey
+                    && doc.profile_topic_id == expected_profile_topic_id =>
+            {
+                if let Some(envelope) =
+                    fetch_author_envelope_by_id(docs_sync, &replica, &doc.envelope_id).await?
+                {
+                    match parse_profile_post(&envelope) {
+                        Ok(Some(profile_post))
+                            if profile_post.author_pubkey == doc.author_pubkey
+                                && profile_post.profile_topic_id == doc.profile_topic_id
+                                && profile_post.origin_topic_id == doc.origin_topic_id
+                                && profile_post.object_id == doc.object_id
+                                && profile_post.created_at == doc.created_at
+                                && profile_post.object_kind == doc.object_kind
+                                && profile_post.content == doc.content
+                                && profile_post.attachments == doc.attachments
+                                && profile_post.reply_to_object_id == doc.reply_to_object_id
+                                && profile_post.root_id == doc.root_id =>
+                        {
+                            if seen_object_ids.insert(profile_post.object_id.clone()) {
+                                items.push(profile_post);
+                            }
+                        }
+                        Ok(Some(_)) | Ok(None) => {}
+                        Err(error) => {
+                            warn!(
+                                author_pubkey = %author_pubkey,
+                                key = %record.key,
+                                envelope_id = %doc.envelope_id.as_str(),
+                                error = %error,
+                                "ignoring invalid profile post envelope"
+                            );
+                        }
+                    }
+                }
+            }
+            Ok(_) => {
+                warn!(
+                    author_pubkey = %author_pubkey,
+                    key = %record.key,
+                    "ignoring profile post doc with mismatched author or topic"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    author_pubkey = %author_pubkey,
+                    key = %record.key,
+                    error = %error,
+                    "failed to decode profile post doc"
+                );
+            }
+        }
+    }
+
+    Ok(items)
 }
 
 fn merge_seed_peers(
@@ -4786,6 +5005,41 @@ fn projection_page_needs_hydration(page: &Page<ObjectProjectionRow>) -> bool {
     page.items.iter().any(|item| item.content.is_none())
 }
 
+fn profile_post_page(
+    posts: Vec<ProfilePost>,
+    cursor: Option<TimelineCursor>,
+    limit: usize,
+) -> Page<ProfilePost> {
+    if limit == 0 {
+        return Page {
+            items: Vec::new(),
+            next_cursor: cursor,
+        };
+    }
+
+    let mut items = Vec::new();
+    let mut next_cursor = None;
+    for post in posts {
+        let include = cursor.as_ref().is_none_or(|current| {
+            post.created_at < current.created_at
+                || (post.created_at == current.created_at && post.object_id < current.object_id)
+        });
+        if !include {
+            continue;
+        }
+        if items.len() >= limit {
+            next_cursor = Some(TimelineCursor {
+                created_at: post.created_at,
+                object_id: post.object_id.clone(),
+            });
+            break;
+        }
+        items.push(post);
+    }
+
+    Page { items, next_cursor }
+}
+
 async fn filtered_timeline_page(
     projection_store: &dyn ProjectionStore,
     topic_id: &str,
@@ -5119,6 +5373,23 @@ async fn attachment_views(
 ) -> Result<Vec<AttachmentView>> {
     let mut attachments = Vec::with_capacity(header.attachments.len());
     for attachment in &header.attachments {
+        attachments.push(AttachmentView {
+            hash: attachment.hash.as_str().to_string(),
+            mime: attachment.mime.clone(),
+            bytes: attachment.bytes,
+            role: attachment_role_name(&attachment.role).to_string(),
+            status: best_effort_blob_view_status(blob_service, &attachment.hash).await,
+        });
+    }
+    Ok(attachments)
+}
+
+async fn attachment_views_from_refs(
+    blob_service: &dyn BlobService,
+    refs: &[kukuri_core::AssetRef],
+) -> Result<Vec<AttachmentView>> {
+    let mut attachments = Vec::with_capacity(refs.len());
+    for attachment in refs {
         attachments.push(AttachmentView {
             hash: attachment.hash.as_str().to_string(),
             mime: attachment.mime.clone(),
@@ -6173,6 +6444,25 @@ mod tests {
         }
     }
 
+    async fn author_profile_post_docs(
+        docs_sync: &dyn DocsSync,
+        author_pubkey: &str,
+    ) -> Vec<AuthorProfilePostDocV1> {
+        docs_sync
+            .query_replica(
+                &author_replica_id(author_pubkey),
+                DocQuery::Prefix("profile/posts/".into()),
+            )
+            .await
+            .expect("profile post docs")
+            .into_iter()
+            .map(|record| {
+                serde_json::from_slice::<AuthorProfilePostDocV1>(record.value.as_slice())
+                    .expect("decode profile post doc")
+            })
+            .collect()
+    }
+
     #[derive(Clone)]
     struct NoopHintTransport;
 
@@ -6318,6 +6608,281 @@ mod tests {
         assert_eq!(timeline.items.len(), 1);
         assert_eq!(timeline.items[0].object_id, object_id);
         assert_eq!(timeline.items[0].content, "hello app");
+    }
+
+    #[tokio::test]
+    async fn create_public_post_persists_profile_post_doc_and_lists_profile_timeline() {
+        let store = Arc::new(MemoryStore::default());
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let keys = generate_keys();
+        let author_pubkey = keys.public_key_hex();
+        let app = AppService::new_with_services(
+            store.clone(),
+            store,
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync.clone(),
+            blob_service,
+            keys,
+        );
+        let topic = "kukuri:topic:profile-doc";
+
+        let object_id = app
+            .create_post(topic, "hello profile", None)
+            .await
+            .expect("create post");
+        let profile_docs =
+            author_profile_post_docs(docs_sync.as_ref(), author_pubkey.as_str()).await;
+
+        assert_eq!(profile_docs.len(), 1);
+        assert_eq!(profile_docs[0].author_pubkey.as_str(), author_pubkey);
+        assert_eq!(
+            profile_docs[0].profile_topic_id,
+            author_profile_topic_id(author_pubkey.as_str())
+        );
+        assert_eq!(profile_docs[0].origin_topic_id.as_str(), topic);
+        assert_eq!(profile_docs[0].object_id.as_str(), object_id);
+        assert_eq!(profile_docs[0].object_kind, "post");
+
+        let timeline = app
+            .list_profile_timeline(author_pubkey.as_str(), None, 20)
+            .await
+            .expect("profile timeline");
+        let post = timeline
+            .items
+            .iter()
+            .find(|post| post.object_id == object_id)
+            .expect("profile post");
+
+        assert_eq!(post.content, "hello profile");
+        assert_eq!(post.origin_topic_id.as_deref(), Some(topic));
+        assert_eq!(post.channel_id, None);
+        assert_eq!(post.audience_label, "Public");
+    }
+
+    #[tokio::test]
+    async fn public_reply_is_indexed_in_profile_timeline() {
+        let store = Arc::new(MemoryStore::default());
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let keys = generate_keys();
+        let author_pubkey = keys.public_key_hex();
+        let app = AppService::new_with_services(
+            store.clone(),
+            store,
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync.clone(),
+            blob_service,
+            keys,
+        );
+        let topic = "kukuri:topic:profile-replies";
+
+        let root_id = app
+            .create_post(topic, "root", None)
+            .await
+            .expect("root post");
+        let reply_id = app
+            .create_post(topic, "reply", Some(root_id.as_str()))
+            .await
+            .expect("reply post");
+        let profile_docs =
+            author_profile_post_docs(docs_sync.as_ref(), author_pubkey.as_str()).await;
+        let reply_doc = profile_docs
+            .iter()
+            .find(|doc| doc.object_id.as_str() == reply_id)
+            .expect("reply profile doc");
+
+        assert_eq!(reply_doc.object_kind, "comment");
+        assert_eq!(
+            reply_doc.reply_to_object_id.as_ref().map(|id| id.as_str()),
+            Some(root_id.as_str())
+        );
+        assert_eq!(
+            reply_doc.root_id.as_ref().map(|id| id.as_str()),
+            Some(root_id.as_str())
+        );
+
+        let timeline = app
+            .list_profile_timeline(author_pubkey.as_str(), None, 20)
+            .await
+            .expect("profile timeline");
+        let reply = timeline
+            .items
+            .iter()
+            .find(|post| post.object_id == reply_id)
+            .expect("profile reply");
+
+        assert_eq!(reply.object_kind, "comment");
+        assert_eq!(reply.reply_to.as_deref(), Some(root_id.as_str()));
+        assert_eq!(reply.root_id.as_deref(), Some(root_id.as_str()));
+        assert_eq!(reply.origin_topic_id.as_deref(), Some(topic));
+    }
+
+    #[tokio::test]
+    async fn private_channel_post_is_not_indexed_in_profile_timeline() {
+        let store = Arc::new(MemoryStore::default());
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let keys = generate_keys();
+        let author_pubkey = keys.public_key_hex();
+        let app = AppService::new_with_services(
+            store.clone(),
+            store,
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync.clone(),
+            blob_service,
+            keys,
+        );
+        let topic = "kukuri:topic:profile-private";
+        let channel = app
+            .create_private_channel(CreatePrivateChannelInput {
+                topic_id: TopicId::new(topic),
+                label: "core".into(),
+                audience_kind: ChannelAudienceKind::InviteOnly,
+            })
+            .await
+            .expect("create private channel");
+
+        let private_object_id = app
+            .create_post_in_channel(
+                topic,
+                ChannelRef::PrivateChannel {
+                    channel_id: ChannelId::new(channel.channel_id.clone()),
+                },
+                "private hello",
+                None,
+            )
+            .await
+            .expect("create private post");
+
+        let profile_docs =
+            author_profile_post_docs(docs_sync.as_ref(), author_pubkey.as_str()).await;
+        assert!(profile_docs.is_empty());
+
+        let timeline = app
+            .list_profile_timeline(author_pubkey.as_str(), None, 20)
+            .await
+            .expect("profile timeline");
+        assert!(
+            timeline
+                .items
+                .iter()
+                .all(|post| post.object_id != private_object_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn list_profile_timeline_ignores_profile_post_with_signer_mismatch() {
+        let store = Arc::new(MemoryStore::default());
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let keys = generate_keys();
+        let author_pubkey = keys.public_key_hex();
+        let app = AppService::new_with_services(
+            store.clone(),
+            store,
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync.clone(),
+            blob_service,
+            keys,
+        );
+        let topic = "kukuri:topic:profile-invalid";
+        let valid_object_id = app
+            .create_post(topic, "valid profile post", None)
+            .await
+            .expect("valid post");
+        let forged_content = KukuriProfilePostEnvelopeContentV1 {
+            author_pubkey: Pubkey::from(author_pubkey.as_str()),
+            profile_topic_id: author_profile_topic_id(author_pubkey.as_str()),
+            origin_topic_id: TopicId::new(topic),
+            object_id: EnvelopeId::from("forged-profile-post"),
+            created_at: 123,
+            object_kind: "post".into(),
+            content: "forged profile post".into(),
+            attachments: Vec::new(),
+            reply_to_object_id: None,
+            root_id: None,
+        };
+        let forged_envelope = kukuri_core::sign_envelope_json(
+            &generate_keys(),
+            "profile-post",
+            vec![
+                vec!["author".into(), author_pubkey.clone()],
+                vec!["object".into(), "profile-post".into()],
+                vec!["origin_topic".into(), topic.into()],
+                vec!["post".into(), forged_content.object_id.as_str().to_string()],
+            ],
+            &forged_content,
+        )
+        .expect("forged envelope");
+        let replica = author_replica_id(author_pubkey.as_str());
+        docs_sync
+            .open_replica(&replica)
+            .await
+            .expect("open author replica");
+        docs_sync
+            .apply_doc_op(
+                &replica,
+                DocOp::SetJson {
+                    key: stable_key("profile/posts", forged_content.object_id.as_str()),
+                    value: serde_json::to_value(AuthorProfilePostDocV1 {
+                        author_pubkey: forged_content.author_pubkey.clone(),
+                        profile_topic_id: forged_content.profile_topic_id.clone(),
+                        origin_topic_id: forged_content.origin_topic_id.clone(),
+                        object_id: forged_content.object_id.clone(),
+                        created_at: forged_content.created_at,
+                        object_kind: forged_content.object_kind.clone(),
+                        content: forged_content.content.clone(),
+                        attachments: forged_content.attachments.clone(),
+                        reply_to_object_id: None,
+                        root_id: None,
+                        envelope_id: forged_envelope.id.clone(),
+                    })
+                    .expect("forged doc json"),
+                },
+            )
+            .await
+            .expect("persist forged profile doc");
+        docs_sync
+            .apply_doc_op(
+                &replica,
+                DocOp::SetJson {
+                    key: stable_key("envelopes", forged_envelope.id.as_str()),
+                    value: serde_json::to_value(&forged_envelope).expect("forged envelope json"),
+                },
+            )
+            .await
+            .expect("persist forged envelope");
+
+        let profile_docs =
+            author_profile_post_docs(docs_sync.as_ref(), author_pubkey.as_str()).await;
+        assert_eq!(profile_docs.len(), 2);
+
+        let timeline = app
+            .list_profile_timeline(author_pubkey.as_str(), None, 20)
+            .await
+            .expect("profile timeline");
+
+        assert!(
+            timeline
+                .items
+                .iter()
+                .any(|post| post.object_id == valid_object_id)
+        );
+        assert!(
+            timeline
+                .items
+                .iter()
+                .all(|post| post.object_id != forged_content.object_id.as_str())
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -153,6 +153,10 @@ impl TopicId {
     }
 }
 
+pub fn author_profile_topic_id(author_pubkey: &str) -> TopicId {
+    TopicId::new(format!("kukuri:topic:profile:{author_pubkey}"))
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct ChannelId(pub String);
@@ -531,6 +535,56 @@ pub struct AuthorProfileDocV1 {
     pub about: Option<String>,
     pub picture: Option<String>,
     pub updated_at: i64,
+    pub envelope_id: EnvelopeId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KukuriProfilePostEnvelopeContentV1 {
+    pub author_pubkey: Pubkey,
+    pub profile_topic_id: TopicId,
+    pub origin_topic_id: TopicId,
+    pub object_id: EnvelopeId,
+    pub created_at: i64,
+    pub object_kind: String,
+    pub content: String,
+    #[serde(default)]
+    pub attachments: Vec<AssetRef>,
+    #[serde(default)]
+    pub reply_to_object_id: Option<EnvelopeId>,
+    #[serde(default)]
+    pub root_id: Option<EnvelopeId>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorProfilePostDocV1 {
+    pub author_pubkey: Pubkey,
+    pub profile_topic_id: TopicId,
+    pub origin_topic_id: TopicId,
+    pub object_id: EnvelopeId,
+    pub created_at: i64,
+    pub object_kind: String,
+    pub content: String,
+    #[serde(default)]
+    pub attachments: Vec<AssetRef>,
+    #[serde(default)]
+    pub reply_to_object_id: Option<EnvelopeId>,
+    #[serde(default)]
+    pub root_id: Option<EnvelopeId>,
+    pub envelope_id: EnvelopeId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfilePost {
+    pub author_pubkey: Pubkey,
+    pub profile_topic_id: TopicId,
+    pub origin_topic_id: TopicId,
+    pub object_id: EnvelopeId,
+    pub created_at: i64,
+    pub object_kind: String,
+    pub content: String,
+    pub attachments: Vec<AssetRef>,
+    pub reply_to_object_id: Option<EnvelopeId>,
+    pub root_id: Option<EnvelopeId>,
     pub envelope_id: EnvelopeId,
 }
 
@@ -1026,6 +1080,39 @@ pub fn build_profile_envelope(
         vec![
             vec!["author".into(), content.author_pubkey.as_str().to_string()],
             vec!["object".into(), "identity-profile".into()],
+        ],
+        encoded,
+        created_at,
+    )
+}
+
+pub fn build_profile_post_envelope(
+    keys: &KukuriKeys,
+    content: &KukuriProfilePostEnvelopeContentV1,
+) -> Result<KukuriEnvelope> {
+    let author_pubkey = keys.public_key();
+    if content.author_pubkey != author_pubkey {
+        bail!("profile post author pubkey must match signer");
+    }
+    if content.profile_topic_id != author_profile_topic_id(content.author_pubkey.as_str()) {
+        bail!("profile post topic id must match author profile topic");
+    }
+    if !matches!(content.object_kind.as_str(), "post" | "comment") {
+        bail!("profile post object kind must be post or comment");
+    }
+    let created_at = now_timestamp_millis()?;
+    let encoded = serde_json::to_string(content).context("failed to encode envelope content")?;
+    sign_envelope_at(
+        keys,
+        "profile-post",
+        vec![
+            vec!["author".into(), content.author_pubkey.as_str().to_string()],
+            vec!["object".into(), "profile-post".into()],
+            vec![
+                "origin_topic".into(),
+                content.origin_topic_id.as_str().to_string(),
+            ],
+            vec!["post".into(), content.object_id.as_str().to_string()],
         ],
         encoded,
         created_at,
@@ -1607,6 +1694,40 @@ pub fn parse_profile(envelope: &KukuriEnvelope) -> Result<Option<Profile>> {
     }))
 }
 
+pub fn parse_profile_post(envelope: &KukuriEnvelope) -> Result<Option<ProfilePost>> {
+    if envelope.kind != "profile-post" {
+        return Ok(None);
+    }
+
+    let content: KukuriProfilePostEnvelopeContentV1 =
+        serde_json::from_str(&envelope.content).context("failed to parse profile post envelope")?;
+    validate_pubkey(content.author_pubkey.as_str())
+        .context("invalid profile post author pubkey")?;
+    if content.author_pubkey != envelope.pubkey {
+        bail!("profile post author pubkey must match envelope signer");
+    }
+    if content.profile_topic_id != author_profile_topic_id(content.author_pubkey.as_str()) {
+        bail!("profile post topic id must match author profile topic");
+    }
+    if !matches!(content.object_kind.as_str(), "post" | "comment") {
+        bail!("profile post object kind must be post or comment");
+    }
+
+    Ok(Some(ProfilePost {
+        author_pubkey: content.author_pubkey,
+        profile_topic_id: content.profile_topic_id,
+        origin_topic_id: content.origin_topic_id,
+        object_id: content.object_id,
+        created_at: content.created_at,
+        object_kind: content.object_kind,
+        content: content.content,
+        attachments: content.attachments,
+        reply_to_object_id: content.reply_to_object_id,
+        root_id: content.root_id,
+        envelope_id: envelope.id.clone(),
+    }))
+}
+
 pub fn parse_follow_edge(envelope: &KukuriEnvelope) -> Result<Option<FollowEdge>> {
     if envelope.kind != "follow-edge" {
         return Ok(None);
@@ -1855,6 +1976,61 @@ mod tests {
         assert_eq!(profile.pubkey, keys.public_key());
         assert_eq!(profile.display_name.as_deref(), Some("Alice"));
         assert_eq!(profile.about.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn profile_post_envelope_roundtrip() {
+        let keys = generate_keys();
+        let author_pubkey = keys.public_key();
+        let envelope = build_profile_post_envelope(
+            &keys,
+            &KukuriProfilePostEnvelopeContentV1 {
+                author_pubkey: author_pubkey.clone(),
+                profile_topic_id: author_profile_topic_id(author_pubkey.as_str()),
+                origin_topic_id: TopicId::new("kukuri:topic:demo"),
+                object_id: EnvelopeId::from("post-1"),
+                created_at: 42,
+                object_kind: "comment".into(),
+                content: "hello profile topic".into(),
+                attachments: vec![AssetRef {
+                    hash: BlobHash::new("hash-1"),
+                    mime: "image/png".into(),
+                    bytes: 12,
+                    role: AssetRole::ImageOriginal,
+                }],
+                reply_to_object_id: Some(EnvelopeId::from("root-1")),
+                root_id: Some(EnvelopeId::from("root-1")),
+            },
+        )
+        .expect("profile post envelope");
+
+        envelope.verify().expect("signature verification");
+        let profile_post = parse_profile_post(&envelope)
+            .expect("parse profile post")
+            .expect("profile post");
+        assert_eq!(profile_post.author_pubkey, author_pubkey);
+        assert_eq!(
+            profile_post.profile_topic_id,
+            author_profile_topic_id(author_pubkey.as_str())
+        );
+        assert_eq!(profile_post.origin_topic_id.as_str(), "kukuri:topic:demo");
+        assert_eq!(profile_post.object_id.as_str(), "post-1");
+        assert_eq!(profile_post.created_at, 42);
+        assert_eq!(profile_post.object_kind, "comment");
+        assert_eq!(profile_post.content, "hello profile topic");
+        assert_eq!(profile_post.attachments.len(), 1);
+        assert_eq!(
+            profile_post
+                .reply_to_object_id
+                .as_ref()
+                .map(EnvelopeId::as_str),
+            Some("root-1")
+        );
+        assert_eq!(
+            profile_post.root_id.as_ref().map(EnvelopeId::as_str),
+            Some("root-1")
+        );
+        assert_eq!(profile_post.envelope_id, envelope.id);
     }
 
     #[test]

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -2868,14 +2868,18 @@ mod tests {
                 } else {
                     (publisher, subscriber)
                 };
-                wait_for_direct_topic_peer_count_result(
-                    active_publisher,
-                    topic,
-                    1,
-                    attempt_timeout,
-                )
-                .await
-                .context("publishing runtime did not observe direct public topic connectivity")?;
+                if publish_from_subscriber {
+                    wait_for_direct_topic_peer_count_result(
+                        active_publisher,
+                        topic,
+                        1,
+                        attempt_timeout,
+                    )
+                    .await
+                    .context(
+                        "publishing runtime did not observe direct public topic connectivity",
+                    )?;
+                }
                 let object_id = active_publisher
                     .create_post(CreatePostRequest {
                         topic: topic.to_string(),

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -94,6 +94,13 @@ pub struct ListThreadRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListProfileTimelineRequest {
+    pub pubkey: String,
+    pub cursor: Option<TimelineCursor>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ImportPeerTicketRequest {
     pub ticket: String,
 }
@@ -746,6 +753,19 @@ impl DesktopRuntime {
             .list_thread(
                 request.topic.as_str(),
                 request.thread_id.as_str(),
+                request.cursor,
+                request.limit.unwrap_or(50),
+            )
+            .await
+    }
+
+    pub async fn list_profile_timeline(
+        &self,
+        request: ListProfileTimelineRequest,
+    ) -> Result<TimelineView> {
+        self.app_service
+            .list_profile_timeline(
+                request.pubkey.as_str(),
                 request.cursor,
                 request.limit.unwrap_or(50),
             )
@@ -2685,6 +2705,62 @@ mod tests {
         }
     }
 
+    async fn wait_for_profile_timeline_posts(
+        runtime: &DesktopRuntime,
+        author_pubkey: &str,
+        object_ids: &[String],
+        timeout_label: &str,
+    ) -> TimelineView {
+        match timeout(runtime_replication_timeout(), async {
+            loop {
+                let timeline = runtime
+                    .list_profile_timeline(ListProfileTimelineRequest {
+                        pubkey: author_pubkey.to_string(),
+                        cursor: None,
+                        limit: Some(20),
+                    })
+                    .await
+                    .expect("profile timeline");
+                if object_ids.iter().all(|object_id| {
+                    timeline
+                        .items
+                        .iter()
+                        .any(|post| post.object_id == *object_id)
+                }) {
+                    return timeline;
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        {
+            Ok(timeline) => timeline,
+            Err(_) => {
+                let status = runtime.get_sync_status().await.expect("sync status");
+                let visible_items = runtime
+                    .list_profile_timeline(ListProfileTimelineRequest {
+                        pubkey: author_pubkey.to_string(),
+                        cursor: None,
+                        limit: Some(20),
+                    })
+                    .await
+                    .ok()
+                    .map(|timeline| {
+                        timeline
+                            .items
+                            .into_iter()
+                            .map(|post| format!("{}@{:?}", post.object_id, post.origin_topic_id))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                panic!(
+                    "{timeout_label}: {}; visible_items={visible_items:?}",
+                    format_sync_snapshot(&status, "")
+                );
+            }
+        }
+    }
+
     fn public_replication_retry_schedule(
         step_timeout: Duration,
         same_author_shared_identity: bool,
@@ -3427,6 +3503,196 @@ mod tests {
         assert_eq!(post.content, "hello desktop runtime");
         let status = runtime_a.get_sync_status().await.expect("sync status");
         assert!(status.last_sync_ts.is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn profile_timeline_reads_author_public_posts_across_untracked_topics() {
+        let dir = tempdir().expect("tempdir");
+        let db_a = dir.path().join("profile-runtime-a.db");
+        let db_b = dir.path().join("profile-runtime-b.db");
+        let runtime_a = DesktopRuntime::new_with_config_and_identity(
+            &db_a,
+            TransportNetworkConfig::loopback(),
+            IdentityStorageMode::FileOnly,
+        )
+        .await
+        .expect("runtime a");
+        let runtime_b = DesktopRuntime::new_with_config_and_identity(
+            &db_b,
+            TransportNetworkConfig::loopback(),
+            IdentityStorageMode::FileOnly,
+        )
+        .await
+        .expect("runtime b");
+        let ticket_a = runtime_a
+            .local_peer_ticket()
+            .await
+            .expect("ticket a")
+            .expect("ticket a value");
+        let ticket_b = runtime_b
+            .local_peer_ticket()
+            .await
+            .expect("ticket b")
+            .expect("ticket b value");
+
+        runtime_a
+            .import_peer_ticket(ImportPeerTicketRequest { ticket: ticket_b })
+            .await
+            .expect("import b");
+        runtime_b
+            .import_peer_ticket(ImportPeerTicketRequest { ticket: ticket_a })
+            .await
+            .expect("import a");
+        wait_for_connected_peer_count(&runtime_a, 1, "profile topic owner peer readiness timeout")
+            .await;
+        wait_for_connected_peer_count(&runtime_b, 1, "profile topic viewer peer readiness timeout")
+            .await;
+
+        let author_pubkey = runtime_a
+            .get_sync_status()
+            .await
+            .expect("status a")
+            .local_author_pubkey;
+        let tracked_topic = "kukuri:topic:desktop-profile-demo";
+        let untracked_topic = "kukuri:topic:desktop-profile-relay";
+        let public_scope = TimelineScope::Public;
+
+        let _ = runtime_a
+            .list_timeline(ListTimelineRequest {
+                topic: tracked_topic.into(),
+                scope: public_scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .expect("subscribe a tracked topic");
+        let _ = runtime_a
+            .list_timeline(ListTimelineRequest {
+                topic: untracked_topic.into(),
+                scope: public_scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .expect("subscribe a untracked topic");
+        let _ = runtime_b
+            .list_timeline(ListTimelineRequest {
+                topic: tracked_topic.into(),
+                scope: public_scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .expect("subscribe b tracked topic");
+
+        let tracked_object_id = runtime_a
+            .create_post(CreatePostRequest {
+                topic: tracked_topic.into(),
+                content: "tracked profile post".into(),
+                reply_to: None,
+                channel_ref: ChannelRef::Public,
+                attachments: vec![],
+            })
+            .await
+            .expect("tracked public post");
+        let untracked_object_id = runtime_a
+            .create_post(CreatePostRequest {
+                topic: untracked_topic.into(),
+                content: "untracked profile post".into(),
+                reply_to: None,
+                channel_ref: ChannelRef::Public,
+                attachments: vec![],
+            })
+            .await
+            .expect("untracked public post");
+
+        wait_for_timeline_post(
+            &runtime_b,
+            tracked_topic,
+            &public_scope,
+            tracked_object_id.as_str(),
+            "tracked topic visibility timeout",
+        )
+        .await;
+
+        let before_profile = runtime_b
+            .get_sync_status()
+            .await
+            .expect("status before profile");
+        assert!(
+            before_profile
+                .subscribed_topics
+                .iter()
+                .any(|topic| topic == tracked_topic)
+        );
+        assert!(
+            before_profile
+                .subscribed_topics
+                .iter()
+                .all(|topic| topic != untracked_topic)
+        );
+
+        let profile_timeline = wait_for_profile_timeline_posts(
+            &runtime_b,
+            author_pubkey.as_str(),
+            &[tracked_object_id.clone(), untracked_object_id.clone()],
+            "profile timeline visibility timeout",
+        )
+        .await;
+        assert!(
+            profile_timeline
+                .items
+                .iter()
+                .any(|post| post.object_id == tracked_object_id
+                    && post.origin_topic_id.as_deref() == Some(tracked_topic))
+        );
+        assert!(
+            profile_timeline
+                .items
+                .iter()
+                .any(|post| post.object_id == untracked_object_id
+                    && post.origin_topic_id.as_deref() == Some(untracked_topic))
+        );
+
+        let after_profile = runtime_b
+            .get_sync_status()
+            .await
+            .expect("status after profile");
+        assert!(
+            after_profile
+                .subscribed_topics
+                .iter()
+                .all(|topic| topic != untracked_topic)
+        );
+
+        let _ = runtime_b
+            .list_timeline(ListTimelineRequest {
+                topic: untracked_topic.into(),
+                scope: public_scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .expect("open original topic");
+        wait_for_timeline_post(
+            &runtime_b,
+            untracked_topic,
+            &public_scope,
+            untracked_object_id.as_str(),
+            "origin topic visibility timeout",
+        )
+        .await;
+
+        let after_origin = runtime_b
+            .get_sync_status()
+            .await
+            .expect("status after origin");
+        assert!(
+            after_origin
+                .subscribed_topics
+                .iter()
+                .any(|topic| topic == untracked_topic)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -565,8 +565,14 @@ async fn run_community_node_connectivity(
 ) -> Result<HarnessResult> {
     unsafe { std::env::set_var("KUKURI_DISABLE_KEYRING", "1") };
 
-    let step_timeout = Duration::from_millis(scenario.timeouts.step_ms);
-    let overall_timeout = Duration::from_millis(scenario.timeouts.overall_ms);
+    let step_timeout = ci_timeout_floor(
+        Duration::from_millis(scenario.timeouts.step_ms),
+        Duration::from_secs(180),
+    );
+    let overall_timeout = ci_timeout_floor(
+        Duration::from_millis(scenario.timeouts.overall_ms),
+        Duration::from_secs(600),
+    );
     let stack = CommunityNodeStack::spawn(match identity_mode {
         CommunityNodeIdentityMode::DistinctUsers => "community_node_public_connectivity",
         CommunityNodeIdentityMode::SharedIdentity => "community_node_multi_device_connectivity",
@@ -782,7 +788,7 @@ async fn run_community_node_connectivity(
             topic,
             "community node scenario post",
             step_timeout,
-            PublicReplicationDirection::PrewarmWithDirectConnectedSubscriber,
+            PublicReplicationDirection::PreferDirectConnectedSubscriber,
             PublicReplicationLabels {
                 failure: "initial scenario post",
                 publisher: "desktop a",
@@ -904,7 +910,19 @@ async fn run_community_node_connectivity(
         let runtime_b = DesktopRuntime::new_with_config(&db_b, TransportNetworkConfig::loopback())
             .await
             .context("failed to restart community-node desktop b for reconnect")?;
-        let reconnect_timeout = ci_timeout_floor(step_timeout, Duration::from_secs(240));
+        let _ = runtime_a
+            .refresh_community_node_metadata(CommunityNodeTargetRequest {
+                base_url: stack.base_url.clone(),
+            })
+            .await
+            .context("failed to refresh community-node metadata for desktop a after restart")?;
+        let _ = runtime_b
+            .refresh_community_node_metadata(CommunityNodeTargetRequest {
+                base_url: stack.base_url.clone(),
+            })
+            .await
+            .context("failed to refresh community-node metadata for desktop b after restart")?;
+        let reconnect_timeout = ci_timeout_floor(step_timeout, Duration::from_secs(360));
         let _ = runtime_b
             .list_timeline(ListTimelineRequest {
                 topic: topic.to_string(),
@@ -946,7 +964,7 @@ async fn run_community_node_connectivity(
             topic,
             "community node reconnect",
             reconnect_timeout,
-            PublicReplicationDirection::PrewarmWithDirectConnectedSubscriber,
+            PublicReplicationDirection::PreferDirectConnectedSubscriber,
             PublicReplicationLabels {
                 failure: "reconnect post after restart",
                 publisher: "desktop a",
@@ -2122,7 +2140,7 @@ fn topic_has_direct_peer(status: &SyncStatus, topic: &str, expected: usize) -> b
         })
 }
 
-fn should_prewarm_public_replication_with_subscriber(
+fn should_publish_from_direct_connected_subscriber(
     publisher_status: &SyncStatus,
     subscriber_status: &SyncStatus,
     topic: &str,
@@ -2131,7 +2149,7 @@ fn should_prewarm_public_replication_with_subscriber(
 ) -> bool {
     matches!(
         direction,
-        PublicReplicationDirection::PrewarmWithDirectConnectedSubscriber
+        PublicReplicationDirection::PreferDirectConnectedSubscriber
     ) && !topic_has_direct_peer(publisher_status, topic, expected)
         && topic_has_direct_peer(subscriber_status, topic, expected)
 }
@@ -2375,7 +2393,7 @@ struct PublicReplicationLabels<'a> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PublicReplicationDirection {
     PreferOriginalPublisher,
-    PrewarmWithDirectConnectedSubscriber,
+    PreferDirectConnectedSubscriber,
 }
 
 async fn replicate_public_post_with_retry(
@@ -2434,64 +2452,31 @@ async fn replicate_public_post_with_retry(
                 .get_sync_status()
                 .await
                 .context("subscriber sync status")?;
-            let prewarm_from_subscriber = should_prewarm_public_replication_with_subscriber(
+            let publish_from_subscriber = should_publish_from_direct_connected_subscriber(
                 &publisher_status,
                 &subscriber_status,
                 topic,
                 1,
                 direction,
             );
-            if prewarm_from_subscriber {
-                wait_for_direct_topic_peer_count(subscriber, topic, 1, attempt_timeout)
+            let (active_publisher, active_subscriber, publisher_label, subscriber_label) =
+                if publish_from_subscriber {
+                    (subscriber, publisher, labels.subscriber, labels.publisher)
+                } else {
+                    (publisher, subscriber, labels.publisher, labels.subscriber)
+                };
+            if publish_from_subscriber {
+                wait_for_direct_topic_peer_count(active_publisher, topic, 1, attempt_timeout)
                     .await
                     .with_context(|| {
                         format!(
                             "{} did not observe direct public topic connectivity",
-                            labels.subscriber
+                            publisher_label
                         )
                     })?;
-                let bootstrap_post_id = subscriber
-                    .create_post(CreatePostRequest {
-                        topic: topic.to_string(),
-                        content: format!("{content_prefix} bootstrap #{attempt}"),
-                        reply_to: None,
-                        channel_ref: ChannelRef::Public,
-                        attachments: Vec::new(),
-                    })
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "failed to create bootstrap public post on {}",
-                            labels.subscriber
-                        )
-                    })?;
-                wait_for_topic_doc_index_entry(
-                    subscriber,
-                    topic,
-                    bootstrap_post_id.as_str(),
-                    attempt_timeout,
-                )
-                .await
-                .context("subscriber did not persist bootstrap public post into docs index")?;
-                wait_for_timeline_object(
-                    publisher,
-                    topic,
-                    bootstrap_post_id.as_str(),
-                    attempt_timeout,
-                )
-                .await
-                .context("publisher did not observe bootstrap public post")?;
-                last_direction = Some(format!(
-                    "prewarm {}->{}, publish {}->{}",
-                    labels.subscriber, labels.publisher, labels.publisher, labels.subscriber
-                ));
-            } else {
-                last_direction = Some(format!(
-                    "publish {}->{}",
-                    labels.publisher, labels.subscriber
-                ));
             }
-            let post_id = publisher
+            last_direction = Some(format!("publish {publisher_label}->{subscriber_label}"));
+            let post_id = active_publisher
                 .create_post(CreatePostRequest {
                     topic: topic.to_string(),
                     content: format!("{content_prefix} #{attempt}"),
@@ -2500,11 +2485,16 @@ async fn replicate_public_post_with_retry(
                     attachments: Vec::new(),
                 })
                 .await
-                .with_context(|| format!("failed to create public post on {}", labels.publisher))?;
-            wait_for_topic_doc_index_entry(publisher, topic, post_id.as_str(), attempt_timeout)
-                .await
-                .context("publisher did not persist public post into docs index")?;
-            wait_for_timeline_object(subscriber, topic, post_id.as_str(), attempt_timeout)
+                .with_context(|| format!("failed to create public post on {publisher_label}"))?;
+            wait_for_topic_doc_index_entry(
+                active_publisher,
+                topic,
+                post_id.as_str(),
+                attempt_timeout,
+            )
+            .await
+            .context("publisher did not persist public post into docs index")?;
+            wait_for_timeline_object(active_subscriber, topic, post_id.as_str(), attempt_timeout)
                 .await
                 .context("timeline assertion timeout")?;
             Ok::<String, anyhow::Error>(post_id)
@@ -3062,17 +3052,17 @@ mod tests {
     }
 
     #[test]
-    fn public_replication_direction_prewarms_from_direct_connected_subscriber_when_requested() {
+    fn public_replication_direction_prefers_direct_connected_subscriber_when_requested() {
         let topic = "kukuri:topic:test";
         let publisher_status = sync_status_with_topic(topic, &[], &["assist-peer"]);
         let subscriber_status = sync_status_with_topic(topic, &["direct-peer"], &["assist-peer"]);
 
-        assert!(should_prewarm_public_replication_with_subscriber(
+        assert!(should_publish_from_direct_connected_subscriber(
             &publisher_status,
             &subscriber_status,
             topic,
             1,
-            PublicReplicationDirection::PrewarmWithDirectConnectedSubscriber,
+            PublicReplicationDirection::PreferDirectConnectedSubscriber,
         ));
     }
 
@@ -3082,7 +3072,7 @@ mod tests {
         let publisher_status = sync_status_with_topic(topic, &[], &["assist-peer"]);
         let subscriber_status = sync_status_with_topic(topic, &["direct-peer"], &["assist-peer"]);
 
-        assert!(!should_prewarm_public_replication_with_subscriber(
+        assert!(!should_publish_from_direct_connected_subscriber(
             &publisher_status,
             &subscriber_status,
             topic,

--- a/docs/adr/0015-profile-topic-author-index.md
+++ b/docs/adr/0015-profile-topic-author-index.md
@@ -1,0 +1,208 @@
+# ADR 0015: Author Profile Topic
+
+## Status
+Proposed
+
+## Date
+2026-03-28
+
+## Base Branch
+`main`
+
+## Related
+- `docs/adr/0011-kukuri-protocol-v1-draft.md`
+- `docs/adr/0012-topic-first_progressive_community_filtering_draft.md`
+- `docs/adr/0013-social-graph-foundation-draft.md`
+- `docs/adr/0014-uiux-dev-flow.md`
+
+## Feature Data Classification
+- Feature 名: author profile topic
+- Durable / Transient: Durable public author-owned index + local read-only query state
+- Canonical Source: public author docs replica (`author::<author_pubkey>`) に保存された author-signed `profile-post`
+- Replicated?: Yes, `profile-post` doc は public author replica に複製される
+- Rebuildable From: author replica 上の `profile-post` doc / signed envelope / attachment ref
+- Public Replica / Private Replica / Local Only: public author replica for `profile-post`, local only UI route / query state
+- Gossip Hint 必要有無: No new hint type; author replica subscription / hydration を使う
+- Blob 必要有無: 既存 blob ref を再利用する
+- SQLite projection 必要有無: v1 では dedicated profile-topic projection を増やさず、author replica query で読む
+- 必須 contract:
+  - `create_public_post_persists_profile_post_doc_and_lists_profile_timeline`
+  - `public_reply_is_indexed_in_profile_timeline`
+  - `private_channel_post_is_not_indexed_in_profile_timeline`
+  - `list_profile_timeline_ignores_profile_post_with_signer_mismatch`
+  - `profile overview aggregates public posts across topics and excludes private channel posts`
+  - `author detail shows profile topic posts and can open an untracked origin topic`
+- 必須 scenario:
+  - `profile_timeline_reads_author_public_posts_across_untracked_topics`
+
+## 1. Current Main Snapshot
+
+current `main` の profile overview は、active topic の public timeline を local author で filter したものとして振る舞っている。
+
+この形では次が満たせない。
+
+- author の public 投稿を topic をまたいで一箇所に集約すること
+- viewer が origin topic を tracked していなくても author の public 投稿を読むこと
+- `#/profile` と author detail を同じ author-centric feed として扱うこと
+
+一方で current architecture は、topic timeline とは別に `author::<author_pubkey>` replica を持ち、署名付き author-owned object をここへ載せる boundary をすでに持っている。
+
+したがって profile topic v1 は、新しい public topic replica を作るのではなく、author replica 上の public index として導入する。
+
+## 2. Decision
+
+profile topic v1 は、author ごとの public 投稿を束ねる virtual / system topic として扱う。
+
+### 2.1 Logical topic id
+
+UI / query 上の stable logical ID を次で固定する。
+
+```text
+kukuri:topic:profile:<author_pubkey>
+```
+
+この ID は virtual topic を識別するための logical handle であり、v1 では tracked topics nav の追加・削除対象にしない。
+
+### 2.2 Canonical source
+
+origin public post の正本は従来どおり topic replica に残す。
+
+```text
+topic::<topic_id>
+```
+
+profile topic の正本は topic replica ではなく、次の author replica に置く。
+
+```text
+author::<author_pubkey>
+```
+
+ここに author-signed `profile-post` doc を保存し、client はこれを profile topic membership と解釈する。
+
+### 2.3 Authority boundary
+
+P2P 上では author 以外が author replica に doc を書こうとすること自体は完全には防げない。v1 の権限境界は docs write capability ではなく署名で決める。
+
+有効な `profile-post` は次を満たすものだけである。
+
+- `content.author_pubkey == envelope.pubkey`
+- `content.profile_topic_id == kukuri:topic:profile:<author_pubkey>`
+- envelope signer と doc owner 解釈が一致する
+- `object_kind` は `post` または `comment`
+
+non-author doc、signer 不一致 doc、owner 不一致 doc、channel/private object を指す doc は無視する。
+
+## 3. Data Model
+
+### 3.1 Envelope kind
+
+v1 は新しい signed envelope kind として `profile-post` を使う。
+
+これは normal topic timeline projection 用の object ではなく、author-owned public index object である。
+
+### 3.2 Minimal document shape
+
+`profile-post` doc は少なくとも次を持つ。
+
+- `author_pubkey`
+- `profile_topic_id`
+- `origin_topic_id`
+- `object_id`
+- `created_at`
+- `object_kind`
+- `reply_to_object_id?`
+- `root_id?`
+- public post card を描画できる display snapshot としての `content`
+- attachment / media ref の最小情報
+- `envelope_id`
+
+v1 の attachment 表示は既存 blob fetch を再利用する。ただし profile feed の基本描画は author replica 内の snapshot だけで成立しなければならない。
+
+## 4. Publish And Read Contract
+
+### 4.1 Publish
+
+public post publish 時は次を行う。
+
+- origin topic replica へ通常の `post` / `comment` object を publish する
+- 同じ author の `author::<author_pubkey>` replica へ `profile-post` doc と signed envelope を追加する
+
+public reply も同じく profile topic に集約する。
+
+次は `profile-post` を作らない。
+
+- private channel post
+- private reply
+- live session
+- game room
+
+### 4.2 Read surface
+
+v1 の read surface は `list_profile_timeline(author_pubkey, cursor, limit)` 相当とする。
+
+この API は author replica を hydrate し、`profile-post` doc を created-at 降順で読む。返却 item には少なくとも次を含める。
+
+- `origin_topic_id`
+- `object_id`
+- `author_pubkey`
+- `content`
+- `attachments`
+- `reply_to`
+- `root_id`
+
+v1 では new dedicated SQLite projection は入れず、author replica query を canonical read path とする。
+
+## 5. UX Boundary
+
+初回の UX 境界は次の二箇所に固定する。
+
+- `#/profile`
+- author detail
+
+この feed は read-only とする。
+
+- profile feed 上では reply / thread affordance を出さない
+- 各カードに `origin topic` を表示する
+- `Open original topic` で通常の topic 文脈へ移る
+
+これにより、network 的には誰でも doc を書ける可能性があっても、UI と client-side interpretation によって「実質的に author だけが書ける topic」として扱う。
+
+current の `profile overview = active topic public self timeline` は superseded target とする。
+
+一方で次は変えない。
+
+- topic-first browsing
+- main timeline
+- thread semantics
+- tracked topic navigation model
+
+## 6. Sync Boundary
+
+profile topic は normal topic subscription map に混ぜない。
+
+理由:
+
+- browsing unit は引き続き topic
+- profile topic は author-centric な virtual feed
+- sync の truth source が topic replica ではなく author replica
+
+したがって v1 では new gossip hint type を増やさず、author replica subscription / hydration を使う。
+
+viewer が origin topic を購読していなくても、author replica が取れれば profile feed は読めるべきである。origin topic そのものを開くのは `Open original topic` を起点にした通常の topic subscription とする。
+
+## 7. Validation
+
+v1 は少なくとも次で固定する。
+
+- `create_public_post_persists_profile_post_doc_and_lists_profile_timeline`
+- `public_reply_is_indexed_in_profile_timeline`
+- `private_channel_post_is_not_indexed_in_profile_timeline`
+- `list_profile_timeline_ignores_profile_post_with_signer_mismatch`
+- `profile_timeline_reads_author_public_posts_across_untracked_topics`
+- `profile overview aggregates public posts across topics and excludes private channel posts`
+- `author detail shows profile topic posts and can open an untracked origin topic`
+
+required scenario は次である。
+
+- A が複数 public topic に投稿し、B はその一部しか tracked していない状態でも、B は A の profile feed で全 public post / reply を見られる
+- B は profile feed 上では返信できず、origin topic を開いた後だけ通常の thread / reply に入れる


### PR DESCRIPTION
## Summary
- add ADR 0015 for the author profile topic as a virtual topic backed by author replicas
- index public posts and replies into author-signed `profile-post` docs and expose `list_profile_timeline` through app-api, desktop-runtime, and tauri
- switch desktop profile and author detail feeds to the read-only profile timeline with origin-topic navigation
- ignore invalid profile-post docs by signer/topic mismatch and fix route sync so explicit null/false overrides clear author/settings state correctly

## Testing
- cargo test -p kukuri-core profile_post_envelope_roundtrip -- --nocapture
- cargo test -p kukuri-app-api create_public_post_persists_profile_post_doc_and_lists_profile_timeline -- --nocapture
- cargo test -p kukuri-app-api public_reply_is_indexed_in_profile_timeline -- --nocapture
- cargo test -p kukuri-app-api private_channel_post_is_not_indexed_in_profile_timeline -- --nocapture
- cargo test -p kukuri-app-api list_profile_timeline_ignores_profile_post_with_signer_mismatch -- --nocapture
- cargo test -p kukuri-desktop-runtime profile_timeline_reads_author_public_posts_across_untracked_topics -- --nocapture
- CI=1 npx pnpm@10.16.1 exec vitest run src/App.test.tsx -t "profile overview aggregates public posts across topics and excludes private channel posts|author detail shows profile topic posts and can open an untracked origin topic" --maxWorkers=1 --reporter=verbose