### PR TITLE
Add public repost and quote repost support

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use kukuri_desktop_runtime::{
     AcceptCommunityNodeConsentsRequest, CommunityNodeConfig, CommunityNodeNodeStatus,
     CommunityNodeTargetRequest, CreateGameRoomRequest, CreateLiveSessionRequest,
-    CreatePostRequest, CreatePrivateChannelRequest, DesktopRuntime, DiscoveryConfig,
+    CreatePostRequest, CreatePrivateChannelRequest, CreateRepostRequest, DesktopRuntime,
+    DiscoveryConfig,
     ExportFriendOnlyGrantRequest, ExportFriendPlusShareRequest,
     ExportPrivateChannelInviteRequest, FreezePrivateChannelRequest, GetBlobMediaRequest,
     GetBlobPreviewRequest, ImportFriendOnlyGrantRequest, ImportFriendPlusShareRequest,
@@ -92,6 +93,14 @@ async fn create_post(
     request: CreatePostRequest,
 ) -> Result<String, String> {
     state.runtime.create_post(request).await.map_err(map_error)
+}
+
+#[tauri::command]
+async fn create_repost(
+    state: tauri::State<'_, DesktopState>,
+    request: CreateRepostRequest,
+) -> Result<String, String> {
+    state.runtime.create_repost(request).await.map_err(map_error)
 }
 
 #[tauri::command]
@@ -611,6 +620,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             create_post,
+            create_repost,
             create_private_channel,
             export_private_channel_invite,
             import_private_channel_invite,

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -640,6 +640,82 @@ test('reply publish reloads thread only once after a successful submit', async (
   expect(listThreadSpy.mock.calls.length - threadCallsBeforeSubmit).toBe(1);
 });
 
+test('desktop shell can create a simple repost from timeline', async () => {
+  const user = userEvent.setup();
+  const api = createDesktopMockApi();
+  const originalCreateRepost = api.createRepost;
+  const createRepostSpy = vi.fn((topic, sourceTopic, sourceObjectId, commentary) =>
+    originalCreateRepost(topic, sourceTopic, sourceObjectId, commentary)
+  );
+  api.createRepost = createRepostSpy;
+
+  render(<App api={api} />);
+
+  await user.type(screen.getByPlaceholderText('Write a post'), 'source post');
+  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  const sourcePost = await screen.findByText('source post');
+  const card = sourcePost.closest('article');
+  if (!card) {
+    throw new Error('source post card not found');
+  }
+
+  await user.click(within(card).getByRole('button', { name: 'Repost' }));
+
+  await waitFor(() => {
+    expect(createRepostSpy).toHaveBeenCalledWith(
+      'kukuri:topic:demo',
+      'kukuri:topic:demo',
+      expect.any(String),
+      null
+    );
+  });
+  expect(screen.getByText('Reposted')).toBeInTheDocument();
+});
+
+test('desktop shell can create a quote repost from the composer', async () => {
+  const user = userEvent.setup();
+  const api = createDesktopMockApi();
+  const originalCreateRepost = api.createRepost;
+  const createRepostSpy = vi.fn((topic, sourceTopic, sourceObjectId, commentary) =>
+    originalCreateRepost(topic, sourceTopic, sourceObjectId, commentary)
+  );
+  api.createRepost = createRepostSpy;
+
+  render(<App api={api} />);
+
+  await user.type(screen.getByPlaceholderText('Write a post'), 'source post');
+  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  const sourcePost = await screen.findByText('source post');
+  const card = sourcePost.closest('article');
+  if (!card) {
+    throw new Error('source post card not found');
+  }
+
+  await user.click(within(card).getByRole('button', { name: 'Quote Repost' }));
+
+  const quoteInput = await screen.findByPlaceholderText('Write a quote repost');
+  expect(screen.getByText('Quote reposting')).toBeInTheDocument();
+  expect(screen.getByLabelText(/attachment/i)).toBeDisabled();
+
+  await user.type(quoteInput, 'quoted take');
+  const composer = quoteInput.closest('form');
+  if (!composer) {
+    throw new Error('quote repost composer form not found');
+  }
+  const submitButton = within(composer).getByRole('button', { name: 'Quote Repost' });
+  await user.click(submitButton);
+
+  await waitFor(() => {
+    expect(createRepostSpy).toHaveBeenCalledWith(
+      'kukuri:topic:demo',
+      'kukuri:topic:demo',
+      expect.any(String),
+      'quoted take'
+    );
+  });
+  expect(screen.getByText('quoted take')).toBeInTheDocument();
+});
+
 test('desktop shell can track multiple topics at once', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -149,6 +149,7 @@ type DesktopShellState = {
   thread: PostView[];
   selectedThread: string | null;
   replyTarget: PostView | null;
+  repostTarget: PostView | null;
   peerTicket: string;
   localPeerTicket: string | null;
   discoveryConfig: DiscoveryConfig;
@@ -331,6 +332,7 @@ function createInitialShellState(): DesktopShellState {
     thread: [],
     selectedThread: null,
     replyTarget: null,
+    repostTarget: null,
     peerTicket: '',
     localPeerTicket: null,
     discoveryConfig: DEFAULT_DISCOVERY_CONFIG,
@@ -558,6 +560,18 @@ function authorDisplayLabel(
   name?: string | null
 ): string {
   return displayName?.trim() || name?.trim() || shortPubkey(authorPubkey);
+}
+
+function publishedTopicIdForPost(post: Pick<PostView, 'published_topic_id' | 'origin_topic_id'>): string | null {
+  return post.published_topic_id?.trim() || post.origin_topic_id?.trim() || null;
+}
+
+function canCreateRepostFromPost(post: PostView): boolean {
+  return (post.object_kind === 'post' || post.object_kind === 'comment') && !post.channel_id;
+}
+
+function isQuoteRepost(post: Pick<PostView, 'object_kind' | 'repost_commentary'>): boolean {
+  return post.object_kind === 'repost' && Boolean(post.repost_commentary?.trim());
 }
 
 function formatListLabel(values: string[]): string {
@@ -1319,6 +1333,7 @@ function DesktopShellPage({
     thread,
     selectedThread,
     replyTarget,
+    repostTarget,
     peerTicket,
     localPeerTicket,
     discoveryConfig,
@@ -1420,6 +1435,7 @@ function DesktopShellPage({
   const setThread = useMemo(() => makeFieldSetter('thread'), [makeFieldSetter]);
   const setSelectedThread = useMemo(() => makeFieldSetter('selectedThread'), [makeFieldSetter]);
   const setReplyTarget = useMemo(() => makeFieldSetter('replyTarget'), [makeFieldSetter]);
+  const setRepostTarget = useMemo(() => makeFieldSetter('repostTarget'), [makeFieldSetter]);
   const setPeerTicket = useMemo(() => makeFieldSetter('peerTicket'), [makeFieldSetter]);
   const setLocalPeerTicket = useMemo(() => makeFieldSetter('localPeerTicket'), [makeFieldSetter]);
   const setDiscoveryConfig = useMemo(() => makeFieldSetter('discoveryConfig'), [makeFieldSetter]);
@@ -1596,6 +1612,9 @@ function DesktopShellPage({
     [activeTopic, timelineScopeByTopic]
   );
   const activeComposeChannel = useMemo(() => {
+    if (repostTarget) {
+      return PUBLIC_CHANNEL_REF;
+    }
     if (replyTarget?.channel_id) {
       return {
         kind: 'private_channel',
@@ -1603,13 +1622,16 @@ function DesktopShellPage({
       } as ChannelRef;
     }
     return composeChannelByTopic[activeTopic] ?? PUBLIC_CHANNEL_REF;
-  }, [activeTopic, composeChannelByTopic, replyTarget]);
+  }, [activeTopic, composeChannelByTopic, replyTarget, repostTarget]);
   const activeComposeAudienceLabel = useMemo(() => {
+    if (repostTarget) {
+      return translate('common:audience.public');
+    }
     if (replyTarget) {
       return replyTarget.audience_label;
     }
     return audienceLabelForChannelRef(activeComposeChannel, activeJoinedChannels);
-  }, [activeComposeChannel, activeJoinedChannels, replyTarget]);
+  }, [activeComposeChannel, activeJoinedChannels, replyTarget, repostTarget]);
   const profileMode = shellChromeState.profileMode;
   const selectedPrivateChannelId = useMemo(
     () => selectedChannelIdByTopic[activeTopic] ?? null,
@@ -2362,6 +2384,7 @@ function DesktopShellPage({
     setSelectedThread(null);
     setThread([]);
     setReplyTarget(null);
+    setRepostTarget(null);
     setSelectedAuthorPubkey(null);
     setSelectedAuthor(null);
     setSelectedAuthorTimeline([]);
@@ -2373,6 +2396,7 @@ function DesktopShellPage({
   }, [
     setAuthorError,
     setReplyTarget,
+    setRepostTarget,
     setSelectedAuthor,
     setSelectedAuthorTimeline,
     setSelectedAuthorPubkey,
@@ -2493,6 +2517,7 @@ function DesktopShellPage({
     setSelectedThread(null);
     setThread([]);
     setReplyTarget(null);
+    setRepostTarget(null);
     setSelectedAuthorPubkey(null);
     setSelectedAuthor(null);
     setSelectedAuthorTimeline([]);
@@ -3032,15 +3057,57 @@ function DesktopShellPage({
 
   async function handlePublish(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    const trimmedComposer = composer.trim();
     const attachments = draftMediaItems.flatMap((item) => item.attachments);
-    if (!composer.trim() && attachments.length === 0) {
+    if (repostTarget) {
+      const sourceTopic = publishedTopicIdForPost(repostTarget);
+      if (!sourceTopic) {
+        setComposerError(translate('common:errors.failedToPublish'));
+        return;
+      }
+      if (!trimmedComposer) {
+        setComposerError(translate('common:errors.quoteRepostRequiresCommentary'));
+        return;
+      }
+
+      try {
+        await api.createRepost(activeTopic, sourceTopic, repostTarget.object_id, trimmedComposer);
+        releaseAllDraftPreviews();
+        setComposer('');
+        setDraftMediaItems([]);
+        setAttachmentInputKey((value) => value + 1);
+        setComposerError(null);
+        setReplyTarget(null);
+        setRepostTarget(null);
+        setSelectedThread(null);
+        setThread([]);
+        setShellChromeState((current) => ({
+          ...current,
+          activePrimarySection: 'timeline',
+        }));
+        await loadTopics(trackedTopics, activeTopic, null);
+        syncRoute('replace', {
+          primarySection: 'timeline',
+          selectedThread: null,
+        });
+      } catch (publishError) {
+        setComposerError(
+          publishError instanceof Error
+            ? publishError.message
+            : translate('common:errors.failedToPublish')
+        );
+      }
+      return;
+    }
+
+    if (!trimmedComposer && attachments.length === 0) {
       return;
     }
 
     try {
       await api.createPost(
         activeTopic,
-        composer.trim(),
+        trimmedComposer,
         replyTarget?.object_id ?? null,
         attachments,
         activeComposeChannel
@@ -3056,6 +3123,7 @@ function DesktopShellPage({
       }));
       await loadTopics(trackedTopics, activeTopic, selectedThread);
       setReplyTarget(null);
+      setRepostTarget(null);
       syncRoute('replace', {
         primarySection: 'timeline',
       });
@@ -3180,6 +3248,7 @@ function DesktopShellPage({
 
   function beginReply(post: PostView) {
     const threadId = post.root_id ?? post.object_id;
+    setRepostTarget(null);
     setReplyTarget(post);
     setSelectedThread(threadId);
     setSelectedAuthorPubkey(null);
@@ -3194,6 +3263,62 @@ function DesktopShellPage({
 
   function clearReply() {
     setReplyTarget(null);
+    setRepostTarget(null);
+  }
+
+  function clearRepost() {
+    setRepostTarget(null);
+  }
+
+  async function handleSimpleRepost(post: PostView) {
+    const sourceTopic = publishedTopicIdForPost(post);
+    if (!sourceTopic || !canCreateRepostFromPost(post)) {
+      setComposerError(translate('common:errors.failedToPublish'));
+      return;
+    }
+
+    try {
+      await api.createRepost(activeTopic, sourceTopic, post.object_id, null);
+      setComposerError(null);
+      setReplyTarget(null);
+      setRepostTarget(null);
+      setSelectedThread(null);
+      setThread([]);
+      setShellChromeState((current) => ({
+        ...current,
+        activePrimarySection: 'timeline',
+      }));
+      await loadTopics(trackedTopics, activeTopic, null);
+      syncRoute('replace', {
+        primarySection: 'timeline',
+        selectedThread: null,
+      });
+    } catch (repostError) {
+      setComposerError(
+        repostError instanceof Error
+          ? repostError.message
+          : translate('common:errors.failedToPublish')
+      );
+    }
+  }
+
+  function beginQuoteRepost(post: PostView) {
+    if (!canCreateRepostFromPost(post)) {
+      return;
+    }
+    releaseAllDraftPreviews();
+    setDraftMediaItems([]);
+    setAttachmentInputKey((value) => value + 1);
+    setComposer('');
+    setComposerError(null);
+    setReplyTarget(null);
+    setRepostTarget(post);
+    setSelectedAuthorPubkey(null);
+    setSelectedAuthor(null);
+    setAuthorError(null);
+    syncRoute('replace', {
+      selectedAuthorPubkey: null,
+    });
   }
 
   const openAuthorDetail = useCallback(async (
@@ -3780,6 +3905,7 @@ function DesktopShellPage({
           setSelectedThread(null);
           setThread([]);
           setReplyTarget(null);
+          setRepostTarget(null);
           setSelectedAuthorPubkey(null);
           setSelectedAuthor(null);
           setAuthorError(null);
@@ -3830,6 +3956,7 @@ function DesktopShellPage({
         setSelectedThread(null);
         setThread([]);
         setReplyTarget(null);
+        setRepostTarget(null);
       }
       if (!requestedAuthorPubkey) {
         shouldNormalize = true;
@@ -3857,6 +3984,7 @@ function DesktopShellPage({
         setSelectedThread(null);
         setThread([]);
         setReplyTarget(null);
+        setRepostTarget(null);
         setSelectedAuthorPubkey(null);
         setSelectedAuthor(null);
         setAuthorError(null);
@@ -3869,6 +3997,7 @@ function DesktopShellPage({
         setSelectedThread(null);
         setThread([]);
         setReplyTarget(null);
+        setRepostTarget(null);
         setSelectedAuthorPubkey(null);
         setSelectedAuthor(null);
         setAuthorError(null);
@@ -3908,6 +4037,7 @@ function DesktopShellPage({
     setSelectedAuthorPubkey,
     setShellChromeState,
     setReplyTarget,
+    setRepostTarget,
     setThread,
     setTimelineScopeByTopic,
     shellChromeState.activePrimarySection,
@@ -3995,6 +4125,15 @@ function DesktopShellPage({
               ? translate('common:media.imageReady')
               : translate('common:media.syncingImage')
             : null;
+      const publishedTopicId = publishedTopicIdForPost(post);
+      const threadTargetId =
+        post.object_kind === 'repost' && !isQuoteRepost(post) && post.repost_of
+          ? post.repost_of.root_id ?? post.repost_of.source_object_id
+          : post.root_id ?? post.object_id;
+      const threadTopicId =
+        post.object_kind === 'repost' && !isQuoteRepost(post) && post.repost_of
+          ? post.repost_of.source_topic_id
+          : publishedTopicId;
 
       return {
         post,
@@ -4015,7 +4154,10 @@ function DesktopShellPage({
           ? activeJoinedChannels.find((channel) => channel.channel_id === post.channel_id)?.label ??
             localizeAudienceLabel(post.audience_label)
           : localizeAudienceLabel(post.audience_label),
-        threadTargetId: post.root_id ?? post.object_id,
+        threadTargetId,
+        threadTopicId,
+        canReply: post.is_threadable ?? (post.object_kind !== 'repost' || isQuoteRepost(post)),
+        canRepost: canCreateRepostFromPost(post),
         media: {
           objectId: post.object_id,
           kind: mediaKind,
@@ -4581,7 +4723,10 @@ function DesktopShellPage({
               })
             }
             onOpenThread={(threadId) => void openThread(threadId)}
+            onOpenThreadInTopic={(threadId, topicId) => void openThread(threadId, { topic: topicId })}
             onReply={beginReply}
+            onRepost={(post) => void handleSimpleRepost(post)}
+            onQuoteRepost={beginQuoteRepost}
           />
         </ContextPane>
       ) : null}
@@ -4612,6 +4757,7 @@ function DesktopShellPage({
                 emptyCopy={t('profile:feed.noAuthorPosts')}
                 onOpenAuthor={(authorPubkey) => void openAuthorDetail(authorPubkey)}
                 onOpenThread={(threadId) => void openThread(threadId)}
+                onOpenThreadInTopic={(threadId, topicId) => void openThread(threadId, { topic: topicId })}
                 onReply={beginReply}
                 readOnly={true}
                 onOpenOriginalTopic={(topicId) => void handleOpenOriginalTopic(topicId)}
@@ -4723,7 +4869,7 @@ function DesktopShellPage({
                         <Select
                           aria-label={t('shell:workspace.composeTarget')}
                           value={channelRefValue(activeComposeChannel)}
-                          disabled={Boolean(replyTarget)}
+                          disabled={Boolean(replyTarget || repostTarget)}
                           onChange={(event) => handleComposeChannelChange(event.target.value)}
                         >
                           {composeTargetOptions.map((option) => (
@@ -4754,7 +4900,21 @@ function DesktopShellPage({
                             }
                           : null
                       }
+                      repostTarget={
+                        repostTarget
+                          ? {
+                              content: repostTarget.content,
+                              authorLabel: authorDisplayLabel(
+                                repostTarget.author_pubkey,
+                                repostTarget.author_display_name,
+                                repostTarget.author_name
+                              ),
+                            }
+                          : null
+                      }
                       onClearReply={clearReply}
+                      onClearRepost={clearRepost}
+                      attachmentsDisabled={Boolean(repostTarget)}
                     />
                   </Card>
                   <Card className='shell-workspace-card'>
@@ -4763,7 +4923,10 @@ function DesktopShellPage({
                       emptyCopy={t('shell:workspace.noPosts')}
                       onOpenAuthor={(authorPubkey) => void openAuthorDetail(authorPubkey)}
                       onOpenThread={(threadId) => void openThread(threadId)}
+                      onOpenThreadInTopic={(threadId, topicId) => void openThread(threadId, { topic: topicId })}
                       onReply={beginReply}
+                      onRepost={(post) => void handleSimpleRepost(post)}
+                      onQuoteRepost={beginQuoteRepost}
                     />
                   </Card>
                 </>
@@ -5317,6 +5480,7 @@ function DesktopShellPage({
                       emptyCopy={t('profile:feed.noOwnPosts')}
                       onOpenAuthor={(authorPubkey) => void openAuthorDetail(authorPubkey)}
                       onOpenThread={(threadId) => void openThread(threadId)}
+                      onOpenThreadInTopic={(threadId, topicId) => void openThread(threadId, { topic: topicId })}
                       onReply={beginReply}
                       readOnly={true}
                       onOpenOriginalTopic={(topicId) => void handleOpenOriginalTopic(topicId)}

--- a/apps/desktop/src/components/core/ComposerPanel.tsx
+++ b/apps/desktop/src/components/core/ComposerPanel.tsx
@@ -16,6 +16,11 @@ type ReplyTargetView = {
   audienceLabel: string;
 };
 
+type RepostTargetView = {
+  content: string;
+  authorLabel: string;
+};
+
 type ComposerPanelProps = {
   value: string;
   onChange: ChangeEventHandler<HTMLTextAreaElement>;
@@ -27,7 +32,10 @@ type ComposerPanelProps = {
   composerError?: string | null;
   audienceLabel: string;
   replyTarget?: ReplyTargetView | null;
+  repostTarget?: RepostTargetView | null;
   onClearReply: () => void;
+  onClearRepost?: () => void;
+  attachmentsDisabled?: boolean;
 };
 
 export function ComposerPanel({
@@ -41,22 +49,27 @@ export function ComposerPanel({
   composerError,
   audienceLabel,
   replyTarget,
+  repostTarget,
   onClearReply,
+  onClearRepost,
+  attachmentsDisabled = false,
 }: ComposerPanelProps) {
   const { t } = useTranslation(['common']);
+  const clearActiveTarget = replyTarget ? onClearReply : onClearRepost;
+  const bannerAriaLabel = replyTarget ? t('composer.clearReply') : t('composer.clearQuoteRepost');
 
   return (
     <form className='composer' onSubmit={onSubmit}>
-      {replyTarget ? (
+      {replyTarget || repostTarget ? (
         <div className='reply-banner'>
-          <strong>{t('composer.replying')}</strong>
+          <strong>{replyTarget ? t('composer.replying') : t('composer.quoteReposting')}</strong>
           <Button
             className='shell-icon-button'
             variant='ghost'
             size='icon'
             type='button'
-            aria-label={t('composer.clearReply')}
-            onClick={onClearReply}
+            aria-label={bannerAriaLabel}
+            onClick={() => clearActiveTarget?.()}
           >
             <X className='size-5' aria-hidden='true' />
           </Button>
@@ -66,7 +79,13 @@ export function ComposerPanel({
       <Textarea
         value={value}
         onChange={onChange}
-        placeholder={replyTarget ? t('composer.writeReply') : t('composer.writePost')}
+        placeholder={
+          replyTarget
+            ? t('composer.writeReply')
+            : repostTarget
+              ? t('composer.writeQuoteRepost')
+              : t('composer.writePost')
+        }
       />
 
       <Label className='file-field file-field-compact'>
@@ -77,6 +96,7 @@ export function ComposerPanel({
           type='file'
           accept='image/*,video/*'
           multiple
+          disabled={attachmentsDisabled}
           onChange={onAttachmentSelection}
         />
       </Label>
@@ -89,7 +109,13 @@ export function ComposerPanel({
         <span>{t('labels.audience')}: {audienceLabel}</span>
       </div>
 
-      <Button type='submit'>{replyTarget ? t('actions.reply') : t('actions.publish')}</Button>
+      <Button type='submit'>
+        {replyTarget
+          ? t('actions.reply')
+          : repostTarget
+            ? t('actions.quoteRepost')
+            : t('actions.publish')}
+      </Button>
     </form>
   );
 }

--- a/apps/desktop/src/components/core/PostCard.test.tsx
+++ b/apps/desktop/src/components/core/PostCard.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { expect, test, vi } from 'vitest';
 
 import { PostCard } from './PostCard';
 import { type PostCardView } from './types';
@@ -78,4 +79,81 @@ test('post card renders the author image when one is available', () => {
     'src',
     'https://example.com/avatar.png'
   );
+});
+
+test('post card renders repost source context for quote reposts', () => {
+  render(
+    <PostCard
+      view={createView({
+        post: {
+          ...createView().post,
+          object_kind: 'repost',
+          content: 'adding context',
+          repost_commentary: 'adding context',
+          repost_of: {
+            source_object_id: 'source-1',
+            source_topic_id: 'kukuri:topic:source',
+            source_author_pubkey: 'b'.repeat(64),
+            source_author_display_name: 'Source Author',
+            source_author_name: null,
+            source_object_kind: 'post',
+            content: 'original body',
+            attachments: [],
+            reply_to: null,
+            root_id: 'source-1',
+          },
+        },
+      })}
+      onOpenAuthor={() => undefined}
+      onOpenThread={() => undefined}
+      onReply={() => undefined}
+    />
+  );
+
+  expect(screen.getByText('Quote repost')).toBeInTheDocument();
+  expect(screen.getByText('Source Author')).toBeInTheDocument();
+  expect(screen.getByText('original body')).toBeInTheDocument();
+});
+
+test('simple repost opens the source thread in its published topic', async () => {
+  const user = userEvent.setup();
+  const onOpenThread = vi.fn();
+  const onOpenThreadInTopic = vi.fn();
+
+  render(
+    <PostCard
+      view={createView({
+        canReply: false,
+        threadTargetId: 'source-root',
+        threadTopicId: 'kukuri:topic:source',
+        post: {
+          ...createView().post,
+          object_kind: 'repost',
+          content: '',
+          repost_commentary: null,
+          repost_of: {
+            source_object_id: 'source-1',
+            source_topic_id: 'kukuri:topic:source',
+            source_author_pubkey: 'b'.repeat(64),
+            source_author_display_name: 'Source Author',
+            source_author_name: null,
+            source_object_kind: 'post',
+            content: 'original body',
+            attachments: [],
+            reply_to: null,
+            root_id: 'source-root',
+          },
+        },
+      })}
+      onOpenAuthor={() => undefined}
+      onOpenThread={onOpenThread}
+      onOpenThreadInTopic={onOpenThreadInTopic}
+      onReply={() => undefined}
+    />
+  );
+
+  await user.click(screen.getByRole('button', { name: /Source Author/i }));
+
+  expect(onOpenThread).not.toHaveBeenCalled();
+  expect(onOpenThreadInTopic).toHaveBeenCalledWith('source-root', 'kukuri:topic:source');
 });

--- a/apps/desktop/src/components/core/PostCard.tsx
+++ b/apps/desktop/src/components/core/PostCard.tsx
@@ -9,11 +9,25 @@ import { RelationshipBadge } from './RelationshipBadge';
 import { PostMedia } from './PostMedia';
 import { type PostCardView } from './types';
 
+function sourceAuthorLabel(view: PostCardView['post']['repost_of']): string | null {
+  if (!view) {
+    return null;
+  }
+  return (
+    view.source_author_display_name?.trim() ||
+    view.source_author_name?.trim() ||
+    `${view.source_author_pubkey.slice(0, 8)}…`
+  );
+}
+
 type PostCardProps = {
   view: PostCardView;
   onOpenAuthor: (authorPubkey: string) => void;
   onOpenThread: (threadId: string) => void;
+  onOpenThreadInTopic?: (threadId: string, topicId: string) => void;
   onReply: (post: PostCardView['post']) => void;
+  onRepost?: (post: PostCardView['post']) => void;
+  onQuoteRepost?: (post: PostCardView['post']) => void;
   readOnly?: boolean;
   onOpenOriginalTopic?: (topicId: string) => void;
 };
@@ -22,7 +36,10 @@ export function PostCard({
   view,
   onOpenAuthor,
   onOpenThread,
+  onOpenThreadInTopic,
   onReply,
+  onRepost,
+  onQuoteRepost,
   readOnly = false,
   onOpenOriginalTopic,
 }: PostCardProps) {
@@ -30,7 +47,21 @@ export function PostCard({
   const { post, context } = view;
   const isPendingText = post.content_status === 'Missing' && post.content === '[blob pending]';
   const audienceChipLabel = view.audienceChipLabel ?? post.audience_label;
-  const originTopicId = post.origin_topic_id?.trim() || null;
+  const publishedTopicId = post.published_topic_id?.trim() || post.origin_topic_id?.trim() || null;
+  const repostSource = post.repost_of ?? null;
+  const isQuoteRepost = post.object_kind === 'repost' && Boolean(post.repost_commentary?.trim());
+  const canReply = view.canReply ?? true;
+  const canRepost = view.canRepost ?? false;
+  const hasPrimaryContent = isPendingText || post.content.trim().length > 0;
+
+  const openPrimaryTarget = () => {
+    const topicId = view.threadTopicId?.trim();
+    if (topicId && onOpenThreadInTopic) {
+      onOpenThreadInTopic(view.threadTargetId, topicId);
+      return;
+    }
+    onOpenThread(view.threadTargetId);
+  };
 
   return (
     <article className={context === 'thread' ? 'post-card post-card-thread' : 'post-card'}>
@@ -71,24 +102,42 @@ export function PostCard({
                 <span className='text-skeleton text-skeleton-line' />
                 <span className='text-skeleton text-skeleton-line text-skeleton-line-short' />
               </div>
-            ) : (
+            ) : hasPrimaryContent ? (
               <strong className='post-title'>{post.content}</strong>
-            )}
+            ) : null}
+
+            {repostSource ? (
+              <div className='repost-source-card'>
+                <div className='topic-diagnostic topic-diagnostic-secondary'>
+                  <span>{isQuoteRepost ? t('feed.quoteRepost') : t('feed.reposted')}</span>
+                  <span>{t('labels.sourceTopic')}</span>
+                  <span className='shell-topic-link-label' title={repostSource.source_topic_id}>
+                    {repostSource.source_topic_id}
+                  </span>
+                </div>
+                <div className='post-body repost-source-body'>
+                  <strong className='post-title'>{sourceAuthorLabel(repostSource)}</strong>
+                  {repostSource.content.trim().length > 0 ? (
+                    <span>{repostSource.content}</span>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
           </div>
 
           <small>{post.envelope_id}</small>
           {post.reply_to ? <em className='post-reply-flag'>{t('actions.reply')}</em> : null}
-          {originTopicId ? (
+          {publishedTopicId ? (
             <div className='topic-diagnostic topic-diagnostic-secondary'>
               <span>{t('feed.originTopic', { ns: 'profile' })}</span>
-              <span className='shell-topic-link-label' title={originTopicId}>
-                {originTopicId}
+              <span className='shell-topic-link-label' title={publishedTopicId}>
+                {publishedTopicId}
               </span>
             </div>
           ) : null}
         </div>
       ) : (
-        <button className='post-link' type='button' onClick={() => onOpenThread(view.threadTargetId)}>
+        <button className='post-link' type='button' onClick={openPrimaryTarget}>
           <PostMedia media={view.media} />
 
           <div className='post-body'>
@@ -101,9 +150,27 @@ export function PostCard({
                 <span className='text-skeleton text-skeleton-line' />
                 <span className='text-skeleton text-skeleton-line text-skeleton-line-short' />
               </div>
-            ) : (
+            ) : hasPrimaryContent ? (
               <strong className='post-title'>{post.content}</strong>
-            )}
+            ) : null}
+
+            {repostSource ? (
+              <div className='repost-source-card'>
+                <div className='topic-diagnostic topic-diagnostic-secondary'>
+                  <span>{isQuoteRepost ? t('feed.quoteRepost') : t('feed.reposted')}</span>
+                  <span>{t('labels.sourceTopic')}</span>
+                  <span className='shell-topic-link-label' title={repostSource.source_topic_id}>
+                    {repostSource.source_topic_id}
+                  </span>
+                </div>
+                <div className='post-body repost-source-body'>
+                  <strong className='post-title'>{sourceAuthorLabel(repostSource)}</strong>
+                  {repostSource.content.trim().length > 0 ? (
+                    <span>{repostSource.content}</span>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
           </div>
 
           <small>{post.envelope_id}</small>
@@ -113,19 +180,33 @@ export function PostCard({
 
       <div className='post-actions'>
         {readOnly ? (
-          originTopicId ? (
+          publishedTopicId ? (
             <Button
               variant='secondary'
               type='button'
-              onClick={() => onOpenOriginalTopic?.(originTopicId)}
+              onClick={() => onOpenOriginalTopic?.(publishedTopicId)}
             >
               {t('feed.openOriginalTopic', { ns: 'profile' })}
             </Button>
           ) : null
         ) : (
-          <Button variant='secondary' type='button' onClick={() => onReply(post)}>
-            {t('actions.reply')}
-          </Button>
+          <>
+            {canRepost && onRepost ? (
+              <Button variant='secondary' type='button' onClick={() => onRepost(post)}>
+                {t('actions.repost')}
+              </Button>
+            ) : null}
+            {canRepost && onQuoteRepost ? (
+              <Button variant='secondary' type='button' onClick={() => onQuoteRepost(post)}>
+                {t('actions.quoteRepost')}
+              </Button>
+            ) : null}
+            {canReply ? (
+              <Button variant='secondary' type='button' onClick={() => onReply(post)}>
+                {t('actions.reply')}
+              </Button>
+            ) : null}
+          </>
         )}
       </div>
     </article>

--- a/apps/desktop/src/components/core/ThreadPanel.tsx
+++ b/apps/desktop/src/components/core/ThreadPanel.tsx
@@ -6,7 +6,10 @@ type ThreadPanelProps = {
   posts: PostCardView[];
   onOpenAuthor: (authorPubkey: string) => void;
   onOpenThread: (threadId: string) => void;
+  onOpenThreadInTopic?: (threadId: string, topicId: string) => void;
   onReply: (post: PostCardView['post']) => void;
+  onRepost?: (post: PostCardView['post']) => void;
+  onQuoteRepost?: (post: PostCardView['post']) => void;
 };
 
 export function ThreadPanel({
@@ -14,7 +17,10 @@ export function ThreadPanel({
   posts,
   onOpenAuthor,
   onOpenThread,
+  onOpenThreadInTopic,
   onReply,
+  onRepost,
+  onQuoteRepost,
 }: ThreadPanelProps) {
   return (
     <div className='shell-main-stack'>
@@ -25,7 +31,10 @@ export function ThreadPanel({
         itemClassName='thread-item'
         onOpenAuthor={onOpenAuthor}
         onOpenThread={onOpenThread}
+        onOpenThreadInTopic={onOpenThreadInTopic}
         onReply={onReply}
+        onRepost={onRepost}
+        onQuoteRepost={onQuoteRepost}
       />
     </div>
   );

--- a/apps/desktop/src/components/core/TimelineFeed.tsx
+++ b/apps/desktop/src/components/core/TimelineFeed.tsx
@@ -8,7 +8,10 @@ type TimelineFeedProps = {
   itemClassName?: string;
   onOpenAuthor: (authorPubkey: string) => void;
   onOpenThread: (threadId: string) => void;
+  onOpenThreadInTopic?: (threadId: string, topicId: string) => void;
   onReply: (post: PostCardView['post']) => void;
+  onRepost?: (post: PostCardView['post']) => void;
+  onQuoteRepost?: (post: PostCardView['post']) => void;
   readOnly?: boolean;
   onOpenOriginalTopic?: (topicId: string) => void;
 };
@@ -20,7 +23,10 @@ export function TimelineFeed({
   itemClassName,
   onOpenAuthor,
   onOpenThread,
+  onOpenThreadInTopic,
   onReply,
+  onRepost,
+  onQuoteRepost,
   readOnly = false,
   onOpenOriginalTopic,
 }: TimelineFeedProps) {
@@ -36,7 +42,10 @@ export function TimelineFeed({
             view={view}
             onOpenAuthor={onOpenAuthor}
             onOpenThread={onOpenThread}
+            onOpenThreadInTopic={onOpenThreadInTopic}
             onReply={onReply}
+            onRepost={onRepost}
+            onQuoteRepost={onQuoteRepost}
             readOnly={readOnly}
             onOpenOriginalTopic={onOpenOriginalTopic}
           />

--- a/apps/desktop/src/components/core/types.ts
+++ b/apps/desktop/src/components/core/types.ts
@@ -48,6 +48,9 @@ export type PostCardView = {
   relationshipLabel: string | null;
   audienceChipLabel?: string | null;
   threadTargetId: string;
+  threadTopicId?: string | null;
+  canReply?: boolean;
+  canRepost?: boolean;
   media: PostMediaView;
 };
 

--- a/apps/desktop/src/i18n/locales/en/common.json
+++ b/apps/desktop/src/i18n/locales/en/common.json
@@ -12,7 +12,9 @@
     "join": "Join",
     "leave": "Leave",
     "publish": "Publish",
+    "quoteRepost": "Quote Repost",
     "refresh": "Refresh",
+    "repost": "Repost",
     "reply": "Reply",
     "reset": "Reset",
     "rotate": "Rotate",
@@ -20,9 +22,12 @@
     "unfollow": "Unfollow"
   },
   "composer": {
+    "clearQuoteRepost": "Clear quote repost",
+    "quoteReposting": "Quote reposting",
     "clearReply": "Clear reply",
     "replying": "Replying",
     "writePost": "Write a post",
+    "writeQuoteRepost": "Write a quote repost",
     "writeReply": "Write a reply"
   },
   "audience": {
@@ -53,7 +58,12 @@
     "failedToUpdateCommunityNodes": "failed to update community nodes",
     "failedToUpdateDiscoverySeeds": "failed to update discovery seeds",
     "failedToUpdateFollowState": "failed to update follow state",
+    "quoteRepostRequiresCommentary": "quote repost requires commentary",
     "unsupportedAttachmentType": "unsupported attachment type: {{name}}"
+  },
+  "feed": {
+    "quoteRepost": "Quote repost",
+    "reposted": "Reposted"
   },
   "fallbacks": {
     "attachment": "attachment",
@@ -77,6 +87,7 @@
     "phase": "phase",
     "policy": "Policy",
     "sharing": "sharing",
+    "sourceTopic": "Source topic",
     "stale": "stale",
     "started": "started",
     "updated": "updated",

--- a/apps/desktop/src/i18n/locales/ja/common.json
+++ b/apps/desktop/src/i18n/locales/ja/common.json
@@ -12,7 +12,9 @@
     "join": "参加",
     "leave": "退出",
     "publish": "投稿",
+    "quoteRepost": "引用リポスト",
     "refresh": "更新",
+    "repost": "リポスト",
     "reply": "返信",
     "reset": "リセット",
     "rotate": "ローテーション",
@@ -20,9 +22,12 @@
     "unfollow": "フォロー解除"
   },
   "composer": {
+    "clearQuoteRepost": "引用リポストをクリア",
+    "quoteReposting": "引用リポスト中",
     "clearReply": "返信をクリア",
     "replying": "返信中",
     "writePost": "投稿を書く",
+    "writeQuoteRepost": "引用リポストを書く",
     "writeReply": "返信を書く"
   },
   "audience": {
@@ -53,7 +58,12 @@
     "failedToUpdateCommunityNodes": "コミュニティノードの更新に失敗しました",
     "failedToUpdateDiscoverySeeds": "ディスカバリーシードの更新に失敗しました",
     "failedToUpdateFollowState": "フォロー状態の更新に失敗しました",
+    "quoteRepostRequiresCommentary": "引用リポストにはコメントが必要です",
     "unsupportedAttachmentType": "未対応の添付タイプです: {{name}}"
+  },
+  "feed": {
+    "quoteRepost": "引用リポスト",
+    "reposted": "リポスト"
   },
   "fallbacks": {
     "attachment": "添付",
@@ -77,6 +87,7 @@
     "phase": "フェーズ",
     "policy": "ポリシー",
     "sharing": "共有",
+    "sourceTopic": "元トピック",
     "stale": "期限切れ",
     "started": "開始",
     "updated": "更新",

--- a/apps/desktop/src/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/common.json
@@ -12,7 +12,9 @@
     "join": "加入",
     "leave": "离开",
     "publish": "发布",
+    "quoteRepost": "引用转发",
     "refresh": "刷新",
+    "repost": "转发",
     "reply": "回复",
     "reset": "重置",
     "rotate": "轮换",
@@ -20,9 +22,12 @@
     "unfollow": "取消关注"
   },
   "composer": {
+    "clearQuoteRepost": "清除引用转发",
+    "quoteReposting": "引用转发中",
     "clearReply": "清除回复",
     "replying": "回复中",
     "writePost": "写一条帖子",
+    "writeQuoteRepost": "写一条引用转发",
     "writeReply": "写一条回复"
   },
   "audience": {
@@ -53,7 +58,12 @@
     "failedToUpdateCommunityNodes": "更新社区节点失败",
     "failedToUpdateDiscoverySeeds": "更新发现种子失败",
     "failedToUpdateFollowState": "更新关注状态失败",
+    "quoteRepostRequiresCommentary": "引用转发需要评论内容",
     "unsupportedAttachmentType": "不支持的附件类型: {{name}}"
+  },
+  "feed": {
+    "quoteRepost": "引用转发",
+    "reposted": "已转发"
   },
   "fallbacks": {
     "attachment": "附件",
@@ -77,6 +87,7 @@
     "phase": "阶段",
     "policy": "策略",
     "sharing": "共享",
+    "sourceTopic": "来源主题",
     "stale": "过期",
     "started": "开始",
     "updated": "更新",

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -34,9 +34,26 @@ export type PostView = {
   created_at: number;
   reply_to?: string | null;
   root_id?: string | null;
+  published_topic_id?: string | null;
   origin_topic_id?: string | null;
+  repost_of?: RepostSourceView | null;
+  repost_commentary?: string | null;
+  is_threadable?: boolean;
   channel_id?: string | null;
   audience_label: string;
+};
+
+export type RepostSourceView = {
+  source_object_id: string;
+  source_topic_id: string;
+  source_author_pubkey: string;
+  source_author_name?: string | null;
+  source_author_display_name?: string | null;
+  source_object_kind: string;
+  content: string;
+  attachments: AttachmentView[];
+  reply_to?: string | null;
+  root_id?: string | null;
 };
 
 export type Profile = {
@@ -85,6 +102,13 @@ export type CreateAttachmentInput = {
   byte_size: number;
   data_base64: string;
   role?: string | null;
+};
+
+export type CreateRepostInput = {
+  topic: string;
+  source_topic: string;
+  source_object_id: string;
+  commentary?: string | null;
 };
 
 export type BlobMediaPayload = {
@@ -288,6 +312,12 @@ export interface DesktopApi {
     attachments?: CreateAttachmentInput[],
     channelRef?: ChannelRef
   ): Promise<string>;
+  createRepost(
+    topic: string,
+    sourceTopic: string,
+    sourceObjectId: string,
+    commentary?: string | null
+  ): Promise<string>;
   listTimeline(
     topic: string,
     cursor?: TimelineCursor | null,
@@ -435,6 +465,24 @@ export const runtimeApi: DesktopApi = {
         reply_to: replyTo,
         channel_ref: channelRef,
         attachments,
+      },
+    });
+  },
+  createRepost: async (topic, sourceTopic, sourceObjectId, commentary) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.createRepost(
+        topic,
+        sourceTopic,
+        sourceObjectId,
+        commentary
+      );
+    }
+    return invokeDesktop<string>('create_repost', {
+      request: {
+        topic,
+        source_topic: sourceTopic,
+        source_object_id: sourceObjectId,
+        commentary,
       },
     });
   },

--- a/apps/desktop/src/mocks/desktopApiMock.ts
+++ b/apps/desktop/src/mocks/desktopApiMock.ts
@@ -44,7 +44,12 @@ function withSocialPostDefaults(post: PostView): PostView {
     followed_by: post.followed_by ?? false,
     mutual: post.mutual ?? false,
     friend_of_friend: post.friend_of_friend ?? false,
+    published_topic_id: post.published_topic_id ?? post.origin_topic_id ?? null,
     origin_topic_id: post.origin_topic_id ?? null,
+    repost_of: post.repost_of ?? null,
+    repost_commentary: post.repost_commentary ?? null,
+    is_threadable:
+      post.is_threadable ?? (post.object_kind !== 'repost' || Boolean(post.repost_commentary)),
     channel_id: post.channel_id ?? null,
     audience_label: post.audience_label ?? (post.channel_id ? 'Private channel' : 'Public'),
     attachments: [...post.attachments],
@@ -331,6 +336,69 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
           last_error: null,
         });
       }
+      return objectId;
+    },
+    async createRepost(topic, sourceTopic, sourceObjectId, commentary) {
+      sequence += 1;
+      const objectId = `${topic}-repost-${sequence}`;
+      const sourcePost = (postsByTopic[sourceTopic] ?? []).find((post) => post.object_id === sourceObjectId);
+      if (!sourcePost || sourcePost.channel_id) {
+        throw new Error('only public posts and comments can be reposted');
+      }
+      const normalizedCommentary = commentary?.trim() ? commentary.trim() : null;
+      if (!normalizedCommentary) {
+        const existing = (postsByTopic[topic] ?? []).find(
+          (post) =>
+            post.object_kind === 'repost' &&
+            post.author_pubkey === syncStatus.local_author_pubkey &&
+            post.repost_of?.source_object_id === sourceObjectId &&
+            !post.repost_commentary
+        );
+        if (existing) {
+          return existing.object_id;
+        }
+      }
+      const repost = withSocialPostDefaults({
+        object_id: objectId,
+        envelope_id: `envelope-${sequence}`,
+        author_pubkey: syncStatus.local_author_pubkey,
+        following: false,
+        followed_by: false,
+        mutual: false,
+        friend_of_friend: false,
+        object_kind: 'repost',
+        content: normalizedCommentary ?? '',
+        content_status: 'Available',
+        attachments: [],
+        created_at: sequence,
+        reply_to: null,
+        root_id: null,
+        published_topic_id: topic,
+        origin_topic_id: topic,
+        repost_of: {
+          source_object_id: sourceObjectId,
+          source_topic_id: sourceTopic,
+          source_author_pubkey: sourcePost.author_pubkey,
+          source_author_name: sourcePost.author_name ?? null,
+          source_author_display_name: sourcePost.author_display_name ?? null,
+          source_object_kind: sourcePost.object_kind,
+          content: sourcePost.content,
+          attachments: sourcePost.attachments.map((attachment) => ({ ...attachment })),
+          reply_to: sourcePost.reply_to ?? null,
+          root_id: sourcePost.root_id ?? null,
+        },
+        repost_commentary: normalizedCommentary,
+        is_threadable: Boolean(normalizedCommentary),
+        channel_id: null,
+        audience_label: 'Public',
+      });
+      postsByTopic[topic] = [repost, ...(postsByTopic[topic] ?? [])];
+      authorProfileTimelines[syncStatus.local_author_pubkey] = [
+        repost,
+        ...(authorProfileTimelines[syncStatus.local_author_pubkey] ?? []).filter(
+          (post) => post.object_id !== objectId
+        ),
+      ];
       return objectId;
     },
     async listTimeline(topic, _cursor, _limit, scope: TimelineScope = { kind: 'public' }) {

--- a/apps/desktop/src/styles/shell-phase1-legacy.css
+++ b/apps/desktop/src/styles/shell-phase1-legacy.css
@@ -424,6 +424,19 @@
   display: block;
 }
 
+.shell-phase1 .repost-source-card {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  background: var(--surface-panel-muted);
+}
+
+.shell-phase1 .repost-source-body {
+  display: grid;
+  gap: 0.35rem;
+}
+
 .shell-phase1 .media-frame {
   position: relative;
   overflow: hidden;
@@ -547,6 +560,8 @@
 .shell-phase1 .post-actions {
   display: flex;
   justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   margin-top: 0.75rem;
 }
 

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -8,28 +8,30 @@ use chrono::Utc;
 use futures_util::StreamExt;
 use kukuri_blob_service::{BlobService, BlobStatus, MemoryBlobService, StoredBlob};
 use kukuri_core::{
-    AssetRole, AuthorProfileDocV1, AuthorProfilePostDocV1, CanonicalPostHeader,
-    ChannelAudienceKind, ChannelId, ChannelRef, ChannelSharingState, CreatePrivateChannelInput,
-    EnvelopeId, FollowEdge, FollowEdgeDocV1, FollowEdgeStatus, FriendOnlyGrantPreview,
-    FriendPlusSharePreview, GAME_MANIFEST_MIME, GameParticipant, GameRoomManifestBlobV1,
-    GameRoomStateDocV1, GameRoomStatus, GameScoreEntry, GossipHint, HintObjectRef, KukuriEnvelope,
-    KukuriKeys, KukuriMediaManifestV1, KukuriProfileEnvelopeContentV1,
-    KukuriProfilePostEnvelopeContentV1, LIVE_MANIFEST_MIME, LiveSessionManifestBlobV1,
+    AssetRole, AuthorProfileDocV1, AuthorProfilePostDocV1, AuthorProfileRepostDocV1,
+    CanonicalPostHeader, ChannelAudienceKind, ChannelId, ChannelRef, ChannelSharingState,
+    CreatePrivateChannelInput, EnvelopeId, FollowEdge, FollowEdgeDocV1, FollowEdgeStatus,
+    FriendOnlyGrantPreview, FriendPlusSharePreview, GAME_MANIFEST_MIME, GameParticipant,
+    GameRoomManifestBlobV1, GameRoomStateDocV1, GameRoomStatus, GameScoreEntry, GossipHint,
+    HintObjectRef, KukuriEnvelope, KukuriKeys, KukuriMediaManifestV1,
+    KukuriProfileEnvelopeContentV1, KukuriProfilePostEnvelopeContentV1,
+    KukuriProfileRepostEnvelopeContentV1, LIVE_MANIFEST_MIME, LiveSessionManifestBlobV1,
     LiveSessionStateDocV1, LiveSessionStatus, ManifestBlobRef, MediaManifestItem, ObjectVisibility,
     PayloadRef, PrivateChannelInvitePreview, PrivateChannelJoinMode, PrivateChannelMetadataDocV1,
     PrivateChannelParticipantDocV1, PrivateChannelPolicyDocV1, PrivateChannelRotationGrantDocV1,
-    PrivateChannelRotationGrantPayloadV1, Profile, ProfilePost, Pubkey, ReplicaId, TimelineScope,
-    TopicId, author_profile_topic_id, build_follow_edge_envelope, build_friend_only_grant_token,
-    build_friend_plus_share_token, build_game_session_envelope, build_live_session_envelope,
-    build_media_manifest_envelope, build_post_envelope_with_payload_in_channel,
-    build_private_channel_invite_token, build_private_channel_participant_envelope,
-    build_private_channel_policy_envelope, build_private_channel_rotation_grant_envelope,
-    build_profile_envelope, build_profile_post_envelope, decrypt_private_channel_rotation_grant,
-    encrypt_private_channel_rotation_grant, generate_keys, parse_follow_edge,
-    parse_friend_only_grant_token, parse_friend_plus_share_token,
+    PrivateChannelRotationGrantPayloadV1, Profile, ProfilePost, ProfileRepost, Pubkey, ReplicaId,
+    RepostSourceSnapshotV1, TimelineScope, TopicId, author_profile_topic_id,
+    build_follow_edge_envelope, build_friend_only_grant_token, build_friend_plus_share_token,
+    build_game_session_envelope, build_live_session_envelope, build_media_manifest_envelope,
+    build_post_envelope_with_payload_in_channel, build_private_channel_invite_token,
+    build_private_channel_participant_envelope, build_private_channel_policy_envelope,
+    build_private_channel_rotation_grant_envelope, build_profile_envelope,
+    build_profile_post_envelope, build_profile_repost_envelope, build_repost_envelope,
+    decrypt_private_channel_rotation_grant, encrypt_private_channel_rotation_grant, generate_keys,
+    parse_follow_edge, parse_friend_only_grant_token, parse_friend_plus_share_token,
     parse_private_channel_invite_token, parse_private_channel_participant,
     parse_private_channel_policy, parse_private_channel_rotation_grant, parse_profile,
-    parse_profile_post, timeline_sort_key,
+    parse_profile_post, parse_profile_repost, timeline_sort_key,
 };
 use kukuri_docs_sync::{
     DocOp, DocQuery, DocsSync, MemoryDocsSync, author_replica_id, private_channel_epoch_replica_id,
@@ -69,9 +71,27 @@ pub struct PostView {
     pub reply_to: Option<String>,
     pub root_id: Option<String>,
     pub object_kind: String,
+    pub published_topic_id: Option<String>,
     pub origin_topic_id: Option<String>,
+    pub repost_of: Option<RepostSourceView>,
+    pub repost_commentary: Option<String>,
+    pub is_threadable: bool,
     pub channel_id: Option<String>,
     pub audience_label: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepostSourceView {
+    pub source_object_id: String,
+    pub source_topic_id: String,
+    pub source_author_pubkey: String,
+    pub source_author_name: Option<String>,
+    pub source_author_display_name: Option<String>,
+    pub source_object_kind: String,
+    pub content: String,
+    pub attachments: Vec<AttachmentView>,
+    pub reply_to: Option<String>,
+    pub root_id: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -186,6 +206,33 @@ pub struct UpdateGameRoomInput {
 pub struct TimelineView {
     pub items: Vec<PostView>,
     pub next_cursor: Option<TimelineCursor>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ProfileTimelineItem {
+    Post(ProfilePost),
+    Repost(ProfileRepost),
+}
+
+impl ProfileTimelineItem {
+    fn created_at(&self) -> i64 {
+        match self {
+            Self::Post(post) => post.created_at,
+            Self::Repost(repost) => repost.created_at,
+        }
+    }
+
+    fn object_id(&self) -> &EnvelopeId {
+        match self {
+            Self::Post(post) => &post.object_id,
+            Self::Repost(repost) => &repost.object_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ResolvedRepostSource {
+    repost_of: RepostSourceSnapshotV1,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -481,21 +528,116 @@ impl AppService {
         let mut posts =
             load_profile_posts_from_author_replica(self.docs_sync.as_ref(), author_pubkey.as_str())
                 .await?;
-        posts.sort_by(|left, right| {
+        let mut reposts = load_profile_reposts_from_author_replica(
+            self.docs_sync.as_ref(),
+            author_pubkey.as_str(),
+        )
+        .await?;
+        let mut items = Vec::with_capacity(posts.len() + reposts.len());
+        items.extend(posts.drain(..).map(ProfileTimelineItem::Post));
+        items.extend(reposts.drain(..).map(ProfileTimelineItem::Repost));
+        items.sort_by(|left, right| {
             right
-                .created_at
-                .cmp(&left.created_at)
-                .then_with(|| right.object_id.cmp(&left.object_id))
+                .created_at()
+                .cmp(&left.created_at())
+                .then_with(|| right.object_id().cmp(left.object_id()))
         });
-        let page = profile_post_page(posts, cursor, limit);
-        let mut items = Vec::with_capacity(page.items.len());
-        for post in page.items {
-            items.push(self.profile_post_to_view(post).await?);
+        let page = profile_timeline_page(items, cursor, limit);
+        let mut views = Vec::with_capacity(page.items.len());
+        for item in page.items {
+            match item {
+                ProfileTimelineItem::Post(post) => {
+                    views.push(self.profile_post_to_view(post).await?)
+                }
+                ProfileTimelineItem::Repost(repost) => {
+                    views.push(self.profile_repost_to_view(repost).await?)
+                }
+            }
         }
         Ok(TimelineView {
-            items,
+            items: views,
             next_cursor: page.next_cursor,
         })
+    }
+
+    pub async fn create_repost(
+        &self,
+        target_topic_id: &str,
+        source_topic_id: &str,
+        source_object_id: &str,
+        commentary: Option<&str>,
+    ) -> Result<String> {
+        self.ensure_topic_subscription(target_topic_id).await?;
+        self.ensure_topic_subscription(source_topic_id).await?;
+
+        let normalized_commentary = normalize_repost_commentary(commentary.map(str::to_string));
+        if let Some(existing_object_id) = self
+            .find_existing_simple_repost(
+                target_topic_id,
+                source_object_id,
+                normalized_commentary.as_deref(),
+            )
+            .await?
+        {
+            return Ok(existing_object_id);
+        }
+
+        let source_object = self
+            .resolve_repost_source(source_topic_id, source_object_id)
+            .await?;
+        let topic = TopicId::new(target_topic_id);
+        let envelope = build_repost_envelope(
+            self.keys.as_ref(),
+            &topic,
+            source_object.repost_of.clone(),
+            normalized_commentary.as_deref(),
+        )?;
+        let repost_object = envelope
+            .to_post_object()?
+            .ok_or_else(|| anyhow::anyhow!("failed to parse repost object"))?;
+        self.ingest_event(
+            &topic_replica_id(target_topic_id),
+            envelope.clone(),
+            None,
+            Vec::new(),
+        )
+        .await?;
+
+        let local_author_pubkey = self.current_author_pubkey();
+        let profile_repost_envelope = build_profile_repost_envelope(
+            self.keys.as_ref(),
+            &KukuriProfileRepostEnvelopeContentV1 {
+                author_pubkey: Pubkey::from(local_author_pubkey.as_str()),
+                profile_topic_id: author_profile_topic_id(local_author_pubkey.as_str()),
+                published_topic_id: topic.clone(),
+                object_id: repost_object.object_id.clone(),
+                created_at: repost_object.created_at,
+                commentary: normalized_commentary.clone(),
+                repost_of: source_object.repost_of,
+            },
+        )?;
+        let profile_repost = parse_profile_repost(&profile_repost_envelope)?
+            .ok_or_else(|| anyhow::anyhow!("failed to parse profile repost envelope"))?;
+        persist_profile_repost_doc(
+            self.docs_sync.as_ref(),
+            &profile_repost,
+            &profile_repost_envelope,
+        )
+        .await?;
+
+        self.hint_transport
+            .publish_hint(
+                &channel_hint_topic_for(target_topic_id, None),
+                GossipHint::TopicObjectsChanged {
+                    topic_id: topic,
+                    objects: vec![HintObjectRef {
+                        object_id: envelope.id.0.clone(),
+                        object_kind: envelope.kind.clone(),
+                    }],
+                },
+            )
+            .await?;
+        Ok(envelope.id.0)
     }
 
     pub async fn create_post(
@@ -562,6 +704,12 @@ impl AppService {
             let content = parent
                 .post_content()?
                 .ok_or_else(|| anyhow::anyhow!("reply target is not a post object"))?;
+            if content.object_kind == "repost"
+                && normalize_repost_commentary(content_from_payload_ref(&content.payload_ref))
+                    .is_none()
+            {
+                anyhow::bail!("simple repost cannot be a reply parent");
+            }
             if content.topic_id.as_str() != topic_id {
                 anyhow::bail!("reply target topic does not match");
             }
@@ -684,7 +832,7 @@ impl AppService {
                 &KukuriProfilePostEnvelopeContentV1 {
                     author_pubkey: Pubkey::from(local_author_pubkey.as_str()),
                     profile_topic_id: author_profile_topic_id(local_author_pubkey.as_str()),
-                    origin_topic_id: topic.clone(),
+                    published_topic_id: topic.clone(),
                     object_id: post_object.object_id.clone(),
                     created_at: post_object.created_at,
                     object_kind: post_object.object_kind.clone(),
@@ -716,6 +864,112 @@ impl AppService {
             )
             .await?;
         Ok(envelope.id.0)
+    }
+
+    async fn resolve_repost_source(
+        &self,
+        source_topic_id: &str,
+        source_object_id: &str,
+    ) -> Result<ResolvedRepostSource> {
+        let source_object_id = EnvelopeId::from(source_object_id);
+        if ProjectionStore::get_object_projection(self.projection_store.as_ref(), &source_object_id)
+            .await?
+            .is_none()
+        {
+            let _ = hydrate_topic_state_with_services(
+                self.docs_sync.as_ref(),
+                self.blob_service.as_ref(),
+                self.projection_store.as_ref(),
+                source_topic_id,
+            )
+            .await?;
+        }
+        let projection = ProjectionStore::get_object_projection(
+            self.projection_store.as_ref(),
+            &source_object_id,
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("repost source object not found"))?;
+        if projection.topic_id != source_topic_id {
+            anyhow::bail!("repost source topic does not match");
+        }
+        if projection.channel_id != PUBLIC_CHANNEL_ID {
+            anyhow::bail!("only public posts and comments can be reposted");
+        }
+        if !matches!(projection.object_kind.as_str(), "post" | "comment") {
+            anyhow::bail!("only public posts and comments can be reposted");
+        }
+
+        let header = fetch_post_object_for_projection(
+            self.docs_sync.as_ref(),
+            &projection.source_replica_id,
+            projection.source_key.as_str(),
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("repost source header not found"))?;
+        let content = match &projection.payload_ref {
+            PayloadRef::InlineText { text } => text.clone(),
+            PayloadRef::BlobText { hash, .. } => {
+                fetch_projection_blob_text(self.blob_service.as_ref(), hash)
+                    .await
+                    .ok_or_else(|| anyhow::anyhow!("repost source content is unavailable"))?
+            }
+        };
+        Ok(ResolvedRepostSource {
+            repost_of: RepostSourceSnapshotV1 {
+                source_object_id: header.object_id,
+                source_topic_id: header.topic_id,
+                source_author_pubkey: header.author,
+                source_object_kind: header.object_kind,
+                content,
+                attachments: header.attachments,
+                reply_to_object_id: header.reply_to,
+                root_id: header.root,
+            },
+        })
+    }
+
+    async fn find_existing_simple_repost(
+        &self,
+        target_topic_id: &str,
+        source_object_id: &str,
+        commentary: Option<&str>,
+    ) -> Result<Option<String>> {
+        if commentary.is_some() {
+            return Ok(None);
+        }
+        let target_replica = topic_replica_id(target_topic_id);
+        let local_author_pubkey = self.current_author_pubkey();
+        for record in self
+            .docs_sync
+            .query_replica(&target_replica, DocQuery::Prefix("objects/".into()))
+            .await?
+        {
+            if !record.key.ends_with("/state") {
+                continue;
+            }
+            let header: CanonicalPostHeader = serde_json::from_slice(&record.value)?;
+            if header.object_kind != "repost"
+                || header.author.as_str() != local_author_pubkey
+                || header.channel_id.is_some()
+            {
+                continue;
+            }
+            let Some(repost_of) = header.repost_of.as_ref() else {
+                continue;
+            };
+            if repost_of.source_object_id.as_str() != source_object_id {
+                continue;
+            }
+            let commentary = match &header.payload_ref {
+                PayloadRef::InlineText { text } => normalize_repost_commentary(Some(text.clone())),
+                PayloadRef::BlobText { .. } => None,
+            };
+            if commentary.is_none() {
+                return Ok(Some(header.object_id.as_str().to_string()));
+            }
+        }
+        Ok(None)
     }
 
     pub async fn list_timeline(
@@ -3225,8 +3479,16 @@ impl AppService {
         &self,
         rows: &[ObjectProjectionRow],
     ) -> Result<()> {
-        for author_pubkey in rows.iter().map(|row| row.author_pubkey.as_str()) {
-            self.ensure_author_subscription(author_pubkey).await?;
+        let mut author_pubkeys = BTreeSet::new();
+        for row in rows {
+            author_pubkeys.insert(row.author_pubkey.clone());
+            if let Some(repost_of) = row.repost_of.as_ref() {
+                author_pubkeys.insert(repost_of.source_author_pubkey.as_str().to_string());
+            }
+        }
+        for author_pubkey in author_pubkeys {
+            self.ensure_author_subscription(author_pubkey.as_str())
+                .await?;
         }
         Ok(())
     }
@@ -3349,16 +3611,18 @@ impl AppService {
         self.store.put_envelope(envelope.clone()).await?;
         let mut object = envelope
             .to_post_object()?
-            .ok_or_else(|| anyhow::anyhow!("expected post/comment envelope"))?;
-        object.attachments = attachments
-            .iter()
-            .map(|(role, stored)| kukuri_core::AssetRef {
-                hash: stored.hash.clone(),
-                mime: stored.mime.clone(),
-                bytes: stored.bytes,
-                role: role.clone(),
-            })
-            .collect();
+            .ok_or_else(|| anyhow::anyhow!("expected timeline envelope"))?;
+        if object.object_kind != "repost" {
+            object.attachments = attachments
+                .iter()
+                .map(|(role, stored)| kukuri_core::AssetRef {
+                    hash: stored.hash.clone(),
+                    mime: stored.mime.clone(),
+                    bytes: stored.bytes,
+                    role: role.clone(),
+                })
+                .collect();
+        }
         let content = match &object.payload_ref {
             PayloadRef::InlineText { text } => Some(text.clone()),
             PayloadRef::BlobText { hash, .. } => self
@@ -3414,14 +3678,10 @@ impl AppService {
             return Ok(None);
         };
 
-        let object_kind = if projection.reply_to_object_id.is_some() {
-            "comment"
-        } else {
-            "post"
-        };
+        let object_kind = projection.object_kind.as_str();
         let mut tags = vec![
             vec!["topic".into(), projection.topic_id.clone()],
-            vec!["object".into(), object_kind.into()],
+            vec!["object".into(), object_kind.to_string()],
         ];
         if projection.channel_id != PUBLIC_CHANNEL_ID {
             tags.push(vec!["channel".into(), projection.channel_id.clone()]);
@@ -3447,6 +3707,7 @@ impl AppService {
                 },
                 reply_to: projection.reply_to_object_id.clone(),
                 root_id: projection.root_object_id.clone(),
+                repost_of: projection.repost_of.clone(),
             })?,
             sig: String::new(),
         }))
@@ -3715,12 +3976,22 @@ impl AppService {
                 row.author_pubkey.as_str(),
             )
             .await?;
-        let content_status =
-            blob_view_status_for_payload(self.blob_service.as_ref(), &row.payload_ref).await?;
-        let attachments = if let Some(post_object) = post_object {
+        let repost_commentary = normalize_repost_commentary(row.content.clone());
+        let content_status = if row.object_kind == "repost" {
+            BlobViewStatus::Available
+        } else {
+            blob_view_status_for_payload(self.blob_service.as_ref(), &row.payload_ref).await?
+        };
+        let attachments = if row.object_kind == "repost" {
+            Vec::new()
+        } else if let Some(post_object) = post_object {
             attachment_views(self.blob_service.as_ref(), &post_object).await?
         } else {
             Vec::new()
+        };
+        let repost_of = match row.repost_of.clone() {
+            Some(snapshot) => Some(self.repost_snapshot_to_view(snapshot).await?),
+            None => None,
         };
         let audience_label = self
             .audience_label_for_storage(row.topic_id.as_str(), row.channel_id.as_str())
@@ -3746,12 +4017,12 @@ impl AppService {
             created_at: row.created_at,
             reply_to: row.reply_to_object_id.clone().map(|id| id.0),
             root_id: row.root_object_id.clone().map(|id| id.0),
-            object_kind: if row.reply_to_object_id.is_some() {
-                "comment".into()
-            } else {
-                "post".into()
-            },
+            object_kind: row.object_kind.clone(),
+            published_topic_id: Some(row.topic_id.clone()),
             origin_topic_id: Some(row.topic_id.clone()),
+            repost_of,
+            repost_commentary: repost_commentary.clone(),
+            is_threadable: row.object_kind != "repost" || repost_commentary.is_some(),
             channel_id: channel_id_for_view(row.channel_id.as_str()),
             audience_label,
         })
@@ -3795,9 +4066,88 @@ impl AppService {
             created_at: profile_post.created_at,
             reply_to: profile_post.reply_to_object_id.map(|id| id.0),
             root_id: profile_post.root_id.map(|id| id.0),
-            origin_topic_id: Some(profile_post.origin_topic_id.as_str().to_string()),
+            published_topic_id: Some(profile_post.published_topic_id.as_str().to_string()),
+            origin_topic_id: Some(profile_post.published_topic_id.as_str().to_string()),
+            repost_of: None,
+            repost_commentary: None,
+            is_threadable: true,
             channel_id: None,
             audience_label: "Public".into(),
+        })
+    }
+
+    async fn profile_repost_to_view(&self, profile_repost: ProfileRepost) -> Result<PostView> {
+        let profile = self
+            .store
+            .get_profile(profile_repost.author_pubkey.as_str())
+            .await?;
+        let relationship = self
+            .projection_store
+            .get_author_relationship(
+                self.current_author_pubkey().as_str(),
+                profile_repost.author_pubkey.as_str(),
+            )
+            .await?;
+
+        Ok(PostView {
+            object_id: profile_repost.object_id.0.clone(),
+            envelope_id: profile_repost.envelope_id.0.clone(),
+            author_pubkey: profile_repost.author_pubkey.as_str().to_string(),
+            author_name: profile.as_ref().and_then(|value| value.name.clone()),
+            author_display_name: profile
+                .as_ref()
+                .and_then(|value| value.display_name.clone()),
+            following: relationship.as_ref().is_some_and(|value| value.following),
+            followed_by: relationship.as_ref().is_some_and(|value| value.followed_by),
+            mutual: relationship.as_ref().is_some_and(|value| value.mutual),
+            friend_of_friend: relationship
+                .as_ref()
+                .is_some_and(|value| value.friend_of_friend),
+            object_kind: "repost".into(),
+            content: profile_repost.commentary.clone().unwrap_or_default(),
+            content_status: BlobViewStatus::Available,
+            attachments: Vec::new(),
+            created_at: profile_repost.created_at,
+            reply_to: None,
+            root_id: None,
+            published_topic_id: Some(profile_repost.published_topic_id.as_str().to_string()),
+            origin_topic_id: Some(profile_repost.published_topic_id.as_str().to_string()),
+            repost_of: Some(
+                self.repost_snapshot_to_view(profile_repost.repost_of)
+                    .await?,
+            ),
+            repost_commentary: profile_repost.commentary.clone(),
+            is_threadable: profile_repost.commentary.is_some(),
+            channel_id: None,
+            audience_label: "Public".into(),
+        })
+    }
+
+    async fn repost_snapshot_to_view(
+        &self,
+        snapshot: RepostSourceSnapshotV1,
+    ) -> Result<RepostSourceView> {
+        let source_profile = self
+            .store
+            .get_profile(snapshot.source_author_pubkey.as_str())
+            .await?;
+        Ok(RepostSourceView {
+            source_object_id: snapshot.source_object_id.as_str().to_string(),
+            source_topic_id: snapshot.source_topic_id.as_str().to_string(),
+            source_author_pubkey: snapshot.source_author_pubkey.as_str().to_string(),
+            source_author_name: source_profile.as_ref().and_then(|value| value.name.clone()),
+            source_author_display_name: source_profile
+                .as_ref()
+                .and_then(|value| value.display_name.clone()),
+            source_object_kind: snapshot.source_object_kind,
+            content: snapshot.content,
+            attachments: attachment_views_from_refs(
+                self.blob_service.as_ref(),
+                &snapshot.attachments,
+            )
+            .await?,
+            reply_to: snapshot.reply_to_object_id.map(|id| id.0),
+            root_id: snapshot.root_id.map(|id| id.0),
         })
     }
 }
@@ -3807,6 +4157,17 @@ fn normalize_optional_text(value: Option<String>) -> Option<String> {
         let trimmed = value.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_string())
     })
+}
+
+fn normalize_repost_commentary(value: Option<String>) -> Option<String> {
+    normalize_optional_text(value)
+}
+
+fn content_from_payload_ref(payload_ref: &PayloadRef) -> Option<String> {
+    match payload_ref {
+        PayloadRef::InlineText { text } => Some(text.clone()),
+        PayloadRef::BlobText { .. } => None,
+    }
 }
 
 fn normalize_author_pubkey(pubkey: &str) -> Result<String> {
@@ -3969,7 +4330,7 @@ async fn persist_profile_post_doc(
                 value: serde_json::to_value(AuthorProfilePostDocV1 {
                     author_pubkey: profile_post.author_pubkey.clone(),
                     profile_topic_id: profile_post.profile_topic_id.clone(),
-                    origin_topic_id: profile_post.origin_topic_id.clone(),
+                    published_topic_id: profile_post.published_topic_id.clone(),
                     object_id: profile_post.object_id.clone(),
                     created_at: profile_post.created_at,
                     object_kind: profile_post.object_kind.clone(),
@@ -3977,6 +4338,42 @@ async fn persist_profile_post_doc(
                     attachments: profile_post.attachments.clone(),
                     reply_to_object_id: profile_post.reply_to_object_id.clone(),
                     root_id: profile_post.root_id.clone(),
+                    envelope_id: envelope.id.clone(),
+                })?,
+            },
+        )
+        .await?;
+    docs_sync
+        .apply_doc_op(
+            &replica,
+            DocOp::SetJson {
+                key: stable_key("envelopes", envelope.id.as_str()),
+                value: serde_json::to_value(envelope)?,
+            },
+        )
+        .await
+}
+
+async fn persist_profile_repost_doc(
+    docs_sync: &dyn DocsSync,
+    profile_repost: &ProfileRepost,
+    envelope: &KukuriEnvelope,
+) -> Result<()> {
+    let replica = author_replica_id(profile_repost.author_pubkey.as_str());
+    docs_sync.open_replica(&replica).await?;
+    docs_sync
+        .apply_doc_op(
+            &replica,
+            DocOp::SetJson {
+                key: stable_key("profile/reposts", profile_repost.object_id.as_str()),
+                value: serde_json::to_value(AuthorProfileRepostDocV1 {
+                    author_pubkey: profile_repost.author_pubkey.clone(),
+                    profile_topic_id: profile_repost.profile_topic_id.clone(),
+                    published_topic_id: profile_repost.published_topic_id.clone(),
+                    object_id: profile_repost.object_id.clone(),
+                    created_at: profile_repost.created_at,
+                    commentary: profile_repost.commentary.clone(),
+                    repost_of: profile_repost.repost_of.clone(),
                     envelope_id: envelope.id.clone(),
                 })?,
             },
@@ -4157,7 +4554,7 @@ async fn load_profile_posts_from_author_replica(
                         Ok(Some(profile_post))
                             if profile_post.author_pubkey == doc.author_pubkey
                                 && profile_post.profile_topic_id == doc.profile_topic_id
-                                && profile_post.origin_topic_id == doc.origin_topic_id
+                                && profile_post.published_topic_id == doc.published_topic_id
                                 && profile_post.object_id == doc.object_id
                                 && profile_post.created_at == doc.created_at
                                 && profile_post.object_kind == doc.object_kind
@@ -4196,6 +4593,76 @@ async fn load_profile_posts_from_author_replica(
                     key = %record.key,
                     error = %error,
                     "failed to decode profile post doc"
+                );
+            }
+        }
+    }
+
+    Ok(items)
+}
+
+async fn load_profile_reposts_from_author_replica(
+    docs_sync: &dyn DocsSync,
+    author_pubkey: &str,
+) -> Result<Vec<ProfileRepost>> {
+    let author_pubkey = normalize_author_pubkey(author_pubkey)?;
+    let replica = author_replica_id(author_pubkey.as_str());
+    let expected_profile_topic_id = author_profile_topic_id(author_pubkey.as_str());
+    let mut items = Vec::new();
+    let mut seen_object_ids = BTreeSet::new();
+
+    for record in docs_sync
+        .query_replica(&replica, DocQuery::Prefix("profile/reposts/".into()))
+        .await?
+    {
+        match serde_json::from_slice::<AuthorProfileRepostDocV1>(record.value.as_slice()) {
+            Ok(doc)
+                if doc.author_pubkey.as_str() == author_pubkey
+                    && doc.profile_topic_id == expected_profile_topic_id =>
+            {
+                if let Some(envelope) =
+                    fetch_author_envelope_by_id(docs_sync, &replica, &doc.envelope_id).await?
+                {
+                    match parse_profile_repost(&envelope) {
+                        Ok(Some(profile_repost))
+                            if profile_repost.author_pubkey == doc.author_pubkey
+                                && profile_repost.profile_topic_id == doc.profile_topic_id
+                                && profile_repost.published_topic_id == doc.published_topic_id
+                                && profile_repost.object_id == doc.object_id
+                                && profile_repost.created_at == doc.created_at
+                                && profile_repost.commentary == doc.commentary
+                                && profile_repost.repost_of == doc.repost_of =>
+                        {
+                            if seen_object_ids.insert(profile_repost.object_id.clone()) {
+                                items.push(profile_repost);
+                            }
+                        }
+                        Ok(Some(_)) | Ok(None) => {}
+                        Err(error) => {
+                            warn!(
+                                author_pubkey = %author_pubkey,
+                                key = %record.key,
+                                envelope_id = %doc.envelope_id.as_str(),
+                                error = %error,
+                                "ignoring invalid profile repost envelope"
+                            );
+                        }
+                    }
+                }
+            }
+            Ok(_) => {
+                warn!(
+                    author_pubkey = %author_pubkey,
+                    key = %record.key,
+                    "ignoring profile repost doc with mismatched author or topic"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    author_pubkey = %author_pubkey,
+                    key = %record.key,
+                    error = %error,
+                    "failed to decode profile repost doc"
                 );
             }
         }
@@ -4809,10 +5276,12 @@ fn projection_row_from_header(
         channel_id: channel_storage_id(header.channel_id.as_ref()),
         author_pubkey: header.author.as_str().to_string(),
         created_at: header.created_at,
+        object_kind: header.object_kind.clone(),
         root_object_id: header.root.clone(),
         reply_to_object_id: header.reply_to.clone(),
         payload_ref: header.payload_ref.clone(),
         content,
+        repost_of: header.repost_of.clone(),
         source_replica_id: source_replica_id.clone(),
         source_key: stable_key("objects", &format!("{}/state", header.object_id.as_str())),
         source_envelope_id: header.envelope_id.clone(),
@@ -5005,11 +5474,11 @@ fn projection_page_needs_hydration(page: &Page<ObjectProjectionRow>) -> bool {
     page.items.iter().any(|item| item.content.is_none())
 }
 
-fn profile_post_page(
-    posts: Vec<ProfilePost>,
+fn profile_timeline_page(
+    posts: Vec<ProfileTimelineItem>,
     cursor: Option<TimelineCursor>,
     limit: usize,
-) -> Page<ProfilePost> {
+) -> Page<ProfileTimelineItem> {
     if limit == 0 {
         return Page {
             items: Vec::new(),
@@ -5021,16 +5490,17 @@ fn profile_post_page(
     let mut next_cursor = None;
     for post in posts {
         let include = cursor.as_ref().is_none_or(|current| {
-            post.created_at < current.created_at
-                || (post.created_at == current.created_at && post.object_id < current.object_id)
+            post.created_at() < current.created_at
+                || (post.created_at() == current.created_at
+                    && post.object_id() < &current.object_id)
         });
         if !include {
             continue;
         }
         if items.len() >= limit {
             next_cursor = Some(TimelineCursor {
-                created_at: post.created_at,
-                object_id: post.object_id.clone(),
+                created_at: post.created_at(),
+                object_id: post.object_id().clone(),
             });
             break;
         }
@@ -6463,6 +6933,25 @@ mod tests {
             .collect()
     }
 
+    async fn author_profile_repost_docs(
+        docs_sync: &dyn DocsSync,
+        author_pubkey: &str,
+    ) -> Vec<AuthorProfileRepostDocV1> {
+        docs_sync
+            .query_replica(
+                &author_replica_id(author_pubkey),
+                DocQuery::Prefix("profile/reposts/".into()),
+            )
+            .await
+            .expect("profile repost docs")
+            .into_iter()
+            .map(|record| {
+                serde_json::from_slice::<AuthorProfileRepostDocV1>(record.value.as_slice())
+                    .expect("decode profile repost doc")
+            })
+            .collect()
+    }
+
     #[derive(Clone)]
     struct NoopHintTransport;
 
@@ -6642,7 +7131,7 @@ mod tests {
             profile_docs[0].profile_topic_id,
             author_profile_topic_id(author_pubkey.as_str())
         );
-        assert_eq!(profile_docs[0].origin_topic_id.as_str(), topic);
+        assert_eq!(profile_docs[0].published_topic_id.as_str(), topic);
         assert_eq!(profile_docs[0].object_id.as_str(), object_id);
         assert_eq!(profile_docs[0].object_kind, "post");
 
@@ -6657,7 +7146,7 @@ mod tests {
             .expect("profile post");
 
         assert_eq!(post.content, "hello profile");
-        assert_eq!(post.origin_topic_id.as_deref(), Some(topic));
+        assert_eq!(post.published_topic_id.as_deref(), Some(topic));
         assert_eq!(post.channel_id, None);
         assert_eq!(post.audience_label, "Public");
     }
@@ -6719,7 +7208,7 @@ mod tests {
         assert_eq!(reply.object_kind, "comment");
         assert_eq!(reply.reply_to.as_deref(), Some(root_id.as_str()));
         assert_eq!(reply.root_id.as_deref(), Some(root_id.as_str()));
-        assert_eq!(reply.origin_topic_id.as_deref(), Some(topic));
+        assert_eq!(reply.published_topic_id.as_deref(), Some(topic));
     }
 
     #[tokio::test]
@@ -6778,6 +7267,364 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_same_topic_repost_persists_repost_object_and_profile_repost_doc() {
+        let store = Arc::new(MemoryStore::default());
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let keys = generate_keys();
+        let author_pubkey = keys.public_key_hex();
+        let app = AppService::new_with_services(
+            store.clone(),
+            store,
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync.clone(),
+            blob_service,
+            keys,
+        );
+        let topic = "kukuri:topic:repost-same";
+
+        let source_object_id = app
+            .create_post(topic, "hello repost", None)
+            .await
+            .expect("create source post");
+        let repost_object_id = app
+            .create_repost(topic, topic, source_object_id.as_str(), None)
+            .await
+            .expect("create repost");
+
+        let timeline = app.list_timeline(topic, None, 20).await.expect("timeline");
+        let repost = timeline
+            .items
+            .iter()
+            .find(|post| post.object_id == repost_object_id)
+            .expect("repost item");
+
+        assert_eq!(repost.object_kind, "repost");
+        assert_eq!(repost.published_topic_id.as_deref(), Some(topic));
+        assert!(repost.repost_of.is_some());
+        assert_eq!(repost.repost_commentary, None);
+        assert!(!repost.is_threadable);
+
+        let profile_docs =
+            author_profile_repost_docs(docs_sync.as_ref(), author_pubkey.as_str()).await;
+        assert_eq!(profile_docs.len(), 1);
+        assert_eq!(profile_docs[0].object_id.as_str(), repost_object_id);
+        assert_eq!(profile_docs[0].published_topic_id.as_str(), topic);
+        assert_eq!(profile_docs[0].repost_of.source_topic_id.as_str(), topic);
+    }
+
+    #[tokio::test]
+    async fn create_cross_topic_repost_renders_from_target_topic_without_tracking_source_topic() {
+        let store_a = Arc::new(MemoryStore::default());
+        let store_b = Arc::new(MemoryStore::default());
+        let peer_snapshot = PeerSnapshot::default();
+        let transport_a = Arc::new(StaticTransport::new(peer_snapshot.clone()));
+        let transport_b = Arc::new(StaticTransport::new(peer_snapshot));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let keys_a = generate_keys();
+        let author_pubkey = keys_a.public_key_hex();
+        let app_a = AppService::new_with_services(
+            store_a.clone(),
+            store_a,
+            transport_a,
+            Arc::new(NoopHintTransport),
+            docs_sync.clone(),
+            blob_service.clone(),
+            keys_a,
+        );
+        let app_b = AppService::new_with_services(
+            store_b.clone(),
+            store_b,
+            transport_b,
+            Arc::new(NoopHintTransport),
+            docs_sync.clone(),
+            blob_service,
+            generate_keys(),
+        );
+        let source_topic = "kukuri:topic:repost-source";
+        let target_topic = "kukuri:topic:repost-target";
+
+        let source_object_id = app_a
+            .create_post(source_topic, "source post", None)
+            .await
+            .expect("create source post");
+        let repost_object_id = app_a
+            .create_repost(target_topic, source_topic, source_object_id.as_str(), None)
+            .await
+            .expect("create cross-topic repost");
+
+        let target_timeline = app_b
+            .list_timeline(target_topic, None, 20)
+            .await
+            .expect("target timeline");
+        let repost = target_timeline
+            .items
+            .iter()
+            .find(|post| post.object_id == repost_object_id)
+            .expect("repost item");
+
+        assert_eq!(repost.object_kind, "repost");
+        assert_eq!(repost.published_topic_id.as_deref(), Some(target_topic));
+        assert_eq!(
+            repost
+                .repost_of
+                .as_ref()
+                .map(|value| value.source_topic_id.as_str()),
+            Some(source_topic)
+        );
+        assert_eq!(
+            repost
+                .repost_of
+                .as_ref()
+                .map(|value| value.source_object_id.as_str()),
+            Some(source_object_id.as_str())
+        );
+        assert_eq!(
+            repost
+                .repost_of
+                .as_ref()
+                .map(|value| value.content.as_str()),
+            Some("source post")
+        );
+
+        let profile_timeline = app_a
+            .list_profile_timeline(author_pubkey.as_str(), None, 20)
+            .await
+            .expect("profile timeline");
+        assert!(
+            profile_timeline
+                .items
+                .iter()
+                .any(|post| post.object_id == repost_object_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn simple_repost_is_unique_per_author_target_and_original() {
+        let store = Arc::new(MemoryStore::default());
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let app = AppService::new_with_services(
+            store.clone(),
+            store,
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync,
+            blob_service,
+            generate_keys(),
+        );
+        let source_topic = "kukuri:topic:repost-unique-source";
+        let target_topic = "kukuri:topic:repost-unique-target";
+
+        let source_object_id = app
+            .create_post(source_topic, "source post", None)
+            .await
+            .expect("create source post");
+        let repost_a = app
+            .create_repost(target_topic, source_topic, source_object_id.as_str(), None)
+            .await
+            .expect("create first repost");
+        let repost_b = app
+            .create_repost(target_topic, source_topic, source_object_id.as_str(), None)
+            .await
+            .expect("create second repost");
+
+        assert_eq!(repost_a, repost_b);
+
+        let timeline = app
+            .list_timeline(target_topic, None, 20)
+            .await
+            .expect("timeline");
+        assert_eq!(
+            timeline
+                .items
+                .iter()
+                .filter(|post| post.object_id == repost_a)
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn quote_repost_allows_multiple_distinct_quotes_for_same_original() {
+        let store = Arc::new(MemoryStore::default());
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let app = AppService::new_with_services(
+            store.clone(),
+            store,
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync,
+            blob_service,
+            generate_keys(),
+        );
+        let source_topic = "kukuri:topic:quote-source";
+        let target_topic = "kukuri:topic:quote-target";
+
+        let source_object_id = app
+            .create_post(source_topic, "quoted source", None)
+            .await
+            .expect("create source post");
+        let quote_a = app
+            .create_repost(
+                target_topic,
+                source_topic,
+                source_object_id.as_str(),
+                Some("first quote"),
+            )
+            .await
+            .expect("create first quote repost");
+        let quote_b = app
+            .create_repost(
+                target_topic,
+                source_topic,
+                source_object_id.as_str(),
+                Some("second quote"),
+            )
+            .await
+            .expect("create second quote repost");
+
+        assert_ne!(quote_a, quote_b);
+
+        let timeline = app
+            .list_timeline(target_topic, None, 20)
+            .await
+            .expect("timeline");
+        assert!(
+            timeline
+                .items
+                .iter()
+                .filter(|post| post.object_kind == "repost")
+                .count()
+                >= 2
+        );
+    }
+
+    #[tokio::test]
+    async fn quote_repost_opens_own_thread_and_simple_repost_cannot_be_reply_parent() {
+        let store = Arc::new(MemoryStore::default());
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let app = AppService::new_with_services(
+            store.clone(),
+            store,
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync,
+            blob_service,
+            generate_keys(),
+        );
+        let source_topic = "kukuri:topic:reply-source";
+        let target_topic = "kukuri:topic:reply-target";
+
+        let source_object_id = app
+            .create_post(source_topic, "source post", None)
+            .await
+            .expect("create source post");
+        let simple_repost_id = app
+            .create_repost(target_topic, source_topic, source_object_id.as_str(), None)
+            .await
+            .expect("create simple repost");
+        let quote_repost_id = app
+            .create_repost(
+                target_topic,
+                source_topic,
+                source_object_id.as_str(),
+                Some("quoted reply target"),
+            )
+            .await
+            .expect("create quote repost");
+
+        let simple_reply_error = app
+            .create_post(
+                target_topic,
+                "reply to simple repost",
+                Some(simple_repost_id.as_str()),
+            )
+            .await
+            .expect_err("simple repost should reject replies");
+        assert!(
+            simple_reply_error
+                .to_string()
+                .contains("simple repost cannot be a reply parent")
+        );
+
+        let reply_id = app
+            .create_post(
+                target_topic,
+                "reply to quote repost",
+                Some(quote_repost_id.as_str()),
+            )
+            .await
+            .expect("reply to quote repost");
+        let thread = app
+            .list_thread(target_topic, quote_repost_id.as_str(), None, 20)
+            .await
+            .expect("quote repost thread");
+        assert!(
+            thread
+                .items
+                .iter()
+                .any(|post| post.object_id == quote_repost_id)
+        );
+        assert!(thread.items.iter().any(|post| post.object_id == reply_id));
+    }
+
+    #[tokio::test]
+    async fn private_channel_post_cannot_be_reposted_publicly() {
+        let store = Arc::new(MemoryStore::default());
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let app = AppService::new_with_services(
+            store.clone(),
+            store,
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync,
+            blob_service,
+            generate_keys(),
+        );
+        let topic = "kukuri:topic:repost-private";
+        let channel = app
+            .create_private_channel(CreatePrivateChannelInput {
+                topic_id: TopicId::new(topic),
+                label: "core".into(),
+                audience_kind: ChannelAudienceKind::InviteOnly,
+            })
+            .await
+            .expect("create private channel");
+        let private_object_id = app
+            .create_post_in_channel(
+                topic,
+                ChannelRef::PrivateChannel {
+                    channel_id: ChannelId::new(channel.channel_id.clone()),
+                },
+                "private source",
+                None,
+            )
+            .await
+            .expect("create private post");
+
+        let error = app
+            .create_repost(topic, topic, private_object_id.as_str(), None)
+            .await
+            .expect_err("private post should not be repostable");
+        assert!(
+            error
+                .to_string()
+                .contains("only public posts and comments can be reposted")
+        );
+    }
+
+    #[tokio::test]
     async fn list_profile_timeline_ignores_profile_post_with_signer_mismatch() {
         let store = Arc::new(MemoryStore::default());
         let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
@@ -6802,7 +7649,7 @@ mod tests {
         let forged_content = KukuriProfilePostEnvelopeContentV1 {
             author_pubkey: Pubkey::from(author_pubkey.as_str()),
             profile_topic_id: author_profile_topic_id(author_pubkey.as_str()),
-            origin_topic_id: TopicId::new(topic),
+            published_topic_id: TopicId::new(topic),
             object_id: EnvelopeId::from("forged-profile-post"),
             created_at: 123,
             object_kind: "post".into(),
@@ -6817,7 +7664,7 @@ mod tests {
             vec![
                 vec!["author".into(), author_pubkey.clone()],
                 vec!["object".into(), "profile-post".into()],
-                vec!["origin_topic".into(), topic.into()],
+                vec!["published_topic".into(), topic.into()],
                 vec!["post".into(), forged_content.object_id.as_str().to_string()],
             ],
             &forged_content,
@@ -6836,7 +7683,7 @@ mod tests {
                     value: serde_json::to_value(AuthorProfilePostDocV1 {
                         author_pubkey: forged_content.author_pubkey.clone(),
                         profile_topic_id: forged_content.profile_topic_id.clone(),
-                        origin_topic_id: forged_content.origin_topic_id.clone(),
+                        published_topic_id: forged_content.published_topic_id.clone(),
                         object_id: forged_content.object_id.clone(),
                         created_at: forged_content.created_at,
                         object_kind: forged_content.object_kind.clone(),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -480,6 +480,8 @@ pub struct KukuriPostEnvelopeContentV1 {
     pub visibility: ObjectVisibility,
     pub reply_to: Option<EnvelopeId>,
     pub root_id: Option<EnvelopeId>,
+    #[serde(default)]
+    pub repost_of: Option<RepostSourceSnapshotV1>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -499,6 +501,8 @@ pub struct KukuriPostObjectV1 {
     pub visibility: ObjectVisibility,
     pub reply_to: Option<EnvelopeId>,
     pub root: Option<EnvelopeId>,
+    #[serde(default)]
+    pub repost_of: Option<RepostSourceSnapshotV1>,
     pub status: ObjectStatus,
     pub signature: String,
 }
@@ -539,10 +543,25 @@ pub struct AuthorProfileDocV1 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepostSourceSnapshotV1 {
+    pub source_object_id: EnvelopeId,
+    pub source_topic_id: TopicId,
+    pub source_author_pubkey: Pubkey,
+    pub source_object_kind: String,
+    pub content: String,
+    #[serde(default)]
+    pub attachments: Vec<AssetRef>,
+    #[serde(default)]
+    pub reply_to_object_id: Option<EnvelopeId>,
+    #[serde(default)]
+    pub root_id: Option<EnvelopeId>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KukuriProfilePostEnvelopeContentV1 {
     pub author_pubkey: Pubkey,
     pub profile_topic_id: TopicId,
-    pub origin_topic_id: TopicId,
+    pub published_topic_id: TopicId,
     pub object_id: EnvelopeId,
     pub created_at: i64,
     pub object_kind: String,
@@ -559,7 +578,7 @@ pub struct KukuriProfilePostEnvelopeContentV1 {
 pub struct AuthorProfilePostDocV1 {
     pub author_pubkey: Pubkey,
     pub profile_topic_id: TopicId,
-    pub origin_topic_id: TopicId,
+    pub published_topic_id: TopicId,
     pub object_id: EnvelopeId,
     pub created_at: i64,
     pub object_kind: String,
@@ -577,7 +596,7 @@ pub struct AuthorProfilePostDocV1 {
 pub struct ProfilePost {
     pub author_pubkey: Pubkey,
     pub profile_topic_id: TopicId,
-    pub origin_topic_id: TopicId,
+    pub published_topic_id: TopicId,
     pub object_id: EnvelopeId,
     pub created_at: i64,
     pub object_kind: String,
@@ -585,6 +604,44 @@ pub struct ProfilePost {
     pub attachments: Vec<AssetRef>,
     pub reply_to_object_id: Option<EnvelopeId>,
     pub root_id: Option<EnvelopeId>,
+    pub envelope_id: EnvelopeId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KukuriProfileRepostEnvelopeContentV1 {
+    pub author_pubkey: Pubkey,
+    pub profile_topic_id: TopicId,
+    pub published_topic_id: TopicId,
+    pub object_id: EnvelopeId,
+    pub created_at: i64,
+    #[serde(default)]
+    pub commentary: Option<String>,
+    pub repost_of: RepostSourceSnapshotV1,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorProfileRepostDocV1 {
+    pub author_pubkey: Pubkey,
+    pub profile_topic_id: TopicId,
+    pub published_topic_id: TopicId,
+    pub object_id: EnvelopeId,
+    pub created_at: i64,
+    #[serde(default)]
+    pub commentary: Option<String>,
+    pub repost_of: RepostSourceSnapshotV1,
+    pub envelope_id: EnvelopeId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfileRepost {
+    pub author_pubkey: Pubkey,
+    pub profile_topic_id: TopicId,
+    pub published_topic_id: TopicId,
+    pub object_id: EnvelopeId,
+    pub created_at: i64,
+    #[serde(default)]
+    pub commentary: Option<String>,
+    pub repost_of: RepostSourceSnapshotV1,
     pub envelope_id: EnvelopeId,
 }
 
@@ -901,7 +958,7 @@ impl KukuriEnvelope {
     }
 
     pub fn post_content(&self) -> Result<Option<KukuriPostEnvelopeContentV1>> {
-        if !matches!(self.kind.as_str(), "post" | "comment") {
+        if !matches!(self.kind.as_str(), "post" | "comment" | "repost") {
             return Ok(None);
         }
         serde_json::from_str(self.content.as_str())
@@ -928,6 +985,7 @@ impl KukuriEnvelope {
             visibility: content.visibility,
             reply_to: content.reply_to,
             root: content.root_id,
+            repost_of: content.repost_of,
             status: ObjectStatus::Active,
             signature: self.sig.clone(),
         }))
@@ -1030,6 +1088,7 @@ pub fn build_post_envelope_with_payload_in_channel(
         visibility,
         reply_to: reply_id.clone(),
         root_id: root_id.clone(),
+        repost_of: None,
     };
     let mut tags = vec![
         vec!["topic".into(), topic.as_str().into()],
@@ -1045,6 +1104,56 @@ pub fn build_post_envelope_with_payload_in_channel(
         tags.push(vec!["channel".into(), channel_id.as_str().to_string()]);
     }
     sign_envelope_json(keys, kind, tags, &content)
+}
+
+pub fn build_repost_envelope(
+    keys: &KukuriKeys,
+    topic: &TopicId,
+    repost_of: RepostSourceSnapshotV1,
+    commentary: Option<&str>,
+) -> Result<KukuriEnvelope> {
+    if !matches!(repost_of.source_object_kind.as_str(), "post" | "comment") {
+        bail!("repost source object kind must be post or comment");
+    }
+    let normalized_commentary = commentary
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let content = KukuriPostEnvelopeContentV1 {
+        object_kind: "repost".into(),
+        topic_id: topic.clone(),
+        channel_id: None,
+        payload_ref: PayloadRef::InlineText {
+            text: normalized_commentary.clone().unwrap_or_default(),
+        },
+        attachments: Vec::new(),
+        media_manifest_refs: Vec::new(),
+        visibility: ObjectVisibility::Public,
+        reply_to: None,
+        root_id: None,
+        repost_of: Some(repost_of.clone()),
+    };
+    sign_envelope_json(
+        keys,
+        "repost",
+        vec![
+            vec!["topic".into(), topic.as_str().into()],
+            vec!["object".into(), "repost".into()],
+            vec![
+                "source_topic".into(),
+                repost_of.source_topic_id.as_str().to_string(),
+            ],
+            vec![
+                "source_object".into(),
+                repost_of.source_object_id.as_str().to_string(),
+            ],
+            vec![
+                "source_author".into(),
+                repost_of.source_author_pubkey.as_str().to_string(),
+            ],
+        ],
+        &content,
+    )
 }
 
 pub fn build_media_manifest_envelope(
@@ -1109,10 +1218,55 @@ pub fn build_profile_post_envelope(
             vec!["author".into(), content.author_pubkey.as_str().to_string()],
             vec!["object".into(), "profile-post".into()],
             vec![
-                "origin_topic".into(),
-                content.origin_topic_id.as_str().to_string(),
+                "published_topic".into(),
+                content.published_topic_id.as_str().to_string(),
             ],
             vec!["post".into(), content.object_id.as_str().to_string()],
+        ],
+        encoded,
+        created_at,
+    )
+}
+
+pub fn build_profile_repost_envelope(
+    keys: &KukuriKeys,
+    content: &KukuriProfileRepostEnvelopeContentV1,
+) -> Result<KukuriEnvelope> {
+    let author_pubkey = keys.public_key();
+    if content.author_pubkey != author_pubkey {
+        bail!("profile repost author pubkey must match signer");
+    }
+    if content.profile_topic_id != author_profile_topic_id(content.author_pubkey.as_str()) {
+        bail!("profile repost topic id must match author profile topic");
+    }
+    if !matches!(
+        content.repost_of.source_object_kind.as_str(),
+        "post" | "comment"
+    ) {
+        bail!("profile repost source object kind must be post or comment");
+    }
+    let created_at = now_timestamp_millis()?;
+    let encoded =
+        serde_json::to_string(content).context("failed to encode profile repost content")?;
+    sign_envelope_at(
+        keys,
+        "profile-repost",
+        vec![
+            vec!["author".into(), content.author_pubkey.as_str().to_string()],
+            vec!["object".into(), "profile-repost".into()],
+            vec![
+                "published_topic".into(),
+                content.published_topic_id.as_str().to_string(),
+            ],
+            vec!["repost".into(), content.object_id.as_str().to_string()],
+            vec![
+                "source_topic".into(),
+                content.repost_of.source_topic_id.as_str().to_string(),
+            ],
+            vec![
+                "source_object".into(),
+                content.repost_of.source_object_id.as_str().to_string(),
+            ],
         ],
         encoded,
         created_at,
@@ -1716,7 +1870,7 @@ pub fn parse_profile_post(envelope: &KukuriEnvelope) -> Result<Option<ProfilePos
     Ok(Some(ProfilePost {
         author_pubkey: content.author_pubkey,
         profile_topic_id: content.profile_topic_id,
-        origin_topic_id: content.origin_topic_id,
+        published_topic_id: content.published_topic_id,
         object_id: content.object_id,
         created_at: content.created_at,
         object_kind: content.object_kind,
@@ -1724,6 +1878,42 @@ pub fn parse_profile_post(envelope: &KukuriEnvelope) -> Result<Option<ProfilePos
         attachments: content.attachments,
         reply_to_object_id: content.reply_to_object_id,
         root_id: content.root_id,
+        envelope_id: envelope.id.clone(),
+    }))
+}
+
+pub fn parse_profile_repost(envelope: &KukuriEnvelope) -> Result<Option<ProfileRepost>> {
+    if envelope.kind != "profile-repost" {
+        return Ok(None);
+    }
+
+    let content: KukuriProfileRepostEnvelopeContentV1 = serde_json::from_str(&envelope.content)
+        .context("failed to parse profile repost envelope")?;
+    validate_pubkey(content.author_pubkey.as_str())
+        .context("invalid profile repost author pubkey")?;
+    validate_pubkey(content.repost_of.source_author_pubkey.as_str())
+        .context("invalid profile repost source author pubkey")?;
+    if content.author_pubkey != envelope.pubkey {
+        bail!("profile repost author pubkey must match envelope signer");
+    }
+    if content.profile_topic_id != author_profile_topic_id(content.author_pubkey.as_str()) {
+        bail!("profile repost topic id must match author profile topic");
+    }
+    if !matches!(
+        content.repost_of.source_object_kind.as_str(),
+        "post" | "comment"
+    ) {
+        bail!("profile repost source object kind must be post or comment");
+    }
+
+    Ok(Some(ProfileRepost {
+        author_pubkey: content.author_pubkey,
+        profile_topic_id: content.profile_topic_id,
+        published_topic_id: content.published_topic_id,
+        object_id: content.object_id,
+        created_at: content.created_at,
+        commentary: content.commentary,
+        repost_of: content.repost_of,
         envelope_id: envelope.id.clone(),
     }))
 }
@@ -1987,7 +2177,7 @@ mod tests {
             &KukuriProfilePostEnvelopeContentV1 {
                 author_pubkey: author_pubkey.clone(),
                 profile_topic_id: author_profile_topic_id(author_pubkey.as_str()),
-                origin_topic_id: TopicId::new("kukuri:topic:demo"),
+                published_topic_id: TopicId::new("kukuri:topic:demo"),
                 object_id: EnvelopeId::from("post-1"),
                 created_at: 42,
                 object_kind: "comment".into(),
@@ -2013,7 +2203,10 @@ mod tests {
             profile_post.profile_topic_id,
             author_profile_topic_id(author_pubkey.as_str())
         );
-        assert_eq!(profile_post.origin_topic_id.as_str(), "kukuri:topic:demo");
+        assert_eq!(
+            profile_post.published_topic_id.as_str(),
+            "kukuri:topic:demo"
+        );
         assert_eq!(profile_post.object_id.as_str(), "post-1");
         assert_eq!(profile_post.created_at, 42);
         assert_eq!(profile_post.object_kind, "comment");
@@ -2031,6 +2224,101 @@ mod tests {
             Some("root-1")
         );
         assert_eq!(profile_post.envelope_id, envelope.id);
+    }
+
+    #[test]
+    fn repost_envelope_roundtrip() {
+        let keys = generate_keys();
+        let envelope = build_repost_envelope(
+            &keys,
+            &TopicId::new("kukuri:topic:target"),
+            RepostSourceSnapshotV1 {
+                source_object_id: EnvelopeId::from("source-1"),
+                source_topic_id: TopicId::new("kukuri:topic:source"),
+                source_author_pubkey: generate_keys().public_key(),
+                source_object_kind: "comment".into(),
+                content: "quoted source".into(),
+                attachments: vec![AssetRef {
+                    hash: BlobHash::new("hash-1"),
+                    mime: "image/png".into(),
+                    bytes: 24,
+                    role: AssetRole::ImageOriginal,
+                }],
+                reply_to_object_id: Some(EnvelopeId::from("root-1")),
+                root_id: Some(EnvelopeId::from("root-1")),
+            },
+            Some("quote commentary"),
+        )
+        .expect("repost envelope");
+
+        envelope.verify().expect("signature verification");
+        let repost = envelope
+            .to_post_object()
+            .expect("parse repost")
+            .expect("repost object");
+        assert_eq!(repost.object_kind, "repost");
+        assert_eq!(repost.topic_id.as_str(), "kukuri:topic:target");
+        assert_eq!(
+            repost
+                .repost_of
+                .as_ref()
+                .map(|value| value.source_topic_id.as_str()),
+            Some("kukuri:topic:source")
+        );
+        assert_eq!(
+            match repost.payload_ref {
+                PayloadRef::InlineText { text } => text,
+                PayloadRef::BlobText { .. } => String::new(),
+            },
+            "quote commentary"
+        );
+    }
+
+    #[test]
+    fn profile_repost_envelope_roundtrip() {
+        let keys = generate_keys();
+        let author_pubkey = keys.public_key();
+        let envelope = build_profile_repost_envelope(
+            &keys,
+            &KukuriProfileRepostEnvelopeContentV1 {
+                author_pubkey: author_pubkey.clone(),
+                profile_topic_id: author_profile_topic_id(author_pubkey.as_str()),
+                published_topic_id: TopicId::new("kukuri:topic:target"),
+                object_id: EnvelopeId::from("repost-1"),
+                created_at: 55,
+                commentary: Some("quote commentary".into()),
+                repost_of: RepostSourceSnapshotV1 {
+                    source_object_id: EnvelopeId::from("source-1"),
+                    source_topic_id: TopicId::new("kukuri:topic:source"),
+                    source_author_pubkey: generate_keys().public_key(),
+                    source_object_kind: "post".into(),
+                    content: "source content".into(),
+                    attachments: Vec::new(),
+                    reply_to_object_id: None,
+                    root_id: Some(EnvelopeId::from("source-1")),
+                },
+            },
+        )
+        .expect("profile repost envelope");
+
+        envelope.verify().expect("signature verification");
+        let profile_repost = parse_profile_repost(&envelope)
+            .expect("parse profile repost")
+            .expect("profile repost");
+        assert_eq!(profile_repost.author_pubkey, author_pubkey);
+        assert_eq!(
+            profile_repost.published_topic_id.as_str(),
+            "kukuri:topic:target"
+        );
+        assert_eq!(profile_repost.object_id.as_str(), "repost-1");
+        assert_eq!(
+            profile_repost.commentary.as_deref(),
+            Some("quote commentary")
+        );
+        assert_eq!(
+            profile_repost.repost_of.source_topic_id.as_str(),
+            "kukuri:topic:source"
+        );
     }
 
     #[test]

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -68,6 +68,15 @@ pub struct CreatePostRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreateRepostRequest {
+    pub topic: String,
+    pub source_topic: String,
+    pub source_object_id: String,
+    #[serde(default)]
+    pub commentary: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CreateAttachmentRequest {
     pub file_name: Option<String>,
     pub mime: String,
@@ -733,6 +742,17 @@ impl DesktopRuntime {
                 request.content.as_str(),
                 request.reply_to.as_deref(),
                 attachments,
+            )
+            .await
+    }
+
+    pub async fn create_repost(&self, request: CreateRepostRequest) -> Result<String> {
+        self.app_service
+            .create_repost(
+                request.topic.as_str(),
+                request.source_topic.as_str(),
+                request.source_object_id.as_str(),
+                request.commentary.as_deref(),
             )
             .await
     }

--- a/crates/store/migrations/20260328000000_repost_projection.down.sql
+++ b/crates/store/migrations/20260328000000_repost_projection.down.sql
@@ -1,0 +1,60 @@
+CREATE TABLE object_index_cache_revert (
+    object_id TEXT PRIMARY KEY,
+    topic_id TEXT NOT NULL,
+    author_pubkey TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    root_object_id TEXT,
+    reply_to_object_id TEXT,
+    payload_ref_json TEXT NOT NULL,
+    content TEXT,
+    source_replica_id TEXT NOT NULL,
+    source_key TEXT NOT NULL,
+    source_envelope_id TEXT NOT NULL,
+    source_blob_hash TEXT,
+    derived_at INTEGER NOT NULL,
+    projection_version INTEGER NOT NULL,
+    channel_id TEXT NOT NULL DEFAULT 'public'
+);
+
+INSERT INTO object_index_cache_revert (
+    object_id,
+    topic_id,
+    author_pubkey,
+    created_at,
+    root_object_id,
+    reply_to_object_id,
+    payload_ref_json,
+    content,
+    source_replica_id,
+    source_key,
+    source_envelope_id,
+    source_blob_hash,
+    derived_at,
+    projection_version,
+    channel_id
+)
+SELECT
+    object_id,
+    topic_id,
+    author_pubkey,
+    created_at,
+    root_object_id,
+    reply_to_object_id,
+    payload_ref_json,
+    content,
+    source_replica_id,
+    source_key,
+    source_envelope_id,
+    source_blob_hash,
+    derived_at,
+    projection_version,
+    channel_id
+FROM object_index_cache;
+
+DROP TABLE object_index_cache;
+
+ALTER TABLE object_index_cache_revert RENAME TO object_index_cache;
+
+DROP INDEX IF EXISTS idx_object_index_cache_topic_created;
+CREATE INDEX IF NOT EXISTS idx_object_index_cache_topic_created
+    ON object_index_cache(topic_id, channel_id, created_at DESC, object_id DESC);

--- a/crates/store/migrations/20260328000000_repost_projection.up.sql
+++ b/crates/store/migrations/20260328000000_repost_projection.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE object_index_cache
+    ADD COLUMN object_kind TEXT NOT NULL DEFAULT 'post';
+
+UPDATE object_index_cache
+SET object_kind = CASE
+    WHEN reply_to_object_id IS NOT NULL THEN 'comment'
+    ELSE 'post'
+END;
+
+ALTER TABLE object_index_cache
+    ADD COLUMN repost_of_json TEXT;

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -7,8 +7,8 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use kukuri_core::{
     BlobHash, EnvelopeId, FollowEdge, FollowEdgeStatus, GameRoomStatus, GameScoreEntry,
-    KukuriEnvelope, LiveSessionStatus, PayloadRef, Profile, ReplicaId, ThreadRef,
-    parse_follow_edge, parse_profile,
+    KukuriEnvelope, LiveSessionStatus, PayloadRef, Profile, ReplicaId, RepostSourceSnapshotV1,
+    ThreadRef, parse_follow_edge, parse_profile,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha384};
@@ -44,10 +44,12 @@ pub struct ObjectProjectionRow {
     pub channel_id: String,
     pub author_pubkey: String,
     pub created_at: i64,
+    pub object_kind: String,
     pub root_object_id: Option<EnvelopeId>,
     pub reply_to_object_id: Option<EnvelopeId>,
     pub payload_ref: PayloadRef,
     pub content: Option<String>,
+    pub repost_of: Option<RepostSourceSnapshotV1>,
     pub source_replica_id: ReplicaId,
     pub source_key: String,
     pub source_envelope_id: EnvelopeId,
@@ -822,23 +824,31 @@ impl Store for MemoryStore {
 impl ProjectionStore for SqliteStore {
     async fn put_object_projection(&self, row: ObjectProjectionRow) -> Result<()> {
         let payload_json = serde_json::to_string(&row.payload_ref)?;
+        let repost_json = row
+            .repost_of
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
         sqlx::query(
             r#"
             INSERT INTO object_index_cache (
-              object_id, topic_id, channel_id, author_pubkey, created_at, root_object_id,
-              reply_to_object_id, payload_ref_json, content, source_replica_id, source_key,
-              source_envelope_id, source_blob_hash, derived_at, projection_version
+              object_id, topic_id, channel_id, author_pubkey, created_at, object_kind,
+              root_object_id, reply_to_object_id, payload_ref_json, content, repost_of_json,
+              source_replica_id, source_key, source_envelope_id, source_blob_hash, derived_at,
+              projection_version
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
             ON CONFLICT(object_id) DO UPDATE SET
               topic_id = excluded.topic_id,
               channel_id = excluded.channel_id,
               author_pubkey = excluded.author_pubkey,
               created_at = excluded.created_at,
+              object_kind = excluded.object_kind,
               root_object_id = excluded.root_object_id,
               reply_to_object_id = excluded.reply_to_object_id,
               payload_ref_json = excluded.payload_ref_json,
               content = excluded.content,
+              repost_of_json = excluded.repost_of_json,
               source_replica_id = excluded.source_replica_id,
               source_key = excluded.source_key,
               source_envelope_id = excluded.source_envelope_id,
@@ -852,10 +862,12 @@ impl ProjectionStore for SqliteStore {
         .bind(row.channel_id.as_str())
         .bind(row.author_pubkey.as_str())
         .bind(row.created_at)
+        .bind(row.object_kind.as_str())
         .bind(row.root_object_id.as_ref().map(EnvelopeId::as_str))
         .bind(row.reply_to_object_id.as_ref().map(EnvelopeId::as_str))
         .bind(payload_json)
         .bind(row.content.as_deref())
+        .bind(repost_json.as_deref())
         .bind(row.source_replica_id.as_str())
         .bind(row.source_key.as_str())
         .bind(row.source_envelope_id.as_str())
@@ -900,9 +912,10 @@ impl ProjectionStore for SqliteStore {
     ) -> Result<Option<ObjectProjectionRow>> {
         let row = sqlx::query(
             r#"
-            SELECT object_id, topic_id, author_pubkey, created_at, root_object_id, reply_to_object_id,
-                   channel_id, payload_ref_json, content, source_replica_id, source_key,
-                   source_envelope_id, source_blob_hash, derived_at, projection_version
+            SELECT object_id, topic_id, author_pubkey, created_at, object_kind, root_object_id,
+                   reply_to_object_id, channel_id, payload_ref_json, content, repost_of_json,
+                   source_replica_id, source_key, source_envelope_id, source_blob_hash, derived_at,
+                   projection_version
             FROM object_index_cache
             WHERE object_id = ?1
             "#,
@@ -922,9 +935,10 @@ impl ProjectionStore for SqliteStore {
     ) -> Result<Page<ObjectProjectionRow>> {
         let rows = sqlx::query(
             r#"
-            SELECT object_id, topic_id, author_pubkey, created_at, root_object_id, reply_to_object_id,
-                   channel_id, payload_ref_json, content, source_replica_id, source_key,
-                   source_envelope_id, source_blob_hash, derived_at, projection_version
+            SELECT object_id, topic_id, author_pubkey, created_at, object_kind, root_object_id,
+                   reply_to_object_id, channel_id, payload_ref_json, content, repost_of_json,
+                   source_replica_id, source_key, source_envelope_id, source_blob_hash, derived_at,
+                   projection_version
             FROM object_index_cache
             WHERE topic_id = ?1
               AND (
@@ -955,10 +969,11 @@ impl ProjectionStore for SqliteStore {
     ) -> Result<Page<ObjectProjectionRow>> {
         let rows = sqlx::query(
             r#"
-            SELECT oic.object_id, oic.topic_id, oic.author_pubkey, oic.created_at, oic.root_object_id,
-                   oic.reply_to_object_id, oic.channel_id, oic.payload_ref_json, oic.content,
-                   oic.source_replica_id, oic.source_key, oic.source_envelope_id,
-                   oic.source_blob_hash, oic.derived_at, oic.projection_version
+            SELECT oic.object_id, oic.topic_id, oic.author_pubkey, oic.created_at, oic.object_kind,
+                   oic.root_object_id, oic.reply_to_object_id, oic.channel_id,
+                   oic.payload_ref_json, oic.content, oic.repost_of_json, oic.source_replica_id,
+                   oic.source_key, oic.source_envelope_id, oic.source_blob_hash, oic.derived_at,
+                   oic.projection_version
             FROM object_thread_cache tc
             INNER JOIN object_index_cache oic ON oic.object_id = tc.object_id
             WHERE tc.topic_id = ?1
@@ -1581,6 +1596,7 @@ fn row_to_object_projection(row: sqlx::sqlite::SqliteRow) -> Result<ObjectProjec
         channel_id: row.get("channel_id"),
         author_pubkey: row.get("author_pubkey"),
         created_at: row.get("created_at"),
+        object_kind: row.get("object_kind"),
         root_object_id: row
             .try_get::<String, _>("root_object_id")
             .ok()
@@ -1593,6 +1609,12 @@ fn row_to_object_projection(row: sqlx::sqlite::SqliteRow) -> Result<ObjectProjec
             .map(EnvelopeId::from),
         payload_ref: serde_json::from_str(row.get::<String, _>("payload_ref_json").as_str())?,
         content: row.try_get("content").ok(),
+        repost_of: row
+            .try_get::<String, _>("repost_of_json")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| serde_json::from_str(value.as_str()))
+            .transpose()?,
         source_replica_id: ReplicaId::new(row.get::<String, _>("source_replica_id")),
         source_key: row.get("source_key"),
         source_envelope_id: row.get::<String, _>("source_envelope_id").into(),
@@ -2006,6 +2028,7 @@ mod tests {
                 channel_id: "public".into(),
                 author_pubkey: "a".repeat(64),
                 created_at: 10,
+                object_kind: "post".into(),
                 root_object_id: None,
                 reply_to_object_id: None,
                 payload_ref: PayloadRef::BlobText {
@@ -2014,6 +2037,7 @@ mod tests {
                     bytes: 4,
                 },
                 content: Some("root".into()),
+                repost_of: None,
                 source_replica_id: ReplicaId::new(format!("topic::{topic}")),
                 source_key: "objects/object-root/header".into(),
                 source_envelope_id: root_id.clone(),
@@ -2027,6 +2051,7 @@ mod tests {
                 channel_id: "public".into(),
                 author_pubkey: "b".repeat(64),
                 created_at: 11,
+                object_kind: "comment".into(),
                 root_object_id: Some(root_id.clone()),
                 reply_to_object_id: Some(root_id.clone()),
                 payload_ref: PayloadRef::BlobText {
@@ -2035,6 +2060,7 @@ mod tests {
                     bytes: 5,
                 },
                 content: Some("reply".into()),
+                repost_of: None,
                 source_replica_id: ReplicaId::new(format!("topic::{topic}")),
                 source_key: "objects/object-reply/header".into(),
                 source_envelope_id: reply_id.clone(),

--- a/docs/adr/0015-profile-topic-author-index.md
+++ b/docs/adr/0015-profile-topic-author-index.md
@@ -14,6 +14,7 @@ Proposed
 - `docs/adr/0012-topic-first_progressive_community_filtering_draft.md`
 - `docs/adr/0013-social-graph-foundation-draft.md`
 - `docs/adr/0014-uiux-dev-flow.md`
+- `docs/adr/0016-repost-data-classification.md`
 
 ## Feature Data Classification
 - Feature 名: author profile topic
@@ -52,6 +53,8 @@ current `main` の profile overview は、active topic の public timeline を l
 ## 2. Decision
 
 profile topic v1 は、author ごとの public 投稿を束ねる virtual / system topic として扱う。
+
+Note: `profile feed は profile-post だけを集約する` という v1 初期制約は `docs/adr/0016-repost-data-classification.md` で superseded される。read-only feed である点は維持する。
 
 ### 2.1 Logical topic id
 

--- a/docs/adr/0016-repost-data-classification.md
+++ b/docs/adr/0016-repost-data-classification.md
@@ -1,0 +1,197 @@
+# ADR 0016: Public Repost / Quote Repost
+
+## Status
+Proposed
+
+## Date
+2026-03-28
+
+## Base Branch
+`main`
+
+## Related
+- `docs/adr/0011-kukuri-protocol-v1-draft.md`
+- `docs/adr/0012-topic-first_progressive_community_filtering_draft.md`
+- `docs/adr/0013-social-graph-foundation-draft.md`
+- `docs/adr/0015-profile-topic-author-index.md`
+
+## Feature Data Classification
+- Feature 名: public repost / quote repost
+- Durable / Transient: Durable public topic object + durable public author-owned index + local read/query state
+- Canonical Source:
+  - target topic 側: `topic::<target_topic_id>` replica の `repost`
+  - profile topic 側: `author::<author_pubkey>` replica の `profile-repost`
+- Replicated?: Yes, `repost` object と `profile-repost` doc は public replica に複製される
+- Rebuildable From: source public object / source snapshot / signed repost envelope / author replica index
+- Public Replica / Private Replica / Local Only:
+  - `repost`: public topic replica
+  - `profile-repost`: public author replica
+  - composer / thread open state: local only
+- Gossip Hint 必要有無: No new hint type; topic 側は既存 `TopicObjectsChanged`、author 側は既存 `ProfileUpdated`
+- Blob 必要有無: source attachment snapshot は envelope に保持し、blob fetch は既存 path を再利用
+- SQLite projection 必要有無: Yes, repost read model を topic timeline / thread projection に含める
+- 必須 contract:
+  - `create_same_topic_repost_persists_repost_object_and_profile_repost_doc`
+  - `create_cross_topic_repost_renders_from_target_topic_without_tracking_source_topic`
+  - `simple_repost_is_unique_per_author_target_and_original`
+  - `quote_repost_allows_multiple_distinct_quotes_for_same_original`
+  - `quote_repost_opens_own_thread_and_simple_repost_cannot_be_reply_parent`
+  - `profile_timeline_merges_profile_posts_and_profile_reposts`
+  - `public_comment_can_be_reposted_with_source_context_snapshot`
+  - `private_channel_post_cannot_be_reposted_publicly`
+- 必須 scenario:
+  - A が topic X の public post / comment を topic Y へ repost / quote repost し、B は Y だけ tracked していてもカードを読めること
+  - repost / quote repost が profile feed にも出ること
+  - quote repost だけが独立 thread を開けること
+
+## 1. Current Main Snapshot
+
+current `main` には repost object kind がなく、topic をまたぐ再配信は forward や manual copy と区別できない。
+
+この状態では次が満たせない。
+
+- same-topic repost と cross-topic repost を同じ contract で扱うこと
+- repost を profile feed に自動集約すること
+- quote repost を独立 thread として扱い、simple repost は original thread に戻すこと
+- viewer が source topic を tracked していなくても repost card を target topic だけで描画すること
+
+一方で current architecture には次の基盤がある。
+
+- public topic object の signed envelope
+- author replica 上の public profile index
+- topic timeline / thread / profile timeline を返す read model
+
+したがって repost v1 は、`create_post` の overload ではなく独立 object kind と独立 publish API として導入する。
+
+## 2. Decision
+
+v1 の repost は `public topics only` に固定する。
+
+- repost target は public `post` / `comment` のみ
+- private channel / private audience object は対象外
+- live session / game room は対象外
+
+`commentary` が空なら simple repost、空でなければ quote repost と定義する。
+
+### 2.1 Canonical source
+
+repost の canonical source は 2 本立てにする。
+
+- target topic 上の正本: `topic::<target_topic_id>` replica の `repost` object
+- profile topic 上の正本: `author::<author_pubkey>` replica の `profile-repost` doc
+
+original object の canonical source は移動しない。original の正本は常に source topic replica に残る。
+
+### 2.2 Publish boundary
+
+publish API は `create_post` の overload ではなく `create_repost` 系 API を追加する。
+
+publish 時は次を行う。
+
+- `topic::<target_topic_id>` に `repost` object を保存する
+- `author::<author_pubkey>` に `profile-repost` doc を保存する
+
+manual に profile topic へ直接 repost する UI は作らない。profile feed への反映は public repost の副作用である。
+
+### 2.3 Simple / quote normalization
+
+- simple repost は `(author_pubkey, target_topic_id, source_object_id)` ごとに 1 件へ正規化する
+- quote repost は別投稿として複数許可する
+- quote repost の commentary は v1 では text-only
+- quote repost 自体への追加 attachment は持たない
+
+## 3. Data Model
+
+### 3.1 Topic repost object
+
+`repost` object は少なくとも次を持つ。
+
+- `target_topic_id`
+- `source_topic_id`
+- `source_object_id`
+- `source_author_pubkey`
+- `source_object_kind`
+- `source_reply_to?`
+- `source_root_id?`
+- `source snapshot`
+- `commentary payload?`
+- `created_at`
+
+cross-topic repost でも target topic だけでカード描画できるよう、source object の最小 snapshot を repost object 自体へ埋め込む。
+
+### 3.2 Profile repost doc
+
+`profile-repost` doc は少なくとも次を持つ。
+
+- `author_pubkey`
+- `profile_topic_id`
+- `published_topic_id`
+- `object_id`
+- `created_at`
+- `commentary payload?`
+- `source snapshot`
+- `envelope_id`
+
+viewer が source topic を tracked していなくても profile feed を描画できるよう、`profile-repost` doc も source snapshot を保持する。
+
+## 4. Read Model
+
+`PostView` 相当の read model は少なくとも次を返す。
+
+- `published_topic_id`
+- `origin_topic_id` は「この item が publish された topic」を指す compatibility alias として残す
+- `repost_of`
+- `repost_commentary?`
+- `is_threadable`
+
+`repost_of` は少なくとも次を含む。
+
+- `source_object_id`
+- `source_topic_id`
+- `source_author_pubkey`
+- `source_object_kind`
+- `source content snapshot`
+- `source attachments snapshot`
+- `source reply/thread refs`
+
+`list_profile_timeline` は `profile-post` と `profile-repost` を merge して返す。
+
+## 5. Thread And UX Boundary
+
+- quote repost だけを threadable にする
+- simple repost は reply parent にできない
+- simple repost を開く UI は original thread / original topic へ遷移させる
+- profile topic は引き続き virtual / read-only feed とする
+
+これにより `0015` の「profile feed は `profile-post` だけを集約する」という制約は superseded される。一方で profile feed の read-only 方針自体は維持する。
+
+## 6. Privacy Boundary
+
+private channel repost は later scope に送る。
+
+理由:
+
+- current `0012` の privacy boundary と衝突させない
+- private audience の capability / encryption / relay semantics を repost v1 に混ぜない
+- v1 を public durable object に固定して canonical read path を先に固める
+
+## 7. Validation
+
+v1 は少なくとも次で固定する。
+
+- `create_same_topic_repost_persists_repost_object_and_profile_repost_doc`
+- `create_cross_topic_repost_renders_from_target_topic_without_tracking_source_topic`
+- `simple_repost_is_unique_per_author_target_and_original`
+- `quote_repost_allows_multiple_distinct_quotes_for_same_original`
+- `quote_repost_opens_own_thread_and_simple_repost_cannot_be_reply_parent`
+- `profile_timeline_merges_profile_posts_and_profile_reposts`
+- `public_comment_can_be_reposted_with_source_context_snapshot`
+- `private_channel_post_cannot_be_reposted_publicly`
+
+required scenario は次である。
+
+- A が topic X の public post / comment を topic Y に repost する
+- A が同じ original を quote repost する
+- B は topic Y だけ tracked していても repost / quote repost card を読める
+- B は profile feed でも同じ repost / quote repost を見られる
+- B は quote repost だけ独立 thread を開け、simple repost は original thread に戻る


### PR DESCRIPTION
## Summary
- add public repost and quote repost data model, storage, and app API support
- wire repost and quote repost flows through desktop runtime, Tauri, and desktop UI
- add ADR 0016 and update profile topic ADR to reflect profile repost aggregation

## Testing
- cargo test -p kukuri-app-api repost -- --nocapture
- cargo test -p kukuri-core --no-run
- cargo test -p kukuri-store --no-run
- cargo test -p kukuri-desktop-runtime --no-run
- npx pnpm@10.16.1 --dir apps/desktop typecheck
- npx pnpm@10.16.1 --dir apps/desktop test src/App.test.tsx src/components/core/PostCard.test.tsx src/components/core/ComposerPanel.test.tsx