### PR TITLE
docs: make README concept-first

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,11 +2,63 @@
 
 # kukuri
 
-Linux-first で再構築中の、Nostr ベースの topic-first social app です。
+kukuri は topic-first な P2P social app / protocol です。Nostr 由来の署名付き identity と envelope の利点は活かしつつ、内部の同期モデルは relay-first ではなく、`docs`、`blobs`、`hints`、connectivity を分離した構成を中核に据えています。
 
-## 現在の入口
+## kukuri とは何か
 
-新規開発は root workspace を対象にします。
+- topic が閲覧と発信の主軸です。
+- channel は topic 配下の audience / scope であり、独立した workspace ではありません。
+- public timeline、private channel、pairwise DM、live session、game room を同じ設計思想で扱います。
+- ユーザーは鍵をローカルに保持し、自分の identity で signed object を発行します。
+
+## 重要な設計原則
+
+- signed envelope は証明とメタデータであり、データプレーン全体そのものではありません。
+- hint は通知と同期のきっかけであり、source of truth ではありません。
+- structured state は `docs` で同期します。
+- media や大きな payload は `blobs` で同期します。
+- connectivity は static-peer、seeded DHT discovery、community-node assist が担います。
+- durability は offline 利用、restart 復元、late join backfill を前提に設計します。
+- community-node は bootstrap、auth、control plane、connectivity assist を担うもので、ユーザーコンテンツの canonical store ではありません。
+- Nostr 互換は identity、envelope 形状、一部 tag に限った subset であり、kukuri の内部同期モデルは kukuri 固有です。
+
+## 現在動いている範囲
+
+- desktop target: Linux / Windows
+- connectivity: static-peer、seeded DHT discovery、community-node connectivity/auth
+- topic timeline: public post、reply/thread、image 添付、video 添付
+- social graph v1: public profile、follow/unfollow、`mutual`、`friend of friend` 表示
+- private channel audience v1: `invite_only`、`friend_only`、`friend_plus` と epoch-aware lifecycle
+- pairwise DM v1: 1on1、mutual 限定、offline 可、local transcript/delete、image/video attachment
+- `docs + blobs` から復元できる live session / game room state
+
+現在のスコープは [foundation progress](./docs/progress/2026-03-10-foundation.md) と [docs/adr/](./docs/adr/) 配下の accepted ADR を正とします。
+
+## 今後の方向性
+
+- 検索やサジェストは、core sync plane に必須で埋め込むのではなく、optional な specialized service として扱えるようにする方針です。
+- gateway / bridge 層によって、選択的な import/export や ecosystem interoperability を持てる余地を残します。
+- trust、moderation、policy assist は community-node の周辺で拡張しうる一方、canonical content store にはしません。
+- これらは longer-term direction / optional ecosystem services であり、現行 workspace ですべて出荷済みという意味ではありません。
+
+## コントリビューター向け
+
+- 新規実装・修正は root workspace を対象にします。
+- `legacy/` は、明示的な移植タスクがない限り参照専用です。
+- 現在の truth は主に次です。
+  - [docs/progress/2026-03-10-foundation.md](./docs/progress/2026-03-10-foundation.md)
+  - [docs/README.md](./docs/README.md)
+  - [docs/runbooks/dev.md](./docs/runbooks/dev.md)
+  - [harness/scenarios/](./harness/scenarios/)
+- protocol / product の主要参照は次です。
+  - [docs/adr/0010-kukuri-protocol-v1-boundary-definition.md](./docs/adr/0010-kukuri-protocol-v1-boundary-definition.md)
+  - [docs/adr/0011-kukuri-protocol-v1-draft.md](./docs/adr/0011-kukuri-protocol-v1-draft.md)
+  - [docs/adr/0012-topic-first_progressive_community_filtering_draft.md](./docs/adr/0012-topic-first_progressive_community_filtering_draft.md)
+  - [docs/adr/0013-social-graph-foundation-draft.md](./docs/adr/0013-social-graph-foundation-draft.md)
+  - [docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md](./docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md)
+  - [docs/adr/0020-pairwise-dm-v1.md](./docs/adr/0020-pairwise-dm-v1.md)
+
+### 作業入口
 
 ```bash
 cargo xtask doctor
@@ -19,42 +71,7 @@ npx pnpm@10.16.1 install
 npx pnpm@10.16.1 dev
 ```
 
-## 現在の構成
-
-```text
-.
-├── apps/              # 現行の desktop app
-├── crates/            # 現行の Rust 実装
-├── docs/              # 現在の真実: adr / runbook / progress
-├── harness/           # scenario 定義
-├── legacy/            # cutover 前の資産と履歴アーカイブ
-└── .github/workflows/ # kukuri-fast.yml / kukuri-nightly.yml
-```
-
-## ルール
-
-- root workspace が実装対象です。
-- `legacy/` は参照専用です。
-- 現在の desktop target は Linux / Windows です。
-- 現在の network scope には static-peer、seeded DHT、community-node connectivity/auth が含まれます。
-- UI/UX 作業は `docs/adr/0014-uiux-dev-flow.md` と `docs/DESIGN.md` に従います。
-- 新規参加者は `AGENTS.md -> docs/*` だけで着手できます。
-
-## ドキュメント
-
-- overview: `docs/README.md`
-- decision: `docs/adr/0001-linux-first-mvp.md`
-- ui/ux flow: `docs/adr/0014-uiux-dev-flow.md`
-- design rules: `docs/DESIGN.md`
-- runbook: `docs/runbooks/dev.md`
-- progress: `docs/progress/2026-03-10-foundation.md`
-
-## 検証済み entrypoint
-
-- `cargo xtask doctor`
-- `cargo xtask check`
-- `cargo xtask test`
-- `cargo xtask e2e-smoke`
+日常コマンドや検証手順の詳細は [docs/runbooks/dev.md](./docs/runbooks/dev.md) を参照してください。
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,63 @@ English | [日本語](./README.ja.md)
 
 # kukuri
 
-A Linux-first rebuild of a Nostr-based topic-first social app.
+kukuri is a topic-first P2P social app and protocol. It keeps Nostr-derived signed identity and envelope semantics where they are useful, but its internal sync model is centered on separated `docs`, `blobs`, `hints`, and connectivity instead of a relay-first design.
 
-## Current Entry Point
+## What Is kukuri
 
-New work targets the root workspace.
+- Topics are the main browsing and publishing surface.
+- Channels are audience scopes under a topic, not standalone workspaces.
+- The same design aims to cover public timelines, private channels, pairwise DM, live sessions, and game rooms.
+- Users keep local key ownership and publish signed objects from their own identity.
+
+## Core Concepts
+
+- Signed envelopes are proof and metadata, not the whole data plane.
+- Hints are notifications and sync triggers, not a source of truth.
+- Structured state is synchronized through `docs`.
+- Media and other large payloads are synchronized through `blobs`.
+- Connectivity comes from static-peer links, seeded DHT discovery, and community-node assist.
+- Durability is designed around offline use, restart recovery, and late join backfill.
+- Community nodes are bootstrap, auth, control-plane, and connectivity-assist components, not the canonical store for user content.
+- Nostr compatibility is a limited subset for identity, envelope shape, and some tags; kukuri's internal sync model is its own.
+
+## What Works Today
+
+- Desktop targets: Linux and Windows.
+- Connectivity: static-peer, seeded DHT discovery, and community-node connectivity/auth.
+- Topic timeline flow: public posts, reply/thread, image attachments, and video attachments.
+- Social graph v1: public profiles, follow/unfollow, `mutual`, and `friend of friend` display.
+- Private channel audience v1: `invite_only`, `friend_only`, and `friend_plus` with epoch-aware lifecycle.
+- Pairwise DM v1: 1:1, mutual-only, offline-capable, local transcript/delete, and image/video attachments.
+- Live session and game room state that recover from `docs + blobs`.
+
+Current scope is defined by [foundation progress](./docs/progress/2026-03-10-foundation.md) and the accepted ADRs under [docs/adr/](./docs/adr/).
+
+## Longer-Term Direction
+
+- Search and suggestion can be provided by optional specialized services instead of becoming required parts of the core sync plane.
+- Gateway and bridge layers can provide selective import/export and ecosystem interoperability.
+- Trust, moderation, and policy-assist functions can grow around community nodes without turning them into the canonical content store.
+- These are planned directions and optional ecosystem services, not a statement that they are all shipped in the current workspace.
+
+## For Contributors
+
+- New work targets the root workspace.
+- `legacy/` is reference-only unless a task explicitly requires migration from it.
+- Current sources of truth:
+  - [docs/progress/2026-03-10-foundation.md](./docs/progress/2026-03-10-foundation.md)
+  - [docs/README.md](./docs/README.md)
+  - [docs/runbooks/dev.md](./docs/runbooks/dev.md)
+  - [harness/scenarios/](./harness/scenarios/)
+- Key protocol and product references:
+  - [docs/adr/0010-kukuri-protocol-v1-boundary-definition.md](./docs/adr/0010-kukuri-protocol-v1-boundary-definition.md)
+  - [docs/adr/0011-kukuri-protocol-v1-draft.md](./docs/adr/0011-kukuri-protocol-v1-draft.md)
+  - [docs/adr/0012-topic-first_progressive_community_filtering_draft.md](./docs/adr/0012-topic-first_progressive_community_filtering_draft.md)
+  - [docs/adr/0013-social-graph-foundation-draft.md](./docs/adr/0013-social-graph-foundation-draft.md)
+  - [docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md](./docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md)
+  - [docs/adr/0020-pairwise-dm-v1.md](./docs/adr/0020-pairwise-dm-v1.md)
+
+### Entry Points
 
 ```bash
 cargo xtask doctor
@@ -19,42 +71,7 @@ npx pnpm@10.16.1 install
 npx pnpm@10.16.1 dev
 ```
 
-## Current Layout
-
-```text
-.
-├── apps/              # current desktop app
-├── crates/            # current Rust implementation
-├── docs/              # current truth: adr / runbook / progress
-├── harness/           # scenario specs
-├── legacy/            # archived pre-cutover assets and docs history
-└── .github/workflows/ # kukuri-fast.yml / kukuri-nightly.yml
-```
-
-## Rules
-
-- root workspace is the active implementation surface.
-- `legacy/` is reference-only.
-- current desktop targets are Linux and Windows.
-- current networking scope includes static-peer, seeded DHT, and community-node connectivity/auth.
-- UI/UX work should follow `docs/adr/0014-uiux-dev-flow.md` and `docs/DESIGN.md`.
-- `AGENTS.md -> docs/*` is sufficient for new contributors.
-
-## Docs
-
-- overview: `docs/README.md`
-- decision: `docs/adr/0001-linux-first-mvp.md`
-- ui/ux flow: `docs/adr/0014-uiux-dev-flow.md`
-- design rules: `docs/DESIGN.md`
-- runbook: `docs/runbooks/dev.md`
-- progress: `docs/progress/2026-03-10-foundation.md`
-
-## Verified Entrypoints
-
-- `cargo xtask doctor`
-- `cargo xtask check`
-- `cargo xtask test`
-- `cargo xtask e2e-smoke`
+For day-to-day commands and validation paths, use [docs/runbooks/dev.md](./docs/runbooks/dev.md).
 
 ## License
 


### PR DESCRIPTION
## Summary
- rewrite the English and Japanese README files around kukuri's product and protocol concepts
- separate current scope from longer-term direction so legacy vision items do not read as shipped features
- move contributor entrypoints and reference docs to the end of each README

## Testing
- not run (documentation-only)