### PR TITLE
feat(desktop): modalize shell actions and support avatar blobs

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,6 +17,8 @@
     "tauri:build": "node ./scripts/tauri-cli.mjs build"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@tauri-apps/api": "^2.10.1",
     "class-variance-authority": "^0.7.1",

--- a/apps/desktop/pnpm-lock.yaml
+++ b/apps/desktop/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
@@ -464,6 +470,21 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -522,8 +543,164 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -539,6 +716,72 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.10':
     resolution: {integrity: sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==}
@@ -1096,6 +1339,10 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -1225,6 +1472,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -1384,6 +1634,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1756,6 +2010,26 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-router-dom@7.13.2:
     resolution: {integrity: sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==}
     engines: {node: '>=20.0.0'}
@@ -1771,6 +2045,16 @@ packages:
       react-dom: '>=18'
     peerDependenciesMeta:
       react-dom:
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   react@19.2.4:
@@ -1978,6 +2262,26 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -2438,6 +2742,23 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -2495,8 +2816,161 @@ snapshots:
     dependencies:
       playwright: 1.58.2
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -2507,6 +2981,56 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.10':
     optional: true
@@ -3044,6 +3568,10 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -3150,6 +3678,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   doctrine@3.0.0:
     dependencies:
@@ -3331,6 +3861,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-nonce@1.0.1: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -3658,6 +4190,25 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react-router-dom@7.13.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -3671,6 +4222,14 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react@19.2.4: {}
 
@@ -3867,6 +4426,21 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -247,17 +247,39 @@ function getPrimaryNavigation() {
   return screen.getByLabelText('Primary navigation');
 }
 
-async function openChannelSection(
-  user: ReturnType<typeof userEvent.setup>,
-  nav = getPrimaryNavigation()
-) {
-  const trigger = nav.querySelector<HTMLButtonElement>('.shell-nav-accordion-trigger');
-  if (!trigger) {
-    throw new Error('channel accordion trigger not found');
-  }
-  if (trigger.getAttribute('aria-expanded') !== 'true') {
-    await user.click(trigger);
-  }
+function getFloatingActionButton() {
+  return screen.getByTestId('shell-fab');
+}
+
+async function openPublishDialog(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(getFloatingActionButton());
+  return await screen.findByRole('dialog', { name: 'Publish' });
+}
+
+async function publishPost(user: ReturnType<typeof userEvent.setup>, content: string) {
+  const dialog = await openPublishDialog(user);
+  await user.type(within(dialog).getByPlaceholderText('Write a post'), content);
+  await user.click(within(dialog).getByRole('button', { name: 'Publish' }));
+  await waitFor(() => {
+    expect(screen.queryByRole('dialog', { name: 'Publish' })).not.toBeInTheDocument();
+  });
+}
+
+async function openChannelManager(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: 'Private Channels' }));
+  return await screen.findByRole('dialog', { name: 'Private Channels' });
+}
+
+async function openLiveCreateDialog(user: ReturnType<typeof userEvent.setup>) {
+  await selectWorkspace(user, 'Live');
+  await user.click(getFloatingActionButton());
+  return await screen.findByRole('dialog', { name: 'Start Live' });
+}
+
+async function openGameCreateDialog(user: ReturnType<typeof userEvent.setup>) {
+  await selectWorkspace(user, 'Game');
+  await user.click(getFloatingActionButton());
+  return await screen.findByRole('dialog', { name: 'Create Room' });
 }
 
 function getDetailPane(name: 'Thread' | 'Author') {
@@ -268,8 +290,7 @@ test('desktop shell can publish and render a post', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
-  await user.type(screen.getByPlaceholderText('Write a post'), 'hello desktop');
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await publishPost(user, 'hello desktop');
 
   await waitFor(() => {
     expect(screen.getByText('hello desktop')).toBeInTheDocument();
@@ -292,22 +313,22 @@ test.each([
   {
     path: '#/timeline',
     workspaceLabel: 'Timeline',
-    expectedControl: () => screen.getByPlaceholderText('Write a post'),
+    expectedControl: () => screen.getByRole('button', { name: 'Publish' }),
   },
   {
     path: '#/channels',
     workspaceLabel: 'Timeline',
-    expectedControl: () => screen.getByPlaceholderText('Write a post'),
+    expectedControl: () => screen.getByRole('button', { name: 'Publish' }),
   },
   {
     path: '#/live',
     workspaceLabel: 'Live',
-    expectedControl: () => screen.getByPlaceholderText('Friday stream'),
+    expectedControl: () => screen.getByRole('button', { name: 'Start Live' }),
   },
   {
     path: '#/game',
     workspaceLabel: 'Game',
-    expectedControl: () => screen.getByPlaceholderText('Top 8 Finals'),
+    expectedControl: () => screen.getByRole('button', { name: 'Create Room' }),
   },
   {
     path: '#/profile',
@@ -343,6 +364,38 @@ test('mobile nav trigger is footer-only and desktop omits it', async () => {
   render(<App api={createDesktopMockApi()} />);
 
   expect(await screen.findByTestId('shell-nav-trigger')).toBeInTheDocument();
+});
+
+test('floating action button tracks the active section and hides on profile', async () => {
+  const user = userEvent.setup();
+  render(<App api={createDesktopMockApi()} />);
+
+  expect(getFloatingActionButton()).toHaveAccessibleName('Publish');
+
+  await selectWorkspace(user, 'Live');
+  expect(getFloatingActionButton()).toHaveAccessibleName('Start Live');
+
+  await selectWorkspace(user, 'Game');
+  expect(getFloatingActionButton()).toHaveAccessibleName('Create Room');
+
+  await selectWorkspace(user, 'Profile');
+  expect(screen.queryByTestId('shell-fab')).not.toBeInTheDocument();
+});
+
+test('channel manager opens as a modal from the navigation summary', async () => {
+  const user = userEvent.setup();
+  render(<App api={createDesktopMockApi()} />);
+
+  expect(getPrimaryNavigation().querySelector('.shell-nav-accordion-trigger')).toBeNull();
+
+  const dialog = await openChannelManager(user);
+  expect(dialog).toBeInTheDocument();
+  expect(within(dialog).getByPlaceholderText('core contributors')).toBeInTheDocument();
+
+  await user.click(within(dialog).getByRole('button', { name: 'Close dialog' }));
+  await waitFor(() => {
+    expect(screen.queryByRole('dialog', { name: 'Private Channels' })).not.toBeInTheDocument();
+  });
 });
 
 test('invalid hash routes fall back to the active public timeline and normalize the URL', async () => {
@@ -550,7 +603,6 @@ test('appearance settings deep link updates the document theme and storage immed
 test('topic and private channel selection sync into the hash route', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
-  const nav = getPrimaryNavigation();
 
   await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:second');
   await user.click(screen.getByRole('button', { name: 'Add' }));
@@ -561,9 +613,9 @@ test('topic and private channel selection sync into the hash route', async () =>
   });
 
   await user.click(screen.getByRole('button', { name: 'kukuri:topic:demo' }));
-  await openChannelSection(user, nav);
-  await user.type(within(nav).getByPlaceholderText('core contributors'), 'core');
-  await user.click(within(nav).getByRole('button', { name: 'Create Channel' }));
+  const channelDialog = await openChannelManager(user);
+  await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'core');
+  await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
 
   await waitFor(() => {
     expect(window.location.hash).toBe(
@@ -575,11 +627,19 @@ test('topic and private channel selection sync into the hash route', async () =>
 test('tracked topics show public and channel scope separately in the sidebar', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
-  const nav = getPrimaryNavigation();
 
-  await openChannelSection(user, nav);
-  await user.type(within(nav).getByPlaceholderText('core contributors'), 'core');
-  await user.click(within(nav).getByRole('button', { name: 'Create Channel' }));
+  const channelDialog = await openChannelManager(user);
+  await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'core');
+  await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
+  await waitFor(() => {
+    expect(within(channelDialog).getByRole('button', { name: 'Share' })).toBeInTheDocument();
+  });
+  await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
+  await waitFor(() => {
+    expect(
+      screen.queryByRole('dialog', { name: 'Private Channels' })
+    ).not.toBeInTheDocument();
+  });
 
   const topicItem = screen.getByRole('button', { name: 'kukuri:topic:demo' }).closest('li');
   if (!(topicItem instanceof HTMLElement)) {
@@ -610,6 +670,82 @@ test('tracked topics show public and channel scope separately in the sidebar', a
   });
 });
 
+test('sidebar can reselect the same private channel after switching back to public', async () => {
+  const user = userEvent.setup();
+  render(<App api={createDesktopMockApi()} />);
+
+  const channelDialog = await openChannelManager(user);
+  await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'core');
+  await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
+  await waitFor(() => {
+    expect(within(channelDialog).getByRole('button', { name: 'Share' })).toBeInTheDocument();
+  });
+  await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
+
+  const topicItem = screen.getByRole('button', { name: 'kukuri:topic:demo' }).closest('li');
+  if (!(topicItem instanceof HTMLElement)) {
+    throw new Error('active topic item not found');
+  }
+
+  const publicButton = within(topicItem).getByText('Public').closest('button');
+  const channelButton = within(topicItem).getByText('core').closest('button');
+  if (!(publicButton instanceof HTMLButtonElement) || !(channelButton instanceof HTMLButtonElement)) {
+    throw new Error('scope buttons not found');
+  }
+
+  await user.click(publicButton);
+  await waitFor(() => {
+    expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo');
+  });
+
+  await user.click(channelButton);
+  await waitFor(() => {
+    expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1');
+    expect(channelButton).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+test('sidebar can switch from one topic public scope to another topic private channel scope', async () => {
+  const user = userEvent.setup();
+  render(<App api={createDesktopMockApi()} />);
+
+  await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:second');
+  await user.click(screen.getByRole('button', { name: 'Add' }));
+  await user.click(screen.getByRole('button', { name: 'kukuri:topic:second' }));
+
+  const channelDialog = await openChannelManager(user);
+  await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'second-core');
+  await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
+  await waitFor(() => {
+    expect(within(channelDialog).getByRole('button', { name: 'Share' })).toBeInTheDocument();
+  });
+  await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
+
+  await user.click(screen.getByRole('button', { name: 'kukuri:topic:demo' }));
+  await waitFor(() => {
+    expectActiveTopicBar('kukuri:topic:demo');
+    expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo');
+  });
+
+  await user.click(screen.getByRole('button', { name: 'kukuri:topic:second' }));
+  const secondTopicItem = screen.getByRole('button', { name: 'kukuri:topic:second' }).closest('li');
+  if (!(secondTopicItem instanceof HTMLElement)) {
+    throw new Error('second topic item not found');
+  }
+
+  const secondChannelButton = within(secondTopicItem).getByText('second-core').closest('button');
+  if (!(secondChannelButton instanceof HTMLButtonElement)) {
+    throw new Error('second topic channel button not found');
+  }
+
+  await user.click(secondChannelButton);
+  await waitFor(() => {
+    expectActiveTopicBar('kukuri:topic:second');
+    expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Asecond&channel=channel-1');
+    expect(secondChannelButton).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
 test('desktop shell can update discovery seeds', async () => {
   const user = userEvent.setup();
   const api = createDesktopMockApi();
@@ -633,32 +769,28 @@ test('desktop shell can enter reply mode and render reply state', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
-  await user.type(screen.getAllByPlaceholderText('Write a post')[0], 'root post');
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await publishPost(user, 'root post');
   await waitFor(() => {
     expect(screen.getByText('root post')).toBeInTheDocument();
   });
 
   await user.click(screen.getAllByRole('button', { name: 'Reply' })[0]);
-  expect(await screen.findByPlaceholderText('Write a reply')).toBeInTheDocument();
-  expect(screen.getByText('Replying')).toBeInTheDocument();
+  const replyDialog = await screen.findByRole('dialog', { name: 'Reply' });
+  expect(within(replyDialog).getByPlaceholderText('Write a reply')).toBeInTheDocument();
+  expect(within(replyDialog).getByText('Replying')).toBeInTheDocument();
 
-  const replyInput = screen.getByPlaceholderText('Write a reply');
+  const replyInput = within(replyDialog).getByPlaceholderText('Write a reply');
   await user.type(replyInput, 'reply post');
   const composer = replyInput.closest('form');
   if (!composer) {
     throw new Error('reply composer form not found');
   }
-  const submitButton = composer.querySelector('button[type="submit"]');
-  if (!(submitButton instanceof HTMLButtonElement)) {
-    throw new Error('reply submit button not found');
-  }
-  await user.click(submitButton);
+  await user.click(within(composer).getByRole('button', { name: 'Reply' }));
 
   await waitFor(() => {
     expect(screen.getAllByText('reply post').length).toBeGreaterThan(0);
   });
-  expect(screen.getAllByText('Reply').length).toBeGreaterThan(0);
+  expect(screen.getAllByRole('button', { name: 'Reply' }).length).toBeGreaterThan(0);
 });
 
 test('reply publish reloads thread only once after a successful submit', async () => {
@@ -672,27 +804,22 @@ test('reply publish reloads thread only once after a successful submit', async (
 
   render(<App api={api} />);
 
-  await user.type(screen.getAllByPlaceholderText('Write a post')[0], 'root post');
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await publishPost(user, 'root post');
   await waitFor(() => {
     expect(screen.getByText('root post')).toBeInTheDocument();
   });
 
   await user.click(screen.getAllByRole('button', { name: 'Reply' })[0]);
-  await screen.findByPlaceholderText('Write a reply');
+  const replyDialog = await screen.findByRole('dialog', { name: 'Reply' });
   const threadCallsBeforeSubmit = listThreadSpy.mock.calls.length;
 
-  const replyInput = screen.getByPlaceholderText('Write a reply');
+  const replyInput = within(replyDialog).getByPlaceholderText('Write a reply');
   await user.type(replyInput, 'reply post');
   const composer = replyInput.closest('form');
   if (!composer) {
     throw new Error('reply composer form not found');
   }
-  const submitButton = composer.querySelector('button[type="submit"]');
-  if (!(submitButton instanceof HTMLButtonElement)) {
-    throw new Error('reply submit button not found');
-  }
-  await user.click(submitButton);
+  await user.click(within(composer).getByRole('button', { name: 'Reply' }));
 
   await waitFor(() => {
     expect(screen.getAllByText('reply post').length).toBeGreaterThan(0);
@@ -711,8 +838,7 @@ test('desktop shell can create a simple repost from timeline', async () => {
 
   render(<App api={api} />);
 
-  await user.type(screen.getByPlaceholderText('Write a post'), 'source post');
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await publishPost(user, 'source post');
   const sourcePost = await screen.findByText('source post');
   const card = sourcePost.closest('article');
   if (!card) {
@@ -720,6 +846,7 @@ test('desktop shell can create a simple repost from timeline', async () => {
   }
 
   await user.click(within(card).getByRole('button', { name: 'Repost' }));
+  await user.click((await screen.findAllByRole('button', { name: 'Repost' }))[1]);
 
   await waitFor(() => {
     expect(createRepostSpy).toHaveBeenCalledWith(
@@ -743,19 +870,20 @@ test('desktop shell can create a quote repost from the composer', async () => {
 
   render(<App api={api} />);
 
-  await user.type(screen.getByPlaceholderText('Write a post'), 'source post');
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await publishPost(user, 'source post');
   const sourcePost = await screen.findByText('source post');
   const card = sourcePost.closest('article');
   if (!card) {
     throw new Error('source post card not found');
   }
 
-  await user.click(within(card).getByRole('button', { name: 'Quote Repost' }));
+  await user.click(within(card).getByRole('button', { name: 'Repost' }));
+  await user.click(await screen.findByRole('button', { name: 'Quote Repost' }));
 
-  const quoteInput = await screen.findByPlaceholderText('Write a quote repost');
-  expect(screen.getByText('Quote reposting')).toBeInTheDocument();
-  expect(screen.getByLabelText(/attachment/i)).toBeDisabled();
+  const quoteDialog = await screen.findByRole('dialog', { name: 'Quote Repost' });
+  const quoteInput = within(quoteDialog).getByPlaceholderText('Write a quote repost');
+  expect(within(quoteDialog).getByText('Quote reposting')).toBeInTheDocument();
+  expect(within(quoteDialog).getByLabelText(/attachment/i)).toBeDisabled();
 
   await user.type(quoteInput, 'quoted take');
   const composer = quoteInput.closest('form');
@@ -785,15 +913,13 @@ test('desktop shell can track multiple topics at once', async () => {
   expect(screen.getByRole('button', { name: 'kukuri:topic:second' })).toBeInTheDocument();
 
   await user.click(screen.getByRole('button', { name: 'kukuri:topic:demo' }));
-  await user.type(screen.getByPlaceholderText('Write a post'), 'demo post');
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await publishPost(user, 'demo post');
   await waitFor(() => {
     expect(screen.getByText('demo post')).toBeInTheDocument();
   });
 
   await user.click(screen.getByRole('button', { name: 'kukuri:topic:second' }));
-  await user.type(screen.getByPlaceholderText('Write a post'), 'second post');
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await publishPost(user, 'second post');
   await waitFor(() => {
     expect(screen.getByText('second post')).toBeInTheDocument();
   });
@@ -810,22 +936,25 @@ test('desktop shell can track multiple topics at once', async () => {
 test('profile overview aggregates public posts across topics and excludes private channel posts', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
-  const nav = getPrimaryNavigation();
 
-  await user.type(screen.getByPlaceholderText('Write a post'), 'demo public post');
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await publishPost(user, 'demo public post');
   await waitFor(() => {
     expect(screen.getByText('demo public post')).toBeInTheDocument();
   });
 
-  await openChannelSection(user, nav);
-  await user.type(within(nav).getByPlaceholderText('core contributors'), 'core');
-  await user.click(within(nav).getByRole('button', { name: 'Create Channel' }));
+  const channelDialog = await openChannelManager(user);
+  await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'core');
+  await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
   await waitFor(() => {
-    expect(within(nav).getByRole('button', { name: 'Share' })).toBeInTheDocument();
+    expect(within(channelDialog).getByRole('button', { name: 'Share' })).toBeInTheDocument();
   });
-  await user.type(screen.getByPlaceholderText('Write a post'), 'demo private post');
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
+  await waitFor(() => {
+    expect(
+      screen.queryByRole('dialog', { name: 'Private Channels' })
+    ).not.toBeInTheDocument();
+  });
+  await publishPost(user, 'demo private post');
   await waitFor(() => {
     expect(screen.getByText('demo private post')).toBeInTheDocument();
   });
@@ -843,8 +972,7 @@ test('profile overview aggregates public posts across topics and excludes privat
   });
 
   await selectWorkspace(user, 'Timeline');
-  await user.type(screen.getByPlaceholderText('Write a post'), 'second public post');
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await publishPost(user, 'second public post');
   await waitFor(() => {
     expect(screen.getByText('second public post')).toBeInTheDocument();
   });
@@ -999,7 +1127,7 @@ test('desktop shell primary nav jumps focus and settings drawer restores trigger
   const gameNav = within(getWorkspaceTabs()).getByRole('tab', { name: 'Game' });
   await user.click(gameNav);
 
-  const gameSection = screen.getByPlaceholderText('Top 8 Finals').closest('.shell-section');
+  const gameSection = screen.getByText('Game Rooms').closest('.shell-section');
   if (!(gameSection instanceof HTMLElement)) {
     throw new Error('game section not found');
   }
@@ -1029,10 +1157,10 @@ test('desktop shell can create, join, leave, and end a live session', async () =
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
-  await selectWorkspace(user, 'Live');
-  await user.type(screen.getByPlaceholderText('Friday stream'), 'Launch Party');
-  await user.type(screen.getByPlaceholderText('short session summary'), 'watch along');
-  await user.click(screen.getByRole('button', { name: 'Start Live' }));
+  const liveDialog = await openLiveCreateDialog(user);
+  await user.type(within(liveDialog).getByPlaceholderText('Friday stream'), 'Launch Party');
+  await user.type(within(liveDialog).getByPlaceholderText('short session summary'), 'watch along');
+  await user.click(within(liveDialog).getByRole('button', { name: 'Start Live' }));
 
   await waitFor(() => {
     expect(screen.getByText('Launch Party')).toBeInTheDocument();
@@ -1064,18 +1192,16 @@ test('desktop shell can create, join, leave, and end a live session', async () =
 test('desktop shell can create a private channel and export an invite', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
-  const nav = getPrimaryNavigation();
-
-  await openChannelSection(user, nav);
-  await user.type(within(nav).getByPlaceholderText('core contributors'), 'core');
-  await user.click(within(nav).getByRole('button', { name: 'Create Channel' }));
+  const channelDialog = await openChannelManager(user);
+  await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'core');
+  await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
 
   await waitFor(() => {
-    expect(within(nav).getByRole('button', { name: 'Share' })).toBeInTheDocument();
+    expect(within(channelDialog).getByRole('button', { name: 'Share' })).toBeInTheDocument();
     expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1');
   });
 
-  await user.click(within(nav).getByRole('button', { name: 'Share' }));
+  await user.click(within(channelDialog).getByRole('button', { name: 'Share' }));
 
   await waitFor(() => {
     expect(screen.getByText('Share')).toBeInTheDocument();
@@ -1101,11 +1227,10 @@ test('desktop shell joins an imported private channel and selects its topic scop
       })}
     />
   );
-  const nav = getPrimaryNavigation();
-
-  await openChannelSection(user, nav);
-  await user.type(within(nav).getByPlaceholderText(/paste private channel invite/i), 'invite-token');
-  await user.click(within(nav).getByRole('button', { name: 'Join' }));
+  const channelDialog = await openChannelManager(user);
+  await user.type(within(channelDialog).getByPlaceholderText(/paste private channel invite/i), 'invite-token');
+  await user.click(within(channelDialog).getByRole('button', { name: 'Join' }));
+  await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
 
   await waitFor(() => {
     expectActiveTopicBar('kukuri:topic:private-imported');
@@ -1118,20 +1243,18 @@ test('desktop shell joins an imported private channel and selects its topic scop
 test('desktop shell shows friend-only controls and can create a grant', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
-  const nav = getPrimaryNavigation();
-
-  await openChannelSection(user, nav);
-  await user.type(within(nav).getByPlaceholderText('core contributors'), 'friends');
-  await user.selectOptions(within(nav).getByLabelText('Audience'), 'friend_only');
-  await user.click(within(nav).getByRole('button', { name: 'Create Channel' }));
+  const channelDialog = await openChannelManager(user);
+  await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'friends');
+  await user.selectOptions(within(channelDialog).getByLabelText('Audience'), 'friend_only');
+  await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
 
   await waitFor(() => {
-    expect(within(nav).getByRole('button', { name: 'Share' })).toBeInTheDocument();
+    expect(within(channelDialog).getByRole('button', { name: 'Share' })).toBeInTheDocument();
     expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1');
     expect(screen.queryByRole('button', { name: 'Rotate' })).not.toBeInTheDocument();
   });
 
-  await user.click(within(nav).getByRole('button', { name: 'Share' }));
+  await user.click(within(channelDialog).getByRole('button', { name: 'Share' }));
 
   await waitFor(() => {
     expect(screen.getByText('Share')).toBeInTheDocument();
@@ -1142,21 +1265,19 @@ test('desktop shell shows friend-only controls and can create a grant', async ()
 test('desktop shell shows friend-plus controls and can create a share', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
-  const nav = getPrimaryNavigation();
-
-  await openChannelSection(user, nav);
-  await user.type(within(nav).getByPlaceholderText('core contributors'), 'friends+');
-  await user.selectOptions(within(nav).getByLabelText('Audience'), 'friend_plus');
-  await user.click(within(nav).getByRole('button', { name: 'Create Channel' }));
+  const channelDialog = await openChannelManager(user);
+  await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'friends+');
+  await user.selectOptions(within(channelDialog).getByLabelText('Audience'), 'friend_plus');
+  await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
 
   await waitFor(() => {
-    expect(within(nav).getByRole('button', { name: 'Share' })).toBeInTheDocument();
+    expect(within(channelDialog).getByRole('button', { name: 'Share' })).toBeInTheDocument();
     expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1');
     expect(screen.queryByRole('button', { name: 'Freeze' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Rotate' })).not.toBeInTheDocument();
   });
 
-  await user.click(within(nav).getByRole('button', { name: 'Share' }));
+  await user.click(within(channelDialog).getByRole('button', { name: 'Share' }));
 
   await waitFor(() => {
     expect(screen.getByText(/share:kukuri:topic:demo:channel-1/i)).toBeInTheDocument();
@@ -1167,11 +1288,11 @@ test('desktop shell can create and update a game room', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
-  await selectWorkspace(user, 'Game');
-  await user.type(screen.getByPlaceholderText('Top 8 Finals'), 'Grand Finals');
-  await user.type(screen.getByPlaceholderText('match summary'), 'set one');
-  await user.type(screen.getByPlaceholderText('Alice, Bob'), 'Alice, Bob');
-  await user.click(screen.getByRole('button', { name: 'Create Room' }));
+  const gameDialog = await openGameCreateDialog(user);
+  await user.type(within(gameDialog).getByPlaceholderText('Top 8 Finals'), 'Grand Finals');
+  await user.type(within(gameDialog).getByPlaceholderText('match summary'), 'set one');
+  await user.type(within(gameDialog).getByPlaceholderText('Alice, Bob'), 'Alice, Bob');
+  await user.click(within(gameDialog).getByRole('button', { name: 'Create Room' }));
 
   await waitFor(() => {
     expect(screen.getByText('Grand Finals')).toBeInTheDocument();
@@ -1208,7 +1329,8 @@ test('single attach button classifies mixed image and video files', async () => 
   const user = userEvent.setup();
   render(<App api={api} />);
 
-  await user.upload(screen.getByLabelText(/attachment/i), [
+  const publishDialog = await openPublishDialog(user);
+  await user.upload(within(publishDialog).getByLabelText(/attachment/i), [
     new File([Uint8Array.from([1, 2, 3, 4])], 'flower.png', { type: 'image/png' }),
     new File([Uint8Array.from([5, 6, 7, 8])], 'clip.mp4', { type: 'video/mp4' }),
   ]);
@@ -1216,7 +1338,7 @@ test('single attach button classifies mixed image and video files', async () => 
     expect(screen.getByText('flower.png')).toBeInTheDocument();
     expect(screen.getByText('clip.mp4')).toBeInTheDocument();
   });
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await user.click(within(publishDialog).getByRole('button', { name: 'Publish' }));
 
   await waitFor(() => {
     expect(attachmentsSeen).toHaveLength(3);
@@ -1242,8 +1364,9 @@ test('video upload generates poster attachment before publish', async () => {
   const user = userEvent.setup();
   render(<App api={api} />);
 
+  const publishDialog = await openPublishDialog(user);
   await user.upload(
-    screen.getByLabelText(/attachment/i),
+    within(publishDialog).getByLabelText(/attachment/i),
     new File([Uint8Array.from([7, 8, 9])], 'clip.mp4', { type: 'video/mp4' })
   );
 
@@ -1252,7 +1375,7 @@ test('video upload generates poster attachment before publish', async () => {
   });
   expect(screen.getByText(/video_poster/)).toBeInTheDocument();
 
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await user.click(within(publishDialog).getByRole('button', { name: 'Publish' }));
 
   await waitFor(() => {
     expect(attachmentsSeen).toHaveLength(2);
@@ -1275,11 +1398,12 @@ test('video upload generates poster attachment with metadata seek fallback', asy
   const user = userEvent.setup();
   render(<App api={api} />);
 
+  const publishDialog = await openPublishDialog(user);
   await user.upload(
-    screen.getByLabelText(/attachment/i),
+    within(publishDialog).getByLabelText(/attachment/i),
     new File([Uint8Array.from([7, 8, 9])], 'clip.mp4', { type: 'video/mp4' })
   );
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await user.click(within(publishDialog).getByRole('button', { name: 'Publish' }));
 
   await waitFor(() => {
     expect(attachmentsSeen).toHaveLength(2);
@@ -1297,16 +1421,17 @@ test('video poster generation failure blocks publish', async () => {
   const user = userEvent.setup();
   render(<App api={api} />);
 
+  const publishDialog = await openPublishDialog(user);
   await user.upload(
-    screen.getByLabelText(/attachment/i),
+    within(publishDialog).getByLabelText(/attachment/i),
     new File([Uint8Array.from([1, 3, 5, 7])], 'broken.mp4', { type: 'video/mp4' })
   );
 
   await waitFor(() => {
-    expect(screen.getByText('failed to generate video poster')).toBeInTheDocument();
+    expect(screen.getAllByText('failed to generate video poster').length).toBeGreaterThan(0);
   });
 
-  await user.click(screen.getByRole('button', { name: 'Publish' }));
+  await user.click(within(publishDialog).getByRole('button', { name: 'Publish' }));
 
   expect(createPostSpy).not.toHaveBeenCalled();
 });
@@ -1316,15 +1441,16 @@ test('composer shows image draft preview before publish', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
+  const publishDialog = await openPublishDialog(user);
   await user.upload(
-    screen.getByLabelText(/attachment/i),
+    within(publishDialog).getByLabelText(/attachment/i),
     new File([Uint8Array.from([1, 2, 3, 4])], 'flower.png', { type: 'image/png' })
   );
 
-  expect(await screen.findByRole('img', { name: 'draft preview flower.png' })).toBeInTheDocument();
-  expect(screen.getByText(/image_original/)).toBeInTheDocument();
-  expect(screen.getByText(/image\/png/)).toBeInTheDocument();
-  expect(screen.getByText(/4 B/)).toBeInTheDocument();
+  expect(await within(publishDialog).findByRole('img', { name: 'draft preview flower.png' })).toBeInTheDocument();
+  expect(within(publishDialog).getByText(/image_original/)).toBeInTheDocument();
+  expect(within(publishDialog).getByText(/image\/png/)).toBeInTheDocument();
+  expect(within(publishDialog).getByText(/4 B/)).toBeInTheDocument();
 });
 
 test('composer shows video poster draft preview before publish', async () => {
@@ -1333,15 +1459,16 @@ test('composer shows video poster draft preview before publish', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
+  const publishDialog = await openPublishDialog(user);
   await user.upload(
-    screen.getByLabelText(/attachment/i),
+    within(publishDialog).getByLabelText(/attachment/i),
     new File([Uint8Array.from([7, 8, 9])], 'clip.mp4', { type: 'video/mp4' })
   );
 
-  expect(await screen.findByRole('img', { name: 'draft preview clip.mp4' })).toBeInTheDocument();
-  expect(screen.getByText(/video_manifest/)).toBeInTheDocument();
-  expect(screen.getByText(/video_poster/)).toBeInTheDocument();
-  expect(screen.getByText(/image\/jpeg/)).toBeInTheDocument();
+  expect(await within(publishDialog).findByRole('img', { name: 'draft preview clip.mp4' })).toBeInTheDocument();
+  expect(within(publishDialog).getByText(/video_manifest/)).toBeInTheDocument();
+  expect(within(publishDialog).getByText(/video_poster/)).toBeInTheDocument();
+  expect(within(publishDialog).getByText(/image\/jpeg/)).toBeInTheDocument();
 });
 
 test('timeline image post shows media skeleton when attachment is missing', async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -19,7 +19,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useStore } from 'zustand';
 import { createStore } from 'zustand/vanilla';
-import { PanelLeftOpen, Settings } from 'lucide-react';
+import { PanelLeftOpen, Plus, Settings } from 'lucide-react';
 
 import { AuthorDetailCard } from '@/components/core/AuthorDetailCard';
 import { ComposerPanel } from '@/components/core/ComposerPanel';
@@ -36,6 +36,7 @@ import {
 } from '@/components/core/types';
 import { ProfileOverviewPanel } from '@/components/extended/ProfileOverviewPanel';
 import { ProfileEditorPanel } from '@/components/extended/ProfileEditorPanel';
+import { PrivateChannelPanel } from '@/components/extended/PrivateChannelPanel';
 import { AppearancePanel } from '@/components/settings/AppearancePanel';
 import { CommunityNodePanel } from '@/components/settings/CommunityNodePanel';
 import { ConnectivityPanel } from '@/components/settings/ConnectivityPanel';
@@ -49,9 +50,11 @@ import {
   type ReactionsPanelView,
 } from '@/components/settings/types';
 import {
+  type ChannelAudienceOption,
   type ExtendedPanelStatus,
   type GameDraftView,
   type InviteOutputLabel,
+  type PrivateChannelListItemView,
   type PrivateChannelPendingAction,
 } from '@/components/extended/types';
 import { ContextPane } from '@/components/shell/ContextPane';
@@ -68,6 +71,14 @@ import {
 import { StatusBadge } from '@/components/StatusBadge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Notice } from '@/components/ui/notice';
@@ -568,7 +579,24 @@ function profileInputFromProfile(profile: Profile): ProfileInput {
     display_name: profile.display_name ?? '',
     about: profile.about ?? '',
     picture: profile.picture ?? '',
+    picture_upload: null,
+    clear_picture: false,
   };
+}
+
+function resolveProfilePictureSrc(
+  profile:
+    | Pick<Profile, 'picture' | 'picture_asset'>
+    | Pick<AuthorSocialView, 'picture' | 'picture_asset'>
+    | null
+    | undefined,
+  mediaObjectUrls: Record<string, string | null>
+): string | null {
+  const pictureAssetHash = profile?.picture_asset?.hash;
+  if (pictureAssetHash && typeof mediaObjectUrls[pictureAssetHash] === 'string') {
+    return mediaObjectUrls[pictureAssetHash];
+  }
+  return profile?.picture ?? null;
 }
 
 function authorDisplayLabel(
@@ -632,12 +660,6 @@ function strongestRelationshipLabel(relationship: {
     return 'friend of friend';
   }
   return null;
-}
-
-function inviteOutputSummaryLabel(label: InviteOutputLabel): string {
-  return label === 'share'
-    ? translate('channels:actions.share')
-    : translate('channels:actions.join');
 }
 
 function privateTimelineScope(channelId: string | null): TimelineScope {
@@ -1379,10 +1401,42 @@ function DesktopShellPage({
     shellChromeState,
     setField,
   } = useDesktopShellStore();
+  const [composeDialogOpen, setComposeDialogOpen] = useState(false);
+  const [channelDialogOpen, setChannelDialogOpen] = useState(false);
+  const [liveCreateDialogOpen, setLiveCreateDialogOpen] = useState(false);
+  const [gameCreateDialogOpen, setGameCreateDialogOpen] = useState(false);
+  const [profileAvatarPreviewUrl, setProfileAvatarPreviewUrl] = useState<string | null>(null);
+  const [profileAvatarInputKey, setProfileAvatarInputKey] = useState(0);
 
   useEffect(() => {
     document.documentElement.lang = locale;
   }, [locale]);
+
+  useEffect(
+    () => () => {
+      if (profileAvatarPreviewUrl) {
+        URL.revokeObjectURL(profileAvatarPreviewUrl);
+      }
+    },
+    [profileAvatarPreviewUrl]
+  );
+
+  useEffect(() => {
+    if (shellChromeState.activePrimarySection !== 'timeline' && composeDialogOpen) {
+      setComposeDialogOpen(false);
+    }
+    if (shellChromeState.activePrimarySection !== 'live' && liveCreateDialogOpen) {
+      setLiveCreateDialogOpen(false);
+    }
+    if (shellChromeState.activePrimarySection !== 'game' && gameCreateDialogOpen) {
+      setGameCreateDialogOpen(false);
+    }
+  }, [
+    composeDialogOpen,
+    gameCreateDialogOpen,
+    liveCreateDialogOpen,
+    shellChromeState.activePrimarySection,
+  ]);
 
   const makeFieldSetter = useCallback(
     function <K extends keyof DesktopShellState>(key: K) {
@@ -1664,6 +1718,41 @@ function DesktopShellPage({
     () => gamePanelStateByTopic[activeTopic] ?? DEFAULT_ASYNC_PANEL_STATE,
     [activeTopic, gamePanelStateByTopic]
   );
+  const channelAudienceOptions = useMemo<ChannelAudienceOption[]>(
+    () => [
+      {
+        value: 'invite_only',
+        label: t('channels:audienceOptions.invite_only'),
+      },
+      {
+        value: 'friend_only',
+        label: t('channels:audienceOptions.friend_only'),
+      },
+      {
+        value: 'friend_plus',
+        label: t('channels:audienceOptions.friend_plus'),
+      },
+    ],
+    [t]
+  );
+  const privateChannelListItems = useMemo<PrivateChannelListItemView[]>(
+    () =>
+      activeJoinedChannels.map((channel) => ({
+        channel,
+        active: channel.channel_id === selectedPrivateChannelId,
+      })),
+    [activeJoinedChannels, selectedPrivateChannelId]
+  );
+  const floatingActionLabel = useMemo(() => {
+    if (shellChromeState.activePrimarySection === 'live') {
+      return t('live:actions.start');
+    }
+    if (shellChromeState.activePrimarySection === 'game') {
+      return t('game:actions.createRoom');
+    }
+    return t('common:actions.publish');
+  }, [shellChromeState.activePrimarySection, t]);
+  const showFloatingActionButton = shellChromeState.activePrimarySection !== 'profile';
   const syncRoute = useCallback((
     mode: 'push' | 'replace' = 'replace',
     overrides?: DesktopShellRouteOverrides
@@ -1773,10 +1862,18 @@ function DesktopShellPage({
       displayName: profileDraft.display_name ?? '',
       name: profileDraft.name ?? '',
       about: profileDraft.about ?? '',
-      picture: profileDraft.picture ?? '',
     }),
     [profileDraft]
   );
+  const profileEditorPictureSrc = profileAvatarPreviewUrl
+    ?? resolveProfilePictureSrc(localProfile, mediaObjectUrls);
+  const profileEditorHasPicture = Boolean(
+    profileAvatarPreviewUrl
+      || profileDraft.clear_picture
+      || profileDraft.picture_upload
+      || localProfile?.picture
+      || localProfile?.picture_asset
+  ) && !profileDraft.clear_picture;
   const communityNodeStatusByBaseUrl = useMemo(
     () =>
       Object.fromEntries(communityNodeStatuses.map((status) => [status.base_url, status])) as Record<
@@ -1830,13 +1927,29 @@ function DesktopShellPage({
         status: 'Available',
       });
     }
+    for (const pictureAsset of [
+      localProfile?.picture_asset ?? null,
+      selectedAuthor?.picture_asset ?? null,
+    ]) {
+      if (pictureAsset) {
+        attachments.set(pictureAsset.hash, {
+          hash: pictureAsset.hash,
+          mime: pictureAsset.mime,
+          bytes: pictureAsset.bytes,
+          role: pictureAsset.role,
+          status: 'Available',
+        });
+      }
+    }
     return [...attachments.values()];
   }, [
     activePublicTimeline,
     activeTimeline,
     bookmarkedReactionAssets,
+    localProfile?.picture_asset,
     ownedReactionAssets,
     profileTimeline,
+    selectedAuthor?.picture_asset,
     selectedAuthorTimeline,
     thread,
   ]);
@@ -2590,15 +2703,10 @@ function DesktopShellPage({
   }
 
   function handleProfileFieldChange(
-    field: 'displayName' | 'name' | 'about' | 'picture',
+    field: 'displayName' | 'name' | 'about',
     value: string
   ) {
-    const nextField: keyof ProfileInput =
-      field === 'displayName'
-        ? 'display_name'
-        : field === 'picture'
-          ? 'picture'
-          : field;
+    const nextField: keyof ProfileInput = field === 'displayName' ? 'display_name' : field;
     setProfileDraft((current) => ({
       ...current,
       [nextField]: value,
@@ -2606,10 +2714,59 @@ function DesktopShellPage({
     setProfileDirty(true);
   }
 
+  async function handleProfileAvatarSelection(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    const pictureUpload = await fileToCreateAttachment(file, 'profile_avatar');
+    const nextPreviewUrl = URL.createObjectURL(file);
+    setProfileAvatarPreviewUrl((current) => {
+      if (current) {
+        URL.revokeObjectURL(current);
+      }
+      return nextPreviewUrl;
+    });
+    setProfileAvatarInputKey((value) => value + 1);
+    setProfileDraft((current) => ({
+      ...current,
+      picture: null,
+      picture_upload: pictureUpload,
+      clear_picture: false,
+    }));
+    setProfileDirty(true);
+    setProfileError(null);
+  }
+
+  function handleClearProfileAvatar() {
+    setProfileAvatarPreviewUrl((current) => {
+      if (current) {
+        URL.revokeObjectURL(current);
+      }
+      return null;
+    });
+    setProfileAvatarInputKey((value) => value + 1);
+    setProfileDraft((current) => ({
+      ...current,
+      picture: null,
+      picture_upload: null,
+      clear_picture: true,
+    }));
+    setProfileDirty(true);
+    setProfileError(null);
+  }
+
   function resetProfileDraft() {
     if (!localProfile) {
       return;
     }
+    setProfileAvatarPreviewUrl((current) => {
+      if (current) {
+        URL.revokeObjectURL(current);
+      }
+      return null;
+    });
+    setProfileAvatarInputKey((value) => value + 1);
     setProfileDraft(profileInputFromProfile(localProfile));
     setProfileDirty(false);
     setProfileError(null);
@@ -2643,32 +2800,44 @@ function DesktopShellPage({
     });
   }, [setShellChromeState, syncRoute]);
 
-  function handleSelectPrivateChannel(channelId: string) {
+  function handleSelectPrivateChannel(topicId: string, channelId: string) {
     setSelectedChannelIdByTopic((current) => ({
       ...current,
-      [activeTopic]: channelId,
+      [topicId]: channelId,
     }));
     setTimelineScopeByTopic((current) => ({
       ...current,
-      [activeTopic]: {
+      [topicId]: {
         kind: 'channel',
         channel_id: channelId,
       },
     }));
     setComposeChannelByTopic((current) => ({
       ...current,
-      [activeTopic]: {
+      [topicId]: {
         kind: 'private_channel',
         channel_id: channelId,
       },
     }));
+    setActiveTopic(topicId);
     setShellChromeState((current) => ({
       ...current,
       activePrimarySection: 'timeline',
       navOpen: false,
     }));
     window.requestAnimationFrame(() => {
-      syncRoute('replace');
+      syncRoute('replace', {
+        activeTopic: topicId,
+        primarySection: 'timeline',
+        timelineScope: {
+          kind: 'channel',
+          channel_id: channelId,
+        },
+        composeTarget: {
+          kind: 'private_channel',
+          channel_id: channelId,
+        },
+      });
     });
   }
 
@@ -2677,6 +2846,13 @@ function DesktopShellPage({
     setProfileSaving(true);
     try {
       const profile = await api.setMyProfile(profileDraft);
+      setProfileAvatarPreviewUrl((current) => {
+        if (current) {
+          URL.revokeObjectURL(current);
+        }
+        return null;
+      });
+      setProfileAvatarInputKey((value) => value + 1);
       setLocalProfile(profile);
       setProfileDraft(profileInputFromProfile(profile));
       setProfileDirty(false);
@@ -3003,6 +3179,7 @@ function DesktopShellPage({
         setComposerError(null);
         setReplyTarget(null);
         setRepostTarget(null);
+        setComposeDialogOpen(false);
         setSelectedThread(null);
         setThread([]);
         setShellChromeState((current) => ({
@@ -3041,6 +3218,7 @@ function DesktopShellPage({
       setDraftMediaItems([]);
       setAttachmentInputKey((value) => value + 1);
       setComposerError(null);
+      setComposeDialogOpen(false);
       setShellChromeState((current) => ({
         ...current,
         activePrimarySection: 'timeline',
@@ -3271,6 +3449,7 @@ function DesktopShellPage({
     const threadId = post.root_id ?? post.object_id;
     setRepostTarget(null);
     setReplyTarget(post);
+    setComposeDialogOpen(true);
     setSelectedThread(threadId);
     setSelectedAuthorPubkey(null);
     setSelectedAuthor(null);
@@ -3289,6 +3468,24 @@ function DesktopShellPage({
 
   function clearRepost() {
     setRepostTarget(null);
+  }
+
+  function openNewPostDialog() {
+    clearReply();
+    clearRepost();
+    setComposeDialogOpen(true);
+  }
+
+  function openFloatingActionDialog() {
+    if (shellChromeState.activePrimarySection === 'live') {
+      setLiveCreateDialogOpen(true);
+      return;
+    }
+    if (shellChromeState.activePrimarySection === 'game') {
+      setGameCreateDialogOpen(true);
+      return;
+    }
+    openNewPostDialog();
   }
 
   async function handleSimpleRepost(post: PostView) {
@@ -3334,6 +3531,7 @@ function DesktopShellPage({
     setComposerError(null);
     setReplyTarget(null);
     setRepostTarget(post);
+    setComposeDialogOpen(true);
     setSelectedAuthorPubkey(null);
     setSelectedAuthor(null);
     setAuthorError(null);
@@ -3588,6 +3786,7 @@ function DesktopShellPage({
       setLiveTitle('');
       setLiveDescription('');
       setLiveError(null);
+      setLiveCreateDialogOpen(false);
       setShellChromeState((current) => ({
         ...current,
         activePrimarySection: 'live',
@@ -3694,6 +3893,7 @@ function DesktopShellPage({
       setGameDescription('');
       setGameParticipantsInput('');
       setGameError(null);
+      setGameCreateDialogOpen(false);
       setShellChromeState((current) => ({
         ...current,
         activePrimarySection: 'game',
@@ -4146,9 +4346,9 @@ function DesktopShellPage({
         ),
         authorPicture:
           post.author_pubkey === syncStatus.local_author_pubkey
-            ? localProfile?.picture ?? null
+            ? resolveProfilePictureSrc(localProfile, mediaObjectUrls)
             : selectedAuthor?.author_pubkey === post.author_pubkey
-              ? selectedAuthor.picture ?? null
+              ? resolveProfilePictureSrc(selectedAuthor, mediaObjectUrls)
               : null,
         relationshipLabel: strongestRelationshipLabel(post),
         audienceChipLabel: post.channel_id
@@ -4197,7 +4397,7 @@ function DesktopShellPage({
     },
     [
       activeJoinedChannels,
-      localProfile?.picture,
+      localProfile,
       locale,
       mediaObjectUrls,
       selectedAuthor,
@@ -4280,6 +4480,7 @@ function DesktopShellPage({
             selectedAuthor.name
           )
         : t('common:fallbacks.authorDetail'),
+      pictureSrc: resolveProfilePictureSrc(selectedAuthor, mediaObjectUrls),
       summary: selectedAuthor
         ? {
             label: strongestRelationshipLabel(selectedAuthor),
@@ -4295,7 +4496,7 @@ function DesktopShellPage({
         : null,
       authorError,
     }),
-    [authorError, selectedAuthor, syncStatus.local_author_pubkey, t]
+    [authorError, mediaObjectUrls, selectedAuthor, syncStatus.local_author_pubkey, t]
   );
   const navRailHeader = (
     <div className='shell-nav-status'>
@@ -4345,78 +4546,19 @@ function DesktopShellPage({
       items={topicNavItems}
       onSelectTopic={(topic) => void handleSelectTopic(topic)}
       onSelectChannel={(topic, channelId) => {
-        if (topic !== activeTopic) {
-          setActiveTopic(topic);
-        }
-        handleSelectPrivateChannel(channelId);
+        handleSelectPrivateChannel(topic, channelId);
       }}
       onRemoveTopic={(topic) => void handleRemoveTopic(topic)}
     />
   );
-  const channelControl = (
-    <div className='shell-main-stack'>
-      {activeChannelPanelState.status === 'loading' ? <Notice>{t('channels:loading')}</Notice> : null}
-      {channelError ?? activeChannelPanelState.error ? (
-        <Notice tone='destructive'>{channelError ?? activeChannelPanelState.error}</Notice>
-      ) : null}
-      <form className='composer composer-compact' onSubmit={handleCreatePrivateChannel}>
-        <Label>
-          <span>{t('channels:editor.createChannel')}</span>
-          <Input
-            value={channelLabelInput}
-            onChange={(event) => setChannelLabelInput(event.target.value)}
-            placeholder={t('channels:editor.placeholders.channelLabel')}
-            disabled={channelActionPending !== null}
-          />
-        </Label>
-        <Label>
-          <span>{t('channels:editor.audience')}</span>
-          <Select
-            aria-label={t('channels:editor.audience')}
-            value={channelAudienceInput}
-            disabled={channelActionPending !== null}
-            onChange={(event) => setChannelAudienceInput(event.target.value as ChannelAudienceKind)}
-          >
-            <option value='invite_only'>{t('channels:audienceOptions.invite_only')}</option>
-            <option value='friend_only'>{t('channels:audienceOptions.friend_only')}</option>
-            <option value='friend_plus'>{t('channels:audienceOptions.friend_plus')}</option>
-          </Select>
-        </Label>
-        <div className='discovery-actions'>
-          <Button variant='secondary' type='submit' disabled={channelActionPending !== null}>
-            {t('channels:actions.createChannel')}
-          </Button>
-          <Button
-            variant='secondary'
-            type='button'
-            disabled={channelActionPending !== null || !activePrivateChannel}
-            onClick={() => void handleShareChannelAccess()}
-          >
-            {t('channels:actions.share')}
-          </Button>
-        </div>
-      </form>
-      <form className='composer composer-compact' onSubmit={handleJoinChannelAccess}>
-        <Label>
-          <span>{t('channels:editor.join')}</span>
-          <Textarea
-            value={inviteTokenInput}
-            onChange={(event) => setInviteTokenInput(event.target.value)}
-            placeholder={t('channels:editor.placeholders.inviteToken')}
-            disabled={channelActionPending !== null}
-          />
-        </Label>
-        <Button variant='secondary' type='submit' disabled={channelActionPending !== null}>
-          {t('channels:actions.join')}
-        </Button>
-      </form>
-      {inviteOutput ? (
-        <Notice tone='accent'>
-          <strong>{inviteOutputSummaryLabel(inviteOutputLabel)}</strong>
-          <code className='extended-inline-code'>{inviteOutput}</code>
-        </Notice>
-      ) : null}
-    </div>
+  const channelAction = (
+    <Button
+      variant='secondary'
+      type='button'
+      onClick={() => setChannelDialogOpen(true)}
+    >
+      {t('channels:title')}
+    </Button>
   );
 
   const connectivityPanelView = useMemo<ConnectivityPanelView>(
@@ -4893,7 +5035,7 @@ function DesktopShellPage({
                 </div>
               </Label>
             }
-            channelControl={channelControl}
+            channelAction={channelAction}
             channelSummary={
               activePrivateChannel
                 ? `${activePrivateChannel.label} · ${translateAudienceKindLabel(activePrivateChannel.audience_kind)}`
@@ -4951,42 +5093,7 @@ function DesktopShellPage({
                         {t('common:actions.refresh')}
                       </Button>
                     </div>
-                    <ComposerPanel
-                      value={composer}
-                      onChange={(event) => setComposer(event.target.value)}
-                      onSubmit={handlePublish}
-                      attachmentInputKey={attachmentInputKey}
-                      onAttachmentSelection={(event) => {
-                        void handleAttachmentSelection(event);
-                      }}
-                      draftMediaItems={composerDraftViews}
-                      onRemoveDraftAttachment={handleRemoveDraftAttachment}
-                      composerError={composerError}
-                      audienceLabel={activeComposeAudienceLabel}
-                      replyTarget={
-                        replyTarget
-                          ? {
-                              content: replyTarget.content,
-                              audienceLabel: replyTarget.audience_label,
-                            }
-                          : null
-                      }
-                      repostTarget={
-                        repostTarget
-                          ? {
-                              content: repostTarget.content,
-                              authorLabel: authorDisplayLabel(
-                                repostTarget.author_pubkey,
-                                repostTarget.author_display_name,
-                                repostTarget.author_name
-                              ),
-                            }
-                          : null
-                      }
-                      onClearReply={clearReply}
-                      onClearRepost={clearRepost}
-                      attachmentsDisabled={Boolean(repostTarget)}
-                    />
+                    {composerError ? <Notice tone='destructive'>{composerError}</Notice> : null}
                   </Card>
                   <Card className='shell-workspace-card'>
                     <TimelineFeed
@@ -5026,36 +5133,6 @@ function DesktopShellPage({
                     (liveError ?? activeLivePanelState.error) ? (
                       <Notice tone='destructive'>{liveError ?? activeLivePanelState.error}</Notice>
                     ) : null}
-                    <form
-                      className='composer composer-compact'
-                      onSubmit={handleCreateLiveSession}
-                      aria-busy={liveCreatePending}
-                    >
-                      <Label>
-                        <span>{t('live:fields.title')}</span>
-                        <Input
-                          value={liveTitle}
-                          onChange={(event) => setLiveTitle(event.target.value)}
-                          placeholder={t('live:fields.placeholders.title')}
-                          disabled={liveCreatePending}
-                        />
-                      </Label>
-                      <Label>
-                        <span>{t('live:fields.description')}</span>
-                        <Textarea
-                          value={liveDescription}
-                          onChange={(event) => setLiveDescription(event.target.value)}
-                          placeholder={t('live:fields.placeholders.description')}
-                          disabled={liveCreatePending}
-                        />
-                      </Label>
-                      <div className='topic-diagnostic topic-diagnostic-secondary'>
-                        <span>{t('common:labels.audience')}: {activeComposeAudienceLabel}</span>
-                      </div>
-                      <Button type='submit' disabled={liveCreatePending}>
-                        {t('live:actions.start')}
-                      </Button>
-                    </form>
                   </Card>
                   <Card className='shell-workspace-card'>
                     {liveSessionListItems.length === 0 && activeLivePanelState.status === 'ready' ? (
@@ -5144,45 +5221,6 @@ function DesktopShellPage({
                     (gameError ?? activeGamePanelState.error) ? (
                       <Notice tone='destructive'>{gameError ?? activeGamePanelState.error}</Notice>
                     ) : null}
-                    <form
-                      className='composer composer-compact'
-                      onSubmit={handleCreateGameRoom}
-                      aria-busy={gameCreatePending}
-                    >
-                      <Label>
-                        <span>{t('game:fields.title')}</span>
-                        <Input
-                          value={gameTitle}
-                          onChange={(event) => setGameTitle(event.target.value)}
-                          placeholder={t('game:fields.placeholders.title')}
-                          disabled={gameCreatePending}
-                        />
-                      </Label>
-                      <Label>
-                        <span>{t('game:fields.description')}</span>
-                        <Textarea
-                          value={gameDescription}
-                          onChange={(event) => setGameDescription(event.target.value)}
-                          placeholder={t('game:fields.placeholders.description')}
-                          disabled={gameCreatePending}
-                        />
-                      </Label>
-                      <Label>
-                        <span>{t('game:fields.participants')}</span>
-                        <Input
-                          value={gameParticipantsInput}
-                          onChange={(event) => setGameParticipantsInput(event.target.value)}
-                          placeholder={t('game:fields.placeholders.participants')}
-                          disabled={gameCreatePending}
-                        />
-                      </Label>
-                      <div className='topic-diagnostic topic-diagnostic-secondary'>
-                        <span>{t('common:labels.audience')}: {activeComposeAudienceLabel}</span>
-                      </div>
-                      <Button type='submit' disabled={gameCreatePending}>
-                        {t('game:actions.createRoom')}
-                      </Button>
-                    </form>
                   </Card>
                   <Card className='shell-workspace-card'>
                     {activeGameRooms.length === 0 && activeGamePanelState.status === 'ready' ? (
@@ -5310,7 +5348,14 @@ function DesktopShellPage({
                       dirty={profileDirty}
                       error={profileError ?? profilePanelState.error}
                       fields={profileEditorFields}
+                      picturePreviewSrc={profileEditorPictureSrc}
+                      hasPicture={profileEditorHasPicture}
+                      pictureInputKey={profileAvatarInputKey}
                       onFieldChange={handleProfileFieldChange}
+                      onPictureSelect={(event) => {
+                        void handleProfileAvatarSelection(event);
+                      }}
+                      onPictureClear={handleClearProfileAvatar}
                       onBack={openProfileOverview}
                       onSave={handleSaveProfile}
                       onReset={resetProfileDraft}
@@ -5319,7 +5364,7 @@ function DesktopShellPage({
                     <ProfileOverviewPanel
                       authorLabel={profileAuthorLabel}
                       about={localProfile?.about ?? null}
-                      picture={localProfile?.picture ?? null}
+                      picture={resolveProfilePictureSrc(localProfile, mediaObjectUrls)}
                       status={profilePanelState.status}
                       error={profileError ?? profilePanelState.error}
                       postCount={profileTimelinePostViews.length}
@@ -5365,6 +5410,197 @@ function DesktopShellPage({
           </Button>
         }
       />
+
+      <Dialog open={channelDialogOpen} onOpenChange={setChannelDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('channels:title')}</DialogTitle>
+            <DialogDescription>{activeTopic}</DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            <PrivateChannelPanel
+              status={activeChannelPanelState.status}
+              error={channelError ?? activeChannelPanelState.error}
+              pendingAction={channelActionPending}
+              channelLabel={channelLabelInput}
+              channelAudience={channelAudienceInput}
+              channelAudienceOptions={channelAudienceOptions}
+              inviteTokenInput={inviteTokenInput}
+              inviteOutput={inviteOutput}
+              inviteOutputLabel={inviteOutputLabel}
+              channels={privateChannelListItems}
+              selectedChannel={activePrivateChannel}
+              onChannelLabelChange={setChannelLabelInput}
+              onChannelAudienceChange={setChannelAudienceInput}
+              onInviteTokenChange={setInviteTokenInput}
+              onCreateChannel={(event) => void handleCreatePrivateChannel(event)}
+              onJoin={(event) => void handleJoinChannelAccess(event)}
+              onSelectChannel={(channelId) => handleSelectPrivateChannel(activeTopic, channelId)}
+              onShare={() => void handleShareChannelAccess()}
+            />
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={composeDialogOpen} onOpenChange={setComposeDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {replyTarget
+                ? t('common:actions.reply')
+                : repostTarget
+                  ? t('common:actions.quoteRepost')
+                  : t('common:actions.publish')}
+            </DialogTitle>
+            <DialogDescription>
+              {t('common:labels.audience')}: {activeComposeAudienceLabel}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            <ComposerPanel
+              value={composer}
+              onChange={(event) => setComposer(event.target.value)}
+              onSubmit={handlePublish}
+              attachmentInputKey={attachmentInputKey}
+              onAttachmentSelection={(event) => {
+                void handleAttachmentSelection(event);
+              }}
+              draftMediaItems={composerDraftViews}
+              onRemoveDraftAttachment={handleRemoveDraftAttachment}
+              composerError={composerError}
+              audienceLabel={activeComposeAudienceLabel}
+              replyTarget={
+                replyTarget
+                  ? {
+                      content: replyTarget.content,
+                      audienceLabel: replyTarget.audience_label,
+                    }
+                  : null
+              }
+              repostTarget={
+                repostTarget
+                  ? {
+                      content: repostTarget.content,
+                      authorLabel: authorDisplayLabel(
+                        repostTarget.author_pubkey,
+                        repostTarget.author_display_name,
+                        repostTarget.author_name
+                      ),
+                    }
+                  : null
+              }
+              onClearReply={clearReply}
+              onClearRepost={clearRepost}
+              attachmentsDisabled={Boolean(repostTarget)}
+            />
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={liveCreateDialogOpen} onOpenChange={setLiveCreateDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('live:actions.start')}</DialogTitle>
+            <DialogDescription>
+              {t('common:labels.audience')}: {activeComposeAudienceLabel}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            <form
+              className='composer composer-compact'
+              onSubmit={handleCreateLiveSession}
+              aria-busy={liveCreatePending}
+            >
+              <Label>
+                <span>{t('live:fields.title')}</span>
+                <Input
+                  value={liveTitle}
+                  onChange={(event) => setLiveTitle(event.target.value)}
+                  placeholder={t('live:fields.placeholders.title')}
+                  disabled={liveCreatePending}
+                />
+              </Label>
+              <Label>
+                <span>{t('live:fields.description')}</span>
+                <Textarea
+                  value={liveDescription}
+                  onChange={(event) => setLiveDescription(event.target.value)}
+                  placeholder={t('live:fields.placeholders.description')}
+                  disabled={liveCreatePending}
+                />
+              </Label>
+              {liveError ? <p className='error error-inline'>{liveError}</p> : null}
+              <Button type='submit' disabled={liveCreatePending}>
+                {t('live:actions.start')}
+              </Button>
+            </form>
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={gameCreateDialogOpen} onOpenChange={setGameCreateDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('game:actions.createRoom')}</DialogTitle>
+            <DialogDescription>
+              {t('common:labels.audience')}: {activeComposeAudienceLabel}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            <form
+              className='composer composer-compact'
+              onSubmit={handleCreateGameRoom}
+              aria-busy={gameCreatePending}
+            >
+              <Label>
+                <span>{t('game:fields.title')}</span>
+                <Input
+                  value={gameTitle}
+                  onChange={(event) => setGameTitle(event.target.value)}
+                  placeholder={t('game:fields.placeholders.title')}
+                  disabled={gameCreatePending}
+                />
+              </Label>
+              <Label>
+                <span>{t('game:fields.description')}</span>
+                <Textarea
+                  value={gameDescription}
+                  onChange={(event) => setGameDescription(event.target.value)}
+                  placeholder={t('game:fields.placeholders.description')}
+                  disabled={gameCreatePending}
+                />
+              </Label>
+              <Label>
+                <span>{t('game:fields.participants')}</span>
+                <Input
+                  value={gameParticipantsInput}
+                  onChange={(event) => setGameParticipantsInput(event.target.value)}
+                  placeholder={t('game:fields.placeholders.participants')}
+                  disabled={gameCreatePending}
+                />
+              </Label>
+              {gameError ? <p className='error error-inline'>{gameError}</p> : null}
+              <Button type='submit' disabled={gameCreatePending}>
+                {t('game:actions.createRoom')}
+              </Button>
+            </form>
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
+
+      {showFloatingActionButton ? (
+        <Button
+          className='shell-fab'
+          variant='primary'
+          size='icon'
+          type='button'
+          data-testid='shell-fab'
+          aria-label={floatingActionLabel}
+          onClick={openFloatingActionDialog}
+        >
+          <Plus className='size-5' aria-hidden='true' />
+        </Button>
+      ) : null}
 
       <SettingsDrawer
         drawerId={SHELL_SETTINGS_ID}

--- a/apps/desktop/src/components/core/AuthorDetailCard.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.tsx
@@ -31,7 +31,7 @@ export function AuthorDetailCard({
               <div className='author-detail-hero'>
                 <AuthorAvatar
                   label={view.displayLabel}
-                  picture={author.picture ?? null}
+                  picture={view.pictureSrc ?? author.picture ?? null}
                   size='sm'
                   testId='author-detail-avatar'
                 />

--- a/apps/desktop/src/components/core/CoreProductFlow.stories.tsx
+++ b/apps/desktop/src/components/core/CoreProductFlow.stories.tsx
@@ -285,7 +285,7 @@ function CoreProductFlowStory({ width }: { width: number }) {
                 </div>
               </Label>
             }
-            channelControl={<div />}
+            channelAction={<Button variant='secondary'>Private Channels</Button>}
             topicList={
               <TopicNavList
                 items={TOPIC_ITEMS}

--- a/apps/desktop/src/components/core/PostCard.tsx
+++ b/apps/desktop/src/components/core/PostCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Reply, Repeat2, SmilePlus } from 'lucide-react';
 
 import { formatLocalizedTime } from '@/i18n/format';
 import type {
@@ -12,6 +13,7 @@ import type {
 import { AuthorAvatar } from './AuthorAvatar';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 import { RelationshipBadge } from './RelationshipBadge';
 import { PostMedia } from './PostMedia';
@@ -80,6 +82,7 @@ export function PostCard({
   const { t } = useTranslation(['common', 'profile']);
   const { post, context } = view;
   const [reactionTrayOpen, setReactionTrayOpen] = useState(false);
+  const [repostMenuOpen, setRepostMenuOpen] = useState(false);
   const [emojiInput, setEmojiInput] = useState('');
   const isPendingText = post.content_status === 'Missing' && post.content === '[blob pending]';
   const audienceChipLabel = view.audienceChipLabel ?? post.audience_label;
@@ -297,24 +300,67 @@ export function PostCard({
             ) : null}
             <Button
               variant='secondary'
+              size='icon'
+              className='post-action-button'
               type='button'
+              aria-label={t('actions.react')}
               onClick={() => setReactionTrayOpen((current) => !current)}
             >
-              {t('actions.react')}
+              <SmilePlus className='size-4' aria-hidden='true' />
             </Button>
-            {canRepost && onRepost ? (
-              <Button variant='secondary' type='button' onClick={() => onRepost(post)}>
-                {t('actions.repost')}
-              </Button>
-            ) : null}
-            {canRepost && onQuoteRepost ? (
-              <Button variant='secondary' type='button' onClick={() => onQuoteRepost(post)}>
-                {t('actions.quoteRepost')}
-              </Button>
+            {canRepost && (onRepost || onQuoteRepost) ? (
+              <Popover open={repostMenuOpen} onOpenChange={setRepostMenuOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant='secondary'
+                    size='icon'
+                    className='post-action-button'
+                    type='button'
+                    aria-label={t('actions.repost')}
+                  >
+                    <Repeat2 className='size-4' aria-hidden='true' />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent align='end' className='post-action-popover'>
+                  <div className='post-action-popover-stack'>
+                    {onRepost ? (
+                      <Button
+                        variant='secondary'
+                        type='button'
+                        onClick={() => {
+                          setRepostMenuOpen(false);
+                          onRepost(post);
+                        }}
+                      >
+                        {t('actions.repost')}
+                      </Button>
+                    ) : null}
+                    {onQuoteRepost ? (
+                      <Button
+                        variant='secondary'
+                        type='button'
+                        onClick={() => {
+                          setRepostMenuOpen(false);
+                          onQuoteRepost(post);
+                        }}
+                      >
+                        {t('actions.quoteRepost')}
+                      </Button>
+                    ) : null}
+                  </div>
+                </PopoverContent>
+              </Popover>
             ) : null}
             {canReply ? (
-              <Button variant='secondary' type='button' onClick={() => onReply(post)}>
-                {t('actions.reply')}
+              <Button
+                variant='secondary'
+                size='icon'
+                className='post-action-button'
+                type='button'
+                aria-label={t('actions.reply')}
+                onClick={() => onReply(post)}
+              >
+                <Reply className='size-4' aria-hidden='true' />
               </Button>
             ) : null}
           </>

--- a/apps/desktop/src/components/core/types.ts
+++ b/apps/desktop/src/components/core/types.ts
@@ -84,6 +84,7 @@ export type AuthorRelationshipSummary = {
 export type AuthorDetailView = {
   author: AuthorSocialView | null;
   displayLabel: string;
+  pictureSrc?: string | null;
   summary: AuthorRelationshipSummary | null;
   authorError?: string | null;
 };

--- a/apps/desktop/src/components/extended/ExtendedProductFlow.stories.tsx
+++ b/apps/desktop/src/components/extended/ExtendedProductFlow.stories.tsx
@@ -25,7 +25,6 @@ function ExtendedProductFlowStory({ width }: { width: number }) {
     displayName: 'Local Author',
     name: 'local-author',
     about: 'Maintains the desktop shell migration.',
-    picture: 'https://example.com/avatar.png',
   });
   const [channelLabel, setChannelLabel] = useState('Core Contributors');
   const [inviteToken, setInviteToken] = useState('');
@@ -182,16 +181,21 @@ function ExtendedProductFlowStory({ width }: { width: number }) {
         <ProfileEditorPanel
           authorLabel='Local Author'
           status='ready'
-          saving={false}
-          dirty={true}
-          error={null}
-          fields={profileFields}
-          onFieldChange={(field, value) =>
-            setProfileFields((current) => ({ ...current, [field]: value }))
-          }
-          onSave={(event) => event.preventDefault()}
-          onReset={() => undefined}
-        />
+        saving={false}
+        dirty={true}
+        error={null}
+        fields={profileFields}
+        picturePreviewSrc='https://example.com/avatar.png'
+        hasPicture={true}
+        pictureInputKey={0}
+        onFieldChange={(field, value) =>
+          setProfileFields((current) => ({ ...current, [field]: value }))
+        }
+        onPictureSelect={() => undefined}
+        onPictureClear={() => undefined}
+        onSave={(event) => event.preventDefault()}
+        onReset={() => undefined}
+      />
       </div>
     </div>
   );

--- a/apps/desktop/src/components/extended/ProfileEditorPanel.stories.tsx
+++ b/apps/desktop/src/components/extended/ProfileEditorPanel.stories.tsx
@@ -24,9 +24,13 @@ const STORY_ARGS = {
     displayName: 'Local Author',
     name: 'local-author',
     about: 'Maintains shell UI migration work.',
-    picture: 'https://example.com/avatar.png',
   },
+  picturePreviewSrc: 'https://example.com/avatar.png',
+  hasPicture: true,
+  pictureInputKey: 0,
   onFieldChange: () => undefined,
+  onPictureSelect: () => undefined,
+  onPictureClear: () => undefined,
   onSave: (event: FormEvent<HTMLFormElement>) => event.preventDefault(),
   onReset: () => undefined,
 } satisfies React.ComponentProps<typeof ProfileEditorPanel>;
@@ -42,7 +46,6 @@ function ProfileStory({
     displayName: 'Local Author',
     name: 'local-author',
     about: 'Maintains shell UI migration work.',
-    picture: 'https://example.com/avatar.png',
   });
 
   return (
@@ -53,7 +56,12 @@ function ProfileStory({
       dirty={false}
       error={error}
       fields={fields}
+      picturePreviewSrc='https://example.com/avatar.png'
+      hasPicture={true}
+      pictureInputKey={0}
       onFieldChange={(field, value) => setFields((current) => ({ ...current, [field]: value }))}
+      onPictureSelect={() => undefined}
+      onPictureClear={() => undefined}
       onSave={(event) => event.preventDefault()}
       onReset={() => undefined}
     />

--- a/apps/desktop/src/components/extended/ProfileEditorPanel.tsx
+++ b/apps/desktop/src/components/extended/ProfileEditorPanel.tsx
@@ -1,4 +1,4 @@
-import type { FormEventHandler } from 'react';
+import type { ChangeEventHandler, FormEventHandler } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -17,7 +17,12 @@ type ProfileEditorPanelProps = {
   dirty: boolean;
   error: string | null;
   fields: ProfileEditorFields;
+  picturePreviewSrc?: string | null;
+  hasPicture: boolean;
+  pictureInputKey: number;
   onFieldChange: (field: keyof ProfileEditorFields, value: string) => void;
+  onPictureSelect: ChangeEventHandler<HTMLInputElement>;
+  onPictureClear: () => void;
   onBack?: () => void;
   onSave: FormEventHandler<HTMLFormElement>;
   onReset: () => void;
@@ -30,12 +35,17 @@ export function ProfileEditorPanel({
   dirty,
   error,
   fields,
+  picturePreviewSrc,
+  hasPicture,
+  pictureInputKey,
   onFieldChange,
+  onPictureSelect,
+  onPictureClear,
   onBack,
   onSave,
   onReset,
 }: ProfileEditorPanelProps) {
-  const { t } = useTranslation('profile');
+  const { t } = useTranslation(['profile', 'common']);
   const disabled = status === 'loading' || saving;
 
   return (
@@ -84,15 +94,31 @@ export function ProfileEditorPanel({
             disabled={disabled}
           />
         </Label>
-        <Label>
-          <span>{t('editor.picture')}</span>
-          <Input
-            value={fields.picture}
-            onChange={(event) => onFieldChange('picture', event.target.value)}
-            placeholder={t('editor.placeholders.picture')}
-            disabled={disabled}
-          />
-        </Label>
+        <div className='profile-editor-picture-panel'>
+          <Label>
+            <span>{t('editor.picture')}</span>
+            <Input
+              key={pictureInputKey}
+              type='file'
+              accept='image/*'
+              disabled={disabled}
+              onChange={onPictureSelect}
+            />
+          </Label>
+          {picturePreviewSrc ? (
+            <div className='profile-editor-picture-preview'>
+              <img src={picturePreviewSrc} alt={`${authorLabel} avatar`} className='profile-overview-image' />
+            </div>
+          ) : null}
+          <Button
+            variant='secondary'
+            type='button'
+            disabled={!hasPicture || disabled}
+            onClick={onPictureClear}
+          >
+            {t('common:actions.clear', { ns: 'common' })}
+          </Button>
+        </div>
 
         {status !== 'error' && error ? <p className='error error-inline'>{error}</p> : null}
 

--- a/apps/desktop/src/components/extended/types.ts
+++ b/apps/desktop/src/components/extended/types.ts
@@ -11,7 +11,6 @@ export type ProfileEditorFields = {
   displayName: string;
   name: string;
   about: string;
-  picture: string;
 };
 
 export type PrivateChannelPendingAction =

--- a/apps/desktop/src/components/review/DesktopShellWorkspaceGallery.stories.tsx
+++ b/apps/desktop/src/components/review/DesktopShellWorkspaceGallery.stories.tsx
@@ -221,7 +221,7 @@ function ShellSurface({
                 </div>
               </Label>
             }
-            channelControl={<ChannelRailControl />}
+            channelAction={<ChannelRailControl />}
             channelSummary='Core Contributors · Friends+'
             topicList={
               <TopicNavList
@@ -493,7 +493,6 @@ function ProfileEditWorkspace() {
     displayName: 'Local Author',
     name: 'local-author',
     about: 'Maintains the desktop shell migration and topic-first review cadence.',
-    picture: '',
   });
 
   return (
@@ -505,7 +504,12 @@ function ProfileEditWorkspace() {
         dirty={true}
         error={null}
         fields={fields}
+        picturePreviewSrc='https://example.com/avatar.png'
+        hasPicture={true}
+        pictureInputKey={0}
         onFieldChange={(field, value) => setFields((current) => ({ ...current, [field]: value }))}
+        onPictureSelect={() => undefined}
+        onPictureClear={() => undefined}
         onBack={() => undefined}
         onSave={(event) => event.preventDefault()}
         onReset={() => undefined}

--- a/apps/desktop/src/components/shell/ShellFrame.stories.tsx
+++ b/apps/desktop/src/components/shell/ShellFrame.stories.tsx
@@ -62,7 +62,7 @@ function ShellFrameStory() {
                 </div>
               </Label>
             }
-            channelControl={<div />}
+            channelAction={<Button variant='secondary'>Private Channels</Button>}
             topicList={
               <TopicNavList
                 items={topicItems}

--- a/apps/desktop/src/components/shell/ShellFrame.tsx
+++ b/apps/desktop/src/components/shell/ShellFrame.tsx
@@ -63,7 +63,7 @@ export function ShellFrame({
           tabIndex={-1}
           aria-label='Primary workspace'
         >
-          {workspace}
+          <div className='shell-main-lane'>{workspace}</div>
         </main>
         {detailPaneStack}
       </div>

--- a/apps/desktop/src/components/shell/ShellNavRail.stories.tsx
+++ b/apps/desktop/src/components/shell/ShellNavRail.stories.tsx
@@ -51,16 +51,10 @@ function ShellNavRailStory() {
             </div>
           </Label>
         }
-        channelControl={
-          <div className='shell-main-stack'>
-            <Label>
-              <span>{i18n.t('channels:editor.createChannel')}</span>
-              <Input value='Core Contributors' readOnly />
-            </Label>
-            <Button variant='secondary' type='button'>
-              {i18n.t('channels:actions.createChannel')}
-            </Button>
-          </div>
+        channelAction={
+          <Button variant='secondary' type='button'>
+            {i18n.t('channels:title')}
+          </Button>
         }
         channelSummary='Core Contributors · Friends+'
         topicList={
@@ -91,8 +85,7 @@ const meta = {
     onOpenChange: () => undefined,
     headerContent: null,
     addTopicControl: null,
-    channelControl: null,
-    channelDefaultOpen: false,
+    channelAction: null,
     channelSummary: null,
     topicList: null,
     topicCount: topicItems.length,
@@ -105,7 +98,5 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  args: {
-    channelDefaultOpen: false,
-  },
+  args: {},
 };

--- a/apps/desktop/src/components/shell/ShellNavRail.tsx
+++ b/apps/desktop/src/components/shell/ShellNavRail.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { ChevronDown, X } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -12,9 +12,8 @@ type ShellNavRailProps = {
   onOpenChange: (open: boolean) => void;
   headerContent: React.ReactNode;
   addTopicControl: React.ReactNode;
-  channelControl?: React.ReactNode;
-  channelDefaultOpen?: boolean;
   channelSummary?: React.ReactNode;
+  channelAction?: React.ReactNode;
   topicList: React.ReactNode;
   topicCount: number;
 };
@@ -25,15 +24,13 @@ export function ShellNavRail({
   onOpenChange,
   headerContent,
   addTopicControl,
-  channelControl,
-  channelDefaultOpen = false,
   channelSummary,
+  channelAction,
   topicList,
   topicCount,
 }: ShellNavRailProps) {
   const { t } = useTranslation('shell');
-  const [channelOpen, setChannelOpen] = React.useState(channelDefaultOpen);
-  const hasChannelControl = channelControl !== null && channelControl !== undefined;
+  const hasChannelAction = channelAction !== null && channelAction !== undefined;
 
   return (
     <>
@@ -69,26 +66,15 @@ export function ShellNavRail({
 
         <div className='shell-nav-topic-entry'>{addTopicControl}</div>
 
-        {hasChannelControl ? (
-          <section
-            className='shell-nav-topic-entry shell-nav-accordion'
-            data-open={channelOpen}
-          >
-            <button
-              className='shell-nav-accordion-trigger'
-              type='button'
-              aria-expanded={channelOpen}
-              onClick={() => setChannelOpen((current) => !current)}
-            >
+        {hasChannelAction ? (
+          <section className='shell-nav-topic-entry shell-nav-channel-summary'>
+            <div className='shell-nav-channel-copy'>
               <span className='shell-nav-accordion-title'>{t('navigation.channel')}</span>
               {channelSummary ? (
                 <span className='shell-nav-accordion-summary'>{channelSummary}</span>
               ) : null}
-              <ChevronDown className='shell-nav-accordion-icon size-4' aria-hidden='true' />
-            </button>
-            <div className='shell-nav-accordion-content' hidden={!channelOpen}>
-              {channelControl}
             </div>
+            {channelAction}
           </section>
         ) : null}
 

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable react-refresh/only-export-components */
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogPortal = DialogPrimitive.Portal;
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('ui-dialog-overlay', className)}
+    {...props}
+  />
+));
+
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    hideClose?: boolean;
+  }
+>(({ className, children, hideClose = false, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn('ui-dialog-content panel', className)}
+      {...props}
+    >
+      {children}
+      {!hideClose ? (
+        <DialogPrimitive.Close className='ui-dialog-close button-ghost' aria-label='Close dialog'>
+          <X className='size-5' aria-hidden='true' />
+        </DialogPrimitive.Close>
+      ) : null}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('ui-dialog-header', className)} {...props} />
+);
+
+export const DialogBody = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('ui-dialog-body', className)} {...props} />
+);
+
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn('ui-dialog-title', className)} {...props} />
+));
+
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('ui-dialog-description', className)}
+    {...props}
+  />
+));
+
+DialogDescription.displayName = DialogPrimitive.Description.displayName;

--- a/apps/desktop/src/components/ui/popover.tsx
+++ b/apps/desktop/src/components/ui/popover.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable react-refresh/only-export-components */
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+
+import { cn } from '@/lib/utils';
+
+export const Popover = PopoverPrimitive.Root;
+export const PopoverTrigger = PopoverPrimitive.Trigger;
+export const PopoverAnchor = PopoverPrimitive.Anchor;
+
+export const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, sideOffset = 8, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn('ui-popover-content panel', className)}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;

--- a/apps/desktop/src/i18n/locales/en/profile.json
+++ b/apps/desktop/src/i18n/locales/en/profile.json
@@ -5,12 +5,11 @@
     "displayName": "Display Name",
     "loading": "Loading profile…",
     "name": "Name",
-    "picture": "Picture URL",
+    "picture": "Picture",
     "placeholders": {
       "about": "Short bio",
       "displayName": "Visible label",
-      "name": "Canonical name",
-      "picture": "https://..."
+      "name": "Canonical name"
     },
     "reset": "Reset",
     "save": "Save Profile",

--- a/apps/desktop/src/i18n/locales/ja/profile.json
+++ b/apps/desktop/src/i18n/locales/ja/profile.json
@@ -5,12 +5,11 @@
     "displayName": "表示名",
     "loading": "プロフィールを読み込み中…",
     "name": "名前",
-    "picture": "画像 URL",
+    "picture": "プロフィール画像",
     "placeholders": {
       "about": "短い自己紹介",
       "displayName": "表示名",
-      "name": "正規名",
-      "picture": "https://..."
+      "name": "正規名"
     },
     "reset": "リセット",
     "save": "プロフィールを保存",

--- a/apps/desktop/src/i18n/locales/zh-CN/profile.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/profile.json
@@ -5,12 +5,11 @@
     "displayName": "显示名称",
     "loading": "正在加载资料…",
     "name": "名称",
-    "picture": "图片 URL",
+    "picture": "头像",
     "placeholders": {
       "about": "简短介绍",
       "displayName": "显示名称",
-      "name": "规范名称",
-      "picture": "https://..."
+      "name": "规范名称"
     },
     "reset": "重置",
     "save": "保存资料",

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -104,6 +104,7 @@ export type Profile = {
   display_name?: string | null;
   about?: string | null;
   picture?: string | null;
+  picture_asset?: ProfileAssetView | null;
   updated_at: number;
 };
 
@@ -112,6 +113,15 @@ export type ProfileInput = {
   display_name?: string | null;
   about?: string | null;
   picture?: string | null;
+  picture_upload?: CreateAttachmentInput | null;
+  clear_picture?: boolean;
+};
+
+export type ProfileAssetView = {
+  hash: string;
+  mime: string;
+  bytes: number;
+  role: 'profile_avatar';
 };
 
 export type AuthorSocialView = {
@@ -120,6 +130,7 @@ export type AuthorSocialView = {
   display_name?: string | null;
   about?: string | null;
   picture?: string | null;
+  picture_asset?: ProfileAssetView | null;
   updated_at?: number | null;
   following: boolean;
   followed_by: boolean;

--- a/apps/desktop/src/mocks/desktopApiMock.ts
+++ b/apps/desktop/src/mocks/desktopApiMock.ts
@@ -108,6 +108,7 @@ function withDefaultAuthorView(
     display_name: null,
     about: null,
     picture: null,
+    picture_asset: null,
     updated_at: null,
     following: false,
     followed_by: false,
@@ -271,6 +272,7 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
     display_name: null,
     about: null,
     picture: null,
+    picture_asset: null,
     updated_at: 0,
     ...options?.myProfile,
   };
@@ -574,12 +576,30 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       return myProfile;
     },
     async setMyProfile(input) {
-      myProfile = { ...myProfile, ...input, updated_at: myProfile.updated_at + 1 };
+      const nextPictureAsset =
+        input.clear_picture
+          ? null
+          : input.picture_upload
+            ? {
+                hash: `profile-avatar-${myProfile.updated_at + 1}`,
+                mime: input.picture_upload.mime,
+                bytes: input.picture_upload.byte_size,
+                role: 'profile_avatar' as const,
+              }
+            : myProfile.picture_asset ?? null;
+      myProfile = {
+        ...myProfile,
+        ...input,
+        picture: input.clear_picture ? null : (input.picture ?? myProfile.picture ?? null),
+        picture_asset: nextPictureAsset,
+        updated_at: myProfile.updated_at + 1,
+      };
       authorSocialViews[myProfile.pubkey] = withDefaultAuthorView(myProfile.pubkey, {
         name: myProfile.name ?? null,
         display_name: myProfile.display_name ?? null,
         about: myProfile.about ?? null,
         picture: myProfile.picture ?? null,
+        picture_asset: myProfile.picture_asset ?? null,
         updated_at: myProfile.updated_at,
       });
       return myProfile;
@@ -617,6 +637,7 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
           display_name: myProfile.display_name ?? null,
           about: myProfile.about ?? null,
           picture: myProfile.picture ?? null,
+          picture_asset: myProfile.picture_asset ?? null,
           updated_at: myProfile.updated_at,
         });
       }

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -140,6 +140,12 @@
   min-width: 0;
 }
 
+.shell-main-lane {
+  width: 100%;
+  max-inline-size: clamp(44rem, 58vw, 64rem);
+  margin-inline: auto;
+}
+
 .shell-main-stack {
   display: grid;
   gap: 1rem;
@@ -264,6 +270,23 @@
 .shell-nav-topic-entry {
   display: grid;
   gap: 0.75rem;
+}
+
+.shell-nav-channel-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 18px;
+  background: var(--surface-panel-muted);
+}
+
+.shell-nav-channel-copy {
+  min-width: 0;
+  display: grid;
+  gap: 0.25rem;
 }
 
 .shell-nav-accordion {
@@ -534,6 +557,114 @@
   object-fit: cover;
 }
 
+.profile-editor-picture-panel {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.profile-editor-picture-preview {
+  width: min(9rem, 100%);
+  aspect-ratio: 1;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 22px;
+  background: var(--surface-avatar);
+}
+
+.ui-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: color-mix(in srgb, var(--surface-overlay) 56%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+.ui-dialog-content {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  z-index: 81;
+  width: min(42rem, calc(100vw - 2rem));
+  max-height: calc(100vh - 2rem);
+  padding: 1.1rem;
+  overflow: auto;
+  transform: translate(-50%, -50%);
+}
+
+.ui-dialog-header {
+  display: grid;
+  gap: 0.35rem;
+  padding-right: 3rem;
+}
+
+.ui-dialog-title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.ui-dialog-description {
+  margin: 0;
+  color: var(--muted-foreground);
+}
+
+.ui-dialog-body {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.ui-dialog-body > .panel-subsection {
+  margin-top: 0;
+}
+
+.ui-dialog-close {
+  position: absolute;
+  top: 0.9rem;
+  right: 0.9rem;
+}
+
+.ui-popover-content {
+  z-index: 82;
+  width: min(14rem, calc(100vw - 1.5rem));
+  padding: 0.5rem;
+}
+
+.post-action-button {
+  width: 2.25rem;
+  height: 2.25rem;
+  min-width: 2.25rem;
+  padding: 0;
+  border-radius: 999px;
+}
+
+.post-action-button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.post-action-popover {
+  width: 10rem;
+}
+
+.post-action-popover-stack {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.shell-fab {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 50;
+  width: 3.5rem;
+  height: 3.5rem;
+  min-width: 3.5rem;
+  border-radius: 999px;
+  box-shadow: var(--shadow-panel);
+}
+
 .shell-settings-drawer {
   position: fixed;
   top: 1rem;
@@ -603,6 +734,12 @@
   pointer-events: auto;
 }
 
+.shell-settings-backdrop {
+  background: color-mix(in srgb, var(--surface-overlay) 52%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
 .shell-mobile-close {
   display: none;
 }
@@ -621,6 +758,10 @@
 @media (max-width: 1099px) {
   .shell-layout {
     grid-template-columns: minmax(260px, 280px) minmax(0, 1fr);
+  }
+
+  .shell-main-lane {
+    max-inline-size: 100%;
   }
 
   .shell-context {
@@ -735,6 +876,11 @@
   .shell-mobile-footer > * {
     width: min(100%, 18rem);
     pointer-events: auto;
+  }
+
+  .shell-fab {
+    right: 1rem;
+    bottom: 5.5rem;
   }
 
   .shell-workspace-header {

--- a/apps/desktop/tests/playwright/extended-flow.spec.ts
+++ b/apps/desktop/tests/playwright/extended-flow.spec.ts
@@ -1,10 +1,20 @@
 import { expect, test, type Page } from '@playwright/test';
 
-async function openChannelSection(page: Page) {
-  const trigger = page.locator('.shell-nav-accordion-trigger').first();
-  if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
-    await trigger.click();
+async function openChannelManager(page: Page) {
+  const dialog = page.getByRole('dialog', { name: 'Channels' });
+  if (await dialog.isVisible().catch(() => false)) {
+    return dialog;
   }
+  await page.getByRole('button', { name: 'Channels' }).click();
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+async function openFloatingActionDialog(page: Page) {
+  await page.getByTestId('shell-fab').click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  return dialog;
 }
 
 test('browser mock shell can run profile, private channel, live, and game flows', async ({
@@ -13,33 +23,30 @@ test('browser mock shell can run profile, private channel, live, and game flows'
   await page.setViewportSize({ width: 1440, height: 980 });
   await page.goto('/');
 
-  await openChannelSection(page);
-  await page.getByPlaceholder('core contributors').fill('Core Contributors');
-  await page.getByRole('button', { name: 'Create Channel' }).click();
+  const channelDialog = await openChannelManager(page);
+  await channelDialog.getByPlaceholder('core contributors').fill('Core Contributors');
+  await channelDialog.getByRole('button', { name: 'Create Channel' }).click();
   await expect(page).toHaveURL(/#\/timeline\?topic=.*&channel=channel-1/);
-  await expect(
-    page.locator('.topic-list').getByRole('button', { name: /^Core Contributors\b/i })
-  ).toBeVisible();
-  await page.getByRole('button', { name: 'Share' }).click();
-  await expect(page.getByText(/^invite:kukuri:topic:demo:channel-1$/)).toBeVisible();
+  await expect(channelDialog.getByRole('heading', { name: 'Core Contributors' })).toBeVisible();
+  await channelDialog.getByRole('button', { name: 'Share' }).click();
+  await expect(channelDialog.getByText(/^invite:kukuri:topic:demo:channel-1$/)).toBeVisible();
 
-  await openChannelSection(page);
-  await page
+  await channelDialog
     .getByPlaceholder('paste private channel invite, friend grant, or friends+ share')
     .fill('invite-token');
-  await page.getByRole('button', { name: 'Join' }).click();
-  await expect(
-    page.locator('.topic-list').getByRole('button', { name: /^Imported\b/i })
-  ).toBeVisible();
+  await channelDialog.getByRole('button', { name: 'Join' }).click();
+  await expect(channelDialog.getByText(/Imported/i).first()).toBeVisible();
+  await page.keyboard.press('Escape');
 
   await page.goto('/#/live');
-  const liveTitle = page.getByLabel('Live Title');
-  const liveDescription = page.getByLabel('Live Description');
+  const liveDialog = await openFloatingActionDialog(page);
+  const liveTitle = liveDialog.getByLabel('Live Title');
+  const liveDescription = liveDialog.getByLabel('Live Description');
   await liveTitle.fill('Launch Party');
   await expect(liveTitle).toHaveValue('Launch Party');
   await liveDescription.fill('watch along');
   await expect(liveDescription).toHaveValue('watch along');
-  await page.getByRole('button', { name: 'Start Live' }).click();
+  await liveDialog.getByRole('button', { name: 'Start Live' }).click();
   const liveCard = page.locator('article.post-card').filter({ has: page.getByText('Launch Party') });
   await expect(liveCard).toBeVisible();
   await page
@@ -61,10 +68,11 @@ test('browser mock shell can run profile, private channel, live, and game flows'
   ).toBeVisible();
 
   await page.goto('/#/game');
-  await page.getByPlaceholder('Top 8 Finals').fill('Grand Finals');
-  await page.getByPlaceholder('match summary').fill('set one');
-  await page.getByPlaceholder('Alice, Bob').fill('Alice, Bob');
-  await page.getByRole('button', { name: 'Create Room' }).click();
+  const gameDialog = await openFloatingActionDialog(page);
+  await gameDialog.getByPlaceholder('Top 8 Finals').fill('Grand Finals');
+  await gameDialog.getByPlaceholder('match summary').fill('set one');
+  await gameDialog.getByPlaceholder('Alice, Bob').fill('Alice, Bob');
+  await gameDialog.getByRole('button', { name: 'Create Room' }).click();
   await expect(page.getByText('Grand Finals')).toBeVisible();
   await page.getByLabel(/game-.*-status/).selectOption('Running');
   await page.getByLabel(/game-.*-phase/).fill('Round 3');

--- a/apps/desktop/tests/playwright/hash-routing.spec.ts
+++ b/apps/desktop/tests/playwright/hash-routing.spec.ts
@@ -1,10 +1,20 @@
 import { expect, test, type Page } from '@playwright/test';
 
-async function openChannelSection(page: Page) {
-  const trigger = page.locator('.shell-nav-accordion-trigger').first();
-  if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
-    await trigger.click();
+async function openChannelManager(page: Page) {
+  const dialog = page.getByRole('dialog', { name: 'Channels' });
+  if (await dialog.isVisible().catch(() => false)) {
+    return dialog;
   }
+  await page.getByRole('button', { name: 'Channels' }).click();
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+async function openComposerDialog(page: Page) {
+  await page.getByTestId('shell-fab').click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  return dialog;
 }
 
 test('browser mock hash routes deep link profile, timeline normalization, and settings surfaces', async ({
@@ -17,7 +27,7 @@ test('browser mock hash routes deep link profile, timeline normalization, and se
   await expect(page).toHaveURL(/#\/profile\?topic=/);
 
   await page.goto('/#/channels');
-  await expect(page.locator('.shell-nav-accordion-trigger').first()).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Channels' })).toBeVisible();
   await expect(page).toHaveURL(/#\/timeline\?topic=/);
 
   await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ademo&settings=appearance');
@@ -46,6 +56,7 @@ test('browser mock hash history keeps route state stable without narrow-width ov
 
   await page.goBack();
   await expect(page).toHaveURL(/#\/timeline\?topic=/);
+  await openComposerDialog(page);
   await expect(page.getByPlaceholder('Write a post')).toBeVisible();
 
   await page.getByPlaceholder('Write a post').fill('route history post');
@@ -58,7 +69,9 @@ test('browser mock hash history keeps route state stable without narrow-width ov
 
   await page.goBack();
   await expect(page).not.toHaveURL(/context=thread/);
+  await openComposerDialog(page);
   await expect(page.getByPlaceholder('Write a post')).toBeVisible();
+  await page.keyboard.press('Escape');
 
   await page.goForward();
   await expect(page).toHaveURL(/context=thread/);
@@ -66,9 +79,9 @@ test('browser mock hash history keeps route state stable without narrow-width ov
 
   await page.goBack();
   await page.getByTestId('shell-nav-trigger').click();
-  await openChannelSection(page);
-  await page.getByPlaceholder('core contributors').fill('Route Room');
-  await page.getByRole('button', { name: 'Create Channel' }).click();
+  const channelDialog = await openChannelManager(page);
+  await channelDialog.getByPlaceholder('core contributors').fill('Route Room');
+  await channelDialog.getByRole('button', { name: 'Create Channel' }).click();
   await expect(page).toHaveURL(/#\/timeline\?topic=.*&channel=channel-/);
 
   const noOverflow = await page.evaluate(

--- a/apps/desktop/tests/playwright/shell.smoke.spec.ts
+++ b/apps/desktop/tests/playwright/shell.smoke.spec.ts
@@ -1,4 +1,9 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
+
+async function openComposerDialog(page: Page) {
+  await page.getByTestId('shell-fab').click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+}
 
 test('browser mock wide shell keeps navigation rail beside the workspace', async ({ page }) => {
   await page.setViewportSize({ width: 1400, height: 980 });
@@ -33,6 +38,7 @@ test('browser mock shell can switch topics, publish, open thread, open author, a
     'kukuri:topic:browser'
   );
 
+  await openComposerDialog(page);
   await page.getByPlaceholder('Write a post').fill('hello browser mock');
   await page.getByRole('button', { name: 'Publish' }).click();
 
@@ -108,7 +114,9 @@ test('browser mock shell persists language changes across reloads', async ({ pag
   await page.goto('/');
 
   await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+  await openComposerDialog(page);
   await expect(page.getByPlaceholder('Write a post')).toBeVisible();
+  await page.keyboard.press('Escape');
 
   await page.getByTestId('shell-settings-trigger').click();
   const settingsDialog = page.getByRole('dialog', { name: 'Settings & diagnostics' });
@@ -116,12 +124,17 @@ test('browser mock shell persists language changes across reloads', async ({ pag
   await settingsDialog.getByLabel('Language').selectOption('ja');
 
   await expect(page.locator('html')).toHaveAttribute('lang', 'ja');
+  await page.keyboard.press('Escape');
+  await expect(settingsDialog).toBeHidden();
+  await openComposerDialog(page);
   await expect(page.getByPlaceholder('投稿を書く')).toBeVisible();
   await expect(page.getByRole('button', { name: '投稿' })).toBeVisible();
+  await page.keyboard.press('Escape');
 
   await page.reload();
 
   await expect(page.locator('html')).toHaveAttribute('lang', 'ja');
+  await openComposerDialog(page);
   await expect(page.getByPlaceholder('投稿を書く')).toBeVisible();
 });
 
@@ -141,6 +154,7 @@ test('browser mock narrow shell keeps nav, context, and settings flows reachable
     'kukuri:topic:demo'
   );
 
+  await openComposerDialog(page);
   await page.getByPlaceholder('Write a post').fill('narrow browser mock');
   await page.getByRole('button', { name: 'Publish' }).click();
   await expect(page.getByText('narrow browser mock')).toBeVisible();

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -177,6 +177,17 @@ pub struct ProfileInput {
     pub display_name: Option<String>,
     pub about: Option<String>,
     pub picture: Option<String>,
+    pub picture_upload: Option<PendingAttachment>,
+    #[serde(default)]
+    pub clear_picture: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfileAssetView {
+    pub hash: String,
+    pub mime: String,
+    pub bytes: u64,
+    pub role: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -186,6 +197,7 @@ pub struct AuthorSocialView {
     pub display_name: Option<String>,
     pub about: Option<String>,
     pub picture: Option<String>,
+    pub picture_asset: Option<ProfileAssetView>,
     pub updated_at: Option<i64>,
     pub following: bool,
     pub followed_by: bool,
@@ -194,7 +206,7 @@ pub struct AuthorSocialView {
     pub friend_of_friend_via_pubkeys: Vec<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingAttachment {
     pub mime: String,
     pub bytes: Vec<u8>,
@@ -536,6 +548,28 @@ impl AppService {
 
     pub async fn set_my_profile(&self, input: ProfileInput) -> Result<Profile> {
         let author_pubkey = Pubkey::from(self.current_author_pubkey());
+        let current_profile = self.get_my_profile().await?;
+        let picture = if input.clear_picture || input.picture_upload.is_some() {
+            normalize_optional_text(input.picture)
+        } else {
+            normalize_optional_text(input.picture).or(current_profile.picture.clone())
+        };
+        let picture_asset = if input.clear_picture {
+            None
+        } else if let Some(upload) = input.picture_upload {
+            let stored = self
+                .blob_service
+                .put_blob(upload.bytes, upload.mime.as_str())
+                .await?;
+            Some(kukuri_core::AssetRef {
+                hash: stored.hash,
+                mime: stored.mime,
+                bytes: stored.bytes,
+                role: AssetRole::ProfileAvatar,
+            })
+        } else {
+            current_profile.picture_asset.clone()
+        };
         let envelope = build_profile_envelope(
             self.keys.as_ref(),
             &KukuriProfileEnvelopeContentV1 {
@@ -543,7 +577,8 @@ impl AppService {
                 name: normalize_optional_text(input.name),
                 display_name: normalize_optional_text(input.display_name),
                 about: normalize_optional_text(input.about),
-                picture: normalize_optional_text(input.picture),
+                picture,
+                picture_asset,
             },
         )?;
         let profile = parse_profile(&envelope)?
@@ -4687,6 +4722,15 @@ fn normalize_optional_text(value: Option<String>) -> Option<String> {
     })
 }
 
+fn profile_asset_view_from_ref(asset: Option<&kukuri_core::AssetRef>) -> Option<ProfileAssetView> {
+    asset.map(|asset| ProfileAssetView {
+        hash: asset.hash.as_str().to_string(),
+        mime: asset.mime.clone(),
+        bytes: asset.bytes,
+        role: "profile_avatar".into(),
+    })
+}
+
 fn normalize_repost_commentary(value: Option<String>) -> Option<String> {
     normalize_optional_text(value)
 }
@@ -4717,6 +4761,9 @@ fn author_social_view_from_parts(
         display_name: profile.and_then(|profile| profile.display_name.clone()),
         about: profile.and_then(|profile| profile.about.clone()),
         picture: profile.and_then(|profile| profile.picture.clone()),
+        picture_asset: profile_asset_view_from_ref(
+            profile.and_then(|profile| profile.picture_asset.as_ref()),
+        ),
         updated_at: profile.map(|profile| profile.updated_at),
         following: relationship.is_some_and(|relationship| relationship.following),
         followed_by: relationship.is_some_and(|relationship| relationship.followed_by),
@@ -4826,6 +4873,7 @@ async fn persist_profile_doc(
                     display_name: profile.display_name.clone(),
                     about: profile.about.clone(),
                     picture: profile.picture.clone(),
+                    picture_asset: profile.picture_asset.clone(),
                     updated_at: profile.updated_at,
                     envelope_id: envelope.id.clone(),
                 })?,
@@ -6619,6 +6667,7 @@ fn attachment_role_name(role: &AssetRole) -> &'static str {
         AssetRole::ImagePreview => "image_preview",
         AssetRole::VideoPoster => "video_poster",
         AssetRole::VideoManifest => "video_manifest",
+        AssetRole::ProfileAvatar => "profile_avatar",
         AssetRole::Attachment => "attachment",
     }
 }
@@ -7720,6 +7769,25 @@ mod tests {
             .collect()
     }
 
+    async fn author_profile_doc(
+        docs_sync: &dyn DocsSync,
+        author_pubkey: &str,
+    ) -> Option<AuthorProfileDocV1> {
+        docs_sync
+            .query_replica(
+                &author_replica_id(author_pubkey),
+                DocQuery::Exact(stable_key("profile", "latest")),
+            )
+            .await
+            .expect("profile doc")
+            .into_iter()
+            .next()
+            .map(|record| {
+                serde_json::from_slice::<AuthorProfileDocV1>(record.value.as_slice())
+                    .expect("decode profile doc")
+            })
+    }
+
     #[derive(Clone)]
     struct NoopHintTransport;
 
@@ -8424,6 +8492,133 @@ mod tests {
                 .iter()
                 .all(|post| post.object_id != private_object_id)
         );
+    }
+
+    #[tokio::test]
+    async fn set_my_profile_with_avatar_upload_persists_blob_backed_profile_and_author_view() {
+        let (app, store, docs_sync, blob_service) = local_app_with_memory_services();
+        let avatar_bytes = tiny_png_bytes();
+
+        let updated = app
+            .set_my_profile(ProfileInput {
+                name: Some("avatar-owner".into()),
+                display_name: Some("Avatar Owner".into()),
+                about: Some("blob avatar".into()),
+                picture: None,
+                picture_upload: Some(PendingAttachment {
+                    mime: "image/png".into(),
+                    bytes: avatar_bytes.clone(),
+                    role: AssetRole::ProfileAvatar,
+                }),
+                clear_picture: false,
+            })
+            .await
+            .expect("set profile");
+
+        let asset = updated.picture_asset.clone().expect("profile avatar asset");
+        let stored_profile = store
+            .get_profile(updated.pubkey.as_str())
+            .await
+            .expect("stored profile")
+            .expect("stored profile value");
+        let profile_doc = author_profile_doc(docs_sync.as_ref(), updated.pubkey.as_str())
+            .await
+            .expect("profile doc");
+        let stored_blob = blob_service
+            .fetch_blob(&asset.hash)
+            .await
+            .expect("fetch avatar blob")
+            .expect("avatar blob");
+        let local_profile = app.get_my_profile().await.expect("get my profile");
+        let author_social = app
+            .get_author_social_view(updated.pubkey.as_str())
+            .await
+            .expect("author social view");
+
+        assert_eq!(updated.picture, None);
+        assert_eq!(asset.mime, "image/png");
+        assert_eq!(asset.role, AssetRole::ProfileAvatar);
+        assert_eq!(stored_blob, avatar_bytes);
+        assert_eq!(stored_profile.picture_asset, updated.picture_asset);
+        assert_eq!(profile_doc.picture_asset, updated.picture_asset);
+        assert_eq!(local_profile.picture_asset, updated.picture_asset);
+        assert_eq!(author_social.picture, None);
+        assert_eq!(
+            author_social
+                .picture_asset
+                .as_ref()
+                .map(|value| value.hash.as_str()),
+            Some(asset.hash.as_str())
+        );
+        assert_eq!(
+            author_social
+                .picture_asset
+                .as_ref()
+                .map(|value| value.mime.as_str()),
+            Some("image/png")
+        );
+        assert_eq!(
+            author_social
+                .picture_asset
+                .as_ref()
+                .map(|value| value.role.as_str()),
+            Some("profile_avatar")
+        );
+    }
+
+    #[tokio::test]
+    async fn set_my_profile_keeps_legacy_picture_url_backward_compatible() {
+        let (app, store, docs_sync, _) = local_app_with_memory_services();
+        let legacy_picture = "https://example.com/avatar.png".to_string();
+
+        let updated = app
+            .set_my_profile(ProfileInput {
+                name: Some("legacy-owner".into()),
+                display_name: Some("Legacy Owner".into()),
+                about: Some("legacy avatar".into()),
+                picture: Some(legacy_picture.clone()),
+                picture_upload: None,
+                clear_picture: false,
+            })
+            .await
+            .expect("set profile");
+
+        let stored_profile = store
+            .get_profile(updated.pubkey.as_str())
+            .await
+            .expect("stored profile")
+            .expect("stored profile value");
+        let profile_doc = author_profile_doc(docs_sync.as_ref(), updated.pubkey.as_str())
+            .await
+            .expect("profile doc");
+        let local_profile = app.get_my_profile().await.expect("get my profile");
+        let author_social = app
+            .get_author_social_view(updated.pubkey.as_str())
+            .await
+            .expect("author social view");
+
+        assert_eq!(updated.picture.as_deref(), Some(legacy_picture.as_str()));
+        assert_eq!(updated.picture_asset, None);
+        assert_eq!(
+            stored_profile.picture.as_deref(),
+            Some(legacy_picture.as_str())
+        );
+        assert_eq!(stored_profile.picture_asset, None);
+        assert_eq!(
+            profile_doc.picture.as_deref(),
+            Some(legacy_picture.as_str())
+        );
+        assert_eq!(profile_doc.picture_asset, None);
+        assert_eq!(
+            local_profile.picture.as_deref(),
+            Some(legacy_picture.as_str())
+        );
+        assert_eq!(local_profile.picture_asset, None);
+        assert_eq!(
+            author_social.picture.as_deref(),
+            Some(legacy_picture.as_str())
+        );
+        assert_eq!(author_social.picture_asset, None);
     }
 
     #[tokio::test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,7 +10,7 @@ use secp256k1::ecdh::SharedSecret;
 use secp256k1::rand::{RngCore, rng};
 use secp256k1::schnorr::Signature;
 use secp256k1::{Keypair, Parity, PublicKey, SECP256K1, SecretKey, XOnlyPublicKey};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use sha2::{Digest, Sha256};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -232,6 +232,7 @@ pub enum AssetRole {
     ImagePreview,
     VideoPoster,
     VideoManifest,
+    ProfileAvatar,
     Attachment,
 }
 
@@ -519,6 +520,12 @@ pub struct Profile {
     pub display_name: Option<String>,
     pub about: Option<String>,
     pub picture: Option<String>,
+    #[serde(
+        default,
+        serialize_with = "serialize_profile_asset_ref",
+        deserialize_with = "deserialize_profile_asset_ref"
+    )]
+    pub picture_asset: Option<AssetRef>,
     pub updated_at: i64,
 }
 
@@ -529,6 +536,12 @@ pub struct KukuriProfileEnvelopeContentV1 {
     pub display_name: Option<String>,
     pub about: Option<String>,
     pub picture: Option<String>,
+    #[serde(
+        default,
+        serialize_with = "serialize_profile_asset_ref",
+        deserialize_with = "deserialize_profile_asset_ref"
+    )]
+    pub picture_asset: Option<AssetRef>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -538,8 +551,59 @@ pub struct AuthorProfileDocV1 {
     pub display_name: Option<String>,
     pub about: Option<String>,
     pub picture: Option<String>,
+    #[serde(
+        default,
+        serialize_with = "serialize_profile_asset_ref",
+        deserialize_with = "deserialize_profile_asset_ref"
+    )]
+    pub picture_asset: Option<AssetRef>,
     pub updated_at: i64,
     pub envelope_id: EnvelopeId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct ProfileAssetRefWire {
+    pub hash: BlobHash,
+    pub mime: String,
+    pub bytes: u64,
+    pub role: String,
+}
+
+fn serialize_profile_asset_ref<S>(
+    value: &Option<AssetRef>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let wire = value.as_ref().map(|asset| ProfileAssetRefWire {
+        hash: asset.hash.clone(),
+        mime: asset.mime.clone(),
+        bytes: asset.bytes,
+        role: "profile_avatar".into(),
+    });
+    wire.serialize(serializer)
+}
+
+fn deserialize_profile_asset_ref<'de, D>(deserializer: D) -> Result<Option<AssetRef>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let wire = Option::<ProfileAssetRefWire>::deserialize(deserializer)?;
+    wire.map(|asset| {
+        if asset.role != "profile_avatar" && asset.role != "ProfileAvatar" {
+            return Err(de::Error::custom(
+                "profile picture asset role must be profile_avatar",
+            ));
+        }
+        Ok(AssetRef {
+            hash: asset.hash,
+            mime: asset.mime,
+            bytes: asset.bytes,
+            role: AssetRole::ProfileAvatar,
+        })
+    })
+    .transpose()
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -2213,6 +2277,7 @@ pub fn parse_profile(envelope: &KukuriEnvelope) -> Result<Option<Profile>> {
         display_name: metadata.display_name,
         about: metadata.about,
         picture: metadata.picture,
+        picture_asset: metadata.picture_asset,
         updated_at: envelope.created_at,
     }))
 }
@@ -2594,6 +2659,12 @@ mod tests {
                 display_name: Some("Alice".into()),
                 about: Some("hello".into()),
                 picture: Some("https://example.com/alice.png".into()),
+                picture_asset: Some(AssetRef {
+                    hash: BlobHash::new("avatar-hash"),
+                    mime: "image/png".into(),
+                    bytes: 42,
+                    role: AssetRole::ProfileAvatar,
+                }),
             },
         )
         .expect("profile envelope");
@@ -2605,6 +2676,13 @@ mod tests {
         assert_eq!(profile.pubkey, keys.public_key());
         assert_eq!(profile.display_name.as_deref(), Some("Alice"));
         assert_eq!(profile.about.as_deref(), Some("hello"));
+        assert_eq!(
+            profile
+                .picture_asset
+                .as_ref()
+                .map(|asset| asset.role.clone()),
+            Some(AssetRole::ProfileAvatar)
+        );
     }
 
     #[test]

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -2844,6 +2844,38 @@ mod tests {
         }
     }
 
+    async fn wait_for_direct_topic_peer_count(
+        runtime: &DesktopRuntime,
+        topic: &str,
+        expected: usize,
+        timeout_label: &str,
+    ) {
+        match timeout(runtime_replication_timeout(), async {
+            let mut stable_ready_polls = 0usize;
+            loop {
+                let status = runtime.get_sync_status().await.expect("sync status");
+                let ready = topic_has_direct_peer(&status, topic, expected);
+                if ready {
+                    stable_ready_polls += 1;
+                    if stable_ready_polls >= 3 {
+                        return;
+                    }
+                } else {
+                    stable_ready_polls = 0;
+                }
+                sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        {
+            Ok(()) => {}
+            Err(_) => {
+                let status = runtime.get_sync_status().await.expect("sync status");
+                panic!("{timeout_label}: {}", format_sync_snapshot(&status, topic));
+            }
+        }
+    }
+
     async fn wait_for_connected_peer_count(
         runtime: &DesktopRuntime,
         expected: usize,
@@ -4119,6 +4151,20 @@ mod tests {
             })
             .await
             .expect("subscribe b tracked topic");
+        wait_for_direct_topic_peer_count(
+            &runtime_a,
+            tracked_topic,
+            1,
+            "profile tracked topic direct readiness timeout a",
+        )
+        .await;
+        wait_for_direct_topic_peer_count(
+            &runtime_b,
+            tracked_topic,
+            1,
+            "profile tracked topic direct readiness timeout b",
+        )
+        .await;
 
         let tracked_object_id = replicate_public_post_with_retry(
             &runtime_a,

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -202,6 +202,9 @@ pub struct SetMyProfileRequest {
     pub display_name: Option<String>,
     pub about: Option<String>,
     pub picture: Option<String>,
+    pub picture_upload: Option<CreateAttachmentRequest>,
+    #[serde(default)]
+    pub clear_picture: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -945,6 +948,11 @@ impl DesktopRuntime {
                 display_name: request.display_name,
                 about: request.about,
                 picture: request.picture,
+                picture_upload: request
+                    .picture_upload
+                    .map(pending_attachment_from_request)
+                    .transpose()?,
+                clear_picture: request.clear_picture,
             })
             .await
     }
@@ -1904,6 +1912,7 @@ fn pending_attachment_from_request(request: CreateAttachmentRequest) -> Result<P
         Some("image_preview") => AssetRole::ImagePreview,
         Some("video_poster") => AssetRole::VideoPoster,
         Some("video_manifest") => AssetRole::VideoManifest,
+        Some("profile_avatar") => AssetRole::ProfileAvatar,
         Some("attachment") => AssetRole::Attachment,
         _ => AssetRole::ImageOriginal,
     };
@@ -2577,7 +2586,7 @@ mod tests {
         if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
             Duration::from_secs(180)
         } else {
-            Duration::from_secs(15)
+            Duration::from_secs(30)
         }
     }
 
@@ -3503,6 +3512,20 @@ mod tests {
         }
     }
 
+    fn profile_avatar_attachment_request(
+        name: &str,
+        mime: &str,
+        bytes: &[u8],
+    ) -> CreateAttachmentRequest {
+        CreateAttachmentRequest {
+            file_name: Some(name.to_string()),
+            mime: mime.to_string(),
+            byte_size: bytes.len() as u64,
+            data_base64: BASE64_STANDARD.encode(bytes),
+            role: Some("profile_avatar".to_string()),
+        }
+    }
+
     fn video_attachment_request(
         name: &str,
         mime: &str,
@@ -3785,6 +3808,141 @@ mod tests {
             .expect("restarted shutdown timeout");
     }
 
+    #[tokio::test]
+    async fn desktop_runtime_restores_profile_avatar_blob_after_restart() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("profile-avatar-restart.db");
+        let avatar_bytes = b"runtime-profile-avatar".to_vec();
+        let expected_payload = BASE64_STANDARD.encode(&avatar_bytes);
+        let runtime = timeout(
+            Duration::from_secs(15),
+            DesktopRuntime::new_with_config_and_identity(
+                &db_path,
+                TransportNetworkConfig::loopback(),
+                IdentityStorageMode::FileOnly,
+            ),
+        )
+        .await
+        .expect("runtime creation timeout")
+        .expect("runtime");
+
+        let updated = runtime
+            .set_my_profile(SetMyProfileRequest {
+                name: Some("runtime-avatar-owner".into()),
+                display_name: Some("Runtime Avatar Owner".into()),
+                about: Some("profile avatar restart".into()),
+                picture: None,
+                picture_upload: Some(profile_avatar_attachment_request(
+                    "avatar.png",
+                    "image/png",
+                    &avatar_bytes,
+                )),
+                clear_picture: false,
+            })
+            .await
+            .expect("set profile");
+        let asset = updated.picture_asset.clone().expect("profile avatar");
+        let author_pubkey = updated.pubkey.as_str().to_string();
+        let payload_before_restart = runtime
+            .get_blob_media_payload(GetBlobMediaRequest {
+                hash: asset.hash.as_str().to_string(),
+                mime: asset.mime.clone(),
+            })
+            .await
+            .expect("avatar payload before restart")
+            .expect("avatar payload before restart value");
+        let author_before_restart = runtime
+            .get_author_social_view(AuthorRequest {
+                pubkey: author_pubkey.clone(),
+            })
+            .await
+            .expect("author social view before restart");
+
+        assert_eq!(payload_before_restart.mime, "image/png");
+        assert_eq!(payload_before_restart.bytes_base64, expected_payload);
+        assert_eq!(
+            author_before_restart
+                .picture_asset
+                .as_ref()
+                .map(|value| value.hash.as_str()),
+            Some(asset.hash.as_str())
+        );
+        assert_eq!(
+            author_before_restart
+                .picture_asset
+                .as_ref()
+                .map(|value| value.role.as_str()),
+            Some("profile_avatar")
+        );
+
+        timeout(Duration::from_secs(15), runtime.shutdown())
+            .await
+            .expect("runtime shutdown timeout");
+        drop(runtime);
+
+        let restarted = timeout(
+            Duration::from_secs(15),
+            DesktopRuntime::new_with_config_and_identity(
+                &db_path,
+                TransportNetworkConfig::loopback(),
+                IdentityStorageMode::FileOnly,
+            ),
+        )
+        .await
+        .expect("runtime restart timeout")
+        .expect("runtime restart");
+        let my_profile = restarted.get_my_profile().await.expect("my profile");
+        let author_after_restart = restarted
+            .get_author_social_view(AuthorRequest {
+                pubkey: author_pubkey,
+            })
+            .await
+            .expect("author social view after restart");
+        let payload_after_restart = restarted
+            .get_blob_media_payload(GetBlobMediaRequest {
+                hash: asset.hash.as_str().to_string(),
+                mime: asset.mime.clone(),
+            })
+            .await
+            .expect("avatar payload after restart")
+            .expect("avatar payload after restart value");
+
+        assert_eq!(
+            my_profile
+                .picture_asset
+                .as_ref()
+                .map(|value| value.hash.as_str()),
+            Some(asset.hash.as_str())
+        );
+        assert_eq!(
+            my_profile
+                .picture_asset
+                .as_ref()
+                .map(|value| value.role.clone()),
+            Some(AssetRole::ProfileAvatar)
+        );
+        assert_eq!(
+            author_after_restart
+                .picture_asset
+                .as_ref()
+                .map(|value| value.hash.as_str()),
+            Some(asset.hash.as_str())
+        );
+        assert_eq!(
+            author_after_restart
+                .picture_asset
+                .as_ref()
+                .map(|value| value.role.as_str()),
+            Some("profile_avatar")
+        );
+        assert_eq!(payload_after_restart.mime, "image/png");
+        assert_eq!(payload_after_restart.bytes_base64, expected_payload);
+
+        timeout(Duration::from_secs(15), restarted.shutdown())
+            .await
+            .expect("restarted shutdown timeout");
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn desktop_runtime_imports_peer_ticket_and_tracks_local_posts() {
         let dir = tempdir().expect("tempdir");
@@ -3962,16 +4120,14 @@ mod tests {
             .await
             .expect("subscribe b tracked topic");
 
-        let tracked_object_id = runtime_a
-            .create_post(CreatePostRequest {
-                topic: tracked_topic.into(),
-                content: "tracked profile post".into(),
-                reply_to: None,
-                channel_ref: ChannelRef::Public,
-                attachments: vec![],
-            })
-            .await
-            .expect("tracked public post");
+        let tracked_object_id = replicate_public_post_with_retry(
+            &runtime_a,
+            &runtime_b,
+            tracked_topic,
+            "tracked profile post",
+            "tracked topic visibility timeout",
+        )
+        .await;
         let untracked_object_id = runtime_a
             .create_post(CreatePostRequest {
                 topic: untracked_topic.into(),
@@ -3982,15 +4138,6 @@ mod tests {
             })
             .await
             .expect("untracked public post");
-
-        wait_for_timeline_post(
-            &runtime_b,
-            tracked_topic,
-            &public_scope,
-            tracked_object_id.as_str(),
-            "tracked topic visibility timeout",
-        )
-        .await;
 
         let before_profile = runtime_b
             .get_sync_status()

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -3634,6 +3634,18 @@ mod tests {
         wait_for_topic_peer_count(&runtime_c, topic, 1, topic_timeout)
             .await
             .expect("desktop c did not observe public topic connectivity after rotate");
+        runtime_a
+            .follow_author(AuthorRequest {
+                pubkey: c_pubkey.clone(),
+            })
+            .await
+            .expect("a refreshes follow to c");
+        runtime_c
+            .follow_author(AuthorRequest {
+                pubkey: a_pubkey.clone(),
+            })
+            .await
+            .expect("c refreshes follow to a");
         warm_author_social_view(&runtime_a, c_pubkey.as_str()).await;
         warm_author_social_view(&runtime_c, a_pubkey.as_str()).await;
         wait_for_mutual_author_view(&runtime_a, c_pubkey.as_str(), topic).await;

--- a/crates/store/migrations/20260329000000_profile_avatar_blob_columns.up.sql
+++ b/crates/store/migrations/20260329000000_profile_avatar_blob_columns.up.sql
@@ -1,0 +1,17 @@
+ALTER TABLE profiles
+    ADD COLUMN picture_blob_hash TEXT;
+
+ALTER TABLE profiles
+    ADD COLUMN picture_mime TEXT;
+
+ALTER TABLE profiles
+    ADD COLUMN picture_bytes INTEGER;
+
+ALTER TABLE profile_cache
+    ADD COLUMN picture_blob_hash TEXT;
+
+ALTER TABLE profile_cache
+    ADD COLUMN picture_mime TEXT;
+
+ALTER TABLE profile_cache
+    ADD COLUMN picture_bytes INTEGER;

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -556,21 +556,45 @@ impl Store for SqliteStore {
 
         sqlx::query(
             r#"
-            INSERT INTO profiles (pubkey, name, display_name, about, picture, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            INSERT INTO profiles (
+              pubkey, name, display_name, about, picture,
+              picture_blob_hash, picture_mime, picture_bytes, updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
             ON CONFLICT(pubkey) DO UPDATE SET
               name = excluded.name,
               display_name = excluded.display_name,
               about = excluded.about,
               picture = excluded.picture,
+              picture_blob_hash = excluded.picture_blob_hash,
+              picture_mime = excluded.picture_mime,
+              picture_bytes = excluded.picture_bytes,
               updated_at = excluded.updated_at
             "#,
         )
         .bind(profile.pubkey.as_str())
-        .bind(profile.name)
-        .bind(profile.display_name)
-        .bind(profile.about)
-        .bind(profile.picture)
+        .bind(profile.name.clone())
+        .bind(profile.display_name.clone())
+        .bind(profile.about.clone())
+        .bind(profile.picture.clone())
+        .bind(
+            profile
+                .picture_asset
+                .as_ref()
+                .map(|asset| asset.hash.as_str().to_string()),
+        )
+        .bind(
+            profile
+                .picture_asset
+                .as_ref()
+                .map(|asset| asset.mime.clone()),
+        )
+        .bind(
+            profile
+                .picture_asset
+                .as_ref()
+                .map(|asset| asset.bytes as i64),
+        )
         .bind(profile.updated_at)
         .execute(&self.pool)
         .await?;
@@ -581,7 +605,9 @@ impl Store for SqliteStore {
     async fn get_profile(&self, pubkey: &str) -> Result<Option<Profile>> {
         let row = sqlx::query(
             r#"
-            SELECT pubkey, name, display_name, about, picture, updated_at
+            SELECT
+              pubkey, name, display_name, about, picture,
+              picture_blob_hash, picture_mime, picture_bytes, updated_at
             FROM profiles
             WHERE pubkey = ?1
             "#,
@@ -596,6 +622,21 @@ impl Store for SqliteStore {
             display_name: row.try_get("display_name").ok(),
             about: row.try_get("about").ok(),
             picture: row.try_get("picture").ok(),
+            picture_asset: row
+                .try_get::<String, _>("picture_blob_hash")
+                .ok()
+                .map(|hash| kukuri_core::AssetRef {
+                    hash: kukuri_core::BlobHash::new(hash),
+                    mime: row
+                        .try_get::<String, _>("picture_mime")
+                        .ok()
+                        .unwrap_or_else(|| "application/octet-stream".into()),
+                    bytes: row
+                        .try_get::<i64, _>("picture_bytes")
+                        .ok()
+                        .unwrap_or_default() as u64,
+                    role: kukuri_core::AssetRole::ProfileAvatar,
+                }),
             updated_at: row.get("updated_at"),
         }))
     }
@@ -1056,13 +1097,19 @@ impl ProjectionStore for SqliteStore {
     async fn upsert_profile_cache(&self, profile: Profile) -> Result<()> {
         sqlx::query(
             r#"
-            INSERT INTO profile_cache (pubkey, name, display_name, about, picture, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            INSERT INTO profile_cache (
+              pubkey, name, display_name, about, picture,
+              picture_blob_hash, picture_mime, picture_bytes, updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
             ON CONFLICT(pubkey) DO UPDATE SET
               name = excluded.name,
               display_name = excluded.display_name,
               about = excluded.about,
               picture = excluded.picture,
+              picture_blob_hash = excluded.picture_blob_hash,
+              picture_mime = excluded.picture_mime,
+              picture_bytes = excluded.picture_bytes,
               updated_at = excluded.updated_at
             "#,
         )
@@ -1071,6 +1118,24 @@ impl ProjectionStore for SqliteStore {
         .bind(profile.display_name)
         .bind(profile.about)
         .bind(profile.picture)
+        .bind(
+            profile
+                .picture_asset
+                .as_ref()
+                .map(|asset| asset.hash.as_str().to_string()),
+        )
+        .bind(
+            profile
+                .picture_asset
+                .as_ref()
+                .map(|asset| asset.mime.clone()),
+        )
+        .bind(
+            profile
+                .picture_asset
+                .as_ref()
+                .map(|asset| asset.bytes as i64),
+        )
         .bind(profile.updated_at)
         .execute(&self.pool)
         .await?;
@@ -2367,6 +2432,7 @@ mod tests {
                 display_name: Some("older".into()),
                 about: None,
                 picture: None,
+                picture_asset: None,
                 updated_at: 10,
             })
             .await
@@ -2378,6 +2444,12 @@ mod tests {
                 display_name: Some("newer".into()),
                 about: None,
                 picture: None,
+                picture_asset: Some(kukuri_core::AssetRef {
+                    hash: kukuri_core::BlobHash::new("avatar-newer"),
+                    mime: "image/png".into(),
+                    bytes: 128,
+                    role: kukuri_core::AssetRole::ProfileAvatar,
+                }),
                 updated_at: 20,
             })
             .await
@@ -2390,6 +2462,13 @@ mod tests {
             .expect("profile");
         assert_eq!(profile.name.as_deref(), Some("newer"));
         assert_eq!(profile.display_name.as_deref(), Some("newer"));
+        assert_eq!(
+            profile
+                .picture_asset
+                .as_ref()
+                .map(|asset| asset.hash.as_str()),
+            Some("avatar-newer")
+        );
     }
 
     #[tokio::test]

--- a/docs/adr/0019-profile-avatar-blob-data-classification.md
+++ b/docs/adr/0019-profile-avatar-blob-data-classification.md
@@ -1,0 +1,66 @@
+# ADR 0019: profile avatar blob data classification
+
+## Status
+Accepted
+
+## Date
+2026-03-29
+
+## Base Branch
+`main`
+
+## Related
+- `docs/adr/0013-social-graph-foundation-draft.md`
+- `docs/adr/0010-kukuri-protocol-v1-boundary-definition.md`
+
+## Feature Data Classification
+- Feature 名: profile avatar blob
+- Durable / Transient: Durable public profile metadata + durable blob payload
+- Canonical Source: public author docs replica (`author::<pubkey>`) for profile header, `iroh-blobs` for avatar image payload
+- Replicated?: Yes, profile doc is replicated and avatar blob is fetchable from blob sync
+- Rebuildable From: author replica profile doc + signed profile envelope + avatar blob
+- Public Replica / Private Replica / Local Only: public author replica for profile metadata, local preview state only for pre-publish file selection
+- Gossip Hint 必要有無: Yes, best-effort only
+- Blob 必要有無: Yes
+- SQLite projection 必要有無: Yes
+- 必須 contract:
+  - `profile_envelope_roundtrip`
+  - `store_profile_upsert_latest_wins`
+  - `set_my_profile_persists_blob_backed_avatar_and_restores_it`
+  - `desktop runtime restart restores blob backed avatar`
+- 必須 scenario:
+  - 実機 2 台で `profile image select -> save -> remote author detail reflect -> restart restore` を確認する
+
+## Decision
+
+profile avatar は URL 文字列を primary source にしない。current `main` では、public author replica に保存された author-signed profile envelope/doc を header とし、画像本体は blob として同期する。
+
+legacy `picture` URL は read compatibility のため維持してよいが、新規 desktop UI の primary write path は blob-backed avatar に固定する。
+
+## Data Model
+
+- signed envelope kind は既存の `identity-profile` を継続利用する
+- `KukuriProfileEnvelopeContentV1` と `AuthorProfileDocV1` は optional `picture_asset` を持つ
+- `picture_asset` は `hash / mime / bytes / role=profile_avatar` を持つ
+- `Profile` / `AuthorSocialView` は `picture_asset` を public contract に含める
+- SQLite `profiles` / `profile_cache` は `picture_blob_hash / picture_mime / picture_bytes` を保持する
+
+## Write Path
+
+1. desktop UI は `image/*` file picker で avatar file を受け取る
+2. runtime/app-api は file bytes を `iroh-blobs` へ put する
+3. resulting blob ref を `picture_asset` として `identity-profile` envelope に含める
+4. author replica の `profile/latest` doc と local projection cache を更新する
+
+## Read Path
+
+1. profile / author detail は `picture_asset` があればそれを優先する
+2. client は既存の blob fetch path で avatar blob を lazy fetch する
+3. `picture_asset` がない場合だけ legacy `picture` URL を fallback として使う
+
+## Non-Goals
+
+- avatar crop editor
+- private avatar
+- animated avatar 専用 manifest
+- community-node hosted profile image canonicalization

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -255,7 +255,11 @@ fn pnpm_command_spec(
     if pnpm_available {
         node_command_spec(platform, "pnpm", args)
     } else {
-        let mut fallback = vec!["--yes".to_string(), "pnpm@10.16.1".to_string()];
+        let mut fallback = match platform {
+            // `npx --yes` can hang under WSL when it resolves to a Windows node shim.
+            HostPlatform::Unix => vec!["pnpm@10.16.1".to_string()],
+            HostPlatform::Windows => vec!["--yes".to_string(), "pnpm@10.16.1".to_string()],
+        };
         fallback.extend(args);
         node_command_spec(platform, "npx", fallback)
     }


### PR DESCRIPTION
## Summary
- modalize desktop shell creation flows around dialogs, popovers, and a fixed FAB
- fix sidebar public/channel reselection behavior and replace channel management accordion with a modal
- move profile avatars from URL input to blob-backed uploads across desktop, app-api, core, store, and runtime
- update ADRs, stories, mocks, Vitest coverage, and Playwright flows for the new UI

## Testing
- `cd apps/desktop && npx pnpm@10.16.1 test`
- `cargo test -p kukuri-app-api`
- `cargo test -p kukuri-desktop-runtime`
- `cargo xtask desktop-ui-check`

## Known issue
- `cargo xtask test` still hits `tests::friend_plus_share_freeze_rotate_and_new_epoch_visibility` during full-workspace execution. The targeted/package checks above passed.