### PR TITLE
Add pairwise DM v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,6 +2813,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64",
  "kukuri-app-api",
  "kukuri-cn-core",
  "kukuri-cn-iroh-relay",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,18 +4,19 @@ use kukuri_desktop_runtime::{
     AcceptCommunityNodeConsentsRequest, AuthorRequest, BookmarkCustomReactionRequest,
     CommunityNodeConfig, CommunityNodeNodeStatus, CommunityNodeTargetRequest,
     CreateCustomReactionAssetRequest, CreateGameRoomRequest, CreateLiveSessionRequest,
-    CreatePostRequest, CreatePrivateChannelRequest, CreateRepostRequest, DesktopRuntime,
-    DiscoveryConfig, ExportChannelAccessTokenRequest, ExportFriendOnlyGrantRequest,
+    CreatePostRequest, CreatePrivateChannelRequest, CreateRepostRequest,
+    DeleteDirectMessageMessageRequest, DesktopRuntime, DirectMessageRequest, DiscoveryConfig,
+    ExportChannelAccessTokenRequest, ExportFriendOnlyGrantRequest,
     ExportFriendPlusShareRequest, ExportPrivateChannelInviteRequest, FreezePrivateChannelRequest,
     GetBlobMediaRequest, GetBlobPreviewRequest, ImportChannelAccessTokenRequest,
     ImportFriendOnlyGrantRequest, ImportFriendPlusShareRequest, ImportPeerTicketRequest,
-    ImportPrivateChannelInviteRequest, ListGameRoomsRequest, ListJoinedPrivateChannelsRequest,
-    ListLiveSessionsRequest, ListProfileTimelineRequest, ListRecentReactionsRequest,
-    ListThreadRequest, ListTimelineRequest, LiveSessionCommandRequest,
+    ImportPrivateChannelInviteRequest, ListDirectMessageMessagesRequest, ListGameRoomsRequest,
+    ListJoinedPrivateChannelsRequest, ListLiveSessionsRequest, ListProfileTimelineRequest,
+    ListRecentReactionsRequest, ListThreadRequest, ListTimelineRequest, LiveSessionCommandRequest,
     RemoveBookmarkedCustomReactionRequest,
-    RotatePrivateChannelRequest, SetCommunityNodeConfigRequest, SetDiscoverySeedsRequest,
-    SetMyProfileRequest, ToggleReactionRequest, UnsubscribeTopicRequest, UpdateGameRoomRequest,
-    resolve_db_path_from_env,
+    RotatePrivateChannelRequest, SendDirectMessageRequest, SetCommunityNodeConfigRequest,
+    SetDiscoverySeedsRequest, SetMyProfileRequest, ToggleReactionRequest,
+    UnsubscribeTopicRequest, UpdateGameRoomRequest, resolve_db_path_from_env,
 };
 use tauri::Manager;
 use tracing::{info, warn};
@@ -403,6 +404,85 @@ async fn get_author_social_view(
 }
 
 #[tauri::command]
+async fn open_direct_message(
+    state: tauri::State<'_, DesktopState>,
+    request: DirectMessageRequest,
+) -> Result<kukuri_app_api::DirectMessageConversationView, String> {
+    state
+        .runtime
+        .open_direct_message(request)
+        .await
+        .map_err(map_error)
+}
+
+#[tauri::command]
+async fn list_direct_messages(
+    state: tauri::State<'_, DesktopState>,
+) -> Result<Vec<kukuri_app_api::DirectMessageConversationView>, String> {
+    state.runtime.list_direct_messages().await.map_err(map_error)
+}
+
+#[tauri::command]
+async fn list_direct_message_messages(
+    state: tauri::State<'_, DesktopState>,
+    request: ListDirectMessageMessagesRequest,
+) -> Result<kukuri_app_api::DirectMessageTimelineView, String> {
+    state
+        .runtime
+        .list_direct_message_messages(request)
+        .await
+        .map_err(map_error)
+}
+
+#[tauri::command]
+async fn send_direct_message(
+    state: tauri::State<'_, DesktopState>,
+    request: SendDirectMessageRequest,
+) -> Result<String, String> {
+    state
+        .runtime
+        .send_direct_message(request)
+        .await
+        .map_err(map_error)
+}
+
+#[tauri::command]
+async fn delete_direct_message_message(
+    state: tauri::State<'_, DesktopState>,
+    request: DeleteDirectMessageMessageRequest,
+) -> Result<(), String> {
+    state
+        .runtime
+        .delete_direct_message_message(request)
+        .await
+        .map_err(map_error)
+}
+
+#[tauri::command]
+async fn clear_direct_message(
+    state: tauri::State<'_, DesktopState>,
+    request: DirectMessageRequest,
+) -> Result<(), String> {
+    state
+        .runtime
+        .clear_direct_message(request)
+        .await
+        .map_err(map_error)
+}
+
+#[tauri::command]
+async fn get_direct_message_status(
+    state: tauri::State<'_, DesktopState>,
+    request: DirectMessageRequest,
+) -> Result<kukuri_app_api::DirectMessageStatusView, String> {
+    state
+        .runtime
+        .get_direct_message_status(request)
+        .await
+        .map_err(map_error)
+}
+
+#[tauri::command]
 async fn get_sync_status(
     state: tauri::State<'_, DesktopState>,
 ) -> Result<kukuri_app_api::SyncStatus, String> {
@@ -752,6 +832,13 @@ pub fn run() {
             follow_author,
             unfollow_author,
             get_author_social_view,
+            open_direct_message,
+            list_direct_messages,
+            list_direct_message_messages,
+            send_direct_message,
+            delete_direct_message_message,
+            clear_direct_message,
+            get_direct_message_status,
             get_sync_status,
             get_discovery_config,
             list_live_sessions,

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -282,7 +282,7 @@ async function openGameCreateDialog(user: ReturnType<typeof userEvent.setup>) {
   return await screen.findByRole('dialog', { name: 'Create Room' });
 }
 
-function getDetailPane(name: 'Thread' | 'Author') {
+function getDetailPane(name: 'Thread' | 'Author' | 'Messages') {
   return screen.getByRole('complementary', { name });
 }
 
@@ -2154,6 +2154,64 @@ test('author detail shows via authors and follow action updates relationship', a
     expect(screen.getByRole('button', { name: 'Unfollow' })).toBeInTheDocument();
   });
   expect(screen.getAllByText('following').length).toBeGreaterThan(0);
+});
+
+test('author detail mutual action opens the direct message pane and sends a local message', async () => {
+  const authorPubkey = 'b'.repeat(64);
+  const api = createDesktopMockApi({
+    seedPosts: {
+      'kukuri:topic:demo': [
+        {
+          object_id: 'post-author-dm',
+          envelope_id: 'envelope-author-dm',
+          author_pubkey: authorPubkey,
+          author_name: 'bob',
+          author_display_name: null,
+          following: true,
+          followed_by: true,
+          mutual: true,
+          friend_of_friend: false,
+          object_kind: 'post',
+          content: 'open dm',
+          content_status: 'Available',
+          attachments: [],
+          created_at: 1,
+          reply_to: null,
+          root_id: 'post-author-dm',
+          audience_label: 'Public',
+        },
+      ],
+    },
+    authorSocialViews: {
+      [authorPubkey]: {
+        name: 'bob',
+        following: true,
+        followed_by: true,
+        mutual: true,
+      },
+    },
+  });
+  const user = userEvent.setup();
+
+  render(<App api={api} />);
+
+  await user.click(await screen.findByRole('button', { name: 'bob' }));
+  await waitFor(() => {
+    expect(getDetailPane('Author')).toBeInTheDocument();
+  });
+
+  await user.click(screen.getByRole('button', { name: 'Message' }));
+
+  await waitFor(() => {
+    expect(getDetailPane('Messages')).toBeInTheDocument();
+  });
+
+  await user.type(screen.getByPlaceholderText('Write a message'), 'hello dm');
+  await user.click(screen.getByRole('button', { name: 'Send' }));
+
+  await waitFor(() => {
+    expect(screen.getAllByText('hello dm').length).toBeGreaterThan(0);
+  });
 });
 
 test('author detail shows profile topic posts and can open an untracked origin topic', async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -5579,7 +5579,7 @@ function DesktopShellPage({
                           </div>
                           <div className='post-actions'>
                             <Button
-                              variant={selected ? 'default' : 'secondary'}
+                              variant={selected ? 'primary' : 'secondary'}
                               type='button'
                               onClick={() => void openDirectMessagePane(conversation.peer_pubkey)}
                             >

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -19,9 +19,10 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useStore } from 'zustand';
 import { createStore } from 'zustand/vanilla';
-import { Lock, PanelLeftOpen, Plus, Settings } from 'lucide-react';
+import { Lock, MessageSquare, PanelLeftOpen, Plus, Settings } from 'lucide-react';
 
 import { AuthorDetailCard } from '@/components/core/AuthorDetailCard';
+import { ComposerDraftPreviewList } from '@/components/core/ComposerDraftPreviewList';
 import { ComposerPanel } from '@/components/core/ComposerPanel';
 import { ThreadPanel } from '@/components/core/ThreadPanel';
 import { TimelineFeed } from '@/components/core/TimelineFeed';
@@ -99,6 +100,9 @@ import {
   CommunityNodeNodeStatus,
   CreateAttachmentInput,
   DesktopApi,
+  DirectMessageConversationView,
+  DirectMessageMessageView,
+  DirectMessageStatusView,
   DiscoveryConfig,
   GameRoomStatus,
   GameRoomView,
@@ -195,6 +199,16 @@ type DesktopShellState = {
   selectedAuthor: AuthorSocialView | null;
   selectedAuthorTimeline: PostView[];
   authorError: string | null;
+  directMessagePaneOpen: boolean;
+  selectedDirectMessagePeerPubkey: string | null;
+  directMessages: DirectMessageConversationView[];
+  directMessageTimelineByPeer: Record<string, DirectMessageMessageView[]>;
+  directMessageStatusByPeer: Record<string, DirectMessageStatusView>;
+  directMessageComposer: string;
+  directMessageDraftMediaItems: DraftMediaItem[];
+  directMessageAttachmentInputKey: number;
+  directMessageError: string | null;
+  directMessageSending: boolean;
   composerError: string | null;
   liveTitle: string;
   liveDescription: string;
@@ -243,6 +257,8 @@ type DesktopShellRouteOverrides = {
   primarySection?: PrimarySection;
   profileMode?: ProfileWorkspaceMode;
   selectedAuthorPubkey?: string | null;
+  directMessagePaneOpen?: boolean;
+  selectedDirectMessagePeerPubkey?: string | null;
   selectedThread?: string | null;
   settingsOpen?: boolean;
   settingsSection?: SettingsSection;
@@ -383,6 +399,16 @@ function createInitialShellState(): DesktopShellState {
     selectedAuthor: null,
     selectedAuthorTimeline: [],
     authorError: null,
+    directMessagePaneOpen: false,
+    selectedDirectMessagePeerPubkey: null,
+    directMessages: [],
+    directMessageTimelineByPeer: {},
+    directMessageStatusByPeer: {},
+    directMessageComposer: '',
+    directMessageDraftMediaItems: [],
+    directMessageAttachmentInputKey: 0,
+    directMessageError: null,
+    directMessageSending: false,
     composerError: null,
     liveTitle: '',
     liveDescription: '',
@@ -544,16 +570,28 @@ function translate(key: string, options?: Record<string, unknown>): string {
 }
 
 function selectPrimaryImage(post: PostView): AttachmentView | null {
-  return post.attachments.find((attachment) => attachment.role === 'image_original') ?? null;
+  return selectPrimaryImageAttachment(post.attachments);
 }
 
 function selectVideoPoster(post: PostView): AttachmentView | null {
-  return post.attachments.find((attachment) => attachment.role === 'video_poster') ?? null;
+  return selectVideoPosterAttachment(post.attachments);
 }
 
 function selectVideoManifest(post: PostView): AttachmentView | null {
+  return selectVideoManifestAttachment(post.attachments);
+}
+
+function selectPrimaryImageAttachment(attachments: AttachmentView[]): AttachmentView | null {
+  return attachments.find((attachment) => attachment.role === 'image_original') ?? null;
+}
+
+function selectVideoPosterAttachment(attachments: AttachmentView[]): AttachmentView | null {
+  return attachments.find((attachment) => attachment.role === 'video_poster') ?? null;
+}
+
+function selectVideoManifestAttachment(attachments: AttachmentView[]): AttachmentView | null {
   return (
-    post.attachments.find(
+    attachments.find(
       (attachment) =>
         attachment.role === 'video_manifest' || attachment.mime.startsWith('video/')
     ) ?? null
@@ -1376,6 +1414,16 @@ function DesktopShellPage({
     selectedAuthor,
     selectedAuthorTimeline,
     authorError,
+    directMessagePaneOpen,
+    selectedDirectMessagePeerPubkey,
+    directMessages,
+    directMessageTimelineByPeer,
+    directMessageStatusByPeer,
+    directMessageComposer,
+    directMessageDraftMediaItems,
+    directMessageAttachmentInputKey,
+    directMessageError,
+    directMessageSending,
     composerError,
     liveTitle,
     liveDescription,
@@ -1557,6 +1605,43 @@ function DesktopShellPage({
     [makeFieldSetter]
   );
   const setAuthorError = useMemo(() => makeFieldSetter('authorError'), [makeFieldSetter]);
+  const setDirectMessagePaneOpen = useMemo(
+    () => makeFieldSetter('directMessagePaneOpen'),
+    [makeFieldSetter]
+  );
+  const setSelectedDirectMessagePeerPubkey = useMemo(
+    () => makeFieldSetter('selectedDirectMessagePeerPubkey'),
+    [makeFieldSetter]
+  );
+  const setDirectMessages = useMemo(() => makeFieldSetter('directMessages'), [makeFieldSetter]);
+  const setDirectMessageTimelineByPeer = useMemo(
+    () => makeFieldSetter('directMessageTimelineByPeer'),
+    [makeFieldSetter]
+  );
+  const setDirectMessageStatusByPeer = useMemo(
+    () => makeFieldSetter('directMessageStatusByPeer'),
+    [makeFieldSetter]
+  );
+  const setDirectMessageComposer = useMemo(
+    () => makeFieldSetter('directMessageComposer'),
+    [makeFieldSetter]
+  );
+  const setDirectMessageDraftMediaItems = useMemo(
+    () => makeFieldSetter('directMessageDraftMediaItems'),
+    [makeFieldSetter]
+  );
+  const setDirectMessageAttachmentInputKey = useMemo(
+    () => makeFieldSetter('directMessageAttachmentInputKey'),
+    [makeFieldSetter]
+  );
+  const setDirectMessageError = useMemo(
+    () => makeFieldSetter('directMessageError'),
+    [makeFieldSetter]
+  );
+  const setDirectMessageSending = useMemo(
+    () => makeFieldSetter('directMessageSending'),
+    [makeFieldSetter]
+  );
   const setComposerError = useMemo(() => makeFieldSetter('composerError'), [makeFieldSetter]);
   const setLiveTitle = useMemo(() => makeFieldSetter('liveTitle'), [makeFieldSetter]);
   const setLiveDescription = useMemo(() => makeFieldSetter('liveDescription'), [makeFieldSetter]);
@@ -1639,6 +1724,7 @@ function DesktopShellPage({
   const mediaFetchAttemptRef = useRef(new Map<string, number>());
   const remoteObjectUrlRef = useRef(new Map<string, string>());
   const draftPreviewUrlRef = useRef(new Map<string, string>());
+  const directMessageDraftPreviewUrlRef = useRef(new Map<string, string>());
   const loadTopicsRequestRef = useRef(0);
   const pendingRouteUrlRef = useRef<string | null>(null);
   const didSyncRouteSectionRef = useRef(false);
@@ -1726,6 +1812,29 @@ function DesktopShellPage({
     () => gamePanelStateByTopic[activeTopic] ?? DEFAULT_ASYNC_PANEL_STATE,
     [activeTopic, gamePanelStateByTopic]
   );
+  const selectedDirectMessageConversation = useMemo(
+    () =>
+      selectedDirectMessagePeerPubkey
+        ? directMessages.find((conversation) => conversation.peer_pubkey === selectedDirectMessagePeerPubkey) ?? null
+        : null,
+    [directMessages, selectedDirectMessagePeerPubkey]
+  );
+  const selectedDirectMessageTimeline = useMemo(
+    () =>
+      selectedDirectMessagePeerPubkey
+        ? directMessageTimelineByPeer[selectedDirectMessagePeerPubkey] ?? []
+        : [],
+    [directMessageTimelineByPeer, selectedDirectMessagePeerPubkey]
+  );
+  const selectedDirectMessageStatus = useMemo(
+    () =>
+      selectedDirectMessagePeerPubkey
+        ? directMessageStatusByPeer[selectedDirectMessagePeerPubkey] ??
+          selectedDirectMessageConversation?.status ??
+          null
+        : null,
+    [directMessageStatusByPeer, selectedDirectMessageConversation, selectedDirectMessagePeerPubkey]
+  );
   const channelAudienceOptions = useMemo<ChannelAudienceOption[]>(
     () => [
       {
@@ -1778,6 +1887,12 @@ function DesktopShellPage({
     const nextSelectedAuthorPubkey = hasOverride('selectedAuthorPubkey')
       ? overrides?.selectedAuthorPubkey ?? null
       : selectedAuthorPubkey;
+    const nextDirectMessagePaneOpen = hasOverride('directMessagePaneOpen')
+      ? overrides?.directMessagePaneOpen ?? false
+      : directMessagePaneOpen;
+    const nextSelectedDirectMessagePeerPubkey = hasOverride('selectedDirectMessagePeerPubkey')
+      ? overrides?.selectedDirectMessagePeerPubkey ?? null
+      : selectedDirectMessagePeerPubkey;
     const nextSettingsOpen = hasOverride('settingsOpen')
       ? overrides?.settingsOpen ?? false
       : shellChromeState.settingsOpen;
@@ -1799,7 +1914,12 @@ function DesktopShellPage({
     if (nextSelectedChannelId) {
       search.set('channel', nextSelectedChannelId);
     }
-    if (nextSelectedThread) {
+    if (nextDirectMessagePaneOpen) {
+      search.set('context', 'dm');
+      if (nextSelectedDirectMessagePeerPubkey) {
+        search.set('peerPubkey', nextSelectedDirectMessagePeerPubkey);
+      }
+    } else if (nextSelectedThread) {
       search.set('context', 'thread');
       search.set('threadId', nextSelectedThread);
       if (nextSelectedAuthorPubkey) {
@@ -1831,6 +1951,8 @@ function DesktopShellPage({
     location.pathname,
     location.search,
     navigate,
+    directMessagePaneOpen,
+    selectedDirectMessagePeerPubkey,
     selectedAuthorPubkey,
     selectedThread,
     selectedChannelIdByTopic,
@@ -1945,6 +2067,15 @@ function DesktopShellPage({
         tryAddAttachment(attachment);
       }
     }
+    for (const message of selectedDirectMessageTimeline) {
+      for (const attachment of [
+        selectPrimaryImageAttachment(message.attachments),
+        selectVideoPosterAttachment(message.attachments),
+        selectVideoManifestAttachment(message.attachments),
+      ]) {
+        tryAddAttachment(attachment);
+      }
+    }
     for (const asset of [...ownedReactionAssets, ...bookmarkedReactionAssets]) {
       tryAddAttachment({
         hash: asset.blob_hash,
@@ -1978,6 +2109,7 @@ function DesktopShellPage({
     localProfile?.picture_asset,
     ownedReactionAssets,
     profileTimeline,
+    selectedDirectMessageTimeline,
     selectedAuthor?.picture_asset,
     selectedAuthorTimeline,
     thread,
@@ -1990,6 +2122,8 @@ function DesktopShellPage({
       const currentState = storeApi.getState();
       const currentSelectedChannelIdByTopic = currentState.selectedChannelIdByTopic;
       const currentSelectedAuthorPubkey = currentState.selectedAuthorPubkey;
+      const currentDirectMessagePaneOpen = currentState.directMessagePaneOpen;
+      const currentSelectedDirectMessagePeerPubkey = currentState.selectedDirectMessagePeerPubkey;
       const currentDiscoveryEditorDirty = currentState.discoveryEditorDirty;
       const currentCommunityNodeEditorDirty = currentState.communityNodeEditorDirty;
       const currentProfileDirty = currentState.profileDirty;
@@ -2002,6 +2136,7 @@ function DesktopShellPage({
           gameViewsResult,
           joinedChannelViewsResult,
           threadView,
+          directMessagesView,
           status,
         ] = await Promise.all([
           Promise.all(
@@ -2048,6 +2183,7 @@ function DesktopShellPage({
           currentThread
             ? api.listThread(currentActiveTopic, currentThread, null, 50)
             : Promise.resolve(null),
+          api.listDirectMessages(),
           api.getSyncStatus(),
         ]);
         const [
@@ -2059,6 +2195,8 @@ function DesktopShellPage({
           authorViewResult,
           profileTimelineResult,
           authorTimelineResult,
+          directMessageTimelineResult,
+          directMessageStatusResult,
           ownedReactionAssetsResult,
           bookmarkedReactionAssetsResult,
           recentReactionsResult,
@@ -2074,6 +2212,12 @@ function DesktopShellPage({
           api.listProfileTimeline(status.local_author_pubkey, null, 50),
           currentSelectedAuthorPubkey
             ? api.listProfileTimeline(currentSelectedAuthorPubkey, null, 50)
+            : Promise.resolve(null),
+          currentDirectMessagePaneOpen && currentSelectedDirectMessagePeerPubkey
+            ? api.listDirectMessageMessages(currentSelectedDirectMessagePeerPubkey, null, 100)
+            : Promise.resolve(null),
+          currentDirectMessagePaneOpen && currentSelectedDirectMessagePeerPubkey
+            ? api.getDirectMessageStatus(currentSelectedDirectMessagePeerPubkey)
             : Promise.resolve(null),
           api.listMyCustomReactionAssets(),
           api.listBookmarkedCustomReactions(),
@@ -2178,6 +2322,7 @@ function DesktopShellPage({
             }
             return next;
           });
+          setDirectMessages(directMessagesView);
           setSyncStatus(status);
           if (discoveryResult.status === 'fulfilled') {
             setDiscoveryConfig(discoveryResult.value);
@@ -2293,6 +2438,40 @@ function DesktopShellPage({
               )
             );
           }
+          if (!currentDirectMessagePaneOpen) {
+            setSelectedDirectMessagePeerPubkey(null);
+            setDirectMessageError(null);
+          } else if (!currentSelectedDirectMessagePeerPubkey) {
+            setDirectMessageError(null);
+          } else if (
+            directMessageTimelineResult.status === 'fulfilled' &&
+            directMessageStatusResult.status === 'fulfilled'
+          ) {
+            setDirectMessageTimelineByPeer((current) => ({
+              ...current,
+              [currentSelectedDirectMessagePeerPubkey]: directMessageTimelineResult.value?.items ?? [],
+            }));
+            setDirectMessageStatusByPeer((current) => ({
+              ...current,
+              [currentSelectedDirectMessagePeerPubkey]: directMessageStatusResult.value!,
+            }));
+            setDirectMessageError(null);
+          } else {
+            setDirectMessageTimelineByPeer((current) => ({
+              ...current,
+              [currentSelectedDirectMessagePeerPubkey]: [],
+            }));
+            setDirectMessageError(
+              messageFromError(
+                directMessageTimelineResult.status === 'rejected'
+                  ? directMessageTimelineResult.reason
+                  : directMessageStatusResult.status === 'rejected'
+                    ? directMessageStatusResult.reason
+                    : null,
+                'failed to load direct messages'
+              )
+            );
+          }
           if (threadView) {
             setThread(threadView.items);
           } else if (!currentThread) {
@@ -2318,6 +2497,11 @@ function DesktopShellPage({
       setCommunityNodeConfig,
       setCommunityNodeInput,
       setCommunityNodeStatuses,
+      setDirectMessageError,
+      setDirectMessages,
+      setDirectMessageStatusByPeer,
+      setDirectMessageTimelineByPeer,
+      setSelectedDirectMessagePeerPubkey,
       setDiscoveryConfig,
       setDiscoverySeedInput,
       setError,
@@ -2370,6 +2554,7 @@ function DesktopShellPage({
   useEffect(() => {
     const remoteObjectUrls = remoteObjectUrlRef.current;
     const draftPreviewUrls = draftPreviewUrlRef.current;
+    const directMessageDraftPreviewUrls = directMessageDraftPreviewUrlRef.current;
 
     return () => {
       for (const url of remoteObjectUrls.values()) {
@@ -2380,6 +2565,10 @@ function DesktopShellPage({
         URL.revokeObjectURL(url);
       }
       draftPreviewUrls.clear();
+      for (const url of directMessageDraftPreviewUrls.values()) {
+        URL.revokeObjectURL(url);
+      }
+      directMessageDraftPreviewUrls.clear();
     };
   }, []);
 
@@ -2612,6 +2801,124 @@ function DesktopShellPage({
     syncRoute,
   ]);
 
+  const closeDirectMessagePane = useCallback(() => {
+    setDirectMessagePaneOpen(false);
+    setSelectedDirectMessagePeerPubkey(null);
+    setDirectMessageError(null);
+    syncRoute('replace', {
+      directMessagePaneOpen: false,
+      selectedDirectMessagePeerPubkey: null,
+    });
+  }, [
+    setDirectMessageError,
+    setDirectMessagePaneOpen,
+    setSelectedDirectMessagePeerPubkey,
+    syncRoute,
+  ]);
+
+  const openDirectMessageList = useCallback((historyMode: 'push' | 'replace' = 'push') => {
+    setReplyTarget(null);
+    setRepostTarget(null);
+    setSelectedThread(null);
+    setThread([]);
+    setSelectedAuthorPubkey(null);
+    setSelectedAuthor(null);
+    setSelectedAuthorTimeline([]);
+    setAuthorError(null);
+    setDirectMessagePaneOpen(true);
+    setSelectedDirectMessagePeerPubkey(null);
+    setDirectMessageError(null);
+    syncRoute(historyMode, {
+      directMessagePaneOpen: true,
+      selectedAuthorPubkey: null,
+      selectedDirectMessagePeerPubkey: null,
+      selectedThread: null,
+    });
+  }, [
+    setAuthorError,
+    setDirectMessageError,
+    setDirectMessagePaneOpen,
+    setReplyTarget,
+    setRepostTarget,
+    setSelectedAuthor,
+    setSelectedAuthorPubkey,
+    setSelectedAuthorTimeline,
+    setSelectedDirectMessagePeerPubkey,
+    setSelectedThread,
+    setThread,
+    syncRoute,
+  ]);
+
+  const openDirectMessagePane = useCallback(async (
+    peerPubkey: string,
+    options?: { historyMode?: 'push' | 'replace'; normalizeOnError?: boolean }
+  ) => {
+    try {
+      const [conversation, timeline, status] = await Promise.all([
+        api.openDirectMessage(peerPubkey),
+        api.listDirectMessageMessages(peerPubkey, null, 100),
+        api.getDirectMessageStatus(peerPubkey),
+      ]);
+      setReplyTarget(null);
+      setRepostTarget(null);
+      setSelectedThread(null);
+      setThread([]);
+      setSelectedAuthorPubkey(null);
+      setSelectedAuthor(null);
+      setSelectedAuthorTimeline([]);
+      setAuthorError(null);
+      setDirectMessages((current) => {
+        const remaining = current.filter((entry) => entry.peer_pubkey !== conversation.peer_pubkey);
+        return [conversation, ...remaining];
+      });
+      setDirectMessageTimelineByPeer((current) => ({
+        ...current,
+        [peerPubkey]: timeline.items,
+      }));
+      setDirectMessageStatusByPeer((current) => ({
+        ...current,
+        [peerPubkey]: status,
+      }));
+      setDirectMessagePaneOpen(true);
+      setSelectedDirectMessagePeerPubkey(peerPubkey);
+      setDirectMessageError(null);
+      syncRoute(options?.historyMode ?? 'push', {
+        directMessagePaneOpen: true,
+        selectedAuthorPubkey: null,
+        selectedDirectMessagePeerPubkey: peerPubkey,
+        selectedThread: null,
+      });
+    } catch (openError) {
+      const nextError = messageFromError(openError, 'failed to open direct message');
+      setDirectMessageError(nextError);
+      if (options?.normalizeOnError) {
+        setDirectMessagePaneOpen(false);
+        setSelectedDirectMessagePeerPubkey(null);
+        syncRoute('replace', {
+          directMessagePaneOpen: false,
+          selectedDirectMessagePeerPubkey: null,
+        });
+      }
+    }
+  }, [
+    api,
+    setAuthorError,
+    setDirectMessageError,
+    setDirectMessagePaneOpen,
+    setDirectMessages,
+    setDirectMessageStatusByPeer,
+    setDirectMessageTimelineByPeer,
+    setReplyTarget,
+    setRepostTarget,
+    setSelectedAuthor,
+    setSelectedAuthorPubkey,
+    setSelectedAuthorTimeline,
+    setSelectedDirectMessagePeerPubkey,
+    setSelectedThread,
+    setThread,
+    syncRoute,
+  ]);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') {
@@ -2620,6 +2927,11 @@ function DesktopShellPage({
       if (shellChromeState.settingsOpen) {
         event.preventDefault();
         setSettingsOpen(false, true);
+        return;
+      }
+      if (directMessagePaneOpen) {
+        event.preventDefault();
+        closeDirectMessagePane();
         return;
       }
       if (selectedAuthorPubkey) {
@@ -2644,7 +2956,9 @@ function DesktopShellPage({
     };
   }, [
     closeAuthorPane,
+    closeDirectMessagePane,
     closeThreadPane,
+    directMessagePaneOpen,
     setNavOpen,
     setSettingsOpen,
     shellChromeState.navOpen,
@@ -2694,6 +3008,26 @@ function DesktopShellPage({
     for (const [itemId, previewUrl] of draftPreviewUrlRef.current.entries()) {
       URL.revokeObjectURL(previewUrl);
       draftPreviewUrlRef.current.delete(itemId);
+    }
+  }
+
+  function rememberDirectMessageDraftPreview(item: DraftMediaItem) {
+    directMessageDraftPreviewUrlRef.current.set(item.id, item.preview_url);
+  }
+
+  function releaseDirectMessageDraftPreview(itemId: string) {
+    const previewUrl = directMessageDraftPreviewUrlRef.current.get(itemId);
+    if (!previewUrl) {
+      return;
+    }
+    URL.revokeObjectURL(previewUrl);
+    directMessageDraftPreviewUrlRef.current.delete(itemId);
+  }
+
+  function releaseAllDirectMessageDraftPreviews() {
+    for (const [itemId, previewUrl] of directMessageDraftPreviewUrlRef.current.entries()) {
+      URL.revokeObjectURL(previewUrl);
+      directMessageDraftPreviewUrlRef.current.delete(itemId);
     }
   }
 
@@ -3310,6 +3644,91 @@ function DesktopShellPage({
     setDraftMediaItems((current) => current.filter((item) => item.id !== itemId));
   }
 
+  async function handleDirectMessageAttachmentSelection(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    try {
+      const nextItem = file.type.startsWith('image/')
+        ? await buildImageDraftItem(file)
+        : file.type.startsWith('video/')
+          ? await buildVideoDraftItem(file)
+          : null;
+      if (!nextItem) {
+        setDirectMessageError(
+          translate('common:errors.unsupportedAttachmentType', { name: file.name })
+        );
+      } else {
+        releaseAllDirectMessageDraftPreviews();
+        rememberDirectMessageDraftPreview(nextItem);
+        setDirectMessageDraftMediaItems([nextItem]);
+        setDirectMessageError(null);
+      }
+    } catch (attachmentError) {
+      setDirectMessageError(
+        messageFromError(attachmentError, translate('common:errors.failedToGenerateVideoPoster'))
+      );
+    } finally {
+      setDirectMessageAttachmentInputKey((value) => value + 1);
+    }
+  }
+
+  function handleRemoveDirectMessageDraftAttachment(itemId: string) {
+    releaseDirectMessageDraftPreview(itemId);
+    setDirectMessageDraftMediaItems((current) => current.filter((item) => item.id !== itemId));
+  }
+
+  async function handleSendDirectMessage(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedDirectMessagePeerPubkey) {
+      return;
+    }
+    const trimmedComposer = directMessageComposer.trim();
+    const attachments = directMessageDraftMediaItems.flatMap((item) => item.attachments);
+    if (!trimmedComposer && attachments.length === 0) {
+      return;
+    }
+    setDirectMessageSending(true);
+    try {
+      await api.sendDirectMessage(
+        selectedDirectMessagePeerPubkey,
+        trimmedComposer || null,
+        attachments,
+        null
+      );
+      releaseAllDirectMessageDraftPreviews();
+      setDirectMessageComposer('');
+      setDirectMessageDraftMediaItems([]);
+      setDirectMessageAttachmentInputKey((value) => value + 1);
+      setDirectMessageError(null);
+      await openDirectMessagePane(selectedDirectMessagePeerPubkey, { historyMode: 'replace' });
+    } catch (sendError) {
+      setDirectMessageError(messageFromError(sendError, 'failed to send direct message'));
+    } finally {
+      setDirectMessageSending(false);
+    }
+  }
+
+  async function handleDeleteDirectMessageMessage(peerPubkey: string, messageId: string) {
+    try {
+      await api.deleteDirectMessageMessage(peerPubkey, messageId);
+      await openDirectMessagePane(peerPubkey, { historyMode: 'replace' });
+    } catch (deleteError) {
+      setDirectMessageError(messageFromError(deleteError, 'failed to delete direct message'));
+    }
+  }
+
+  async function handleClearDirectMessage(peerPubkey: string) {
+    try {
+      await api.clearDirectMessage(peerPubkey);
+      await openDirectMessagePane(peerPubkey, { historyMode: 'replace' });
+    } catch (clearError) {
+      setDirectMessageError(messageFromError(clearError, 'failed to clear direct message'));
+    }
+  }
+
   function patchReactionState(reactionState: ReactionStateView) {
     setTimelinesByTopic((current) =>
       Object.fromEntries(
@@ -3427,9 +3846,13 @@ function DesktopShellPage({
           setSelectedAuthorPubkey(null);
           setSelectedAuthor(null);
           setAuthorError(null);
+          setDirectMessagePaneOpen(false);
+          setSelectedDirectMessagePeerPubkey(null);
+          setDirectMessageError(null);
         });
         syncRoute('replace', {
           activeTopic: topic,
+          directMessagePaneOpen: false,
           selectedAuthorPubkey: null,
           selectedThread: null,
         });
@@ -3442,10 +3865,14 @@ function DesktopShellPage({
         setSelectedAuthorPubkey(null);
         setSelectedAuthor(null);
         setAuthorError(null);
+        setDirectMessagePaneOpen(false);
+        setSelectedDirectMessagePeerPubkey(null);
+        setDirectMessageError(null);
         setError(null);
       });
       syncRoute(options?.historyMode ?? 'push', {
         activeTopic: topic,
+        directMessagePaneOpen: false,
         selectedAuthorPubkey: null,
         selectedThread: threadId,
       });
@@ -3462,9 +3889,13 @@ function DesktopShellPage({
           setSelectedAuthorPubkey(null);
           setSelectedAuthor(null);
           setAuthorError(null);
+          setDirectMessagePaneOpen(false);
+          setSelectedDirectMessagePeerPubkey(null);
+          setDirectMessageError(null);
         });
         syncRoute('replace', {
           activeTopic: topic,
+          directMessagePaneOpen: false,
           selectedAuthorPubkey: null,
           selectedThread: null,
         });
@@ -3475,9 +3906,12 @@ function DesktopShellPage({
     api,
     setActiveTopic,
     setAuthorError,
+    setDirectMessageError,
+    setDirectMessagePaneOpen,
     setError,
     setSelectedAuthor,
     setSelectedAuthorPubkey,
+    setSelectedDirectMessagePeerPubkey,
     setSelectedThread,
     setThread,
     syncRoute,
@@ -3589,11 +4023,15 @@ function DesktopShellPage({
       setSelectedAuthor(socialView);
       setSelectedAuthorTimeline([]);
       setAuthorError(null);
+      setDirectMessagePaneOpen(false);
+      setSelectedDirectMessagePeerPubkey(null);
+      setDirectMessageError(null);
       if (!options?.fromThread) {
         setSelectedThread(null);
         setThread([]);
       }
       syncRoute(options?.historyMode ?? 'push', {
+        directMessagePaneOpen: false,
         selectedThread: nextThreadId,
         selectedAuthorPubkey: authorPubkey,
       });
@@ -3623,6 +4061,9 @@ function DesktopShellPage({
     setSelectedAuthor,
     setSelectedAuthorTimeline,
     setSelectedAuthorPubkey,
+    setDirectMessageError,
+    setDirectMessagePaneOpen,
+    setSelectedDirectMessagePeerPubkey,
     setSelectedThread,
     setThread,
     selectedThread,
@@ -4036,6 +4477,7 @@ function DesktopShellPage({
     const requestedProfileMode = params.get('profileMode');
     const requestedThreadId = params.get('threadId');
     const requestedAuthorPubkey = params.get('authorPubkey');
+    const requestedPeerPubkey = params.get('peerPubkey');
 
     let nextTopic = activeTopic;
     let shouldReload = false;
@@ -4131,7 +4573,44 @@ function DesktopShellPage({
       shouldNormalize = true;
     }
 
-    if (requestedContext === 'thread') {
+    if (requestedContext === 'dm') {
+      if (requestedThreadId || requestedAuthorPubkey) {
+        shouldNormalize = true;
+      }
+      if (selectedThread) {
+        setSelectedThread(null);
+        setThread([]);
+        setReplyTarget(null);
+        setRepostTarget(null);
+      }
+      if (selectedAuthorPubkey) {
+        setSelectedAuthorPubkey(null);
+        setSelectedAuthor(null);
+        setAuthorError(null);
+      }
+      if (!directMessagePaneOpen) {
+        setDirectMessagePaneOpen(true);
+      }
+      if (!requestedPeerPubkey) {
+        if (selectedDirectMessagePeerPubkey) {
+          setSelectedDirectMessagePeerPubkey(null);
+        }
+        setDirectMessageError(null);
+      } else if (!isHex64(requestedPeerPubkey)) {
+        shouldNormalize = true;
+        if (selectedDirectMessagePeerPubkey) {
+          setSelectedDirectMessagePeerPubkey(null);
+        }
+      } else if (
+        requestedPeerPubkey !== selectedDirectMessagePeerPubkey ||
+        !directMessagePaneOpen
+      ) {
+        void openDirectMessagePane(requestedPeerPubkey, {
+          historyMode: 'replace',
+          normalizeOnError: true,
+        });
+      }
+    } else if (requestedContext === 'thread') {
       const threadReadyForNestedAuthor =
         requestedThreadId !== null &&
         requestedThreadId.length > 0 &&
@@ -4228,11 +4707,16 @@ function DesktopShellPage({
         setSelectedAuthor(null);
         setAuthorError(null);
       }
+      if (directMessagePaneOpen || selectedDirectMessagePeerPubkey) {
+        setDirectMessagePaneOpen(false);
+        setSelectedDirectMessagePeerPubkey(null);
+        setDirectMessageError(null);
+      }
     } else {
-      if (requestedThreadId || requestedAuthorPubkey) {
+      if (requestedThreadId || requestedAuthorPubkey || requestedPeerPubkey) {
         shouldNormalize = true;
       }
-      if (selectedThread || selectedAuthorPubkey) {
+      if (selectedThread || selectedAuthorPubkey || directMessagePaneOpen || selectedDirectMessagePeerPubkey) {
         setSelectedThread(null);
         setThread([]);
         setReplyTarget(null);
@@ -4240,6 +4724,9 @@ function DesktopShellPage({
         setSelectedAuthorPubkey(null);
         setSelectedAuthor(null);
         setAuthorError(null);
+        setDirectMessagePaneOpen(false);
+        setSelectedDirectMessagePeerPubkey(null);
+        setDirectMessageError(null);
       }
     }
 
@@ -4261,19 +4748,25 @@ function DesktopShellPage({
     location.search,
     navigate,
     openAuthorDetail,
+    openDirectMessagePane,
     openThread,
     routeSection,
+    directMessagePaneOpen,
     selectedAuthor,
     selectedAuthorPubkey,
+    selectedDirectMessagePeerPubkey,
     selectedChannelIdByTopic,
     selectedThread,
     setAuthorError,
+    setDirectMessageError,
+    setDirectMessagePaneOpen,
     setSelectedThread,
     setActiveTopic,
     setComposeChannelByTopic,
     setSelectedChannelIdByTopic,
     setSelectedAuthor,
     setSelectedAuthorPubkey,
+    setSelectedDirectMessagePeerPubkey,
     setShellChromeState,
     setReplyTarget,
     setRepostTarget,
@@ -4507,6 +5000,21 @@ function DesktopShellPage({
       })),
     [draftMediaItems, locale]
   );
+  const directMessageDraftViews = useMemo<ComposerDraftMediaView[]>(
+    () =>
+      directMessageDraftMediaItems.map((item) => ({
+        id: item.id,
+        sourceName: item.source_name,
+        previewUrl: item.preview_url,
+        attachments: item.attachments.map((attachment) => ({
+          key: `${attachment.role ?? attachment.mime}-${attachment.file_name ?? item.source_name}`,
+          label: attachment.role ?? translate('common:fallbacks.attachment'),
+          mime: attachment.mime,
+          byteSizeLabel: formatBytes(attachment.byte_size, locale),
+        })),
+      })),
+    [directMessageDraftMediaItems, locale]
+  );
   const threadPanelState = useMemo<ThreadPanelState>(
     () => ({
       selectedThreadId: selectedThread,
@@ -4541,6 +5049,11 @@ function DesktopShellPage({
             followActionLabel: selectedAuthor.following ? 'Unfollow' : 'Follow',
           }
         : null,
+      canMessage: Boolean(
+        selectedAuthor &&
+          selectedAuthor.author_pubkey !== syncStatus.local_author_pubkey &&
+          selectedAuthor.mutual
+      ),
       authorError,
     }),
     [authorError, mediaObjectUrls, selectedAuthor, syncStatus.local_author_pubkey, t]
@@ -4599,16 +5112,28 @@ function DesktopShellPage({
     />
   );
   const channelAction = (
-    <Button
-      className='shell-icon-button shell-nav-channel-action'
-      variant='secondary'
-      size='icon'
-      type='button'
-      aria-label={t('channels:title')}
-      onClick={() => setChannelDialogOpen(true)}
-    >
-      <Lock className='size-4' aria-hidden='true' />
-    </Button>
+    <div className='post-actions'>
+      <Button
+        className='shell-icon-button shell-nav-channel-action'
+        variant='secondary'
+        size='icon'
+        type='button'
+        aria-label='Messages'
+        onClick={() => openDirectMessageList()}
+      >
+        <MessageSquare className='size-4' aria-hidden='true' />
+      </Button>
+      <Button
+        className='shell-icon-button shell-nav-channel-action'
+        variant='secondary'
+        size='icon'
+        type='button'
+        aria-label={t('channels:title')}
+        onClick={() => setChannelDialogOpen(true)}
+      >
+        <Lock className='size-4' aria-hidden='true' />
+      </Button>
+    </div>
   );
 
   const connectivityPanelView = useMemo<ConnectivityPanelView>(
@@ -4989,6 +5514,270 @@ function DesktopShellPage({
   );
   const detailPaneStack = (
     <>
+      {directMessagePaneOpen ? (
+        <ContextPane
+          paneId={`${SHELL_CONTEXT_ID}-direct-message`}
+          title='Messages'
+          summary={
+            selectedDirectMessageConversation
+              ? authorDisplayLabel(
+                  selectedDirectMessageConversation.peer_pubkey,
+                  selectedDirectMessageConversation.peer_display_name,
+                  selectedDirectMessageConversation.peer_name
+                )
+              : 'Direct messages'
+          }
+          showBackdrop={true}
+          stackIndex={0}
+          onClose={closeDirectMessagePane}
+        >
+          <div className='shell-main-stack'>
+            <Card className='shell-workspace-card'>
+              <div className='panel-header'>
+                <div>
+                  <h3>Messages</h3>
+                  <small>{formatCount(directMessages.length)} conversations</small>
+                </div>
+                {selectedDirectMessagePeerPubkey ? (
+                  <Button
+                    variant='secondary'
+                    type='button'
+                    onClick={() => openDirectMessageList('replace')}
+                  >
+                    All
+                  </Button>
+                ) : null}
+              </div>
+              {directMessageError ? <Notice tone='destructive'>{directMessageError}</Notice> : null}
+              {directMessages.length === 0 ? (
+                <p className='empty'>No direct messages yet.</p>
+              ) : (
+                <ul className='post-list'>
+                  {directMessages.map((conversation) => {
+                    const label = authorDisplayLabel(
+                      conversation.peer_pubkey,
+                      conversation.peer_display_name,
+                      conversation.peer_name
+                    );
+                    const selected =
+                      conversation.peer_pubkey === selectedDirectMessagePeerPubkey;
+                    return (
+                      <li key={conversation.peer_pubkey}>
+                        <article className='post-card'>
+                          <div className='post-meta'>
+                            <span>{label}</span>
+                            <span>
+                              {conversation.last_message_at
+                                ? formatLocalizedTime(conversation.last_message_at, locale)
+                                : t('common:fallbacks.noEvents')}
+                            </span>
+                          </div>
+                          <div className='post-body'>
+                            <strong className='post-title'>
+                              {conversation.last_message_preview ?? t('common:fallbacks.none')}
+                            </strong>
+                          </div>
+                          <div className='post-actions'>
+                            <Button
+                              variant={selected ? 'default' : 'secondary'}
+                              type='button'
+                              onClick={() => void openDirectMessagePane(conversation.peer_pubkey)}
+                            >
+                              Open
+                            </Button>
+                          </div>
+                        </article>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </Card>
+
+            {selectedDirectMessagePeerPubkey ? (
+              <>
+                <Card className='shell-workspace-card'>
+                  <div className='shell-workspace-header'>
+                    <div className='shell-workspace-summary'>
+                      <span className='relationship-badge'>
+                        {selectedDirectMessageConversation
+                          ? authorDisplayLabel(
+                              selectedDirectMessageConversation.peer_pubkey,
+                              selectedDirectMessageConversation.peer_display_name,
+                              selectedDirectMessageConversation.peer_name
+                            )
+                          : selectedDirectMessagePeerPubkey}
+                      </span>
+                      {selectedDirectMessageStatus ? (
+                        <span className='relationship-badge relationship-badge-direct'>
+                          {selectedDirectMessageStatus.send_enabled
+                            ? `peers ${formatCount(selectedDirectMessageStatus.peer_count)}`
+                            : 'send disabled'}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className='post-actions'>
+                      <Button
+                        variant='secondary'
+                        type='button'
+                        onClick={() =>
+                          void openDirectMessagePane(selectedDirectMessagePeerPubkey, {
+                            historyMode: 'replace',
+                          })
+                        }
+                      >
+                        {t('common:actions.refresh')}
+                      </Button>
+                      <Button
+                        variant='secondary'
+                        type='button'
+                        disabled={selectedDirectMessageTimeline.length === 0}
+                        onClick={() => void handleClearDirectMessage(selectedDirectMessagePeerPubkey)}
+                      >
+                        {t('common:actions.clear')}
+                      </Button>
+                    </div>
+                  </div>
+                </Card>
+
+                <Card className='shell-workspace-card'>
+                  {selectedDirectMessageTimeline.length === 0 ? (
+                    <p className='empty'>No messages yet.</p>
+                  ) : (
+                    <ul className='post-list'>
+                      {selectedDirectMessageTimeline.map((message) => {
+                        const image = selectPrimaryImageAttachment(message.attachments);
+                        const poster = selectVideoPosterAttachment(message.attachments);
+                        const video = selectVideoManifestAttachment(message.attachments);
+                        const imageSrc = image ? mediaObjectUrls[image.hash] ?? null : null;
+                        const posterSrc = poster ? mediaObjectUrls[poster.hash] ?? null : null;
+                        const videoSrc = video ? mediaObjectUrls[video.hash] ?? null : null;
+                        const videoUnsupported = Boolean(
+                          video && unsupportedVideoManifests[video.hash]
+                        );
+                        return (
+                          <li key={message.message_id}>
+                            <article className='post-card'>
+                              <div className='post-meta'>
+                                <span>
+                                  {message.outgoing ? 'You' : 'Peer'}
+                                </span>
+                                <span>{formatLocalizedTime(message.created_at, locale)}</span>
+                                <span className='reply-chip'>
+                                  {message.delivered ? 'Delivered' : 'Pending'}
+                                </span>
+                              </div>
+                              {message.text ? (
+                                <div className='post-body'>
+                                  <strong className='post-title'>{message.text}</strong>
+                                </div>
+                              ) : null}
+                              {image ? (
+                                imageSrc ? (
+                                  <div className='draft-preview-frame'>
+                                    <img
+                                      className='draft-preview-image'
+                                      src={imageSrc}
+                                      alt={t('common:media.imageAlt')}
+                                    />
+                                  </div>
+                                ) : (
+                                  <small>{t('common:media.syncingImage')}</small>
+                                )
+                              ) : null}
+                              {video ? (
+                                videoSrc && !videoUnsupported ? (
+                                  <video
+                                    className='post-card-video'
+                                    controls
+                                    playsInline
+                                    poster={posterSrc ?? undefined}
+                                    src={videoSrc}
+                                  />
+                                ) : posterSrc ? (
+                                  <div className='draft-preview-frame'>
+                                    <img
+                                      className='draft-preview-image'
+                                      src={posterSrc}
+                                      alt={t('common:media.videoPosterAlt')}
+                                    />
+                                  </div>
+                                ) : (
+                                  <small>{t('common:media.syncingPoster')}</small>
+                                )
+                              ) : null}
+                              <div className='post-actions'>
+                                <Button
+                                  variant='secondary'
+                                  type='button'
+                                  onClick={() =>
+                                    void handleDeleteDirectMessageMessage(
+                                      selectedDirectMessagePeerPubkey,
+                                      message.message_id
+                                    )
+                                  }
+                                >
+                                  {t('common:actions.clear')}
+                                </Button>
+                              </div>
+                            </article>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </Card>
+
+                <Card className='shell-workspace-card'>
+                  {selectedDirectMessageStatus && !selectedDirectMessageStatus.send_enabled ? (
+                    <Notice tone='warning'>
+                      Direct message send is disabled until the relationship is mutual again.
+                    </Notice>
+                  ) : null}
+                  <form className='composer' onSubmit={(event) => void handleSendDirectMessage(event)}>
+                    <Textarea
+                      value={directMessageComposer}
+                      onChange={(event) => setDirectMessageComposer(event.target.value)}
+                      placeholder='Write a message'
+                      disabled={directMessageSending || !selectedDirectMessageStatus?.send_enabled}
+                    />
+                    <Label className='file-field file-field-compact'>
+                      <span>{t('common:fallbacks.attachment')}</span>
+                      <Input
+                        key={directMessageAttachmentInputKey}
+                        aria-label={t('common:fallbacks.attachment')}
+                        type='file'
+                        accept='image/*,video/*'
+                        disabled={
+                          directMessageSending || !selectedDirectMessageStatus?.send_enabled
+                        }
+                        onChange={(event) => {
+                          void handleDirectMessageAttachmentSelection(event);
+                        }}
+                      />
+                    </Label>
+                    <ComposerDraftPreviewList
+                      items={directMessageDraftViews}
+                      onRemove={handleRemoveDirectMessageDraftAttachment}
+                    />
+                    <div className='topic-diagnostic topic-diagnostic-secondary'>
+                      <span>
+                        pending outbox {formatCount(selectedDirectMessageStatus?.pending_outbox_count ?? 0)}
+                      </span>
+                    </div>
+                    <Button
+                      type='submit'
+                      disabled={directMessageSending || !selectedDirectMessageStatus?.send_enabled}
+                    >
+                      {directMessageSending ? 'Sending...' : 'Send'}
+                    </Button>
+                  </form>
+                </Card>
+              </>
+            ) : null}
+          </div>
+        </ContextPane>
+      ) : null}
       {selectedThread ? (
         <ContextPane
           paneId={`${SHELL_CONTEXT_ID}-thread`}
@@ -5042,6 +5831,7 @@ function DesktopShellPage({
               onToggleRelationship={(authorPubkey, following) =>
                 void handleRelationshipAction(authorPubkey, following)
               }
+              onOpenDirectMessage={(authorPubkey) => void openDirectMessagePane(authorPubkey)}
             />
             <Card className='shell-workspace-card'>
               <TimelineFeed
@@ -5441,7 +6231,9 @@ function DesktopShellPage({
           </div>
         }
         detailPaneStack={detailPaneStack}
-        detailPaneCount={(selectedThread ? 1 : 0) + (selectedAuthorPubkey ? 1 : 0)}
+        detailPaneCount={
+          (directMessagePaneOpen ? 1 : 0) + (selectedThread ? 1 : 0) + (selectedAuthorPubkey ? 1 : 0)
+        }
         mobileFooter={
           <Button
             ref={navTriggerRef}

--- a/apps/desktop/src/components/core/AuthorDetailCard.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.tsx
@@ -10,17 +10,25 @@ type AuthorDetailCardProps = {
   view: AuthorDetailView;
   localAuthorPubkey: string;
   onToggleRelationship: (authorPubkey: string, following: boolean) => void;
+  onOpenDirectMessage?: (authorPubkey: string) => void;
 };
 
 export function AuthorDetailCard({
   view,
   localAuthorPubkey,
   onToggleRelationship,
+  onOpenDirectMessage,
 }: AuthorDetailCardProps) {
   const { t } = useTranslation(['common']);
   const author = view.author;
   const relationshipLabel = view.summary?.label ?? null;
   const showFollowAction = author?.author_pubkey !== localAuthorPubkey;
+  const showMessageAction = Boolean(
+    author &&
+      author.author_pubkey !== localAuthorPubkey &&
+      view.canMessage &&
+      onOpenDirectMessage
+  );
 
   return (
     <Card className='author-detail'>
@@ -55,20 +63,31 @@ export function AuthorDetailCard({
             </div>
           ) : null}
 
-          {relationshipLabel || showFollowAction ? (
+          {relationshipLabel || showFollowAction || showMessageAction ? (
             <div className='author-detail-actions'>
               {relationshipLabel ? <RelationshipBadge label={relationshipLabel} /> : <span />}
-              {showFollowAction ? (
-                <button
-                  className='button button-secondary'
-                  type='button'
-                  onClick={() => onToggleRelationship(author.author_pubkey, author.following)}
-                >
-                  {view.summary?.followActionLabel === 'Unfollow'
-                    ? t('actions.unfollow')
-                    : t('actions.follow')}
-                </button>
-              ) : null}
+              <div className='post-actions'>
+                {showMessageAction ? (
+                  <button
+                    className='button button-secondary'
+                    type='button'
+                    onClick={() => onOpenDirectMessage?.(author.author_pubkey)}
+                  >
+                    {t('actions.message', { defaultValue: 'Message' })}
+                  </button>
+                ) : null}
+                {showFollowAction ? (
+                  <button
+                    className='button button-secondary'
+                    type='button'
+                    onClick={() => onToggleRelationship(author.author_pubkey, author.following)}
+                  >
+                    {view.summary?.followActionLabel === 'Unfollow'
+                      ? t('actions.unfollow')
+                      : t('actions.follow')}
+                  </button>
+                ) : null}
+              </div>
             </div>
           ) : null}
         </>

--- a/apps/desktop/src/components/core/types.ts
+++ b/apps/desktop/src/components/core/types.ts
@@ -86,5 +86,6 @@ export type AuthorDetailView = {
   displayLabel: string;
   pictureSrc?: string | null;
   summary: AuthorRelationshipSummary | null;
+  canMessage?: boolean;
   authorError?: string | null;
 };

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -144,6 +144,47 @@ export type AuthorSocialView = {
   friend_of_friend_via_pubkeys: string[];
 };
 
+export type DirectMessageStatusView = {
+  peer_pubkey: string;
+  dm_id: string;
+  mutual: boolean;
+  send_enabled: boolean;
+  peer_count: number;
+  pending_outbox_count: number;
+};
+
+export type DirectMessageMessageView = {
+  dm_id: string;
+  message_id: string;
+  sender_pubkey: string;
+  recipient_pubkey: string;
+  created_at: number;
+  text: string;
+  reply_to_message_id?: string | null;
+  attachments: AttachmentView[];
+  outgoing: boolean;
+  delivered: boolean;
+};
+
+export type DirectMessageConversationView = {
+  dm_id: string;
+  peer_pubkey: string;
+  peer_name?: string | null;
+  peer_display_name?: string | null;
+  peer_picture?: string | null;
+  peer_picture_asset?: ProfileAssetView | null;
+  updated_at: number;
+  last_message_at?: number | null;
+  last_message_id?: string | null;
+  last_message_preview?: string | null;
+  status: DirectMessageStatusView;
+};
+
+export type DirectMessageTimelineView = {
+  items: DirectMessageMessageView[];
+  next_cursor?: TimelineCursor | null;
+};
+
 export type BlobViewStatus = 'Missing' | 'Available' | 'Pinned';
 
 export type AttachmentView = {
@@ -434,6 +475,22 @@ export interface DesktopApi {
   followAuthor(pubkey: string): Promise<AuthorSocialView>;
   unfollowAuthor(pubkey: string): Promise<AuthorSocialView>;
   getAuthorSocialView(pubkey: string): Promise<AuthorSocialView>;
+  openDirectMessage(pubkey: string): Promise<DirectMessageConversationView>;
+  listDirectMessages(): Promise<DirectMessageConversationView[]>;
+  listDirectMessageMessages(
+    pubkey: string,
+    cursor?: TimelineCursor | null,
+    limit?: number
+  ): Promise<DirectMessageTimelineView>;
+  sendDirectMessage(
+    pubkey: string,
+    text?: string | null,
+    attachments?: CreateAttachmentInput[],
+    replyToMessageId?: string | null
+  ): Promise<string>;
+  deleteDirectMessageMessage(pubkey: string, messageId: string): Promise<void>;
+  clearDirectMessage(pubkey: string): Promise<void>;
+  getDirectMessageStatus(pubkey: string): Promise<DirectMessageStatusView>;
   listLiveSessions(topic: string, scope?: TimelineScope): Promise<LiveSessionView[]>;
   createLiveSession(
     topic: string,
@@ -751,6 +808,77 @@ export const runtimeApi: DesktopApi = {
       return window.__KUKURI_DESKTOP__.getAuthorSocialView(pubkey);
     }
     return invokeDesktop<AuthorSocialView>('get_author_social_view', {
+      request: { pubkey },
+    });
+  },
+  openDirectMessage: async (pubkey) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.openDirectMessage(pubkey);
+    }
+    return invokeDesktop<DirectMessageConversationView>('open_direct_message', {
+      request: { pubkey },
+    });
+  },
+  listDirectMessages: async () => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.listDirectMessages();
+    }
+    return invokeDesktop<DirectMessageConversationView[]>('list_direct_messages');
+  },
+  listDirectMessageMessages: async (pubkey, cursor, limit) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.listDirectMessageMessages(pubkey, cursor, limit);
+    }
+    return invokeDesktop<DirectMessageTimelineView>('list_direct_message_messages', {
+      request: {
+        pubkey,
+        cursor,
+        limit,
+      },
+    });
+  },
+  sendDirectMessage: async (pubkey, text, attachments = [], replyToMessageId) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.sendDirectMessage(
+        pubkey,
+        text,
+        attachments,
+        replyToMessageId
+      );
+    }
+    return invokeDesktop<string>('send_direct_message', {
+      request: {
+        pubkey,
+        text,
+        reply_to_message_id: replyToMessageId,
+        attachments,
+      },
+    });
+  },
+  deleteDirectMessageMessage: async (pubkey, messageId) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.deleteDirectMessageMessage(pubkey, messageId);
+    }
+    return invokeDesktop<void>('delete_direct_message_message', {
+      request: {
+        pubkey,
+        message_id: messageId,
+      },
+    });
+  },
+  clearDirectMessage: async (pubkey) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.clearDirectMessage(pubkey);
+    }
+    return invokeDesktop<void>('clear_direct_message', {
+      request: { pubkey },
+    });
+  },
+  getDirectMessageStatus: async (pubkey) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.getDirectMessageStatus(pubkey);
+    }
+    return invokeDesktop<DirectMessageStatusView>('get_direct_message_status', {
       request: { pubkey },
     });
   },

--- a/apps/desktop/src/mocks/desktopApiMock.ts
+++ b/apps/desktop/src/mocks/desktopApiMock.ts
@@ -11,6 +11,10 @@ import {
   type CustomReactionAssetView,
   type CustomReactionCropRect,
   type DesktopApi,
+  type DirectMessageConversationView,
+  type DirectMessageMessageView,
+  type DirectMessageStatusView,
+  type DirectMessageTimelineView,
   type DiscoveryConfig,
   type FriendOnlyGrantPreview,
   type FriendPlusSharePreview,
@@ -316,9 +320,50 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       withDefaultAuthorView(pubkey, view),
     ])
   );
+  const directMessageMessagesByPeer: Record<string, DirectMessageMessageView[]> = {};
+  const openedDirectMessagePeers = new Set<string>();
   const ownedCustomReactionAssets: CustomReactionAssetView[] = [];
   const bookmarkedCustomReactionAssets: BookmarkedCustomReactionView[] = [];
   let recentReactions: RecentReactionView[] = [];
+
+  function directMessageStatusFor(pubkey: string): DirectMessageStatusView {
+    const author = withDefaultAuthorView(pubkey, authorSocialViews[pubkey]);
+    return {
+      peer_pubkey: pubkey,
+      dm_id: [syncStatus.local_author_pubkey, pubkey].sort().join(':'),
+      mutual: author.mutual,
+      send_enabled: author.mutual,
+      peer_count: author.mutual ? 1 : 0,
+      pending_outbox_count: 0,
+    };
+  }
+
+  function directMessageConversationFor(pubkey: string): DirectMessageConversationView {
+    const messages = directMessageMessagesByPeer[pubkey] ?? [];
+    const latest = [...messages].sort(
+      (left, right) => right.created_at - left.created_at || right.message_id.localeCompare(left.message_id)
+    )[0];
+    const author = withDefaultAuthorView(pubkey, authorSocialViews[pubkey]);
+    return {
+      dm_id: directMessageStatusFor(pubkey).dm_id,
+      peer_pubkey: pubkey,
+      peer_name: author.name ?? null,
+      peer_display_name: author.display_name ?? null,
+      peer_picture: author.picture ?? null,
+      peer_picture_asset: author.picture_asset ?? null,
+      updated_at: latest?.created_at ?? 0,
+      last_message_at: latest?.created_at ?? null,
+      last_message_id: latest?.message_id ?? null,
+      last_message_preview:
+        latest?.text?.trim() ||
+        (latest?.attachments.some((attachment) => attachment.role === 'video_manifest')
+          ? '[Video]'
+          : latest?.attachments.length
+            ? '[Image]'
+            : null),
+      status: directMessageStatusFor(pubkey),
+    };
+  }
 
   const api: DesktopApi = {
     async createPost(topic, content, replyTo, attachments, channelRef = { kind: 'public' }) {
@@ -685,6 +730,81 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
         });
       }
       return withDefaultAuthorView(pubkey, authorSocialViews[pubkey]);
+    },
+    async openDirectMessage(pubkey) {
+      const status = directMessageStatusFor(pubkey);
+      if (!status.send_enabled && !openedDirectMessagePeers.has(pubkey)) {
+        throw new Error('direct message requires a mutual relationship');
+      }
+      openedDirectMessagePeers.add(pubkey);
+      return directMessageConversationFor(pubkey);
+    },
+    async listDirectMessages() {
+      return [...openedDirectMessagePeers]
+        .map((pubkey) => directMessageConversationFor(pubkey))
+        .sort(
+          (left, right) =>
+            (right.last_message_at ?? right.updated_at) - (left.last_message_at ?? left.updated_at) ||
+            left.peer_pubkey.localeCompare(right.peer_pubkey)
+        );
+    },
+    async listDirectMessageMessages(pubkey) {
+      return {
+        items: [...(directMessageMessagesByPeer[pubkey] ?? [])].sort(
+          (left, right) => right.created_at - left.created_at || right.message_id.localeCompare(left.message_id)
+        ),
+        next_cursor: null,
+      } satisfies DirectMessageTimelineView;
+    },
+    async sendDirectMessage(pubkey, text, attachments = [], replyToMessageId) {
+      const status = directMessageStatusFor(pubkey);
+      if (!status.send_enabled) {
+        throw new Error('direct message requires a mutual relationship');
+      }
+      if (!text?.trim() && attachments.length === 0) {
+        throw new Error('direct message requires text or attachment');
+      }
+      openedDirectMessagePeers.add(pubkey);
+      sequence += 1;
+      const messageId = `dm-${sequence}`;
+      const messageAttachments: AttachmentView[] = attachments.map((attachment, index) => ({
+        hash: `${messageId}-attachment-${index}`,
+        mime: attachment.mime,
+        bytes: attachment.byte_size,
+        role: attachment.role ?? 'image_original',
+        status: 'Available',
+      }));
+      const nextMessage: DirectMessageMessageView = {
+        dm_id: status.dm_id,
+        message_id: messageId,
+        sender_pubkey: syncStatus.local_author_pubkey,
+        recipient_pubkey: pubkey,
+        created_at: Date.now(),
+        text: text?.trim() ?? '',
+        reply_to_message_id: replyToMessageId ?? null,
+        attachments: messageAttachments,
+        outgoing: true,
+        delivered: true,
+      };
+      directMessageMessagesByPeer[pubkey] = [
+        nextMessage,
+        ...(directMessageMessagesByPeer[pubkey] ?? []).filter(
+          (message) => message.message_id !== nextMessage.message_id
+        ),
+      ];
+      return messageId;
+    },
+    async deleteDirectMessageMessage(pubkey, messageId) {
+      directMessageMessagesByPeer[pubkey] = (directMessageMessagesByPeer[pubkey] ?? []).filter(
+        (message) => message.message_id !== messageId
+      );
+    },
+    async clearDirectMessage(pubkey) {
+      directMessageMessagesByPeer[pubkey] = [];
+      openedDirectMessagePeers.add(pubkey);
+    },
+    async getDirectMessageStatus(pubkey) {
+      return directMessageStatusFor(pubkey);
     },
     async listLiveSessions(topic, scope: TimelineScope = { kind: 'public' }) {
       return filterChannelScopedItems(

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -4767,6 +4767,7 @@ impl AppService {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn handle_direct_message_hint_with_services(
         projection_store: &dyn ProjectionStore,
         blob_service: &dyn BlobService,
@@ -4821,6 +4822,7 @@ impl AppService {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn ingest_direct_message_frame_with_services(
         projection_store: &dyn ProjectionStore,
         blob_service: &dyn BlobService,

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use chrono::Utc;
@@ -10,11 +10,14 @@ use kukuri_blob_service::{BlobService, BlobStatus, MemoryBlobService, StoredBlob
 use kukuri_core::{
     AssetRole, AuthorProfileDocV1, AuthorProfilePostDocV1, AuthorProfileRepostDocV1,
     CanonicalPostHeader, ChannelAudienceKind, ChannelId, ChannelRef, ChannelSharingState,
-    CreatePrivateChannelInput, CustomReactionAssetDocV1, CustomReactionAssetSnapshotV1, EnvelopeId,
-    FollowEdge, FollowEdgeDocV1, FollowEdgeStatus, FriendOnlyGrantPreview, FriendPlusSharePreview,
-    GAME_MANIFEST_MIME, GameParticipant, GameRoomManifestBlobV1, GameRoomStateDocV1,
-    GameRoomStatus, GameScoreEntry, GossipHint, HintObjectRef, KukuriEnvelope, KukuriKeys,
-    KukuriMediaManifestV1, KukuriProfileEnvelopeContentV1, KukuriProfilePostEnvelopeContentV1,
+    CreatePrivateChannelInput, CustomReactionAssetDocV1, CustomReactionAssetSnapshotV1,
+    DirectMessageAttachmentKind, DirectMessageAttachmentManifestV1,
+    DirectMessageEncryptedAttachmentV1, DirectMessageEncryptedBlobRefV1, DirectMessageFrameV1,
+    DirectMessagePayloadV1, EnvelopeId, FollowEdge, FollowEdgeDocV1, FollowEdgeStatus,
+    FriendOnlyGrantPreview, FriendPlusSharePreview, GAME_MANIFEST_MIME, GameParticipant,
+    GameRoomManifestBlobV1, GameRoomStateDocV1, GameRoomStatus, GameScoreEntry, GossipHint,
+    HintObjectRef, KukuriEnvelope, KukuriKeys, KukuriMediaManifestV1,
+    KukuriProfileEnvelopeContentV1, KukuriProfilePostEnvelopeContentV1,
     KukuriProfileRepostEnvelopeContentV1, LIVE_MANIFEST_MIME, LiveSessionManifestBlobV1,
     LiveSessionStateDocV1, LiveSessionStatus, ManifestBlobRef, MediaManifestItem, ObjectStatus,
     ObjectVisibility, PayloadRef, PrivateChannelEpochHandoffGrantDocV1,
@@ -23,19 +26,21 @@ use kukuri_core::{
     PrivateChannelParticipantDocV1, PrivateChannelPolicyDocV1, Profile, ProfilePost, ProfileRepost,
     Pubkey, ReactionDocV1, ReactionKeyKind, ReactionKeyV1, ReplicaId, RepostSourceSnapshotV1,
     TimelineScope, TopicId, author_profile_topic_id, build_custom_reaction_asset_envelope,
-    build_follow_edge_envelope, build_friend_only_grant_token, build_friend_plus_share_token,
-    build_game_session_envelope, build_live_session_envelope, build_media_manifest_envelope,
-    build_post_envelope_with_payload_in_channel,
+    build_direct_message_ack, build_follow_edge_envelope, build_friend_only_grant_token,
+    build_friend_plus_share_token, build_game_session_envelope, build_live_session_envelope,
+    build_media_manifest_envelope, build_post_envelope_with_payload_in_channel,
     build_private_channel_epoch_handoff_grant_envelope, build_private_channel_invite_token,
     build_private_channel_participant_envelope, build_private_channel_policy_envelope,
     build_profile_envelope, build_profile_post_envelope, build_profile_repost_envelope,
-    build_reaction_envelope, build_repost_envelope, decrypt_private_channel_epoch_handoff_grant,
-    deterministic_reaction_id, encrypt_private_channel_epoch_handoff_grant, generate_keys,
-    parse_custom_reaction_asset, parse_follow_edge, parse_friend_only_grant_token,
-    parse_friend_plus_share_token, parse_private_channel_epoch_handoff_grant,
-    parse_private_channel_invite_token, parse_private_channel_participant,
-    parse_private_channel_policy, parse_profile, parse_profile_post, parse_profile_repost,
-    parse_reaction, timeline_sort_key,
+    build_reaction_envelope, build_repost_envelope, decrypt_direct_message_attachment,
+    decrypt_direct_message_frame, decrypt_private_channel_epoch_handoff_grant,
+    derive_direct_message_topic, deterministic_reaction_id, direct_message_id_for_participants,
+    encrypt_direct_message_attachment, encrypt_direct_message_frame,
+    encrypt_private_channel_epoch_handoff_grant, generate_keys, parse_custom_reaction_asset,
+    parse_follow_edge, parse_friend_only_grant_token, parse_friend_plus_share_token,
+    parse_private_channel_epoch_handoff_grant, parse_private_channel_invite_token,
+    parse_private_channel_participant, parse_private_channel_policy, parse_profile,
+    parse_profile_post, parse_profile_repost, parse_reaction, timeline_sort_key,
 };
 use kukuri_docs_sync::{
     DocOp, DocQuery, DocsSync, MemoryDocsSync, author_replica_id, private_channel_epoch_replica_id,
@@ -43,8 +48,9 @@ use kukuri_docs_sync::{
 };
 use kukuri_store::{
     AuthorRelationshipProjectionRow, BlobCacheStatus, BookmarkedCustomReactionRow,
-    GameRoomProjectionRow, LiveSessionProjectionRow, ObjectProjectionRow, Page, ProjectionStore,
-    ReactionProjectionRow, Store, TimelineCursor,
+    DirectMessageConversationRow, DirectMessageMessageRow, DirectMessageOutboxRow,
+    DirectMessageTombstoneRow, GameRoomProjectionRow, LiveSessionProjectionRow,
+    ObjectProjectionRow, Page, ProjectionStore, ReactionProjectionRow, Store, TimelineCursor,
 };
 use kukuri_transport::{
     ConnectMode, DiscoveryMode, DiscoverySnapshot, HintTransport, PeerSnapshot, SeedPeer,
@@ -57,6 +63,10 @@ use tracing::{info, warn};
 
 const REPLICA_SYNC_RESTART_RETRY_SECONDS: i64 = 5;
 const PUBLIC_CHANNEL_ID: &str = "public";
+const DIRECT_MESSAGE_FRAME_MIME: &str = "application/vnd.kukuri.direct-message-frame+json";
+const DIRECT_MESSAGE_ATTACHMENT_MIME: &str =
+    "application/vnd.kukuri.direct-message-attachment+json";
+const DIRECT_MESSAGE_RETRY_INTERVAL_MS: u64 = 2_000;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PostView {
@@ -225,6 +235,45 @@ pub struct PendingAttachment {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageStatusView {
+    pub peer_pubkey: String,
+    pub dm_id: String,
+    pub mutual: bool,
+    pub send_enabled: bool,
+    pub peer_count: usize,
+    pub pending_outbox_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageMessageView {
+    pub dm_id: String,
+    pub message_id: String,
+    pub sender_pubkey: String,
+    pub recipient_pubkey: String,
+    pub created_at: i64,
+    pub text: String,
+    pub reply_to_message_id: Option<String>,
+    pub attachments: Vec<AttachmentView>,
+    pub outgoing: bool,
+    pub delivered: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageConversationView {
+    pub dm_id: String,
+    pub peer_pubkey: String,
+    pub peer_name: Option<String>,
+    pub peer_display_name: Option<String>,
+    pub peer_picture: Option<String>,
+    pub peer_picture_asset: Option<ProfileAssetView>,
+    pub updated_at: i64,
+    pub last_message_at: Option<i64>,
+    pub last_message_id: Option<String>,
+    pub last_message_preview: Option<String>,
+    pub status: DirectMessageStatusView,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LiveSessionView {
     pub session_id: String,
     pub host_pubkey: String,
@@ -283,6 +332,12 @@ pub struct UpdateGameRoomInput {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TimelineView {
     pub items: Vec<PostView>,
+    pub next_cursor: Option<TimelineCursor>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageTimelineView {
+    pub items: Vec<DirectMessageMessageView>,
     pub next_cursor: Option<TimelineCursor>,
 }
 
@@ -443,6 +498,7 @@ pub struct AppService {
     blob_service: Arc<dyn BlobService>,
     keys: Arc<KukuriKeys>,
     subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
+    direct_message_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
     private_channel_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
     author_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
     joined_private_channels: Arc<Mutex<HashMap<String, JoinedPrivateChannelState>>>,
@@ -516,6 +572,7 @@ impl AppService {
             blob_service,
             keys: Arc::new(keys),
             subscriptions: Arc::new(Mutex::new(HashMap::new())),
+            direct_message_subscriptions: Arc::new(Mutex::new(HashMap::new())),
             private_channel_subscriptions: Arc::new(Mutex::new(HashMap::new())),
             author_subscriptions: Arc::new(Mutex::new(HashMap::new())),
             joined_private_channels: Arc::new(Mutex::new(HashMap::new())),
@@ -646,6 +703,217 @@ impl AppService {
             .await?;
         self.rebuild_author_relationships().await?;
         self.build_author_social_view(author_pubkey.as_str()).await
+    }
+
+    pub async fn resume_direct_message_state(&self) -> Result<()> {
+        let mut peers = self
+            .projection_store
+            .list_direct_message_conversations()
+            .await?
+            .into_iter()
+            .map(|row| row.peer_pubkey)
+            .collect::<BTreeSet<_>>();
+        for row in self.projection_store.list_direct_message_outbox().await? {
+            peers.insert(row.peer_pubkey);
+        }
+        for peer_pubkey in peers {
+            self.ensure_author_subscription(peer_pubkey.as_str())
+                .await?;
+            self.rebuild_author_relationships().await?;
+            if self
+                .direct_message_send_enabled(peer_pubkey.as_str())
+                .await?
+            {
+                self.ensure_direct_message_subscription(peer_pubkey.as_str())
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn open_direct_message(
+        &self,
+        peer_pubkey: &str,
+    ) -> Result<DirectMessageConversationView> {
+        let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
+        self.ensure_author_subscription(peer_pubkey.as_str())
+            .await?;
+        self.rebuild_author_relationships().await?;
+        let existing = self
+            .projection_store
+            .get_direct_message_conversation_by_peer(peer_pubkey.as_str())
+            .await?;
+        let can_send = self
+            .direct_message_send_enabled(peer_pubkey.as_str())
+            .await?;
+        if existing.is_none() && !can_send {
+            anyhow::bail!("direct message requires a mutual relationship");
+        }
+        if can_send {
+            self.restart_direct_message_subscription(peer_pubkey.as_str())
+                .await?;
+        }
+        self.ensure_direct_message_conversation_row(peer_pubkey.as_str())
+            .await?;
+        self.direct_message_conversation_view(peer_pubkey.as_str())
+            .await
+    }
+
+    pub async fn list_direct_messages(&self) -> Result<Vec<DirectMessageConversationView>> {
+        let rows = self
+            .projection_store
+            .list_direct_message_conversations()
+            .await?;
+        let mut items = Vec::with_capacity(rows.len());
+        for row in rows {
+            items.push(
+                self.direct_message_conversation_view(row.peer_pubkey.as_str())
+                    .await?,
+            );
+        }
+        Ok(items)
+    }
+
+    pub async fn list_direct_message_messages(
+        &self,
+        peer_pubkey: &str,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<DirectMessageTimelineView> {
+        let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
+        let existing = self
+            .projection_store
+            .get_direct_message_conversation_by_peer(peer_pubkey.as_str())
+            .await?;
+        let can_send = self
+            .direct_message_send_enabled(peer_pubkey.as_str())
+            .await?;
+        if existing.is_none() && !can_send {
+            anyhow::bail!("direct message requires a mutual relationship");
+        }
+        if can_send {
+            self.ensure_direct_message_subscription(peer_pubkey.as_str())
+                .await?;
+        }
+        self.ensure_direct_message_conversation_row(peer_pubkey.as_str())
+            .await?;
+        let dm_id = direct_message_id_for_participants(
+            &Pubkey::from(self.current_author_pubkey()),
+            &Pubkey::from(peer_pubkey.as_str()),
+        );
+        let page = self
+            .projection_store
+            .list_direct_message_messages(dm_id.as_str(), cursor, limit)
+            .await?;
+        let mut items = Vec::with_capacity(page.items.len());
+        for row in page.items {
+            items.push(self.direct_message_message_view(row).await?);
+        }
+        Ok(DirectMessageTimelineView {
+            items,
+            next_cursor: page.next_cursor,
+        })
+    }
+
+    pub async fn send_direct_message(
+        &self,
+        peer_pubkey: &str,
+        text: Option<&str>,
+        reply_to_message_id: Option<&str>,
+        attachments: Vec<PendingAttachment>,
+    ) -> Result<String> {
+        let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
+        self.ensure_author_subscription(peer_pubkey.as_str())
+            .await?;
+        self.rebuild_author_relationships().await?;
+        if !self
+            .direct_message_send_enabled(peer_pubkey.as_str())
+            .await?
+        {
+            anyhow::bail!("direct message requires a mutual relationship");
+        }
+        self.restart_direct_message_subscription(peer_pubkey.as_str())
+            .await?;
+        self.send_direct_message_internal(
+            peer_pubkey.as_str(),
+            text,
+            reply_to_message_id,
+            attachments,
+        )
+        .await
+    }
+
+    pub async fn delete_direct_message_message(
+        &self,
+        peer_pubkey: &str,
+        message_id: &str,
+    ) -> Result<()> {
+        let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
+        let message_id = message_id.trim();
+        if message_id.is_empty() {
+            anyhow::bail!("direct message message_id is required");
+        }
+        let dm_id = direct_message_id_for_participants(
+            &Pubkey::from(self.current_author_pubkey()),
+            &Pubkey::from(peer_pubkey.as_str()),
+        );
+        self.projection_store
+            .put_direct_message_tombstone(DirectMessageTombstoneRow {
+                dm_id: dm_id.clone(),
+                message_id: message_id.to_string(),
+                deleted_at: Utc::now().timestamp_millis(),
+            })
+            .await?;
+        self.projection_store
+            .delete_direct_message_message_local(dm_id.as_str(), message_id)
+            .await?;
+        self.refresh_direct_message_conversation(peer_pubkey.as_str())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn clear_direct_message(&self, peer_pubkey: &str) -> Result<()> {
+        let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
+        let dm_id = direct_message_id_for_participants(
+            &Pubkey::from(self.current_author_pubkey()),
+            &Pubkey::from(peer_pubkey.as_str()),
+        );
+        let deleted_at = Utc::now().timestamp_millis();
+        let mut cursor = None;
+        loop {
+            let page = self
+                .projection_store
+                .list_direct_message_messages(dm_id.as_str(), cursor.clone(), 500)
+                .await?;
+            for row in &page.items {
+                self.projection_store
+                    .put_direct_message_tombstone(DirectMessageTombstoneRow {
+                        dm_id: dm_id.clone(),
+                        message_id: row.message_id.clone(),
+                        deleted_at,
+                    })
+                    .await?;
+            }
+            if page.next_cursor.is_none() {
+                break;
+            }
+            cursor = page.next_cursor;
+        }
+        self.projection_store
+            .clear_direct_message_local(dm_id.as_str())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn get_direct_message_status(
+        &self,
+        peer_pubkey: &str,
+    ) -> Result<DirectMessageStatusView> {
+        let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
+        self.ensure_author_subscription(peer_pubkey.as_str())
+            .await?;
+        self.rebuild_author_relationships().await?;
+        self.direct_message_status_view(peer_pubkey.as_str()).await
     }
 
     pub async fn list_profile_timeline(
@@ -2947,6 +3215,17 @@ impl AppService {
         for author in existing_authors {
             self.restart_author_subscription(author.as_str()).await?;
         }
+        let existing_direct_messages = self
+            .direct_message_subscriptions
+            .lock()
+            .await
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        for peer_pubkey in existing_direct_messages {
+            self.restart_direct_message_subscription(peer_pubkey.as_str())
+                .await?;
+        }
         Ok(())
     }
 
@@ -3008,6 +3287,17 @@ impl AppService {
             .collect::<Vec<_>>();
         for author in existing_authors {
             self.restart_author_subscription(author.as_str()).await?;
+        }
+        let existing_direct_messages = self
+            .direct_message_subscriptions
+            .lock()
+            .await
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        for peer_pubkey in existing_direct_messages {
+            self.restart_direct_message_subscription(peer_pubkey.as_str())
+                .await?;
         }
         Ok(())
     }
@@ -3169,6 +3459,31 @@ impl AppService {
                 .hint_transport
                 .unsubscribe_hints(&TopicId::new(topic_id))
                 .await;
+        }
+        let dm_peers_to_unsubscribe = self
+            .direct_message_subscriptions
+            .lock()
+            .await
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let dm_handles = {
+            let mut subscriptions = self.direct_message_subscriptions.lock().await;
+            subscriptions
+                .drain()
+                .map(|(_, handle)| handle)
+                .collect::<Vec<_>>()
+        };
+        for handle in dm_handles {
+            handle.abort();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        }
+        for peer_pubkey in dm_peers_to_unsubscribe {
+            if let Ok(topic) =
+                derive_direct_message_topic(self.keys.as_ref(), &Pubkey::from(peer_pubkey.as_str()))
+            {
+                let _ = self.hint_transport.unsubscribe_hints(&topic).await;
+            }
         }
         let author_handles = {
             let mut subscriptions = self.author_subscriptions.lock().await;
@@ -4166,6 +4481,771 @@ impl AppService {
             .await
             .insert(author_key, handle);
         Ok(())
+    }
+
+    async fn direct_message_send_enabled(&self, peer_pubkey: &str) -> Result<bool> {
+        Ok(self
+            .projection_store
+            .get_author_relationship(self.current_author_pubkey().as_str(), peer_pubkey)
+            .await?
+            .as_ref()
+            .is_some_and(|relationship| relationship.mutual))
+    }
+
+    async fn direct_message_status_view(
+        &self,
+        peer_pubkey: &str,
+    ) -> Result<DirectMessageStatusView> {
+        let dm_id = direct_message_id_for_participants(
+            &Pubkey::from(self.current_author_pubkey()),
+            &Pubkey::from(peer_pubkey),
+        );
+        let send_enabled = self.direct_message_send_enabled(peer_pubkey).await?;
+        let peer_count = if send_enabled {
+            self.direct_message_topic_peer_count(peer_pubkey).await?
+        } else {
+            0
+        };
+        let pending_outbox_count = self
+            .projection_store
+            .list_direct_message_outbox()
+            .await?
+            .into_iter()
+            .filter(|row| row.peer_pubkey == peer_pubkey)
+            .count();
+        Ok(DirectMessageStatusView {
+            peer_pubkey: peer_pubkey.to_string(),
+            dm_id,
+            mutual: send_enabled,
+            send_enabled,
+            peer_count,
+            pending_outbox_count,
+        })
+    }
+
+    async fn ensure_direct_message_conversation_row(&self, peer_pubkey: &str) -> Result<()> {
+        if self
+            .projection_store
+            .get_direct_message_conversation_by_peer(peer_pubkey)
+            .await?
+            .is_some()
+        {
+            return Ok(());
+        }
+        let dm_id = direct_message_id_for_participants(
+            &Pubkey::from(self.current_author_pubkey()),
+            &Pubkey::from(peer_pubkey),
+        );
+        self.projection_store
+            .upsert_direct_message_conversation(DirectMessageConversationRow {
+                dm_id,
+                peer_pubkey: peer_pubkey.to_string(),
+                updated_at: Utc::now().timestamp_millis(),
+                last_message_at: None,
+                last_message_id: None,
+                last_message_preview: None,
+            })
+            .await
+    }
+
+    async fn refresh_direct_message_conversation(&self, peer_pubkey: &str) -> Result<()> {
+        let dm_id = direct_message_id_for_participants(
+            &Pubkey::from(self.current_author_pubkey()),
+            &Pubkey::from(peer_pubkey),
+        );
+        let existing = self
+            .projection_store
+            .get_direct_message_conversation_by_peer(peer_pubkey)
+            .await?;
+        let page = self
+            .projection_store
+            .list_direct_message_messages(dm_id.as_str(), None, 1)
+            .await?;
+        let (updated_at, last_message_at, last_message_id, last_message_preview) =
+            if let Some(message) = page.items.first() {
+                (
+                    message.created_at,
+                    Some(message.created_at),
+                    Some(message.message_id.clone()),
+                    Some(direct_message_preview(message)),
+                )
+            } else if let Some(existing) = existing.as_ref() {
+                (existing.updated_at, None, None, None)
+            } else if self.direct_message_send_enabled(peer_pubkey).await? {
+                (Utc::now().timestamp_millis(), None, None, None)
+            } else {
+                return Ok(());
+            };
+        self.projection_store
+            .upsert_direct_message_conversation(DirectMessageConversationRow {
+                dm_id,
+                peer_pubkey: peer_pubkey.to_string(),
+                updated_at,
+                last_message_at,
+                last_message_id,
+                last_message_preview,
+            })
+            .await
+    }
+
+    async fn direct_message_conversation_view(
+        &self,
+        peer_pubkey: &str,
+    ) -> Result<DirectMessageConversationView> {
+        let conversation = self
+            .projection_store
+            .get_direct_message_conversation_by_peer(peer_pubkey)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("direct message conversation is not initialized"))?;
+        let profile = self.store.get_profile(peer_pubkey).await?;
+        let status = self.direct_message_status_view(peer_pubkey).await?;
+        Ok(DirectMessageConversationView {
+            dm_id: conversation.dm_id,
+            peer_pubkey: peer_pubkey.to_string(),
+            peer_name: profile.as_ref().and_then(|value| value.name.clone()),
+            peer_display_name: profile
+                .as_ref()
+                .and_then(|value| value.display_name.clone()),
+            peer_picture: profile.as_ref().and_then(|value| value.picture.clone()),
+            peer_picture_asset: profile_asset_view_from_ref(
+                profile
+                    .as_ref()
+                    .and_then(|value| value.picture_asset.as_ref()),
+            ),
+            updated_at: conversation.updated_at,
+            last_message_at: conversation.last_message_at,
+            last_message_id: conversation.last_message_id,
+            last_message_preview: conversation.last_message_preview,
+            status,
+        })
+    }
+
+    async fn direct_message_message_view(
+        &self,
+        row: DirectMessageMessageRow,
+    ) -> Result<DirectMessageMessageView> {
+        Ok(DirectMessageMessageView {
+            dm_id: row.dm_id,
+            message_id: row.message_id,
+            sender_pubkey: row.sender_pubkey,
+            recipient_pubkey: row.recipient_pubkey,
+            created_at: row.created_at,
+            text: row.text.unwrap_or_default(),
+            reply_to_message_id: row.reply_to_message_id,
+            attachments: direct_message_attachment_views(
+                self.blob_service.as_ref(),
+                row.attachment_manifest.as_ref(),
+            )
+            .await?,
+            outgoing: row.outgoing,
+            delivered: row.acked_at.is_some() || !row.outgoing,
+        })
+    }
+
+    async fn ensure_direct_message_subscription(&self, peer_pubkey: &str) -> Result<()> {
+        if !self.direct_message_send_enabled(peer_pubkey).await? {
+            return Ok(());
+        }
+        let mut subscriptions = self.direct_message_subscriptions.lock().await;
+        if subscriptions
+            .get(peer_pubkey)
+            .is_some_and(|handle| !handle.is_finished())
+        {
+            return Ok(());
+        }
+        subscriptions.remove(peer_pubkey);
+        drop(subscriptions);
+        self.spawn_direct_message_subscription(peer_pubkey).await
+    }
+
+    async fn restart_direct_message_subscription(&self, peer_pubkey: &str) -> Result<()> {
+        if let Some(handle) = self
+            .direct_message_subscriptions
+            .lock()
+            .await
+            .remove(peer_pubkey)
+        {
+            handle.abort();
+        }
+        let topic = derive_direct_message_topic(self.keys.as_ref(), &Pubkey::from(peer_pubkey))?;
+        self.hint_transport.unsubscribe_hints(&topic).await?;
+        if self.direct_message_send_enabled(peer_pubkey).await? {
+            self.spawn_direct_message_subscription(peer_pubkey).await?;
+        }
+        Ok(())
+    }
+
+    async fn spawn_direct_message_subscription(&self, peer_pubkey: &str) -> Result<()> {
+        let projection_store = Arc::clone(&self.projection_store);
+        let blob_service = Arc::clone(&self.blob_service);
+        let hint_transport = Arc::clone(&self.hint_transport);
+        let transport = Arc::clone(&self.transport);
+        let keys = Arc::clone(&self.keys);
+        let last_sync = Arc::clone(&self.last_sync_ts);
+        let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
+        let local_author_pubkey = self.current_author_pubkey();
+        let topic =
+            derive_direct_message_topic(keys.as_ref(), &Pubkey::from(peer_pubkey.as_str()))?;
+        let mut hint_stream = hint_transport.subscribe_hints(&topic).await?;
+        let topic_for_task = topic.clone();
+        let peer_for_task = peer_pubkey.clone();
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(
+                DIRECT_MESSAGE_RETRY_INTERVAL_MS,
+            ));
+            let _ = AppService::flush_direct_message_outbox_for_peer_with_services(
+                projection_store.as_ref(),
+                hint_transport.as_ref(),
+                transport.as_ref(),
+                local_author_pubkey.as_str(),
+                keys.as_ref(),
+                peer_for_task.as_str(),
+            )
+            .await;
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let _ = AppService::flush_direct_message_outbox_for_peer_with_services(
+                            projection_store.as_ref(),
+                            hint_transport.as_ref(),
+                            transport.as_ref(),
+                            local_author_pubkey.as_str(),
+                            keys.as_ref(),
+                            peer_for_task.as_str(),
+                        ).await;
+                    }
+                    Some(event) = hint_stream.next() => {
+                        if !matches!(
+                            &event.hint,
+                            GossipHint::DirectMessageFrame { topic_id, .. } | GossipHint::DirectMessageAck { topic_id, .. }
+                            if topic_id.as_str() == topic_for_task.as_str()
+                        ) {
+                            continue;
+                        }
+                        if let Err(error) = blob_service.learn_peer(event.source_peer.as_str()).await {
+                            warn!(
+                                peer_pubkey = %peer_for_task,
+                                source_peer = %event.source_peer,
+                                error = %error,
+                                "failed to learn direct message blob peer"
+                            );
+                        }
+                        match AppService::handle_direct_message_hint_with_services(
+                            projection_store.as_ref(),
+                            blob_service.as_ref(),
+                            hint_transport.as_ref(),
+                            keys.as_ref(),
+                            local_author_pubkey.as_str(),
+                            peer_for_task.as_str(),
+                            &topic_for_task,
+                            &event.hint,
+                        ).await {
+                            Ok(true) => {
+                                *last_sync.lock().await = Some(Utc::now().timestamp_millis());
+                            }
+                            Ok(false) => {}
+                            Err(error) => {
+                                warn!(
+                                    peer_pubkey = %peer_for_task,
+                                    error = %error,
+                                    "failed to handle direct message hint"
+                                );
+                            }
+                        }
+                    }
+                    else => {
+                        let _ = hint_transport.unsubscribe_hints(&topic_for_task).await;
+                        break;
+                    }
+                }
+            }
+        });
+        self.direct_message_subscriptions
+            .lock()
+            .await
+            .insert(peer_pubkey, handle);
+        Ok(())
+    }
+
+    async fn handle_direct_message_hint_with_services(
+        projection_store: &dyn ProjectionStore,
+        blob_service: &dyn BlobService,
+        hint_transport: &dyn HintTransport,
+        keys: &KukuriKeys,
+        local_author_pubkey: &str,
+        peer_pubkey: &str,
+        topic: &TopicId,
+        hint: &GossipHint,
+    ) -> Result<bool> {
+        match hint {
+            GossipHint::DirectMessageFrame {
+                dm_id,
+                message_id,
+                frame_hash,
+                ..
+            } => {
+                AppService::ingest_direct_message_frame_with_services(
+                    projection_store,
+                    blob_service,
+                    hint_transport,
+                    keys,
+                    local_author_pubkey,
+                    peer_pubkey,
+                    topic,
+                    dm_id.as_str(),
+                    message_id.as_str(),
+                    frame_hash,
+                )
+                .await
+            }
+            GossipHint::DirectMessageAck { ack, .. } => {
+                ack.verify()?;
+                if ack.sender.as_str() != peer_pubkey
+                    || ack.recipient.as_str() != local_author_pubkey
+                {
+                    return Ok(false);
+                }
+                projection_store
+                    .set_direct_message_acked_at(
+                        ack.dm_id.as_str(),
+                        ack.message_id.as_str(),
+                        ack.acked_at,
+                    )
+                    .await?;
+                projection_store
+                    .remove_direct_message_outbox(ack.dm_id.as_str(), ack.message_id.as_str())
+                    .await?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    async fn ingest_direct_message_frame_with_services(
+        projection_store: &dyn ProjectionStore,
+        blob_service: &dyn BlobService,
+        hint_transport: &dyn HintTransport,
+        keys: &KukuriKeys,
+        local_author_pubkey: &str,
+        peer_pubkey: &str,
+        topic: &TopicId,
+        dm_id: &str,
+        message_id: &str,
+        frame_hash: &kukuri_core::BlobHash,
+    ) -> Result<bool> {
+        let expected_dm_id = direct_message_id_for_participants(
+            &Pubkey::from(local_author_pubkey),
+            &Pubkey::from(peer_pubkey),
+        );
+        if dm_id != expected_dm_id {
+            return Ok(false);
+        }
+        let Some(frame_bytes) = blob_service.fetch_blob(frame_hash).await? else {
+            return Ok(false);
+        };
+        let frame: DirectMessageFrameV1 = serde_json::from_slice(frame_bytes.as_slice())
+            .context("failed to decode direct message frame blob")?;
+        if frame.message_id != message_id || frame.dm_id != dm_id {
+            return Ok(false);
+        }
+        if frame.sender.as_str() != peer_pubkey || frame.recipient.as_str() != local_author_pubkey {
+            return Ok(false);
+        }
+        let payload = decrypt_direct_message_frame(keys, &frame)?;
+        let ack = build_direct_message_ack(
+            keys,
+            dm_id,
+            message_id,
+            &frame.sender,
+            Utc::now().timestamp_millis(),
+        )?;
+        if projection_store
+            .has_direct_message_tombstone(dm_id, message_id)
+            .await?
+        {
+            hint_transport
+                .publish_hint(
+                    topic,
+                    GossipHint::DirectMessageAck {
+                        topic_id: topic.clone(),
+                        ack,
+                    },
+                )
+                .await?;
+            return Ok(false);
+        }
+        if projection_store
+            .get_direct_message_message(dm_id, message_id)
+            .await?
+            .is_some()
+        {
+            hint_transport
+                .publish_hint(
+                    topic,
+                    GossipHint::DirectMessageAck {
+                        topic_id: topic.clone(),
+                        ack,
+                    },
+                )
+                .await?;
+            return Ok(false);
+        }
+        let local_manifest = materialize_direct_message_manifest(
+            blob_service,
+            keys,
+            &frame.sender,
+            frame.message_id.as_str(),
+            payload.attachment_manifest.as_ref(),
+        )
+        .await?;
+        projection_store
+            .put_direct_message_message(DirectMessageMessageRow {
+                dm_id: dm_id.to_string(),
+                message_id: message_id.to_string(),
+                sender_pubkey: frame.sender.as_str().to_string(),
+                recipient_pubkey: frame.recipient.as_str().to_string(),
+                created_at: frame.created_at,
+                text: payload.text,
+                reply_to_message_id: payload.reply_to,
+                attachment_manifest: local_manifest,
+                outgoing: false,
+                acked_at: None,
+            })
+            .await?;
+        projection_store
+            .upsert_direct_message_conversation(DirectMessageConversationRow {
+                dm_id: dm_id.to_string(),
+                peer_pubkey: peer_pubkey.to_string(),
+                updated_at: frame.created_at,
+                last_message_at: Some(frame.created_at),
+                last_message_id: Some(message_id.to_string()),
+                last_message_preview: projection_store
+                    .get_direct_message_message(dm_id, message_id)
+                    .await?
+                    .as_ref()
+                    .map(direct_message_preview),
+            })
+            .await?;
+        hint_transport
+            .publish_hint(
+                topic,
+                GossipHint::DirectMessageAck {
+                    topic_id: topic.clone(),
+                    ack,
+                },
+            )
+            .await?;
+        Ok(true)
+    }
+
+    async fn flush_direct_message_outbox_for_peer_with_services(
+        projection_store: &dyn ProjectionStore,
+        hint_transport: &dyn HintTransport,
+        transport: &dyn Transport,
+        local_author_pubkey: &str,
+        keys: &KukuriKeys,
+        peer_pubkey: &str,
+    ) -> Result<usize> {
+        let relationship = projection_store
+            .get_author_relationship(local_author_pubkey, peer_pubkey)
+            .await?;
+        if !relationship.as_ref().is_some_and(|value| value.mutual) {
+            return Ok(0);
+        }
+        let topic = derive_direct_message_topic(keys, &Pubkey::from(peer_pubkey))?;
+        let peer_count = direct_message_topic_peer_count(transport, &topic).await?;
+        if peer_count == 0 {
+            return Ok(0);
+        }
+        let mut published = 0usize;
+        let attempted_at = Utc::now().timestamp_millis();
+        for row in projection_store.list_direct_message_outbox().await? {
+            if row.peer_pubkey != peer_pubkey {
+                continue;
+            }
+            projection_store
+                .touch_direct_message_outbox_attempt(
+                    row.dm_id.as_str(),
+                    row.message_id.as_str(),
+                    attempted_at,
+                )
+                .await?;
+            hint_transport
+                .publish_hint(
+                    &topic,
+                    GossipHint::DirectMessageFrame {
+                        topic_id: topic.clone(),
+                        dm_id: row.dm_id.clone(),
+                        message_id: row.message_id.clone(),
+                        frame_hash: row.frame_blob_hash.clone(),
+                    },
+                )
+                .await?;
+            published += 1;
+        }
+        Ok(published)
+    }
+
+    async fn direct_message_topic_peer_count(&self, peer_pubkey: &str) -> Result<usize> {
+        let topic = derive_direct_message_topic(self.keys.as_ref(), &Pubkey::from(peer_pubkey))?;
+        direct_message_topic_peer_count(self.transport.as_ref(), &topic).await
+    }
+
+    async fn send_direct_message_internal(
+        &self,
+        peer_pubkey: &str,
+        text: Option<&str>,
+        reply_to_message_id: Option<&str>,
+        attachments: Vec<PendingAttachment>,
+    ) -> Result<String> {
+        let text = normalize_optional_text(text.map(str::to_string));
+        let dm_id = direct_message_id_for_participants(
+            &Pubkey::from(self.current_author_pubkey()),
+            &Pubkey::from(peer_pubkey),
+        );
+        if text.is_none() && attachments.is_empty() {
+            anyhow::bail!("direct message text or attachment is required");
+        }
+        let message_id = format!(
+            "dm-message-{}-{}",
+            Utc::now().timestamp_millis(),
+            short_id_suffix(self.current_author_pubkey().as_str())
+        );
+        if let Some(reply_to_message_id) = reply_to_message_id
+            && self
+                .projection_store
+                .get_direct_message_message(dm_id.as_str(), reply_to_message_id.trim())
+                .await?
+                .is_none()
+        {
+            anyhow::bail!("direct message reply target was not found");
+        }
+        let (local_manifest, encrypted_manifest) = self
+            .prepare_direct_message_manifests(peer_pubkey, message_id.as_str(), attachments)
+            .await?;
+        let created_at = Utc::now().timestamp_millis();
+        let frame = encrypt_direct_message_frame(
+            self.keys.as_ref(),
+            &Pubkey::from(peer_pubkey),
+            dm_id.as_str(),
+            message_id.as_str(),
+            created_at,
+            &DirectMessagePayloadV1 {
+                text: text.clone(),
+                reply_to: normalize_optional_text(reply_to_message_id.map(str::to_string)),
+                attachment_manifest: encrypted_manifest,
+            },
+        )?;
+        let frame_bytes =
+            serde_json::to_vec(&frame).context("failed to encode direct message frame blob")?;
+        let frame_blob = self
+            .blob_service
+            .put_blob(frame_bytes, DIRECT_MESSAGE_FRAME_MIME)
+            .await?;
+        self.projection_store
+            .put_direct_message_message(DirectMessageMessageRow {
+                dm_id: dm_id.clone(),
+                message_id: message_id.clone(),
+                sender_pubkey: self.current_author_pubkey(),
+                recipient_pubkey: peer_pubkey.to_string(),
+                created_at,
+                text,
+                reply_to_message_id: normalize_optional_text(
+                    reply_to_message_id.map(str::to_string),
+                ),
+                attachment_manifest: local_manifest,
+                outgoing: true,
+                acked_at: None,
+            })
+            .await?;
+        self.projection_store
+            .put_direct_message_outbox(DirectMessageOutboxRow {
+                dm_id: dm_id.clone(),
+                message_id: message_id.clone(),
+                peer_pubkey: peer_pubkey.to_string(),
+                frame_blob_hash: frame_blob.hash,
+                created_at,
+                last_attempt_at: None,
+            })
+            .await?;
+        self.refresh_direct_message_conversation(peer_pubkey)
+            .await?;
+        let _ = Self::flush_direct_message_outbox_for_peer_with_services(
+            self.projection_store.as_ref(),
+            self.hint_transport.as_ref(),
+            self.transport.as_ref(),
+            self.current_author_pubkey().as_str(),
+            self.keys.as_ref(),
+            peer_pubkey,
+        )
+        .await?;
+        Ok(message_id)
+    }
+
+    async fn prepare_direct_message_manifests(
+        &self,
+        peer_pubkey: &str,
+        message_id: &str,
+        attachments: Vec<PendingAttachment>,
+    ) -> Result<(
+        Option<DirectMessageAttachmentManifestV1>,
+        Option<DirectMessageAttachmentManifestV1>,
+    )> {
+        if attachments.is_empty() {
+            return Ok((None, None));
+        }
+        let image = attachments
+            .iter()
+            .find(|attachment| attachment.role == AssetRole::ImageOriginal);
+        let video = attachments
+            .iter()
+            .find(|attachment| attachment.role == AssetRole::VideoManifest);
+        let poster = attachments
+            .iter()
+            .find(|attachment| attachment.role == AssetRole::VideoPoster);
+        match (image, video, poster) {
+            (Some(image), None, None) => {
+                if attachments.len() != 1 || !image.mime.starts_with("image/") {
+                    anyhow::bail!(
+                        "direct message image attachment must be a single image/* payload"
+                    );
+                }
+                let local_blob = self
+                    .blob_service
+                    .put_blob(image.bytes.clone(), image.mime.as_str())
+                    .await?;
+                let encrypted = encrypt_direct_message_attachment(
+                    self.keys.as_ref(),
+                    &Pubkey::from(peer_pubkey),
+                    message_id,
+                    "original",
+                    image.bytes.as_slice(),
+                )?;
+                let encrypted_blob = self
+                    .blob_service
+                    .put_blob(
+                        serde_json::to_vec(&encrypted)
+                            .context("failed to encode encrypted direct message attachment")?,
+                        DIRECT_MESSAGE_ATTACHMENT_MIME,
+                    )
+                    .await?;
+                Ok((
+                    Some(DirectMessageAttachmentManifestV1 {
+                        attachment_id: "attachment-1".into(),
+                        kind: DirectMessageAttachmentKind::Image,
+                        original: DirectMessageEncryptedBlobRefV1 {
+                            blob_id: "original".into(),
+                            hash: local_blob.hash,
+                            mime: image.mime.clone(),
+                            bytes: image.bytes.len() as u64,
+                            nonce_hex: String::new(),
+                        },
+                        poster: None,
+                    }),
+                    Some(DirectMessageAttachmentManifestV1 {
+                        attachment_id: "attachment-1".into(),
+                        kind: DirectMessageAttachmentKind::Image,
+                        original: DirectMessageEncryptedBlobRefV1 {
+                            blob_id: "original".into(),
+                            hash: encrypted_blob.hash,
+                            mime: image.mime.clone(),
+                            bytes: image.bytes.len() as u64,
+                            nonce_hex: encrypted.nonce_hex,
+                        },
+                        poster: None,
+                    }),
+                ))
+            }
+            (None, Some(video), Some(poster)) => {
+                if attachments.len() != 2
+                    || !video.mime.starts_with("video/")
+                    || !poster.mime.starts_with("image/")
+                {
+                    anyhow::bail!(
+                        "direct message video attachment must contain one video/* payload and one image/* poster"
+                    );
+                }
+                let local_video = self
+                    .blob_service
+                    .put_blob(video.bytes.clone(), video.mime.as_str())
+                    .await?;
+                let local_poster = self
+                    .blob_service
+                    .put_blob(poster.bytes.clone(), poster.mime.as_str())
+                    .await?;
+                let encrypted_video = encrypt_direct_message_attachment(
+                    self.keys.as_ref(),
+                    &Pubkey::from(peer_pubkey),
+                    message_id,
+                    "original",
+                    video.bytes.as_slice(),
+                )?;
+                let encrypted_poster = encrypt_direct_message_attachment(
+                    self.keys.as_ref(),
+                    &Pubkey::from(peer_pubkey),
+                    message_id,
+                    "poster",
+                    poster.bytes.as_slice(),
+                )?;
+                let encrypted_video_blob = self
+                    .blob_service
+                    .put_blob(
+                        serde_json::to_vec(&encrypted_video)
+                            .context("failed to encode encrypted direct message video")?,
+                        DIRECT_MESSAGE_ATTACHMENT_MIME,
+                    )
+                    .await?;
+                let encrypted_poster_blob = self
+                    .blob_service
+                    .put_blob(
+                        serde_json::to_vec(&encrypted_poster)
+                            .context("failed to encode encrypted direct message poster")?,
+                        DIRECT_MESSAGE_ATTACHMENT_MIME,
+                    )
+                    .await?;
+                Ok((
+                    Some(DirectMessageAttachmentManifestV1 {
+                        attachment_id: "attachment-1".into(),
+                        kind: DirectMessageAttachmentKind::Video,
+                        original: DirectMessageEncryptedBlobRefV1 {
+                            blob_id: "original".into(),
+                            hash: local_video.hash,
+                            mime: video.mime.clone(),
+                            bytes: video.bytes.len() as u64,
+                            nonce_hex: String::new(),
+                        },
+                        poster: Some(DirectMessageEncryptedBlobRefV1 {
+                            blob_id: "poster".into(),
+                            hash: local_poster.hash,
+                            mime: poster.mime.clone(),
+                            bytes: poster.bytes.len() as u64,
+                            nonce_hex: String::new(),
+                        }),
+                    }),
+                    Some(DirectMessageAttachmentManifestV1 {
+                        attachment_id: "attachment-1".into(),
+                        kind: DirectMessageAttachmentKind::Video,
+                        original: DirectMessageEncryptedBlobRefV1 {
+                            blob_id: "original".into(),
+                            hash: encrypted_video_blob.hash,
+                            mime: video.mime.clone(),
+                            bytes: video.bytes.len() as u64,
+                            nonce_hex: encrypted_video.nonce_hex,
+                        },
+                        poster: Some(DirectMessageEncryptedBlobRefV1 {
+                            blob_id: "poster".into(),
+                            hash: encrypted_poster_blob.hash,
+                            mime: poster.mime.clone(),
+                            bytes: poster.bytes.len() as u64,
+                            nonce_hex: encrypted_poster.nonce_hex,
+                        }),
+                    }),
+                ))
+            }
+            _ => anyhow::bail!(
+                "direct message attachment must be one image or one video with a poster"
+            ),
+        }
     }
 
     async fn ensure_topic_subscription(&self, topic_id: &str) -> Result<()> {
@@ -6310,7 +7390,9 @@ fn hint_targets_topic(hint: &GossipHint, topic: &str) -> bool {
         | GossipHint::Presence { topic_id, .. }
         | GossipHint::Typing { topic_id, .. }
         | GossipHint::SessionChanged { topic_id, .. }
-        | GossipHint::LivePresence { topic_id, .. } => topic_id.as_str() == topic,
+        | GossipHint::LivePresence { topic_id, .. }
+        | GossipHint::DirectMessageFrame { topic_id, .. }
+        | GossipHint::DirectMessageAck { topic_id, .. } => topic_id.as_str() == topic,
         GossipHint::ThreadUpdated { .. } | GossipHint::ProfileUpdated { .. } => true,
     }
 }
@@ -6715,6 +7797,141 @@ async fn attachment_views_from_refs(
     Ok(attachments)
 }
 
+async fn direct_message_attachment_views(
+    blob_service: &dyn BlobService,
+    manifest: Option<&DirectMessageAttachmentManifestV1>,
+) -> Result<Vec<AttachmentView>> {
+    let Some(manifest) = manifest else {
+        return Ok(Vec::new());
+    };
+    let mut attachments = Vec::new();
+    attachments.push(AttachmentView {
+        hash: manifest.original.hash.as_str().to_string(),
+        mime: manifest.original.mime.clone(),
+        bytes: manifest.original.bytes,
+        role: match manifest.kind {
+            DirectMessageAttachmentKind::Image => "image_original".into(),
+            DirectMessageAttachmentKind::Video => "video_manifest".into(),
+        },
+        status: best_effort_blob_view_status(blob_service, &manifest.original.hash).await,
+    });
+    if let Some(poster) = manifest.poster.as_ref() {
+        attachments.push(AttachmentView {
+            hash: poster.hash.as_str().to_string(),
+            mime: poster.mime.clone(),
+            bytes: poster.bytes,
+            role: "video_poster".into(),
+            status: best_effort_blob_view_status(blob_service, &poster.hash).await,
+        });
+    }
+    Ok(attachments)
+}
+
+fn direct_message_preview(row: &DirectMessageMessageRow) -> String {
+    if let Some(text) = row
+        .text
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return text.chars().take(80).collect();
+    }
+    match row
+        .attachment_manifest
+        .as_ref()
+        .map(|manifest| &manifest.kind)
+    {
+        Some(DirectMessageAttachmentKind::Image) => "[Image]".into(),
+        Some(DirectMessageAttachmentKind::Video) => "[Video]".into(),
+        None => String::new(),
+    }
+}
+
+async fn materialize_direct_message_manifest(
+    blob_service: &dyn BlobService,
+    keys: &KukuriKeys,
+    sender_pubkey: &Pubkey,
+    message_id: &str,
+    manifest: Option<&DirectMessageAttachmentManifestV1>,
+) -> Result<Option<DirectMessageAttachmentManifestV1>> {
+    let Some(manifest) = manifest else {
+        return Ok(None);
+    };
+    let original = materialize_direct_message_blob_ref(
+        blob_service,
+        keys,
+        sender_pubkey,
+        message_id,
+        &manifest.original,
+    )
+    .await?;
+    let poster = match manifest.poster.as_ref() {
+        Some(poster) => Some(
+            materialize_direct_message_blob_ref(
+                blob_service,
+                keys,
+                sender_pubkey,
+                message_id,
+                poster,
+            )
+            .await?,
+        ),
+        None => None,
+    };
+    Ok(Some(DirectMessageAttachmentManifestV1 {
+        attachment_id: manifest.attachment_id.clone(),
+        kind: manifest.kind.clone(),
+        original,
+        poster,
+    }))
+}
+
+async fn materialize_direct_message_blob_ref(
+    blob_service: &dyn BlobService,
+    keys: &KukuriKeys,
+    sender_pubkey: &Pubkey,
+    message_id: &str,
+    encrypted_ref: &DirectMessageEncryptedBlobRefV1,
+) -> Result<DirectMessageEncryptedBlobRefV1> {
+    let Some(bytes) = blob_service.fetch_blob(&encrypted_ref.hash).await? else {
+        anyhow::bail!("direct message attachment blob is missing");
+    };
+    let encrypted: DirectMessageEncryptedAttachmentV1 = serde_json::from_slice(bytes.as_slice())
+        .context("failed to decode direct message attachment blob")?;
+    let decrypted = decrypt_direct_message_attachment(keys, sender_pubkey, message_id, &encrypted)?;
+    let local = blob_service
+        .put_blob(decrypted, encrypted_ref.mime.as_str())
+        .await?;
+    Ok(DirectMessageEncryptedBlobRefV1 {
+        blob_id: encrypted_ref.blob_id.clone(),
+        hash: local.hash,
+        mime: encrypted_ref.mime.clone(),
+        bytes: encrypted_ref.bytes,
+        nonce_hex: String::new(),
+    })
+}
+
+async fn direct_message_topic_peer_count(
+    transport: &dyn Transport,
+    topic: &TopicId,
+) -> Result<usize> {
+    let snapshot = transport.peers().await?;
+    let hint_topic = format!("hint/{}", topic.as_str());
+    let topic_peer_count = snapshot
+        .topic_diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.topic == hint_topic || diagnostic.topic == topic.as_str())
+        .map(|diagnostic| diagnostic.peer_count)
+        .unwrap_or(0);
+    if topic_peer_count > 0 {
+        return Ok(topic_peer_count);
+    }
+    if snapshot.connected && snapshot.peer_count > 0 {
+        return Ok(snapshot.peer_count);
+    }
+    Ok(0)
+}
+
 fn blob_view_status(status: BlobStatus) -> BlobViewStatus {
     match status {
         BlobStatus::Missing => BlobViewStatus::Missing,
@@ -6849,7 +8066,7 @@ fn normalize_topic_name(topic: String) -> Option<String> {
     let normalized = topic
         .strip_prefix("hint/")
         .map_or(topic.clone(), ToOwned::to_owned);
-    if normalized.starts_with("private/") {
+    if normalized.starts_with("private/") || normalized.starts_with("kukuri:dm:") {
         None
     } else {
         Some(normalized)
@@ -7878,6 +9095,27 @@ mod tests {
     }
 
     #[derive(Clone, Default)]
+    struct CountingClosingHintTransport {
+        subscribe_count: Arc<TokioMutex<usize>>,
+    }
+
+    #[async_trait]
+    impl HintTransport for CountingClosingHintTransport {
+        async fn subscribe_hints(&self, _topic: &TopicId) -> Result<HintStream> {
+            *self.subscribe_count.lock().await += 1;
+            Ok(Box::pin(futures_util::stream::empty()))
+        }
+
+        async fn unsubscribe_hints(&self, _topic: &TopicId) -> Result<()> {
+            Ok(())
+        }
+
+        async fn publish_hint(&self, _topic: &TopicId, _hint: GossipHint) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Default)]
     struct TrackingHintTransport {
         hints: Arc<TokioMutex<HashMap<String, broadcast::Sender<HintEnvelope>>>>,
         unsubscribed_topics: Arc<TokioMutex<Vec<String>>>,
@@ -8004,6 +9242,330 @@ mod tests {
         assert_eq!(timeline.items.len(), 1);
         assert_eq!(timeline.items[0].object_id, object_id);
         assert_eq!(timeline.items[0].content, "hello app");
+    }
+
+    #[tokio::test]
+    async fn dm_send_requires_mutual_relationship() {
+        let (app, _, _, _) = local_app_with_memory_services();
+        let peer_keys = generate_keys();
+
+        let error = app
+            .send_direct_message(
+                peer_keys.public_key_hex().as_str(),
+                Some("hello"),
+                None,
+                Vec::new(),
+            )
+            .await
+            .expect_err("direct message send should require mutual relationship");
+
+        assert!(
+            error
+                .to_string()
+                .contains("direct message requires a mutual relationship")
+        );
+    }
+
+    #[tokio::test]
+    async fn dm_reopens_finished_subscription_when_hint_stream_closes() {
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot {
+            connected: true,
+            peer_count: 1,
+            connected_peers: vec!["peer-b".into()],
+            configured_peers: vec!["peer-b".into()],
+            subscribed_topics: Vec::new(),
+            pending_events: 0,
+            status_detail: "connected".into(),
+            last_error: None,
+            topic_diagnostics: Vec::new(),
+        }));
+        let hint_transport = Arc::new(CountingClosingHintTransport::default());
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let store = Arc::new(MemoryStore::default());
+        let keys_local = generate_keys();
+        let keys_peer = generate_keys();
+        let local_pubkey = keys_local.public_key_hex();
+        let peer_pubkey = keys_peer.public_key_hex();
+        let follow_local_to_peer = parse_follow_edge(
+            &build_follow_edge_envelope(
+                &keys_local,
+                &Pubkey::from(peer_pubkey.as_str()),
+                FollowEdgeStatus::Active,
+            )
+            .expect("build follow edge local->peer"),
+        )
+        .expect("parse follow edge local->peer")
+        .expect("follow edge local->peer");
+        let follow_peer_to_local = parse_follow_edge(
+            &build_follow_edge_envelope(
+                &keys_peer,
+                &Pubkey::from(local_pubkey.as_str()),
+                FollowEdgeStatus::Active,
+            )
+            .expect("build follow edge peer->local"),
+        )
+        .expect("parse follow edge peer->local")
+        .expect("follow edge peer->local");
+        store
+            .upsert_follow_edge(follow_local_to_peer)
+            .await
+            .expect("seed local->peer follow edge");
+        store
+            .upsert_follow_edge(follow_peer_to_local)
+            .await
+            .expect("seed peer->local follow edge");
+
+        let app = AppService::new_with_services(
+            store.clone(),
+            store.clone(),
+            transport,
+            hint_transport.clone(),
+            docs_sync,
+            blob_service,
+            keys_local,
+        );
+
+        app.open_direct_message(peer_pubkey.as_str())
+            .await
+            .expect("open direct message first time");
+        sleep(Duration::from_millis(50)).await;
+        app.open_direct_message(peer_pubkey.as_str())
+            .await
+            .expect("open direct message second time");
+        sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(*hint_transport.subscribe_count.lock().await, 2);
+    }
+
+    #[tokio::test]
+    async fn dm_restart_resumes_pending_outbox_and_local_delete_prevents_duplicate_reinsert() {
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let hint_transport = Arc::new(TrackingHintTransport::default());
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let store_a = Arc::new(MemoryStore::default());
+        let store_b = Arc::new(MemoryStore::default());
+        let keys_a = generate_keys();
+        let keys_b = generate_keys();
+        let a_pubkey = keys_a.public_key_hex();
+        let b_pubkey = keys_b.public_key_hex();
+        let follow_a_to_b = parse_follow_edge(
+            &build_follow_edge_envelope(
+                &keys_a,
+                &Pubkey::from(b_pubkey.as_str()),
+                FollowEdgeStatus::Active,
+            )
+            .expect("build follow edge a->b"),
+        )
+        .expect("parse follow edge a->b")
+        .expect("follow edge a->b");
+        let follow_b_to_a = parse_follow_edge(
+            &build_follow_edge_envelope(
+                &keys_b,
+                &Pubkey::from(a_pubkey.as_str()),
+                FollowEdgeStatus::Active,
+            )
+            .expect("build follow edge b->a"),
+        )
+        .expect("parse follow edge b->a")
+        .expect("follow edge b->a");
+
+        store_a
+            .upsert_follow_edge(follow_a_to_b.clone())
+            .await
+            .expect("seed follow edge a->b in store a");
+        store_a
+            .upsert_follow_edge(follow_b_to_a.clone())
+            .await
+            .expect("seed follow edge b->a in store a");
+        store_b
+            .upsert_follow_edge(follow_a_to_b)
+            .await
+            .expect("seed follow edge a->b in store b");
+        store_b
+            .upsert_follow_edge(follow_b_to_a)
+            .await
+            .expect("seed follow edge b->a in store b");
+
+        let app_a = AppService::new_with_services(
+            store_a.clone(),
+            store_a.clone(),
+            transport.clone(),
+            hint_transport.clone(),
+            docs_sync.clone(),
+            blob_service.clone(),
+            keys_a.clone(),
+        );
+        let app_b = AppService::new_with_services(
+            store_b.clone(),
+            store_b.clone(),
+            transport.clone(),
+            hint_transport.clone(),
+            docs_sync.clone(),
+            blob_service.clone(),
+            keys_b.clone(),
+        );
+
+        app_b
+            .open_direct_message(a_pubkey.as_str())
+            .await
+            .expect("recipient opens direct message");
+
+        let message_id = app_a
+            .send_direct_message(
+                b_pubkey.as_str(),
+                None,
+                None,
+                vec![pending_image_attachment(
+                    "image/png",
+                    tiny_png_bytes().as_slice(),
+                )],
+            )
+            .await
+            .expect("queue direct message while offline");
+        let queued_status = app_a
+            .get_direct_message_status(b_pubkey.as_str())
+            .await
+            .expect("queued status");
+        assert_eq!(queued_status.pending_outbox_count, 1);
+        let queued_outbox = store_a
+            .list_direct_message_outbox()
+            .await
+            .expect("list queued outbox");
+        assert_eq!(queued_outbox.len(), 1);
+        let queued_frame = queued_outbox[0].clone();
+
+        let initial_timeline = app_b
+            .list_direct_message_messages(a_pubkey.as_str(), None, 20)
+            .await
+            .expect("initial recipient timeline");
+        assert!(initial_timeline.items.is_empty());
+
+        drop(app_a);
+
+        let reopened_app_a = AppService::new_with_services(
+            store_a.clone(),
+            store_a.clone(),
+            transport.clone(),
+            hint_transport.clone(),
+            docs_sync.clone(),
+            blob_service.clone(),
+            keys_a.clone(),
+        );
+        reopened_app_a
+            .resume_direct_message_state()
+            .await
+            .expect("resume direct message state");
+        assert!(
+            reopened_app_a
+                .direct_message_subscriptions
+                .lock()
+                .await
+                .contains_key(b_pubkey.as_str()),
+            "resume should restore the direct message subscription",
+        );
+
+        let topic = derive_direct_message_topic(&keys_a, &Pubkey::from(b_pubkey.as_str()))
+            .expect("derive dm topic");
+        {
+            let mut snapshot = transport.peers.lock().await;
+            snapshot.connected = true;
+            snapshot.peer_count = 1;
+            snapshot.connected_peers = vec!["peer-b".into()];
+            snapshot.topic_diagnostics = vec![TopicPeerSnapshot {
+                topic: format!("hint/{}", topic.as_str()),
+                joined: true,
+                peer_count: 1,
+                connected_peers: vec!["peer-b".into()],
+                configured_peer_ids: vec!["peer-b".into()],
+                missing_peer_ids: Vec::new(),
+                last_received_at: None,
+                status_detail: "connected".into(),
+                last_error: None,
+            }];
+        }
+        let published = AppService::flush_direct_message_outbox_for_peer_with_services(
+            store_a.as_ref(),
+            hint_transport.as_ref(),
+            transport.as_ref(),
+            a_pubkey.as_str(),
+            &keys_a,
+            b_pubkey.as_str(),
+        )
+        .await
+        .expect("flush queued direct message after restart");
+        assert_eq!(published, 1);
+
+        let delivered = timeout(Duration::from_secs(10), async {
+            loop {
+                let timeline = app_b
+                    .list_direct_message_messages(a_pubkey.as_str(), None, 20)
+                    .await
+                    .expect("recipient timeline");
+                if let Some(message) = timeline
+                    .items
+                    .iter()
+                    .find(|item| item.message_id == message_id)
+                {
+                    break message.clone();
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("wait for delivered direct message");
+        assert_eq!(delivered.text, "");
+        assert_eq!(delivered.attachments.len(), 1);
+        assert_eq!(delivered.attachments[0].role, "image_original");
+        assert_eq!(delivered.attachments[0].mime, "image/png");
+        assert!(!delivered.outgoing);
+        assert!(delivered.delivered);
+
+        timeout(Duration::from_secs(10), async {
+            loop {
+                let status = reopened_app_a
+                    .get_direct_message_status(b_pubkey.as_str())
+                    .await
+                    .expect("sender status");
+                if status.pending_outbox_count == 0 {
+                    break;
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("ack clears outbox");
+
+        app_b
+            .delete_direct_message_message(a_pubkey.as_str(), message_id.as_str())
+            .await
+            .expect("delete direct message locally");
+        let after_delete = app_b
+            .list_direct_message_messages(a_pubkey.as_str(), None, 20)
+            .await
+            .expect("timeline after delete");
+        assert!(after_delete.items.is_empty());
+
+        hint_transport
+            .publish_hint(
+                &topic,
+                GossipHint::DirectMessageFrame {
+                    topic_id: topic.clone(),
+                    dm_id: queued_frame.dm_id.clone(),
+                    message_id: queued_frame.message_id.clone(),
+                    frame_hash: queued_frame.frame_blob_hash.clone(),
+                },
+            )
+            .await
+            .expect("republish duplicate direct message frame");
+        sleep(Duration::from_millis(200)).await;
+
+        let after_duplicate = app_b
+            .list_direct_message_messages(a_pubkey.as_str(), None, 20)
+            .await
+            .expect("timeline after duplicate frame");
+        assert!(after_duplicate.items.is_empty());
     }
 
     #[tokio::test]
@@ -9778,6 +11340,32 @@ mod tests {
         assert_eq!(status.subscribed_topics, vec!["kukuri:topic:demo"]);
         assert_eq!(status.topic_diagnostics.len(), 1);
         assert_eq!(status.topic_diagnostics[0].topic, "kukuri:topic:demo");
+    }
+
+    #[tokio::test]
+    async fn direct_message_peer_count_falls_back_to_connected_peers_when_topic_diagnostic_is_missing()
+     {
+        let transport = StaticTransport::new(PeerSnapshot {
+            connected: true,
+            peer_count: 1,
+            connected_peers: vec!["peer-a".into()],
+            configured_peers: vec!["peer-a".into()],
+            subscribed_topics: vec!["kukuri:topic:demo".into()],
+            pending_events: 0,
+            status_detail: "Connected".into(),
+            last_error: None,
+            topic_diagnostics: Vec::new(),
+        });
+        let keys_a = generate_keys();
+        let keys_b = generate_keys();
+        let topic = derive_direct_message_topic(&keys_a, &keys_b.public_key())
+            .expect("direct message topic");
+
+        let peer_count = direct_message_topic_peer_count(&transport, &topic)
+            .await
+            .expect("direct message peer count");
+
+        assert_eq!(peer_count, 1);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -200,6 +200,70 @@ impl BlobHash {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DirectMessageAttachmentKind {
+    Image,
+    Video,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageEncryptedBlobRefV1 {
+    pub blob_id: String,
+    pub hash: BlobHash,
+    pub mime: String,
+    pub bytes: u64,
+    pub nonce_hex: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageAttachmentManifestV1 {
+    pub attachment_id: String,
+    pub kind: DirectMessageAttachmentKind,
+    pub original: DirectMessageEncryptedBlobRefV1,
+    #[serde(default)]
+    pub poster: Option<DirectMessageEncryptedBlobRefV1>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessagePayloadV1 {
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub reply_to: Option<String>,
+    #[serde(default)]
+    pub attachment_manifest: Option<DirectMessageAttachmentManifestV1>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageFrameV1 {
+    pub dm_id: String,
+    pub message_id: String,
+    pub sender: Pubkey,
+    pub recipient: Pubkey,
+    pub created_at: i64,
+    pub nonce_hex: String,
+    pub ciphertext_hex: String,
+    pub signature: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageAckV1 {
+    pub dm_id: String,
+    pub message_id: String,
+    pub sender: Pubkey,
+    pub recipient: Pubkey,
+    pub acked_at: i64,
+    pub signature: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageEncryptedAttachmentV1 {
+    pub blob_id: String,
+    pub nonce_hex: String,
+    pub ciphertext_hex: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PayloadRef {
     InlineText {
         text: String,
@@ -463,6 +527,16 @@ pub enum GossipHint {
         session_id: String,
         author: Pubkey,
         ttl_ms: u32,
+    },
+    DirectMessageFrame {
+        topic_id: TopicId,
+        dm_id: String,
+        message_id: String,
+        frame_hash: BlobHash,
+    },
+    DirectMessageAck {
+        topic_id: TopicId,
+        ack: DirectMessageAckV1,
     },
 }
 
@@ -1252,6 +1326,60 @@ impl KukuriEnvelope {
             updated_at: self.created_at,
             envelope_id: self.id.clone(),
         }))
+    }
+}
+
+impl DirectMessageFrameV1 {
+    pub fn verify(&self) -> Result<()> {
+        validate_pubkey(self.sender.as_str()).context("invalid direct message sender pubkey")?;
+        validate_pubkey(self.recipient.as_str())
+            .context("invalid direct message recipient pubkey")?;
+        if self.dm_id.trim().is_empty() {
+            bail!("direct message frame dm_id is required");
+        }
+        if self.message_id.trim().is_empty() {
+            bail!("direct message frame message_id is required");
+        }
+        let nonce =
+            hex::decode(self.nonce_hex.trim()).context("invalid direct message frame nonce")?;
+        if nonce.len() != 24 {
+            bail!("direct message frame nonce must be 24 bytes");
+        }
+        let _ = hex::decode(self.ciphertext_hex.trim())
+            .context("invalid direct message frame ciphertext")?;
+        let signature = Signature::from_str(self.signature.as_str())
+            .context("invalid direct message frame signature")?;
+        let sender =
+            XOnlyPublicKey::from_str(self.sender.as_str()).context("invalid frame sender")?;
+        let digest = sha256_digest(canonical_direct_message_frame_payload(self)?.as_bytes());
+        SECP256K1
+            .verify_schnorr(&signature, &digest, &sender)
+            .context("direct message frame signature verification failed")?;
+        Ok(())
+    }
+}
+
+impl DirectMessageAckV1 {
+    pub fn verify(&self) -> Result<()> {
+        validate_pubkey(self.sender.as_str())
+            .context("invalid direct message ack sender pubkey")?;
+        validate_pubkey(self.recipient.as_str())
+            .context("invalid direct message ack recipient pubkey")?;
+        if self.dm_id.trim().is_empty() {
+            bail!("direct message ack dm_id is required");
+        }
+        if self.message_id.trim().is_empty() {
+            bail!("direct message ack message_id is required");
+        }
+        let signature = Signature::from_str(self.signature.as_str())
+            .context("invalid direct message ack signature")?;
+        let sender =
+            XOnlyPublicKey::from_str(self.sender.as_str()).context("invalid ack sender")?;
+        let digest = sha256_digest(canonical_direct_message_ack_payload(self)?.as_bytes());
+        SECP256K1
+            .verify_schnorr(&signature, &digest, &sender)
+            .context("direct message ack signature verification failed")?;
+        Ok(())
     }
 }
 
@@ -2460,6 +2588,272 @@ pub fn parse_custom_reaction_asset(
     Ok(Some(asset))
 }
 
+pub fn direct_message_id_for_participants(left: &Pubkey, right: &Pubkey) -> String {
+    let mut participants = [left.as_str().to_string(), right.as_str().to_string()];
+    participants.sort();
+    let digest = blake3::hash(
+        format!(
+            "kukuri:direct-message:{}:{}",
+            participants[0], participants[1]
+        )
+        .as_bytes(),
+    );
+    format!("dm-{}", digest.to_hex())
+}
+
+pub fn derive_direct_message_secret(
+    local_keys: &KukuriKeys,
+    remote_pubkey: &Pubkey,
+) -> Result<[u8; 32]> {
+    let shared = pairwise_shared_secret(local_keys, remote_pubkey)?;
+    let mut participants = [
+        local_keys.public_key_hex(),
+        remote_pubkey.as_str().to_string(),
+    ];
+    participants.sort();
+    let hkdf = Hkdf::<Sha256>::new(
+        Some(b"kukuri/direct-message/root"),
+        shared.secret_bytes().as_slice(),
+    );
+    let mut secret = [0u8; 32];
+    hkdf.expand(
+        format!(
+            "kukuri:direct-message:{}:{}",
+            participants[0], participants[1]
+        )
+        .as_bytes(),
+        &mut secret,
+    )
+    .map_err(|_| anyhow::anyhow!("failed to derive direct message root secret"))?;
+    Ok(secret)
+}
+
+pub fn derive_direct_message_topic(
+    local_keys: &KukuriKeys,
+    remote_pubkey: &Pubkey,
+) -> Result<TopicId> {
+    let secret = derive_direct_message_secret(local_keys, remote_pubkey)?;
+    let hkdf = Hkdf::<Sha256>::new(Some(b"kukuri/direct-message/topic"), secret.as_slice());
+    let mut topic_key = [0u8; 32];
+    hkdf.expand(b"kukuri:direct-message:pairwise-topic", &mut topic_key)
+        .map_err(|_| anyhow::anyhow!("failed to derive direct message topic"))?;
+    Ok(TopicId::new(format!(
+        "kukuri:dm:{}",
+        hex::encode(topic_key)
+    )))
+}
+
+pub fn encrypt_direct_message_frame(
+    local_keys: &KukuriKeys,
+    recipient_pubkey: &Pubkey,
+    dm_id: &str,
+    message_id: &str,
+    created_at: i64,
+    payload: &DirectMessagePayloadV1,
+) -> Result<DirectMessageFrameV1> {
+    if dm_id.trim().is_empty() {
+        bail!("direct message dm_id is required");
+    }
+    if message_id.trim().is_empty() {
+        bail!("direct message message_id is required");
+    }
+    validate_pubkey(recipient_pubkey.as_str())
+        .context("invalid direct message recipient pubkey")?;
+    let sender = local_keys.public_key();
+    let plaintext =
+        serde_json::to_vec(payload).context("failed to encode direct message payload")?;
+    let mut nonce = [0u8; 24];
+    rng().fill_bytes(&mut nonce);
+    let key = derive_direct_message_frame_key(
+        &derive_direct_message_secret(local_keys, recipient_pubkey)?,
+        dm_id,
+        message_id,
+        sender.as_str(),
+        recipient_pubkey.as_str(),
+        created_at,
+    )?;
+    let cipher = XChaCha20Poly1305::new_from_slice(key.as_slice())
+        .context("failed to initialize direct message frame cipher")?;
+    let aad = direct_message_frame_aad(
+        dm_id,
+        message_id,
+        sender.as_str(),
+        recipient_pubkey.as_str(),
+        created_at,
+    );
+    let ciphertext = cipher
+        .encrypt(
+            XNonce::from_slice(&nonce),
+            Payload {
+                msg: plaintext.as_slice(),
+                aad: aad.as_bytes(),
+            },
+        )
+        .map_err(|_| anyhow::anyhow!("failed to encrypt direct message frame"))?;
+    let mut frame = DirectMessageFrameV1 {
+        dm_id: dm_id.trim().to_string(),
+        message_id: message_id.trim().to_string(),
+        sender,
+        recipient: recipient_pubkey.clone(),
+        created_at,
+        nonce_hex: hex::encode(nonce),
+        ciphertext_hex: hex::encode(ciphertext),
+        signature: String::new(),
+    };
+    let digest = sha256_digest(canonical_direct_message_frame_payload(&frame)?.as_bytes());
+    frame.signature = local_keys.sign_schnorr(&digest).to_string();
+    Ok(frame)
+}
+
+pub fn decrypt_direct_message_frame(
+    local_keys: &KukuriKeys,
+    frame: &DirectMessageFrameV1,
+) -> Result<DirectMessagePayloadV1> {
+    frame.verify()?;
+    if local_keys.public_key() != frame.recipient {
+        bail!("direct message frame recipient pubkey must match decrypting author");
+    }
+    let nonce =
+        hex::decode(frame.nonce_hex.trim()).context("invalid direct message frame nonce")?;
+    if nonce.len() != 24 {
+        bail!("direct message frame nonce must be 24 bytes");
+    }
+    let ciphertext = hex::decode(frame.ciphertext_hex.trim())
+        .context("invalid direct message frame ciphertext")?;
+    let key = derive_direct_message_frame_key(
+        &derive_direct_message_secret(local_keys, &frame.sender)?,
+        frame.dm_id.as_str(),
+        frame.message_id.as_str(),
+        frame.sender.as_str(),
+        frame.recipient.as_str(),
+        frame.created_at,
+    )?;
+    let cipher = XChaCha20Poly1305::new_from_slice(key.as_slice())
+        .context("failed to initialize direct message frame cipher")?;
+    let aad = direct_message_frame_aad(
+        frame.dm_id.as_str(),
+        frame.message_id.as_str(),
+        frame.sender.as_str(),
+        frame.recipient.as_str(),
+        frame.created_at,
+    );
+    let plaintext = cipher
+        .decrypt(
+            XNonce::from_slice(nonce.as_slice()),
+            Payload {
+                msg: ciphertext.as_slice(),
+                aad: aad.as_bytes(),
+            },
+        )
+        .map_err(|_| anyhow::anyhow!("failed to decrypt direct message frame"))?;
+    serde_json::from_slice(&plaintext).context("failed to decode direct message payload")
+}
+
+pub fn build_direct_message_ack(
+    local_keys: &KukuriKeys,
+    dm_id: &str,
+    message_id: &str,
+    recipient_pubkey: &Pubkey,
+    acked_at: i64,
+) -> Result<DirectMessageAckV1> {
+    if dm_id.trim().is_empty() {
+        bail!("direct message ack dm_id is required");
+    }
+    if message_id.trim().is_empty() {
+        bail!("direct message ack message_id is required");
+    }
+    validate_pubkey(recipient_pubkey.as_str())
+        .context("invalid direct message ack recipient pubkey")?;
+    let mut ack = DirectMessageAckV1 {
+        dm_id: dm_id.trim().to_string(),
+        message_id: message_id.trim().to_string(),
+        sender: local_keys.public_key(),
+        recipient: recipient_pubkey.clone(),
+        acked_at,
+        signature: String::new(),
+    };
+    let digest = sha256_digest(canonical_direct_message_ack_payload(&ack)?.as_bytes());
+    ack.signature = local_keys.sign_schnorr(&digest).to_string();
+    Ok(ack)
+}
+
+pub fn encrypt_direct_message_attachment(
+    local_keys: &KukuriKeys,
+    recipient_pubkey: &Pubkey,
+    message_id: &str,
+    blob_id: &str,
+    plaintext: &[u8],
+) -> Result<DirectMessageEncryptedAttachmentV1> {
+    if message_id.trim().is_empty() {
+        bail!("direct message attachment message_id is required");
+    }
+    if blob_id.trim().is_empty() {
+        bail!("direct message attachment blob_id is required");
+    }
+    let mut nonce = [0u8; 24];
+    rng().fill_bytes(&mut nonce);
+    let key = derive_direct_message_attachment_key(
+        &derive_direct_message_secret(local_keys, recipient_pubkey)?,
+        message_id,
+        blob_id,
+    )?;
+    let cipher = XChaCha20Poly1305::new_from_slice(key.as_slice())
+        .context("failed to initialize direct message attachment cipher")?;
+    let aad = direct_message_attachment_aad(message_id, blob_id);
+    let ciphertext = cipher
+        .encrypt(
+            XNonce::from_slice(&nonce),
+            Payload {
+                msg: plaintext,
+                aad: aad.as_bytes(),
+            },
+        )
+        .map_err(|_| anyhow::anyhow!("failed to encrypt direct message attachment"))?;
+    Ok(DirectMessageEncryptedAttachmentV1 {
+        blob_id: blob_id.trim().to_string(),
+        nonce_hex: hex::encode(nonce),
+        ciphertext_hex: hex::encode(ciphertext),
+    })
+}
+
+pub fn decrypt_direct_message_attachment(
+    local_keys: &KukuriKeys,
+    remote_pubkey: &Pubkey,
+    message_id: &str,
+    attachment: &DirectMessageEncryptedAttachmentV1,
+) -> Result<Vec<u8>> {
+    if message_id.trim().is_empty() {
+        bail!("direct message attachment message_id is required");
+    }
+    if attachment.blob_id.trim().is_empty() {
+        bail!("direct message attachment blob_id is required");
+    }
+    let nonce = hex::decode(attachment.nonce_hex.trim())
+        .context("invalid direct message attachment nonce")?;
+    if nonce.len() != 24 {
+        bail!("direct message attachment nonce must be 24 bytes");
+    }
+    let ciphertext = hex::decode(attachment.ciphertext_hex.trim())
+        .context("invalid direct message attachment ciphertext")?;
+    let key = derive_direct_message_attachment_key(
+        &derive_direct_message_secret(local_keys, remote_pubkey)?,
+        message_id,
+        attachment.blob_id.as_str(),
+    )?;
+    let cipher = XChaCha20Poly1305::new_from_slice(key.as_slice())
+        .context("failed to initialize direct message attachment cipher")?;
+    let aad = direct_message_attachment_aad(message_id, attachment.blob_id.as_str());
+    cipher
+        .decrypt(
+            XNonce::from_slice(nonce.as_slice()),
+            Payload {
+                msg: ciphertext.as_slice(),
+                aad: aad.as_bytes(),
+            },
+        )
+        .map_err(|_| anyhow::anyhow!("failed to decrypt direct message attachment"))
+}
+
 fn validate_private_channel_secret_hex(value: &str, label: &str) -> Result<()> {
     let secret_bytes = hex::decode(value.trim()).with_context(|| format!("invalid {label} hex"))?;
     if secret_bytes.len() != 32 {
@@ -2484,6 +2878,18 @@ fn derive_rotation_grant_key(
     remote_pubkey: &Pubkey,
     payload: &PrivateChannelRotationGrantPayloadV1,
 ) -> Result<[u8; 32]> {
+    let shared = pairwise_shared_secret(local_keys, remote_pubkey)?;
+    let hkdf = Hkdf::<Sha256>::new(
+        Some(b"kukuri/private-channel/rotation-grant"),
+        shared.secret_bytes().as_slice(),
+    );
+    let mut key = [0u8; 32];
+    hkdf.expand(rotation_grant_aad(payload).as_bytes(), &mut key)
+        .map_err(|_| anyhow::anyhow!("failed to derive channel rotation grant key"))?;
+    Ok(key)
+}
+
+fn pairwise_shared_secret(local_keys: &KukuriKeys, remote_pubkey: &Pubkey) -> Result<SharedSecret> {
     let remote_xonly = XOnlyPublicKey::from_str(remote_pubkey.as_str())
         .context("invalid remote x-only public key")?;
     let remote_public = PublicKey::from_x_only_public_key(remote_xonly, Parity::Even);
@@ -2494,14 +2900,42 @@ fn derive_rotation_grant_key(
     } else {
         local_keys.secret_key
     };
-    let shared = SharedSecret::new(&remote_public, &local_secret);
+    Ok(SharedSecret::new(&remote_public, &local_secret))
+}
+
+fn derive_direct_message_frame_key(
+    root_secret: &[u8; 32],
+    dm_id: &str,
+    message_id: &str,
+    sender: &str,
+    recipient: &str,
+    created_at: i64,
+) -> Result<[u8; 32]> {
+    let hkdf = Hkdf::<Sha256>::new(Some(b"kukuri/direct-message/frame"), root_secret.as_slice());
+    let mut key = [0u8; 32];
+    hkdf.expand(
+        direct_message_frame_aad(dm_id, message_id, sender, recipient, created_at).as_bytes(),
+        &mut key,
+    )
+    .map_err(|_| anyhow::anyhow!("failed to derive direct message frame key"))?;
+    Ok(key)
+}
+
+fn derive_direct_message_attachment_key(
+    root_secret: &[u8; 32],
+    message_id: &str,
+    blob_id: &str,
+) -> Result<[u8; 32]> {
     let hkdf = Hkdf::<Sha256>::new(
-        Some(b"kukuri/private-channel/rotation-grant"),
-        shared.secret_bytes().as_slice(),
+        Some(b"kukuri/direct-message/attachment"),
+        root_secret.as_slice(),
     );
     let mut key = [0u8; 32];
-    hkdf.expand(rotation_grant_aad(payload).as_bytes(), &mut key)
-        .map_err(|_| anyhow::anyhow!("failed to derive channel rotation grant key"))?;
+    hkdf.expand(
+        direct_message_attachment_aad(message_id, blob_id).as_bytes(),
+        &mut key,
+    )
+    .map_err(|_| anyhow::anyhow!("failed to derive direct message attachment key"))?;
     Ok(key)
 }
 
@@ -2569,6 +3003,46 @@ fn canonical_envelope_payload(
         0, pubkey, created_at, kind, tags, content
     ]))
     .context("failed to encode canonical envelope payload")
+}
+
+fn canonical_direct_message_frame_payload(frame: &DirectMessageFrameV1) -> Result<String> {
+    serde_json::to_string(&serde_json::json!([
+        0,
+        frame.dm_id,
+        frame.message_id,
+        frame.sender,
+        frame.recipient,
+        frame.created_at,
+        frame.nonce_hex,
+        frame.ciphertext_hex
+    ]))
+    .context("failed to encode canonical direct message frame payload")
+}
+
+fn canonical_direct_message_ack_payload(ack: &DirectMessageAckV1) -> Result<String> {
+    serde_json::to_string(&serde_json::json!([
+        0,
+        ack.dm_id,
+        ack.message_id,
+        ack.sender,
+        ack.recipient,
+        ack.acked_at
+    ]))
+    .context("failed to encode canonical direct message ack payload")
+}
+
+fn direct_message_frame_aad(
+    dm_id: &str,
+    message_id: &str,
+    sender: &str,
+    recipient: &str,
+    created_at: i64,
+) -> String {
+    format!("kukuri:direct-message:frame:{dm_id}:{message_id}:{sender}:{recipient}:{created_at}")
+}
+
+fn direct_message_attachment_aad(message_id: &str, blob_id: &str) -> String {
+    format!("kukuri:direct-message:attachment:{message_id}:{blob_id}")
 }
 
 fn validate_pubkey(value: &str) -> Result<()> {
@@ -3187,5 +3661,101 @@ mod tests {
         let error = decrypt_private_channel_rotation_grant(&wrong_recipient, &parsed_doc)
             .expect_err("wrong recipient must fail");
         assert!(error.to_string().contains("recipient pubkey"));
+    }
+
+    #[test]
+    fn dm_pairwise_secret_derives_same_topic_for_pair() {
+        let alice = generate_keys();
+        let bob = generate_keys();
+        let mallory = generate_keys();
+
+        let topic_ab = derive_direct_message_topic(&alice, &bob.public_key()).expect("topic a->b");
+        let topic_ba = derive_direct_message_topic(&bob, &alice.public_key()).expect("topic b->a");
+        let topic_am =
+            derive_direct_message_topic(&alice, &mallory.public_key()).expect("topic a->m");
+
+        assert_eq!(topic_ab, topic_ba);
+        assert_ne!(topic_ab, topic_am);
+        assert_eq!(
+            direct_message_id_for_participants(&alice.public_key(), &bob.public_key()),
+            direct_message_id_for_participants(&bob.public_key(), &alice.public_key())
+        );
+    }
+
+    #[test]
+    fn dm_frame_encrypt_decrypt_roundtrip_and_tamper_reject() {
+        let alice = generate_keys();
+        let bob = generate_keys();
+        let dm_id = direct_message_id_for_participants(&alice.public_key(), &bob.public_key());
+        let payload = DirectMessagePayloadV1 {
+            text: Some("hello bob".into()),
+            reply_to: Some("message-0".into()),
+            attachment_manifest: None,
+        };
+
+        let frame = encrypt_direct_message_frame(
+            &alice,
+            &bob.public_key(),
+            dm_id.as_str(),
+            "message-1",
+            42,
+            &payload,
+        )
+        .expect("encrypt frame");
+        let decrypted = decrypt_direct_message_frame(&bob, &frame).expect("decrypt frame");
+        assert_eq!(decrypted, payload);
+
+        let mut tampered = frame.clone();
+        tampered.ciphertext_hex = "00".repeat(32);
+        let error =
+            decrypt_direct_message_frame(&bob, &tampered).expect_err("tampered frame must fail");
+        assert!(
+            error.to_string().contains("signature")
+                || error.to_string().contains("decrypt")
+                || error.to_string().contains("ciphertext")
+        );
+    }
+
+    #[test]
+    fn dm_attachment_encrypt_decrypt_roundtrip_and_wrong_recipient_fails() {
+        let alice = generate_keys();
+        let bob = generate_keys();
+        let mallory = generate_keys();
+        let encrypted = encrypt_direct_message_attachment(
+            &alice,
+            &bob.public_key(),
+            "message-1",
+            "attachment-1",
+            b"attachment-bytes",
+        )
+        .expect("encrypt attachment");
+
+        let decrypted =
+            decrypt_direct_message_attachment(&bob, &alice.public_key(), "message-1", &encrypted)
+                .expect("decrypt attachment");
+        assert_eq!(decrypted, b"attachment-bytes");
+
+        let error = decrypt_direct_message_attachment(
+            &mallory,
+            &alice.public_key(),
+            "message-1",
+            &encrypted,
+        )
+        .expect_err("wrong recipient must fail");
+        assert!(error.to_string().contains("decrypt"));
+    }
+
+    #[test]
+    fn dm_ack_signature_verification_rejects_wrong_signer() {
+        let alice = generate_keys();
+        let bob = generate_keys();
+        let ack = build_direct_message_ack(&bob, "dm-1", "message-1", &alice.public_key(), 99)
+            .expect("build ack");
+        ack.verify().expect("verify ack");
+
+        let mut tampered = ack.clone();
+        tampered.sender = alice.public_key();
+        let error = tampered.verify().expect_err("tampered ack must fail");
+        assert!(error.to_string().contains("signature"));
     }
 }

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -15,8 +15,9 @@ use image::{AnimationDecoder, DynamicImage, ImageDecoder, ImageFormat};
 use kukuri_app_api::{
     AppService, AuthorSocialView, BlobMediaPayload, BookmarkedCustomReactionView,
     ChannelAccessTokenExport, ChannelAccessTokenPreview, CreateCustomReactionAssetInput,
-    CreateGameRoomInput, CreateLiveSessionInput, CustomReactionAssetView, GameRoomView,
-    GameScoreView, JoinedPrivateChannelView, LiveSessionView, PendingAttachment,
+    CreateGameRoomInput, CreateLiveSessionInput, CustomReactionAssetView,
+    DirectMessageConversationView, DirectMessageStatusView, DirectMessageTimelineView,
+    GameRoomView, GameScoreView, JoinedPrivateChannelView, LiveSessionView, PendingAttachment,
     PrivateChannelCapability, ProfileInput, ReactionStateView, RecentReactionView, SyncStatus,
     TimelineView, UpdateGameRoomInput,
 };
@@ -202,6 +203,33 @@ pub struct GetBlobMediaRequest {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthorRequest {
     pub pubkey: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageRequest {
+    pub pubkey: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListDirectMessageMessagesRequest {
+    pub pubkey: String,
+    pub cursor: Option<TimelineCursor>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SendDirectMessageRequest {
+    pub pubkey: String,
+    pub text: Option<String>,
+    pub reply_to_message_id: Option<String>,
+    #[serde(default)]
+    pub attachments: Vec<CreateAttachmentRequest>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeleteDirectMessageMessageRequest {
+    pub pubkey: String,
+    pub message_id: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -767,6 +795,7 @@ impl DesktopRuntime {
                 .await?;
         }
         app_service.warm_social_graph().await?;
+        app_service.resume_direct_message_state().await?;
 
         Ok(Self {
             app_service,
@@ -991,6 +1020,72 @@ impl DesktopRuntime {
     pub async fn get_author_social_view(&self, request: AuthorRequest) -> Result<AuthorSocialView> {
         self.app_service
             .get_author_social_view(request.pubkey.as_str())
+            .await
+    }
+
+    pub async fn open_direct_message(
+        &self,
+        request: DirectMessageRequest,
+    ) -> Result<DirectMessageConversationView> {
+        self.app_service
+            .open_direct_message(request.pubkey.as_str())
+            .await
+    }
+
+    pub async fn list_direct_messages(&self) -> Result<Vec<DirectMessageConversationView>> {
+        self.app_service.list_direct_messages().await
+    }
+
+    pub async fn list_direct_message_messages(
+        &self,
+        request: ListDirectMessageMessagesRequest,
+    ) -> Result<DirectMessageTimelineView> {
+        self.app_service
+            .list_direct_message_messages(
+                request.pubkey.as_str(),
+                request.cursor,
+                request.limit.unwrap_or(50),
+            )
+            .await
+    }
+
+    pub async fn send_direct_message(&self, request: SendDirectMessageRequest) -> Result<String> {
+        let attachments = request
+            .attachments
+            .into_iter()
+            .map(pending_attachment_from_request)
+            .collect::<Result<Vec<_>>>()?;
+        self.app_service
+            .send_direct_message(
+                request.pubkey.as_str(),
+                request.text.as_deref(),
+                request.reply_to_message_id.as_deref(),
+                attachments,
+            )
+            .await
+    }
+
+    pub async fn delete_direct_message_message(
+        &self,
+        request: DeleteDirectMessageMessageRequest,
+    ) -> Result<()> {
+        self.app_service
+            .delete_direct_message_message(request.pubkey.as_str(), request.message_id.as_str())
+            .await
+    }
+
+    pub async fn clear_direct_message(&self, request: DirectMessageRequest) -> Result<()> {
+        self.app_service
+            .clear_direct_message(request.pubkey.as_str())
+            .await
+    }
+
+    pub async fn get_direct_message_status(
+        &self,
+        request: DirectMessageRequest,
+    ) -> Result<DirectMessageStatusView> {
+        self.app_service
+            .get_direct_message_status(request.pubkey.as_str())
             .await
     }
 

--- a/crates/harness/Cargo.toml
+++ b/crates/harness/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true
+base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -5,9 +5,11 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use kukuri_app_api::{
-    AppService, CreateGameRoomInput, CreateLiveSessionInput, GameScoreView, SyncStatus,
-    UpdateGameRoomInput,
+    AppService, CreateGameRoomInput, CreateLiveSessionInput, DirectMessageMessageView,
+    DirectMessageStatusView, GameScoreView, SyncStatus, UpdateGameRoomInput,
 };
 use kukuri_cn_core::{JwtConfig, TestDatabase};
 use kukuri_cn_iroh_relay::{IrohRelayConfig, SpawnedIrohRelay};
@@ -16,11 +18,13 @@ use kukuri_cn_user_api::{
 };
 use kukuri_core::{ChannelRef, GameRoomStatus, KukuriKeys, TimelineScope};
 use kukuri_desktop_runtime::{
-    AcceptCommunityNodeConsentsRequest, CommunityNodeTargetRequest, CreateGameRoomRequest,
-    CreateLiveSessionRequest, CreatePostRequest, CreatePrivateChannelRequest, DesktopRuntime,
-    ExportPrivateChannelInviteRequest, ImportPeerTicketRequest, ImportPrivateChannelInviteRequest,
+    AcceptCommunityNodeConsentsRequest, CommunityNodeTargetRequest, CreateAttachmentRequest,
+    CreateGameRoomRequest, CreateLiveSessionRequest, CreatePostRequest,
+    CreatePrivateChannelRequest, DeleteDirectMessageMessageRequest, DesktopRuntime,
+    DirectMessageRequest, ExportPrivateChannelInviteRequest, GetBlobMediaRequest,
+    ImportPeerTicketRequest, ImportPrivateChannelInviteRequest, ListDirectMessageMessagesRequest,
     ListGameRoomsRequest, ListJoinedPrivateChannelsRequest, ListLiveSessionsRequest,
-    ListThreadRequest, ListTimelineRequest, LiveSessionCommandRequest,
+    ListThreadRequest, ListTimelineRequest, LiveSessionCommandRequest, SendDirectMessageRequest,
     SetCommunityNodeConfigRequest,
 };
 use kukuri_store::SqliteStore;
@@ -38,6 +42,7 @@ pub enum ScenarioKind {
     CommunityNodePublicConnectivity,
     CommunityNodeMultiDeviceConnectivity,
     PrivateChannelInviteConnectivity,
+    PairwiseDirectMessageConnectivity,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -289,6 +294,9 @@ pub async fn run_scenario(
         }
         ScenarioKind::PrivateChannelInviteConnectivity => {
             run_private_channel_invite_connectivity(scenario, artifacts_dir).await
+        }
+        ScenarioKind::PairwiseDirectMessageConnectivity => {
+            run_pairwise_direct_message_connectivity(scenario, artifacts_dir).await
         }
     }
 }
@@ -1954,6 +1962,446 @@ async fn run_private_channel_invite_connectivity(
     .context("scenario exceeded overall timeout")?
 }
 
+async fn run_pairwise_direct_message_connectivity(
+    scenario: &ScenarioSpec,
+    artifacts_dir: &Path,
+) -> Result<HarnessResult> {
+    unsafe { std::env::set_var("KUKURI_DISABLE_KEYRING", "1") };
+
+    let db_a = artifacts_dir.join("pairwise-dm-a.db");
+    let db_b = artifacts_dir.join("pairwise-dm-b.db");
+    cleanup_runtime_artifacts(&db_a)?;
+    cleanup_runtime_artifacts(&db_b)?;
+
+    let runtime_a = DesktopRuntime::new_with_config(&db_a, TransportNetworkConfig::loopback())
+        .await
+        .context("failed to launch desktop a for direct-message scenario")?;
+    let runtime_b = DesktopRuntime::new_with_config(&db_b, TransportNetworkConfig::loopback())
+        .await
+        .context("failed to launch desktop b for direct-message scenario")?;
+    let overall_timeout =
+        if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
+            Duration::from_millis(scenario.timeouts.overall_ms).max(Duration::from_secs(600))
+        } else {
+            Duration::from_millis(scenario.timeouts.overall_ms)
+        };
+    let step_timeout = ci_timeout_floor(
+        Duration::from_millis(scenario.timeouts.step_ms),
+        Duration::from_secs(180),
+    );
+
+    timeout(overall_timeout, async move {
+        let mut steps = Vec::new();
+        let topic = scenario.fixtures.topic.as_str();
+        let public_scope = TimelineScope::Public;
+        let mut runtime_a = runtime_a;
+        let mut runtime_b = runtime_b;
+
+        let started_at = Instant::now();
+        let ticket_a = runtime_a
+            .local_peer_ticket()
+            .await
+            .context("failed to export ticket for desktop a")?
+            .context("missing ticket for desktop a")?;
+        let ticket_b = runtime_b
+            .local_peer_ticket()
+            .await
+            .context("failed to export ticket for desktop b")?
+            .context("missing ticket for desktop b")?;
+        runtime_a
+            .import_peer_ticket(ImportPeerTicketRequest {
+                ticket: ticket_b.clone(),
+            })
+            .await
+            .context("failed to import desktop b ticket into desktop a")?;
+        runtime_b
+            .import_peer_ticket(ImportPeerTicketRequest {
+                ticket: ticket_a.clone(),
+            })
+            .await
+            .context("failed to import desktop a ticket into desktop b")?;
+        let _ = runtime_a
+            .list_timeline(ListTimelineRequest {
+                topic: topic.to_string(),
+                scope: public_scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .context("failed to subscribe desktop a to public topic")?;
+        let _ = runtime_b
+            .list_timeline(ListTimelineRequest {
+                topic: topic.to_string(),
+                scope: public_scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .context("failed to subscribe desktop b to public topic")?;
+        wait_for_topic_peer_count(&runtime_a, topic, 1, step_timeout)
+            .await
+            .context("desktop a did not observe public topic connectivity")?;
+        wait_for_topic_peer_count(&runtime_b, topic, 1, step_timeout)
+            .await
+            .context("desktop b did not observe public topic connectivity")?;
+        push_named_step(&mut steps, "connect", started_at);
+
+        let started_at = Instant::now();
+        let a_pubkey = runtime_a
+            .get_sync_status()
+            .await
+            .context("status a")?
+            .local_author_pubkey;
+        let b_pubkey = runtime_b
+            .get_sync_status()
+            .await
+            .context("status b")?
+            .local_author_pubkey;
+        wait_for_author_social_view(&runtime_a, b_pubkey.as_str(), step_timeout)
+            .await
+            .context("desktop a did not warm author social view for desktop b")?;
+        wait_for_author_social_view(&runtime_b, a_pubkey.as_str(), step_timeout)
+            .await
+            .context("desktop b did not warm author social view for desktop a")?;
+        runtime_a
+            .follow_author(kukuri_desktop_runtime::AuthorRequest {
+                pubkey: b_pubkey.clone(),
+            })
+            .await
+            .context("desktop a failed to follow desktop b")?;
+        runtime_b
+            .follow_author(kukuri_desktop_runtime::AuthorRequest {
+                pubkey: a_pubkey.clone(),
+            })
+            .await
+            .context("desktop b failed to follow desktop a")?;
+        wait_for_mutual_author_view_result(&runtime_a, b_pubkey.as_str(), topic, step_timeout)
+            .await
+            .context("desktop a did not observe mutual relationship")?;
+        wait_for_mutual_author_view_result(&runtime_b, a_pubkey.as_str(), topic, step_timeout)
+            .await
+            .context("desktop b did not observe mutual relationship")?;
+        runtime_a
+            .open_direct_message(DirectMessageRequest {
+                pubkey: b_pubkey.clone(),
+            })
+            .await
+            .context("desktop a failed to open direct message")?;
+        runtime_b
+            .open_direct_message(DirectMessageRequest {
+                pubkey: a_pubkey.clone(),
+            })
+            .await
+            .context("desktop b failed to open direct message")?;
+        push_named_step(&mut steps, "mutual_open_dm", started_at);
+
+        let started_at = Instant::now();
+        let image_bytes = b"pairwise-dm-image";
+        let image_message_id = runtime_a
+            .send_direct_message(SendDirectMessageRequest {
+                pubkey: b_pubkey.clone(),
+                text: Some("image caption".to_string()),
+                reply_to_message_id: None,
+                attachments: vec![image_attachment_request(
+                    "pairwise-dm-image.png",
+                    "image/png",
+                    image_bytes,
+                )],
+            })
+            .await
+            .context("desktop a failed to send image direct message")?;
+        let delivered_image = wait_for_direct_message_result(
+            &runtime_b,
+            a_pubkey.as_str(),
+            image_message_id.as_str(),
+            step_timeout,
+        )
+        .await
+        .context("desktop b did not receive image direct message")?;
+        assert_eq!(delivered_image.text, "image caption");
+        assert_eq!(delivered_image.attachments.len(), 1);
+        assert_eq!(delivered_image.attachments[0].role, "image_original");
+        assert_eq!(delivered_image.attachments[0].mime, "image/png");
+        let image_payload = runtime_b
+            .get_blob_media_payload(GetBlobMediaRequest {
+                hash: delivered_image.attachments[0].hash.clone(),
+                mime: delivered_image.attachments[0].mime.clone(),
+            })
+            .await
+            .context("desktop b failed to load image attachment payload")?
+            .context("desktop b missing image attachment payload")?;
+        assert_eq!(image_payload.mime, "image/png");
+        assert_eq!(
+            image_payload.bytes_base64,
+            BASE64_STANDARD.encode(image_bytes)
+        );
+        wait_for_direct_message_outbox_count(&runtime_a, b_pubkey.as_str(), 0, step_timeout)
+            .await
+            .context("desktop a image direct message outbox did not drain")?;
+        push_named_step(&mut steps, "image_delivery", started_at);
+
+        let started_at = Instant::now();
+        shutdown_runtime(runtime_b, "desktop b direct-message restart pre-shutdown")
+            .await
+            .context("failed to shut down desktop b before offline direct message")?;
+        let queued_video_message_id = runtime_a
+            .send_direct_message(SendDirectMessageRequest {
+                pubkey: b_pubkey.clone(),
+                text: Some("offline video".to_string()),
+                reply_to_message_id: None,
+                attachments: vec![
+                    video_attachment_request(
+                        "pairwise-dm-video.mp4",
+                        "video/mp4",
+                        b"pairwise-dm-video",
+                        "video_manifest",
+                    ),
+                    video_attachment_request(
+                        "pairwise-dm-video-poster.jpg",
+                        "image/jpeg",
+                        b"pairwise-dm-video-poster",
+                        "video_poster",
+                    ),
+                ],
+            })
+            .await
+            .context("desktop a failed to queue offline video direct message")?;
+        let queued_status =
+            wait_for_direct_message_outbox_count(&runtime_a, b_pubkey.as_str(), 1, step_timeout)
+                .await
+                .context("desktop a did not retain queued video direct message in outbox")?;
+        assert_eq!(queued_status.pending_outbox_count, 1);
+        shutdown_runtime(runtime_a, "desktop a direct-message outbox restart")
+            .await
+            .context("failed to shut down desktop a before outbox restart")?;
+        runtime_b = DesktopRuntime::new_with_config(&db_b, TransportNetworkConfig::loopback())
+            .await
+            .context("failed to restart desktop b for direct-message scenario")?;
+        runtime_a = DesktopRuntime::new_with_config(&db_a, TransportNetworkConfig::loopback())
+            .await
+            .context("failed to restart desktop a for direct-message scenario")?;
+        let ticket_a_after_restart = runtime_a
+            .local_peer_ticket()
+            .await
+            .context("failed to export restarted desktop a ticket")?
+            .context("missing restarted desktop a ticket")?;
+        let ticket_b_after_restart = runtime_b
+            .local_peer_ticket()
+            .await
+            .context("failed to export restarted desktop b ticket")?
+            .context("missing restarted desktop b ticket")?;
+        runtime_a
+            .import_peer_ticket(ImportPeerTicketRequest {
+                ticket: ticket_b_after_restart,
+            })
+            .await
+            .context("failed to import restarted desktop b ticket into desktop a")?;
+        runtime_b
+            .import_peer_ticket(ImportPeerTicketRequest {
+                ticket: ticket_a_after_restart,
+            })
+            .await
+            .context("failed to import desktop a ticket into restarted desktop b")?;
+        let _ = runtime_a
+            .list_timeline(ListTimelineRequest {
+                topic: topic.to_string(),
+                scope: public_scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .context("failed to refresh desktop a public topic after restart")?;
+        let _ = runtime_b
+            .list_timeline(ListTimelineRequest {
+                topic: topic.to_string(),
+                scope: public_scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .context("failed to refresh desktop b public topic after restart")?;
+        wait_for_topic_peer_count(&runtime_a, topic, 1, step_timeout)
+            .await
+            .context("desktop a did not reconnect to public topic after restart")?;
+        wait_for_topic_peer_count(&runtime_b, topic, 1, step_timeout)
+            .await
+            .context("desktop b did not reconnect to public topic after restart")?;
+        wait_for_author_social_view(&runtime_a, b_pubkey.as_str(), step_timeout)
+            .await
+            .context("desktop a did not rewarm author social view after restart")?;
+        wait_for_author_social_view(&runtime_b, a_pubkey.as_str(), step_timeout)
+            .await
+            .context("desktop b did not rewarm author social view after restart")?;
+        wait_for_mutual_author_view_result(&runtime_a, b_pubkey.as_str(), topic, step_timeout)
+            .await
+            .context("desktop a did not restore mutual relationship after restart")?;
+        wait_for_mutual_author_view_result(&runtime_b, a_pubkey.as_str(), topic, step_timeout)
+            .await
+            .context("desktop b did not restore mutual relationship after restart")?;
+        runtime_a
+            .open_direct_message(DirectMessageRequest {
+                pubkey: b_pubkey.clone(),
+            })
+            .await
+            .context("desktop a failed to reopen direct message after restart")?;
+        runtime_b
+            .open_direct_message(DirectMessageRequest {
+                pubkey: a_pubkey.clone(),
+            })
+            .await
+            .context("desktop b failed to reopen direct message after restart")?;
+        let delivered_video = wait_for_direct_message_result(
+            &runtime_b,
+            a_pubkey.as_str(),
+            queued_video_message_id.as_str(),
+            step_timeout,
+        )
+        .await
+        .context("desktop b did not receive queued video direct message after restart")?;
+        assert_eq!(delivered_video.text, "offline video");
+        assert_eq!(delivered_video.attachments.len(), 2);
+        let manifest = delivered_video
+            .attachments
+            .iter()
+            .find(|attachment| attachment.role == "video_manifest")
+            .context("missing delivered video manifest attachment")?;
+        let poster = delivered_video
+            .attachments
+            .iter()
+            .find(|attachment| attachment.role == "video_poster")
+            .context("missing delivered video poster attachment")?;
+        let manifest_payload = runtime_b
+            .get_blob_media_payload(GetBlobMediaRequest {
+                hash: manifest.hash.clone(),
+                mime: manifest.mime.clone(),
+            })
+            .await
+            .context("desktop b failed to load video manifest payload")?
+            .context("desktop b missing video manifest payload")?;
+        assert_eq!(manifest_payload.mime, "video/mp4");
+        assert_eq!(
+            manifest_payload.bytes_base64,
+            BASE64_STANDARD.encode(b"pairwise-dm-video")
+        );
+        let poster_payload = runtime_b
+            .get_blob_media_payload(GetBlobMediaRequest {
+                hash: poster.hash.clone(),
+                mime: poster.mime.clone(),
+            })
+            .await
+            .context("desktop b failed to load video poster payload")?
+            .context("desktop b missing video poster payload")?;
+        assert_eq!(poster_payload.mime, "image/jpeg");
+        assert_eq!(
+            poster_payload.bytes_base64,
+            BASE64_STANDARD.encode(b"pairwise-dm-video-poster")
+        );
+        wait_for_direct_message_outbox_count(&runtime_a, b_pubkey.as_str(), 0, step_timeout)
+            .await
+            .context("desktop a queued video direct message outbox did not drain")?;
+        push_named_step(&mut steps, "offline_video_delivery", started_at);
+
+        let started_at = Instant::now();
+        runtime_b
+            .delete_direct_message_message(DeleteDirectMessageMessageRequest {
+                pubkey: a_pubkey.clone(),
+                message_id: queued_video_message_id.clone(),
+            })
+            .await
+            .context("desktop b failed to delete video direct message locally")?;
+        wait_for_direct_message_absence(
+            &runtime_b,
+            a_pubkey.as_str(),
+            queued_video_message_id.as_str(),
+            step_timeout,
+        )
+        .await
+        .context("desktop b local delete did not remove video direct message")?;
+        let sender_timeline = runtime_a
+            .list_direct_message_messages(ListDirectMessageMessagesRequest {
+                pubkey: b_pubkey.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .context("desktop a failed to list sender direct messages after recipient delete")?;
+        assert!(
+            sender_timeline
+                .items
+                .iter()
+                .any(|message| message.message_id == queued_video_message_id),
+            "recipient local delete should not remove sender history",
+        );
+        shutdown_runtime(
+            runtime_b,
+            "desktop b direct-message delete persistence restart",
+        )
+        .await
+        .context("failed to shut down desktop b before delete persistence restart")?;
+        runtime_b = DesktopRuntime::new_with_config(&db_b, TransportNetworkConfig::loopback())
+            .await
+            .context("failed to restart desktop b after local delete")?;
+        runtime_b
+            .open_direct_message(DirectMessageRequest {
+                pubkey: a_pubkey.clone(),
+            })
+            .await
+            .context("desktop b failed to reopen direct message after delete restart")?;
+        let restored_timeline = runtime_b
+            .list_direct_message_messages(ListDirectMessageMessagesRequest {
+                pubkey: a_pubkey.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .context("desktop b failed to list restored direct message timeline")?;
+        assert!(
+            restored_timeline
+                .items
+                .iter()
+                .any(|message| message.message_id == image_message_id),
+            "desktop b should retain the earlier image direct message",
+        );
+        assert!(
+            restored_timeline
+                .items
+                .iter()
+                .all(|message| message.message_id != queued_video_message_id),
+            "desktop b should persist the local delete across restart",
+        );
+        push_named_step(&mut steps, "local_delete_persisted", started_at);
+
+        let metrics_snapshot = if scenario.artifacts.metrics_snapshot {
+            Some(
+                runtime_a
+                    .get_sync_status()
+                    .await
+                    .context("failed to collect final direct-message sync status")?,
+            )
+        } else {
+            None
+        };
+        shutdown_runtime(runtime_a, "desktop a final shutdown")
+            .await
+            .context("desktop a final shutdown timed out")?;
+        shutdown_runtime(runtime_b, "desktop b final shutdown")
+            .await
+            .context("desktop b final shutdown timed out")?;
+
+        let result = HarnessResult {
+            status: HarnessStatus::Pass,
+            scenario: scenario.name.clone(),
+            steps,
+            artifacts: vec![artifacts_dir.join("result.json").display().to_string()],
+            metrics_snapshot,
+        };
+        write_result_artifact(Path::new("."), artifacts_dir, &result)?;
+        Ok::<HarnessResult, anyhow::Error>(result)
+    })
+    .await
+    .context("scenario exceeded overall timeout")?
+}
+
 async fn shutdown_runtime(runtime: DesktopRuntime, label: &str) -> Result<()> {
     timeout(Duration::from_secs(30), runtime.shutdown())
         .await
@@ -2329,6 +2777,206 @@ async fn wait_for_direct_topic_peer_count(
                 .unwrap_or_else(|| "failed to read sync status".to_string());
             anyhow::bail!("direct topic connected-peer assertion timeout; {snapshot}");
         }
+    }
+}
+
+async fn wait_for_author_social_view(
+    runtime: &DesktopRuntime,
+    author_pubkey: &str,
+    step_timeout: Duration,
+) -> Result<()> {
+    match timeout(step_timeout, async {
+        loop {
+            if runtime
+                .get_author_social_view(kukuri_desktop_runtime::AuthorRequest {
+                    pubkey: author_pubkey.to_string(),
+                })
+                .await
+                .is_ok()
+            {
+                return Ok::<(), anyhow::Error>(());
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!("author social view warmup timeout for {author_pubkey}"),
+    }
+}
+
+async fn wait_for_mutual_author_view_result(
+    runtime: &DesktopRuntime,
+    author_pubkey: &str,
+    topic: &str,
+    step_timeout: Duration,
+) -> Result<()> {
+    match timeout(step_timeout, async {
+        loop {
+            let view = runtime
+                .get_author_social_view(kukuri_desktop_runtime::AuthorRequest {
+                    pubkey: author_pubkey.to_string(),
+                })
+                .await
+                .context("author social view")?;
+            if view.mutual {
+                return Ok::<(), anyhow::Error>(());
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            let social_view = runtime
+                .get_author_social_view(kukuri_desktop_runtime::AuthorRequest {
+                    pubkey: author_pubkey.to_string(),
+                })
+                .await
+                .ok()
+                .map(|value| {
+                    format!(
+                        "following={}, followed_by={}, mutual={}, friend_of_friend={}, fof_via={:?}",
+                        value.following,
+                        value.followed_by,
+                        value.mutual,
+                        value.friend_of_friend,
+                        value.friend_of_friend_via_pubkeys
+                    )
+                })
+                .unwrap_or_else(|| "social_view=unavailable".to_string());
+            let snapshot = runtime
+                .get_sync_status()
+                .await
+                .ok()
+                .map(|status| format_sync_snapshot(&status, topic))
+                .unwrap_or_else(|| "failed to read sync status".to_string());
+            anyhow::bail!(
+                "mutual relationship timeout for {author_pubkey}; {social_view}, {snapshot}"
+            );
+        }
+    }
+}
+
+async fn wait_for_direct_message_result(
+    runtime: &DesktopRuntime,
+    peer_pubkey: &str,
+    message_id: &str,
+    step_timeout: Duration,
+) -> Result<DirectMessageMessageView> {
+    match timeout(step_timeout, async {
+        loop {
+            let timeline = runtime
+                .list_direct_message_messages(ListDirectMessageMessagesRequest {
+                    pubkey: peer_pubkey.to_string(),
+                    cursor: None,
+                    limit: Some(20),
+                })
+                .await
+                .context("list direct message timeline")?;
+            if let Some(message) = timeline
+                .items
+                .into_iter()
+                .find(|item| item.message_id == message_id)
+            {
+                return Ok::<DirectMessageMessageView, anyhow::Error>(message);
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!("direct message delivery timeout for {message_id}"),
+    }
+}
+
+async fn wait_for_direct_message_absence(
+    runtime: &DesktopRuntime,
+    peer_pubkey: &str,
+    message_id: &str,
+    step_timeout: Duration,
+) -> Result<()> {
+    match timeout(step_timeout, async {
+        loop {
+            let timeline = runtime
+                .list_direct_message_messages(ListDirectMessageMessagesRequest {
+                    pubkey: peer_pubkey.to_string(),
+                    cursor: None,
+                    limit: Some(20),
+                })
+                .await
+                .context("list direct message timeline")?;
+            if timeline
+                .items
+                .iter()
+                .all(|item| item.message_id != message_id)
+            {
+                return Ok::<(), anyhow::Error>(());
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!("direct message delete timeout for {message_id}"),
+    }
+}
+
+async fn wait_for_direct_message_outbox_count(
+    runtime: &DesktopRuntime,
+    peer_pubkey: &str,
+    expected: usize,
+    step_timeout: Duration,
+) -> Result<DirectMessageStatusView> {
+    match timeout(step_timeout, async {
+        loop {
+            let status = runtime
+                .get_direct_message_status(DirectMessageRequest {
+                    pubkey: peer_pubkey.to_string(),
+                })
+                .await
+                .context("direct message status")?;
+            if status.pending_outbox_count == expected {
+                return Ok::<DirectMessageStatusView, anyhow::Error>(status);
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!(
+            "direct message outbox count timeout for {peer_pubkey}; expected={expected}"
+        ),
+    }
+}
+
+fn image_attachment_request(name: &str, mime: &str, bytes: &[u8]) -> CreateAttachmentRequest {
+    CreateAttachmentRequest {
+        file_name: Some(name.to_string()),
+        mime: mime.to_string(),
+        byte_size: bytes.len() as u64,
+        data_base64: BASE64_STANDARD.encode(bytes),
+        role: Some("image_original".to_string()),
+    }
+}
+
+fn video_attachment_request(
+    name: &str,
+    mime: &str,
+    bytes: &[u8],
+    role: &str,
+) -> CreateAttachmentRequest {
+    CreateAttachmentRequest {
+        file_name: Some(name.to_string()),
+        mime: mime.to_string(),
+        byte_size: bytes.len() as u64,
+        data_base64: BASE64_STANDARD.encode(bytes),
+        role: Some(role.to_string()),
     }
 }
 
@@ -3320,6 +3968,29 @@ mod tests {
         let result = run_named_scenario(root, "private_channel_invite_connectivity", &artifacts)
             .await
             .expect("scenario");
+
+        assert_eq!(result.status, HarnessStatus::Pass);
+        assert!(artifacts.join("result.json").exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pairwise_dm_offline_text_image_video_delivery_and_local_delete() {
+        disable_keyring_for_tests();
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("workspace root");
+        let artifacts = root
+            .join("test-results")
+            .join("kukuri")
+            .join("pairwise-dm-connectivity");
+        let result = run_named_scenario(
+            root,
+            "pairwise_dm_offline_text_image_video_delivery_and_local_delete",
+            &artifacts,
+        )
+        .await
+        .expect("scenario");
 
         assert_eq!(result.status, HarnessStatus::Pass);
         assert!(artifacts.join("result.json").exists());

--- a/crates/store/migrations/20260330010000_direct_messages.down.sql
+++ b/crates/store/migrations/20260330010000_direct_messages.down.sql
@@ -1,0 +1,11 @@
+DROP INDEX IF EXISTS idx_dm_tombstones_dm_id;
+DROP TABLE IF EXISTS dm_message_tombstones;
+
+DROP INDEX IF EXISTS idx_dm_outbox_created_at;
+DROP TABLE IF EXISTS dm_outbox;
+
+DROP INDEX IF EXISTS idx_dm_messages_timeline;
+DROP TABLE IF EXISTS dm_messages;
+
+DROP INDEX IF EXISTS idx_dm_conversations_updated_at;
+DROP TABLE IF EXISTS dm_conversations;

--- a/crates/store/migrations/20260330010000_direct_messages.up.sql
+++ b/crates/store/migrations/20260330010000_direct_messages.up.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS dm_conversations (
+    dm_id TEXT PRIMARY KEY,
+    peer_pubkey TEXT NOT NULL UNIQUE,
+    updated_at INTEGER NOT NULL,
+    last_message_at INTEGER,
+    last_message_id TEXT,
+    last_message_preview TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_dm_conversations_updated_at
+    ON dm_conversations(updated_at DESC, dm_id DESC);
+
+CREATE TABLE IF NOT EXISTS dm_messages (
+    dm_id TEXT NOT NULL,
+    message_id TEXT NOT NULL,
+    sender_pubkey TEXT NOT NULL,
+    recipient_pubkey TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    text TEXT,
+    reply_to_message_id TEXT,
+    attachment_manifest_json TEXT,
+    outgoing INTEGER NOT NULL DEFAULT 0,
+    acked_at INTEGER,
+    PRIMARY KEY (dm_id, message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dm_messages_timeline
+    ON dm_messages(dm_id, created_at DESC, message_id DESC);
+
+CREATE TABLE IF NOT EXISTS dm_outbox (
+    dm_id TEXT NOT NULL,
+    message_id TEXT NOT NULL,
+    peer_pubkey TEXT NOT NULL,
+    frame_blob_hash TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    last_attempt_at INTEGER,
+    PRIMARY KEY (dm_id, message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dm_outbox_created_at
+    ON dm_outbox(created_at ASC, message_id ASC);
+
+CREATE TABLE IF NOT EXISTS dm_message_tombstones (
+    dm_id TEXT NOT NULL,
+    message_id TEXT NOT NULL,
+    deleted_at INTEGER NOT NULL,
+    PRIMARY KEY (dm_id, message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dm_tombstones_dm_id
+    ON dm_message_tombstones(dm_id, deleted_at DESC, message_id DESC);

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use kukuri_core::{
-    BlobHash, CustomReactionAssetSnapshotV1, EnvelopeId, FollowEdge, FollowEdgeStatus,
-    GameRoomStatus, GameScoreEntry, KukuriEnvelope, LiveSessionStatus, ObjectStatus, PayloadRef,
-    Profile, ReactionKeyKind, ReplicaId, RepostSourceSnapshotV1, ThreadRef, parse_follow_edge,
-    parse_profile,
+    BlobHash, CustomReactionAssetSnapshotV1, DirectMessageAttachmentManifestV1, EnvelopeId,
+    FollowEdge, FollowEdgeStatus, GameRoomStatus, GameScoreEntry, KukuriEnvelope,
+    LiveSessionStatus, ObjectStatus, PayloadRef, Profile, ReactionKeyKind, ReplicaId,
+    RepostSourceSnapshotV1, ThreadRef, parse_follow_edge, parse_profile,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha384};
@@ -143,6 +143,47 @@ pub struct AuthorRelationshipProjectionRow {
     pub derived_at: i64,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageConversationRow {
+    pub dm_id: String,
+    pub peer_pubkey: String,
+    pub updated_at: i64,
+    pub last_message_at: Option<i64>,
+    pub last_message_id: Option<String>,
+    pub last_message_preview: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageMessageRow {
+    pub dm_id: String,
+    pub message_id: String,
+    pub sender_pubkey: String,
+    pub recipient_pubkey: String,
+    pub created_at: i64,
+    pub text: Option<String>,
+    pub reply_to_message_id: Option<String>,
+    pub attachment_manifest: Option<DirectMessageAttachmentManifestV1>,
+    pub outgoing: bool,
+    pub acked_at: Option<i64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageOutboxRow {
+    pub dm_id: String,
+    pub message_id: String,
+    pub peer_pubkey: String,
+    pub frame_blob_hash: BlobHash,
+    pub created_at: i64,
+    pub last_attempt_at: Option<i64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectMessageTombstoneRow {
+    pub dm_id: String,
+    pub message_id: String,
+    pub deleted_at: i64,
+}
+
 type LivePresenceKey = (String, String, String);
 type LivePresenceValue = (String, String, i64, i64);
 
@@ -239,6 +280,63 @@ pub trait ProjectionStore: Send + Sync {
     async fn put_bookmarked_custom_reaction(&self, row: BookmarkedCustomReactionRow) -> Result<()>;
     async fn list_bookmarked_custom_reactions(&self) -> Result<Vec<BookmarkedCustomReactionRow>>;
     async fn remove_bookmarked_custom_reaction(&self, asset_id: &str) -> Result<()>;
+    async fn upsert_direct_message_conversation(
+        &self,
+        row: DirectMessageConversationRow,
+    ) -> Result<()>;
+    async fn get_direct_message_conversation_by_peer(
+        &self,
+        peer_pubkey: &str,
+    ) -> Result<Option<DirectMessageConversationRow>>;
+    async fn get_direct_message_conversation_by_dm_id(
+        &self,
+        dm_id: &str,
+    ) -> Result<Option<DirectMessageConversationRow>>;
+    async fn list_direct_message_conversations(&self) -> Result<Vec<DirectMessageConversationRow>>;
+    async fn put_direct_message_message(&self, row: DirectMessageMessageRow) -> Result<()>;
+    async fn get_direct_message_message(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+    ) -> Result<Option<DirectMessageMessageRow>>;
+    async fn list_direct_message_messages(
+        &self,
+        dm_id: &str,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<Page<DirectMessageMessageRow>>;
+    async fn set_direct_message_acked_at(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+        acked_at: i64,
+    ) -> Result<()>;
+    async fn put_direct_message_outbox(&self, row: DirectMessageOutboxRow) -> Result<()>;
+    async fn get_direct_message_outbox(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+    ) -> Result<Option<DirectMessageOutboxRow>>;
+    async fn list_direct_message_outbox(&self) -> Result<Vec<DirectMessageOutboxRow>>;
+    async fn touch_direct_message_outbox_attempt(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+        attempted_at: i64,
+    ) -> Result<()>;
+    async fn remove_direct_message_outbox(&self, dm_id: &str, message_id: &str) -> Result<()>;
+    async fn put_direct_message_tombstone(&self, row: DirectMessageTombstoneRow) -> Result<()>;
+    async fn list_direct_message_tombstones(
+        &self,
+        dm_id: &str,
+    ) -> Result<Vec<DirectMessageTombstoneRow>>;
+    async fn has_direct_message_tombstone(&self, dm_id: &str, message_id: &str) -> Result<bool>;
+    async fn delete_direct_message_message_local(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+    ) -> Result<()>;
+    async fn clear_direct_message_local(&self, dm_id: &str) -> Result<()>;
     async fn rebuild_object_projections(&self, rows: Vec<ObjectProjectionRow>) -> Result<()>;
 }
 
@@ -722,6 +820,9 @@ impl Store for SqliteStore {
 }
 
 type MemoryReactionProjectionRows = HashMap<(String, String, String), ReactionProjectionRow>;
+type MemoryDirectMessageRows = HashMap<(String, String), DirectMessageMessageRow>;
+type MemoryDirectMessageOutboxRows = HashMap<(String, String), DirectMessageOutboxRow>;
+type MemoryDirectMessageTombstones = HashMap<(String, String), DirectMessageTombstoneRow>;
 
 #[derive(Clone, Default)]
 pub struct MemoryStore {
@@ -739,6 +840,10 @@ pub struct MemoryStore {
     blob_statuses: Arc<RwLock<HashMap<String, BlobCacheStatus>>>,
     reaction_projection_rows: Arc<RwLock<MemoryReactionProjectionRows>>,
     bookmarked_custom_reactions: Arc<RwLock<HashMap<String, BookmarkedCustomReactionRow>>>,
+    direct_message_conversations: Arc<RwLock<HashMap<String, DirectMessageConversationRow>>>,
+    direct_message_rows: Arc<RwLock<MemoryDirectMessageRows>>,
+    direct_message_outbox_rows: Arc<RwLock<MemoryDirectMessageOutboxRows>>,
+    direct_message_tombstones: Arc<RwLock<MemoryDirectMessageTombstones>>,
 }
 
 #[async_trait]
@@ -1610,6 +1715,415 @@ impl ProjectionStore for SqliteStore {
         Ok(())
     }
 
+    async fn upsert_direct_message_conversation(
+        &self,
+        row: DirectMessageConversationRow,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO dm_conversations (
+              dm_id, peer_pubkey, updated_at, last_message_at, last_message_id, last_message_preview
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            ON CONFLICT(dm_id) DO UPDATE SET
+              peer_pubkey = excluded.peer_pubkey,
+              updated_at = excluded.updated_at,
+              last_message_at = excluded.last_message_at,
+              last_message_id = excluded.last_message_id,
+              last_message_preview = excluded.last_message_preview
+            "#,
+        )
+        .bind(row.dm_id.as_str())
+        .bind(row.peer_pubkey.as_str())
+        .bind(row.updated_at)
+        .bind(row.last_message_at)
+        .bind(row.last_message_id.as_deref())
+        .bind(row.last_message_preview.as_deref())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_direct_message_conversation_by_peer(
+        &self,
+        peer_pubkey: &str,
+    ) -> Result<Option<DirectMessageConversationRow>> {
+        let row = sqlx::query(
+            r#"
+            SELECT dm_id, peer_pubkey, updated_at, last_message_at, last_message_id, last_message_preview
+            FROM dm_conversations
+            WHERE peer_pubkey = ?1
+            "#,
+        )
+        .bind(peer_pubkey)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(row_to_direct_message_conversation).transpose()
+    }
+
+    async fn get_direct_message_conversation_by_dm_id(
+        &self,
+        dm_id: &str,
+    ) -> Result<Option<DirectMessageConversationRow>> {
+        let row = sqlx::query(
+            r#"
+            SELECT dm_id, peer_pubkey, updated_at, last_message_at, last_message_id, last_message_preview
+            FROM dm_conversations
+            WHERE dm_id = ?1
+            "#,
+        )
+        .bind(dm_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(row_to_direct_message_conversation).transpose()
+    }
+
+    async fn list_direct_message_conversations(&self) -> Result<Vec<DirectMessageConversationRow>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT dm_id, peer_pubkey, updated_at, last_message_at, last_message_id, last_message_preview
+            FROM dm_conversations
+            ORDER BY updated_at DESC, dm_id DESC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(row_to_direct_message_conversation)
+            .collect()
+    }
+
+    async fn put_direct_message_message(&self, row: DirectMessageMessageRow) -> Result<()> {
+        let tombstoned = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT 1
+            FROM dm_message_tombstones
+            WHERE dm_id = ?1 AND message_id = ?2
+            LIMIT 1
+            "#,
+        )
+        .bind(row.dm_id.as_str())
+        .bind(row.message_id.as_str())
+        .fetch_optional(&self.pool)
+        .await?
+        .is_some();
+        if tombstoned {
+            return Ok(());
+        }
+        let attachment_manifest_json = row
+            .attachment_manifest
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
+        sqlx::query(
+            r#"
+            INSERT INTO dm_messages (
+              dm_id, message_id, sender_pubkey, recipient_pubkey, created_at, text,
+              reply_to_message_id, attachment_manifest_json, outgoing, acked_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            ON CONFLICT(dm_id, message_id) DO UPDATE SET
+              sender_pubkey = excluded.sender_pubkey,
+              recipient_pubkey = excluded.recipient_pubkey,
+              created_at = excluded.created_at,
+              text = excluded.text,
+              reply_to_message_id = excluded.reply_to_message_id,
+              attachment_manifest_json = excluded.attachment_manifest_json,
+              outgoing = excluded.outgoing,
+              acked_at = excluded.acked_at
+            "#,
+        )
+        .bind(row.dm_id.as_str())
+        .bind(row.message_id.as_str())
+        .bind(row.sender_pubkey.as_str())
+        .bind(row.recipient_pubkey.as_str())
+        .bind(row.created_at)
+        .bind(row.text.as_deref())
+        .bind(row.reply_to_message_id.as_deref())
+        .bind(attachment_manifest_json.as_deref())
+        .bind(if row.outgoing { 1_i64 } else { 0_i64 })
+        .bind(row.acked_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_direct_message_message(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+    ) -> Result<Option<DirectMessageMessageRow>> {
+        let row = sqlx::query(
+            r#"
+            SELECT dm_id, message_id, sender_pubkey, recipient_pubkey, created_at, text,
+                   reply_to_message_id, attachment_manifest_json, outgoing, acked_at
+            FROM dm_messages
+            WHERE dm_id = ?1 AND message_id = ?2
+            "#,
+        )
+        .bind(dm_id)
+        .bind(message_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(row_to_direct_message_message).transpose()
+    }
+
+    async fn list_direct_message_messages(
+        &self,
+        dm_id: &str,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<Page<DirectMessageMessageRow>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT dm_id, message_id, sender_pubkey, recipient_pubkey, created_at, text,
+                   reply_to_message_id, attachment_manifest_json, outgoing, acked_at
+            FROM dm_messages
+            WHERE dm_id = ?1
+              AND (
+                ?2 IS NULL
+                OR created_at < ?2
+                OR (created_at = ?2 AND message_id < ?3)
+              )
+            ORDER BY created_at DESC, message_id DESC
+            LIMIT ?4
+            "#,
+        )
+        .bind(dm_id)
+        .bind(cursor.as_ref().map(|value| value.created_at))
+        .bind(cursor.as_ref().map(|value| value.object_id.as_str()))
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await?;
+        direct_message_page_from_rows(rows, limit)
+    }
+
+    async fn set_direct_message_acked_at(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+        acked_at: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            UPDATE dm_messages
+            SET acked_at = ?3
+            WHERE dm_id = ?1 AND message_id = ?2
+            "#,
+        )
+        .bind(dm_id)
+        .bind(message_id)
+        .bind(acked_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn put_direct_message_outbox(&self, row: DirectMessageOutboxRow) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO dm_outbox (
+              dm_id, message_id, peer_pubkey, frame_blob_hash, created_at, last_attempt_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            ON CONFLICT(dm_id, message_id) DO UPDATE SET
+              peer_pubkey = excluded.peer_pubkey,
+              frame_blob_hash = excluded.frame_blob_hash,
+              created_at = excluded.created_at,
+              last_attempt_at = excluded.last_attempt_at
+            "#,
+        )
+        .bind(row.dm_id.as_str())
+        .bind(row.message_id.as_str())
+        .bind(row.peer_pubkey.as_str())
+        .bind(row.frame_blob_hash.as_str())
+        .bind(row.created_at)
+        .bind(row.last_attempt_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_direct_message_outbox(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+    ) -> Result<Option<DirectMessageOutboxRow>> {
+        let row = sqlx::query(
+            r#"
+            SELECT dm_id, message_id, peer_pubkey, frame_blob_hash, created_at, last_attempt_at
+            FROM dm_outbox
+            WHERE dm_id = ?1 AND message_id = ?2
+            "#,
+        )
+        .bind(dm_id)
+        .bind(message_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(row_to_direct_message_outbox).transpose()
+    }
+
+    async fn list_direct_message_outbox(&self) -> Result<Vec<DirectMessageOutboxRow>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT dm_id, message_id, peer_pubkey, frame_blob_hash, created_at, last_attempt_at
+            FROM dm_outbox
+            ORDER BY created_at ASC, message_id ASC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(row_to_direct_message_outbox).collect()
+    }
+
+    async fn touch_direct_message_outbox_attempt(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+        attempted_at: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            UPDATE dm_outbox
+            SET last_attempt_at = ?3
+            WHERE dm_id = ?1 AND message_id = ?2
+            "#,
+        )
+        .bind(dm_id)
+        .bind(message_id)
+        .bind(attempted_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn remove_direct_message_outbox(&self, dm_id: &str, message_id: &str) -> Result<()> {
+        sqlx::query(
+            r#"
+            DELETE FROM dm_outbox
+            WHERE dm_id = ?1 AND message_id = ?2
+            "#,
+        )
+        .bind(dm_id)
+        .bind(message_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn put_direct_message_tombstone(&self, row: DirectMessageTombstoneRow) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO dm_message_tombstones (dm_id, message_id, deleted_at)
+            VALUES (?1, ?2, ?3)
+            ON CONFLICT(dm_id, message_id) DO UPDATE SET
+              deleted_at = excluded.deleted_at
+            "#,
+        )
+        .bind(row.dm_id.as_str())
+        .bind(row.message_id.as_str())
+        .bind(row.deleted_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn list_direct_message_tombstones(
+        &self,
+        dm_id: &str,
+    ) -> Result<Vec<DirectMessageTombstoneRow>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT dm_id, message_id, deleted_at
+            FROM dm_message_tombstones
+            WHERE dm_id = ?1
+            ORDER BY deleted_at DESC, message_id DESC
+            "#,
+        )
+        .bind(dm_id)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(row_to_direct_message_tombstone)
+            .collect()
+    }
+
+    async fn has_direct_message_tombstone(&self, dm_id: &str, message_id: &str) -> Result<bool> {
+        let exists = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT 1
+            FROM dm_message_tombstones
+            WHERE dm_id = ?1 AND message_id = ?2
+            LIMIT 1
+            "#,
+        )
+        .bind(dm_id)
+        .bind(message_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .is_some();
+        Ok(exists)
+    }
+
+    async fn delete_direct_message_message_local(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            DELETE FROM dm_messages
+            WHERE dm_id = ?1 AND message_id = ?2
+            "#,
+        )
+        .bind(dm_id)
+        .bind(message_id)
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"
+            DELETE FROM dm_outbox
+            WHERE dm_id = ?1 AND message_id = ?2
+            "#,
+        )
+        .bind(dm_id)
+        .bind(message_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn clear_direct_message_local(&self, dm_id: &str) -> Result<()> {
+        sqlx::query(
+            r#"
+            DELETE FROM dm_messages
+            WHERE dm_id = ?1
+            "#,
+        )
+        .bind(dm_id)
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"
+            DELETE FROM dm_outbox
+            WHERE dm_id = ?1
+            "#,
+        )
+        .bind(dm_id)
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            r#"
+            DELETE FROM dm_conversations
+            WHERE dm_id = ?1
+            "#,
+        )
+        .bind(dm_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     async fn rebuild_object_projections(&self, rows: Vec<ObjectProjectionRow>) -> Result<()> {
         sqlx::query("DELETE FROM object_thread_cache")
             .execute(&self.pool)
@@ -1977,6 +2491,259 @@ impl ProjectionStore for MemoryStore {
         Ok(())
     }
 
+    async fn upsert_direct_message_conversation(
+        &self,
+        row: DirectMessageConversationRow,
+    ) -> Result<()> {
+        self.direct_message_conversations
+            .write()
+            .await
+            .insert(row.dm_id.clone(), row);
+        Ok(())
+    }
+
+    async fn get_direct_message_conversation_by_peer(
+        &self,
+        peer_pubkey: &str,
+    ) -> Result<Option<DirectMessageConversationRow>> {
+        Ok(self
+            .direct_message_conversations
+            .read()
+            .await
+            .values()
+            .find(|row| row.peer_pubkey == peer_pubkey)
+            .cloned())
+    }
+
+    async fn get_direct_message_conversation_by_dm_id(
+        &self,
+        dm_id: &str,
+    ) -> Result<Option<DirectMessageConversationRow>> {
+        Ok(self
+            .direct_message_conversations
+            .read()
+            .await
+            .get(dm_id)
+            .cloned())
+    }
+
+    async fn list_direct_message_conversations(&self) -> Result<Vec<DirectMessageConversationRow>> {
+        let mut items = self
+            .direct_message_conversations
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        items.sort_by(|left, right| {
+            right
+                .updated_at
+                .cmp(&left.updated_at)
+                .then_with(|| right.dm_id.cmp(&left.dm_id))
+        });
+        Ok(items)
+    }
+
+    async fn put_direct_message_message(&self, row: DirectMessageMessageRow) -> Result<()> {
+        if self
+            .direct_message_tombstones
+            .read()
+            .await
+            .contains_key(&(row.dm_id.clone(), row.message_id.clone()))
+        {
+            return Ok(());
+        }
+        self.direct_message_rows
+            .write()
+            .await
+            .insert((row.dm_id.clone(), row.message_id.clone()), row);
+        Ok(())
+    }
+
+    async fn get_direct_message_message(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+    ) -> Result<Option<DirectMessageMessageRow>> {
+        Ok(self
+            .direct_message_rows
+            .read()
+            .await
+            .get(&(dm_id.to_string(), message_id.to_string()))
+            .cloned())
+    }
+
+    async fn list_direct_message_messages(
+        &self,
+        dm_id: &str,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<Page<DirectMessageMessageRow>> {
+        let mut items = self
+            .direct_message_rows
+            .read()
+            .await
+            .values()
+            .filter(|row| row.dm_id == dm_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        items.sort_by(|left, right| {
+            right
+                .created_at
+                .cmp(&left.created_at)
+                .then_with(|| right.message_id.cmp(&left.message_id))
+        });
+        Ok(apply_desc_direct_message_cursor(items, cursor, limit))
+    }
+
+    async fn set_direct_message_acked_at(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+        acked_at: i64,
+    ) -> Result<()> {
+        if let Some(row) = self
+            .direct_message_rows
+            .write()
+            .await
+            .get_mut(&(dm_id.to_string(), message_id.to_string()))
+        {
+            row.acked_at = Some(acked_at);
+        }
+        Ok(())
+    }
+
+    async fn put_direct_message_outbox(&self, row: DirectMessageOutboxRow) -> Result<()> {
+        self.direct_message_outbox_rows
+            .write()
+            .await
+            .insert((row.dm_id.clone(), row.message_id.clone()), row);
+        Ok(())
+    }
+
+    async fn get_direct_message_outbox(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+    ) -> Result<Option<DirectMessageOutboxRow>> {
+        Ok(self
+            .direct_message_outbox_rows
+            .read()
+            .await
+            .get(&(dm_id.to_string(), message_id.to_string()))
+            .cloned())
+    }
+
+    async fn list_direct_message_outbox(&self) -> Result<Vec<DirectMessageOutboxRow>> {
+        let mut items = self
+            .direct_message_outbox_rows
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        items.sort_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.message_id.cmp(&right.message_id))
+        });
+        Ok(items)
+    }
+
+    async fn touch_direct_message_outbox_attempt(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+        attempted_at: i64,
+    ) -> Result<()> {
+        if let Some(row) = self
+            .direct_message_outbox_rows
+            .write()
+            .await
+            .get_mut(&(dm_id.to_string(), message_id.to_string()))
+        {
+            row.last_attempt_at = Some(attempted_at);
+        }
+        Ok(())
+    }
+
+    async fn remove_direct_message_outbox(&self, dm_id: &str, message_id: &str) -> Result<()> {
+        self.direct_message_outbox_rows
+            .write()
+            .await
+            .remove(&(dm_id.to_string(), message_id.to_string()));
+        Ok(())
+    }
+
+    async fn put_direct_message_tombstone(&self, row: DirectMessageTombstoneRow) -> Result<()> {
+        self.direct_message_tombstones
+            .write()
+            .await
+            .insert((row.dm_id.clone(), row.message_id.clone()), row);
+        Ok(())
+    }
+
+    async fn list_direct_message_tombstones(
+        &self,
+        dm_id: &str,
+    ) -> Result<Vec<DirectMessageTombstoneRow>> {
+        let mut items = self
+            .direct_message_tombstones
+            .read()
+            .await
+            .values()
+            .filter(|row| row.dm_id == dm_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        items.sort_by(|left, right| {
+            right
+                .deleted_at
+                .cmp(&left.deleted_at)
+                .then_with(|| right.message_id.cmp(&left.message_id))
+        });
+        Ok(items)
+    }
+
+    async fn has_direct_message_tombstone(&self, dm_id: &str, message_id: &str) -> Result<bool> {
+        Ok(self
+            .direct_message_tombstones
+            .read()
+            .await
+            .contains_key(&(dm_id.to_string(), message_id.to_string())))
+    }
+
+    async fn delete_direct_message_message_local(
+        &self,
+        dm_id: &str,
+        message_id: &str,
+    ) -> Result<()> {
+        self.direct_message_rows
+            .write()
+            .await
+            .remove(&(dm_id.to_string(), message_id.to_string()));
+        self.direct_message_outbox_rows
+            .write()
+            .await
+            .remove(&(dm_id.to_string(), message_id.to_string()));
+        Ok(())
+    }
+
+    async fn clear_direct_message_local(&self, dm_id: &str) -> Result<()> {
+        self.direct_message_rows
+            .write()
+            .await
+            .retain(|(row_dm_id, _), _| row_dm_id != dm_id);
+        self.direct_message_outbox_rows
+            .write()
+            .await
+            .retain(|(row_dm_id, _), _| row_dm_id != dm_id);
+        self.direct_message_conversations
+            .write()
+            .await
+            .remove(dm_id);
+        Ok(())
+    }
+
     async fn rebuild_object_projections(&self, rows: Vec<ObjectProjectionRow>) -> Result<()> {
         let mut guard = self.object_projection_rows.write().await;
         guard.clear();
@@ -2086,6 +2853,79 @@ fn row_to_bookmarked_custom_reaction(
         width: row.get::<i64, _>("width") as u32,
         height: row.get::<i64, _>("height") as u32,
         bookmarked_at: row.get("bookmarked_at"),
+    })
+}
+
+fn row_to_direct_message_conversation(
+    row: sqlx::sqlite::SqliteRow,
+) -> Result<DirectMessageConversationRow> {
+    Ok(DirectMessageConversationRow {
+        dm_id: row.get("dm_id"),
+        peer_pubkey: row.get("peer_pubkey"),
+        updated_at: row.get("updated_at"),
+        last_message_at: row.try_get("last_message_at").ok(),
+        last_message_id: row.try_get("last_message_id").ok(),
+        last_message_preview: row.try_get("last_message_preview").ok(),
+    })
+}
+
+fn row_to_direct_message_message(row: sqlx::sqlite::SqliteRow) -> Result<DirectMessageMessageRow> {
+    Ok(DirectMessageMessageRow {
+        dm_id: row.get("dm_id"),
+        message_id: row.get("message_id"),
+        sender_pubkey: row.get("sender_pubkey"),
+        recipient_pubkey: row.get("recipient_pubkey"),
+        created_at: row.get("created_at"),
+        text: row.try_get("text").ok(),
+        reply_to_message_id: row.try_get("reply_to_message_id").ok(),
+        attachment_manifest: row
+            .try_get::<String, _>("attachment_manifest_json")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| serde_json::from_str(value.as_str()))
+            .transpose()?,
+        outgoing: row.get::<i64, _>("outgoing") != 0,
+        acked_at: row.try_get("acked_at").ok(),
+    })
+}
+
+fn direct_message_page_from_rows(
+    rows: Vec<sqlx::sqlite::SqliteRow>,
+    limit: usize,
+) -> Result<Page<DirectMessageMessageRow>> {
+    let mut items = Vec::with_capacity(rows.len());
+    for row in rows {
+        items.push(row_to_direct_message_message(row)?);
+    }
+    let next_cursor = if items.len() == limit {
+        items.last().map(|row| TimelineCursor {
+            created_at: row.created_at,
+            object_id: EnvelopeId::from(row.message_id.clone()),
+        })
+    } else {
+        None
+    };
+    Ok(Page { items, next_cursor })
+}
+
+fn row_to_direct_message_outbox(row: sqlx::sqlite::SqliteRow) -> Result<DirectMessageOutboxRow> {
+    Ok(DirectMessageOutboxRow {
+        dm_id: row.get("dm_id"),
+        message_id: row.get("message_id"),
+        peer_pubkey: row.get("peer_pubkey"),
+        frame_blob_hash: BlobHash::new(row.get::<String, _>("frame_blob_hash")),
+        created_at: row.get("created_at"),
+        last_attempt_at: row.try_get("last_attempt_at").ok(),
+    })
+}
+
+fn row_to_direct_message_tombstone(
+    row: sqlx::sqlite::SqliteRow,
+) -> Result<DirectMessageTombstoneRow> {
+    Ok(DirectMessageTombstoneRow {
+        dm_id: row.get("dm_id"),
+        message_id: row.get("message_id"),
+        deleted_at: row.get("deleted_at"),
     })
 }
 
@@ -2362,6 +3202,36 @@ fn apply_desc_projection_cursor(
         filtered.last().map(|row| TimelineCursor {
             created_at: row.created_at,
             object_id: row.object_id.clone(),
+        })
+    } else {
+        None
+    };
+    Page {
+        items: std::mem::take(&mut filtered),
+        next_cursor,
+    }
+}
+
+fn apply_desc_direct_message_cursor(
+    items: Vec<DirectMessageMessageRow>,
+    cursor: Option<TimelineCursor>,
+    limit: usize,
+) -> Page<DirectMessageMessageRow> {
+    let mut filtered = items
+        .into_iter()
+        .filter(|row| {
+            cursor.as_ref().is_none_or(|cursor| {
+                row.created_at < cursor.created_at
+                    || (row.created_at == cursor.created_at
+                        && row.message_id.as_str() < cursor.object_id.as_str())
+            })
+        })
+        .take(limit)
+        .collect::<Vec<_>>();
+    let next_cursor = if filtered.len() == limit {
+        filtered.last().map(|row| TimelineCursor {
+            created_at: row.created_at,
+            object_id: EnvelopeId::from(row.message_id.clone()),
         })
     } else {
         None
@@ -2751,6 +3621,137 @@ mod tests {
         assert_eq!(recent.len(), 2);
         assert_eq!(recent[0].normalized_reaction_key, "emoji:😂");
         assert_eq!(recent[1].normalized_reaction_key, "emoji:🔥");
+    }
+
+    #[tokio::test]
+    async fn direct_message_local_delete_prevents_duplicate_reinsert() {
+        let store = SqliteStore::connect_memory().await.expect("sqlite store");
+        let dm_id = "dm-test";
+        let message = DirectMessageMessageRow {
+            dm_id: dm_id.into(),
+            message_id: "message-1".into(),
+            sender_pubkey: "a".repeat(64),
+            recipient_pubkey: "b".repeat(64),
+            created_at: 10,
+            text: Some("hello".into()),
+            reply_to_message_id: None,
+            attachment_manifest: None,
+            outgoing: false,
+            acked_at: None,
+        };
+
+        ProjectionStore::put_direct_message_message(&store, message.clone())
+            .await
+            .expect("insert message");
+        ProjectionStore::put_direct_message_tombstone(
+            &store,
+            DirectMessageTombstoneRow {
+                dm_id: dm_id.into(),
+                message_id: "message-1".into(),
+                deleted_at: 20,
+            },
+        )
+        .await
+        .expect("insert tombstone");
+        ProjectionStore::delete_direct_message_message_local(&store, dm_id, "message-1")
+            .await
+            .expect("delete local message");
+        ProjectionStore::put_direct_message_message(&store, message)
+            .await
+            .expect("reinsert ignored");
+
+        let page = ProjectionStore::list_direct_message_messages(&store, dm_id, None, 20)
+            .await
+            .expect("list messages");
+        assert!(page.items.is_empty());
+        assert!(
+            ProjectionStore::has_direct_message_tombstone(&store, dm_id, "message-1")
+                .await
+                .expect("has tombstone")
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_message_delete_clears_outbox_but_keeps_tombstone() {
+        let store = SqliteStore::connect_memory().await.expect("sqlite store");
+        let dm_id = "dm-test";
+        ProjectionStore::upsert_direct_message_conversation(
+            &store,
+            DirectMessageConversationRow {
+                dm_id: dm_id.into(),
+                peer_pubkey: "b".repeat(64),
+                updated_at: 10,
+                last_message_at: Some(10),
+                last_message_id: Some("message-1".into()),
+                last_message_preview: Some("queued".into()),
+            },
+        )
+        .await
+        .expect("upsert conversation");
+        ProjectionStore::put_direct_message_message(
+            &store,
+            DirectMessageMessageRow {
+                dm_id: dm_id.into(),
+                message_id: "message-1".into(),
+                sender_pubkey: "a".repeat(64),
+                recipient_pubkey: "b".repeat(64),
+                created_at: 10,
+                text: Some("queued".into()),
+                reply_to_message_id: None,
+                attachment_manifest: None,
+                outgoing: true,
+                acked_at: None,
+            },
+        )
+        .await
+        .expect("put message");
+        ProjectionStore::put_direct_message_outbox(
+            &store,
+            DirectMessageOutboxRow {
+                dm_id: dm_id.into(),
+                message_id: "message-1".into(),
+                peer_pubkey: "b".repeat(64),
+                frame_blob_hash: BlobHash::new("frame-hash"),
+                created_at: 10,
+                last_attempt_at: None,
+            },
+        )
+        .await
+        .expect("put outbox");
+        ProjectionStore::put_direct_message_tombstone(
+            &store,
+            DirectMessageTombstoneRow {
+                dm_id: dm_id.into(),
+                message_id: "message-1".into(),
+                deleted_at: 20,
+            },
+        )
+        .await
+        .expect("put tombstone");
+        ProjectionStore::delete_direct_message_message_local(&store, dm_id, "message-1")
+            .await
+            .expect("delete message");
+        ProjectionStore::clear_direct_message_local(&store, dm_id)
+            .await
+            .expect("clear conversation");
+
+        assert!(
+            ProjectionStore::get_direct_message_outbox(&store, dm_id, "message-1")
+                .await
+                .expect("get outbox")
+                .is_none()
+        );
+        assert!(
+            ProjectionStore::get_direct_message_conversation_by_dm_id(&store, dm_id)
+                .await
+                .expect("get conversation")
+                .is_none()
+        );
+        assert!(
+            ProjectionStore::has_direct_message_tombstone(&store, dm_id, "message-1")
+                .await
+                .expect("has tombstone")
+        );
     }
 
     #[tokio::test]

--- a/docs/adr/0012-topic-first_progressive_community_filtering_draft.md
+++ b/docs/adr/0012-topic-first_progressive_community_filtering_draft.md
@@ -15,6 +15,10 @@ Accepted
 - `docs/adr/0010-kukuri-protocol-v1-boundary-definition.md`
 - `docs/adr/0011-kukuri-protocol-v1-draft.md`
 - `docs/adr/0013-social-graph-foundation-draft.md`
+- `docs/adr/0020-pairwise-dm-v1.md`
+
+## Note
+- pairwise DM は `private channel audience v1` の一部ではない。1on1 / local-only transcript / local-only delete / account-key E2E を持つ別データプレーンとして `0020` で扱う。
 
 ## Feature Data Classification
 

--- a/docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md
+++ b/docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md
@@ -14,6 +14,10 @@ Accepted
 - `docs/adr/0013-social-graph-foundation-draft.md`
 - `docs/adr/0014-uiux-dev-flow.md`
 - `docs/DESIGN.md`
+- `docs/adr/0020-pairwise-dm-v1.md`
+
+## Note
+- pairwise DM は channel / epoch lifecycle の対象外であり、global pairwise surface として `0020` の contract を優先する。
 
 ## Context
 - 現行 desktop shell では `channel` が `topic` の子である一方、UI 上は `Timeline / Channels / Live / Game / Profile` の並列 workspace として扱われていた。

--- a/docs/adr/0020-pairwise-dm-v1.md
+++ b/docs/adr/0020-pairwise-dm-v1.md
@@ -1,0 +1,76 @@
+# ADR 0020: Pairwise DM v1
+
+## Status
+Accepted
+
+## Date
+2026-03-30
+
+## Base Branch
+`main`
+
+## Related
+- `docs/adr/0012-topic-first_progressive_community_filtering_draft.md`
+- `docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md`
+- `docs/adr/0019-profile-avatar-blob-data-classification.md`
+
+## Summary
+- `chat` ではなく `DM` を正式方針にする。
+- DM v1 は `1on1 / global pairwise / mutual 限定 / offline 可 / local-only transcript / local-only delete / account-key E2E / image+video attachment 対応` で固定する。
+- private channel の UI / secure storage / blob transport / social graph は再利用するが、`docs` を正本にする private channel data plane は使わない。DM は `private channel audience v1` の外側にある別データプレーンとして定義する。
+
+## Feature Data Classification
+
+| 対象 | Canonical Source | Local Cache / Projection | v1 扱い |
+|---|---|---|---|
+| DM transcript | local SQLite DM store | same | local only |
+| DM outbox / retry state | local SQLite DM store | same | local only |
+| DM attachment blob | local encrypted blob store | blob cache | local only |
+| DM transport frame / ack | pairwise hint + blob transport | なし | transient |
+| social graph mutual 判定 | public author docs replica | SQLite projection | send gate 入力 |
+
+## Decision
+
+### 1. Conversation boundary
+- DM は `sorted(local_pubkey, peer_pubkey)` から導く stable `dm_id` を持つ。
+- 1 pair = 1 conversation とし、topic 配下には置かない。
+- `open/send` は mutual 相手にだけ許可する。
+- mutual が崩れた後も local history は読めるが、`send` と queued retry は停止する。mutual 復帰で再開する。
+
+### 2. Crypto / transport
+- account key から secp256k1 ECDH で pairwise root secret を導出し、HKDF で `frame key` と `attachment key` を domain-separated に派生する。
+- 本文は encrypted `DirectMessageFrameV1` として送る。
+- attachment blob は plaintext のまま送らず、message / attachment 単位の subkey で暗号化して送る。
+- `GossipHint` に DM 専用 variant を追加し、opaque な `dm_id / message_id` 通知だけを流す。
+- sender は encrypted frame を local outbox に保持し、recipient 到達時に再送する。recipient は decrypt / store 後に `DirectMessageAckV1` を返し、sender は retry state を外す。
+
+### 3. Attachment scope
+- v1 attachment は `image/*` と `video/*` のみ。
+- cardinality は single attach に揃え、`1 message = 1 image` または `1 video + poster` に固定する。
+- video は既存 poster pipeline を再利用し、poster 生成を必須にする。
+- attachment manifest は encrypted frame の内側にのみ入れる。
+
+### 4. Persistence / delete
+- `dm_conversations`, `dm_messages`, `dm_outbox`, `dm_message_tombstones` を local store に持つ。
+- delete は message 単位と conversation 全消去の両方を持つが、どちらも local only。
+- local delete は transcript と local attachment 参照を消す。queued outgoing message の delete は future delivery も中止する。
+- delete 済み message が retry / duplicate receive で復活しないよう、`message_id` tombstone は保持する。
+
+### 5. API / desktop surface
+- `kukuri-core` に `DirectMessageFrameV1`, `DirectMessageAckV1`, pairwise secret / topic, frame / attachment encrypt-decrypt helper を追加する。
+- `kukuri-app-api` / `desktop-runtime` に `open_direct_message`, `list_direct_messages`, `list_direct_message_messages`, `send_direct_message`, `delete_direct_message_message`, `clear_direct_message`, `get_direct_message_status` を追加する。
+- desktop は `AuthorDetail` の mutual 相手に `Message` action を出し、DM 一覧は private channel とは別 surface に置く。
+
+## Consequences
+- DM は docs replica に書かれないため、shared durable replica を truth source にしない。
+- sender が local delete した後の recipient 側 attachment 再取得は保証しない。
+- `reaction / repost / live / game / arbitrary file` は scope 外とし、v1 は text + reply-to + image/video attachment に限定する。
+
+## Test Plan
+- `dm_pairwise_secret_derives_same_topic_for_pair`
+- `dm_frame_encrypt_decrypt_roundtrip_and_tamper_reject`
+- `dm_send_requires_mutual_relationship`
+- `dm_offline_outbox_delivers_after_reconnect`
+- `dm_local_delete_prevents_duplicate_reinsert`
+- `dm_restart_resumes_pending_outbox`
+- `pairwise_dm_offline_text_image_video_delivery_and_local_delete`

--- a/harness/scenarios/pairwise_dm_offline_text_image_video_delivery_and_local_delete.yaml
+++ b/harness/scenarios/pairwise_dm_offline_text_image_video_delivery_and_local_delete.yaml
@@ -1,0 +1,12 @@
+name: pairwise_dm_offline_text_image_video_delivery_and_local_delete
+kind: pairwise_direct_message_connectivity
+fixtures:
+  seed: 20
+  topic: kukuri:topic:pairwise-dm-connectivity
+steps: []
+artifacts:
+  dump_logs: false
+  metrics_snapshot: true
+timeouts:
+  overall_ms: 180000
+  step_ms: 60000


### PR DESCRIPTION
## Summary
- add ADR 0020 and implement pairwise DM v1 across core, store, app-api, desktop runtime, Tauri bridge, and desktop UI
- support mutual-only 1:1 DMs with account-key E2E encryption, local-only transcript/outbox/tombstones, and image/video attachments
- add DM end-to-end coverage in app-api and harness, including restart/outbox recovery and local delete persistence

## Testing
- cd apps/desktop && npx pnpm@10.16.1 test -- --runInBand App.test.tsx
- cargo test -p kukuri-app-api dm_send_requires_mutual_relationship -- --nocapture
- cargo test -p kukuri-app-api dm_restart_resumes_pending_outbox_and_local_delete_prevents_duplicate_reinsert -- --nocapture
- cargo test -p kukuri-app-api dm_reopens_finished_subscription_when_hint_stream_closes -- --nocapture
- cargo test -p kukuri-app-api direct_message_peer_count_falls_back_to_connected_peers_when_topic_diagnostic_is_missing -- --nocapture
- cargo test -p kukuri-harness pairwise_dm_offline_text_image_video_delivery_and_local_delete -- --nocapture