### PR TITLE
Add local author mute and social management page

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -13,8 +13,9 @@ use kukuri_desktop_runtime::{
     ImportFriendOnlyGrantRequest, ImportFriendPlusShareRequest, ImportPeerTicketRequest,
     ImportPrivateChannelInviteRequest, ListDirectMessageMessagesRequest, ListGameRoomsRequest,
     ListJoinedPrivateChannelsRequest, ListLiveSessionsRequest, ListProfileTimelineRequest,
-    ListRecentReactionsRequest, ListThreadRequest, ListTimelineRequest, LiveSessionCommandRequest,
-    RemoveBookmarkedCustomReactionRequest, RemoveBookmarkedPostRequest,
+    ListRecentReactionsRequest, ListSocialConnectionsRequest, ListThreadRequest,
+    ListTimelineRequest, LiveSessionCommandRequest, RemoveBookmarkedCustomReactionRequest,
+    RemoveBookmarkedPostRequest,
     RotatePrivateChannelRequest, SendDirectMessageRequest, SetCommunityNodeConfigRequest,
     SetDiscoverySeedsRequest, SetMyProfileRequest, ToggleReactionRequest,
     UnsubscribeTopicRequest, UpdateGameRoomRequest, resolve_db_path_from_env,
@@ -435,6 +436,34 @@ async fn get_author_social_view(
     state
         .runtime
         .get_author_social_view(request)
+        .await
+        .map_err(map_error)
+}
+
+#[tauri::command]
+async fn mute_author(
+    state: tauri::State<'_, DesktopState>,
+    request: AuthorRequest,
+) -> Result<kukuri_app_api::AuthorSocialView, String> {
+    state.runtime.mute_author(request).await.map_err(map_error)
+}
+
+#[tauri::command]
+async fn unmute_author(
+    state: tauri::State<'_, DesktopState>,
+    request: AuthorRequest,
+) -> Result<kukuri_app_api::AuthorSocialView, String> {
+    state.runtime.unmute_author(request).await.map_err(map_error)
+}
+
+#[tauri::command]
+async fn list_social_connections(
+    state: tauri::State<'_, DesktopState>,
+    request: ListSocialConnectionsRequest,
+) -> Result<Vec<kukuri_app_api::AuthorSocialView>, String> {
+    state
+        .runtime
+        .list_social_connections(request)
         .await
         .map_err(map_error)
 }
@@ -871,6 +900,9 @@ pub fn run() {
             follow_author,
             unfollow_author,
             get_author_social_view,
+            mute_author,
+            unmute_author,
+            list_social_connections,
             open_direct_message,
             list_direct_messages,
             list_direct_message_messages,

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -2392,7 +2392,7 @@ test('profile social management updates follow and mute lists and muted authors 
               host_pubkey: mutedAuthorPubkey,
               title: 'Muted Room',
               description: 'muted host room',
-              status: 'Open',
+              status: 'Waiting',
               phase_label: null,
               scores: [
                 {
@@ -2415,7 +2415,7 @@ test('profile social management updates follow and mute lists and muted authors 
               host_pubkey: visibleAuthorPubkey,
               title: 'Visible Room',
               description: 'visible host room',
-              status: 'Open',
+              status: 'Waiting',
               phase_label: null,
               scores: [
                 {

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -234,6 +234,10 @@ function getTimelineViewTabs() {
   return screen.getByRole('tablist', { name: 'Timeline views' });
 }
 
+function getSocialConnectionsTabs() {
+  return screen.getByRole('tablist', { name: 'Social connections' });
+}
+
 async function selectWorkspace(
   user: ReturnType<typeof userEvent.setup>,
   label: 'Timeline' | 'Live' | 'Game' | 'Profile'
@@ -626,6 +630,63 @@ test('profile edit route restores the editor and keeps overview as the default p
 
   expect(screen.getByPlaceholderText('Visible label')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Back to profile' })).toBeInTheDocument();
+});
+
+test('profile connections route restores the requested view', async () => {
+  const authorPubkey = 'b'.repeat(64);
+  renderAtHash(
+    '#/profile?topic=kukuri%3Atopic%3Ademo&profileMode=connections&connectionsView=muted',
+    createDesktopMockApi({
+      authorSocialViews: {
+        [authorPubkey]: {
+          name: 'bob',
+          muted: true,
+        },
+      },
+    })
+  );
+
+  const tabs = await screen.findByRole('tablist', { name: 'Social connections' });
+  await waitFor(() => {
+    expect(within(tabs).getByRole('tab', { name: 'Muted' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(window.location.hash).toBe(
+      '#/profile?topic=kukuri%3Atopic%3Ademo&profileMode=connections&connectionsView=muted'
+    );
+  });
+  expect(
+    screen.getAllByText('Muted is local-only and is not shared with other devices.').length
+  ).toBeGreaterThan(0);
+  expect(screen.getByText(authorPubkey)).toBeInTheDocument();
+});
+
+test('invalid profile connections view normalizes to following', async () => {
+  const authorPubkey = 'b'.repeat(64);
+  renderAtHash(
+    '#/profile?topic=kukuri%3Atopic%3Ademo&profileMode=connections&connectionsView=invalid',
+    createDesktopMockApi({
+      authorSocialViews: {
+        [authorPubkey]: {
+          name: 'bob',
+          following: true,
+        },
+      },
+    })
+  );
+
+  const tabs = await screen.findByRole('tablist', { name: 'Social connections' });
+  await waitFor(() => {
+    expect(within(tabs).getByRole('tab', { name: 'Following' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(window.location.hash).toBe(
+      '#/profile?topic=kukuri%3Atopic%3Ademo&profileMode=connections&connectionsView=following'
+    );
+  });
+  expect(screen.getByText(authorPubkey)).toBeInTheDocument();
 });
 
 test('invalid nested author route keeps the thread pane and normalizes only the author param', async () => {
@@ -2244,6 +2305,259 @@ test('post card shows friend of friend badge and author name fallback', async ()
   expect(screen.getByText('friend of friend')).toBeInTheDocument();
 });
 
+test('profile social management updates follow and mute lists and muted authors disappear from content surfaces', async () => {
+  const mutedAuthorPubkey = 'b'.repeat(64);
+  const visibleAuthorPubkey = 'c'.repeat(64);
+  const user = userEvent.setup();
+
+  render(
+    <App
+      api={createDesktopMockApi({
+        seedPosts: {
+          'kukuri:topic:demo': [
+            {
+              object_id: 'post-muted-author',
+              envelope_id: 'envelope-muted-author',
+              author_pubkey: mutedAuthorPubkey,
+              author_name: 'bob',
+              author_display_name: null,
+              following: false,
+              followed_by: true,
+              mutual: false,
+              friend_of_friend: false,
+              object_kind: 'post',
+              content: 'mute this post',
+              content_status: 'Available',
+              attachments: [],
+              created_at: 2,
+              reply_to: null,
+              root_id: 'post-muted-author',
+              audience_label: 'Public',
+            },
+            {
+              object_id: 'post-visible-author',
+              envelope_id: 'envelope-visible-author',
+              author_pubkey: visibleAuthorPubkey,
+              author_name: 'carol',
+              author_display_name: null,
+              following: false,
+              followed_by: false,
+              mutual: false,
+              friend_of_friend: false,
+              object_kind: 'post',
+              content: 'keep this post',
+              content_status: 'Available',
+              attachments: [],
+              created_at: 1,
+              reply_to: null,
+              root_id: 'post-visible-author',
+              audience_label: 'Public',
+            },
+          ],
+        },
+        seedLiveSessions: {
+          'kukuri:topic:demo': [
+            {
+              session_id: 'live-muted',
+              host_pubkey: mutedAuthorPubkey,
+              title: 'Muted Live',
+              description: 'muted host session',
+              status: 'Live',
+              started_at: 2,
+              ended_at: null,
+              viewer_count: 0,
+              joined_by_me: false,
+              channel_id: null,
+              audience_label: 'Public',
+            },
+            {
+              session_id: 'live-visible',
+              host_pubkey: visibleAuthorPubkey,
+              title: 'Visible Live',
+              description: 'visible host session',
+              status: 'Live',
+              started_at: 1,
+              ended_at: null,
+              viewer_count: 0,
+              joined_by_me: false,
+              channel_id: null,
+              audience_label: 'Public',
+            },
+          ],
+        },
+        seedGameRooms: {
+          'kukuri:topic:demo': [
+            {
+              room_id: 'room-muted',
+              host_pubkey: mutedAuthorPubkey,
+              title: 'Muted Room',
+              description: 'muted host room',
+              status: 'Open',
+              phase_label: null,
+              scores: [
+                {
+                  participant_id: 'participant-bob',
+                  label: 'Bob',
+                  score: 0,
+                },
+                {
+                  participant_id: 'participant-carol',
+                  label: 'Carol',
+                  score: 0,
+                },
+              ],
+              updated_at: 2,
+              channel_id: null,
+              audience_label: 'Public',
+            },
+            {
+              room_id: 'room-visible',
+              host_pubkey: visibleAuthorPubkey,
+              title: 'Visible Room',
+              description: 'visible host room',
+              status: 'Open',
+              phase_label: null,
+              scores: [
+                {
+                  participant_id: 'participant-dave',
+                  label: 'Dave',
+                  score: 0,
+                },
+                {
+                  participant_id: 'participant-erin',
+                  label: 'Erin',
+                  score: 0,
+                },
+              ],
+              updated_at: 1,
+              channel_id: null,
+              audience_label: 'Public',
+            },
+          ],
+        },
+        authorSocialViews: {
+          [mutedAuthorPubkey]: {
+            name: 'bob',
+            followed_by: true,
+          },
+          [visibleAuthorPubkey]: {
+            name: 'carol',
+          },
+        },
+      })}
+    />
+  );
+
+  const mutedPostCard = (await screen.findByText('mute this post')).closest('article');
+  if (!(mutedPostCard instanceof HTMLElement)) {
+    throw new Error('muted author post card not found');
+  }
+  await user.click(within(mutedPostCard).getByRole('button', { name: 'Bookmark' }));
+  await waitFor(() => {
+    expect(within(mutedPostCard).getByRole('button', { name: 'Remove bookmark' })).toBeInTheDocument();
+  });
+
+  await selectWorkspace(user, 'Profile');
+  await user.click(screen.getByRole('button', { name: 'Manage Follows & Mutes' }));
+
+  const tabs = getSocialConnectionsTabs();
+  await waitFor(() => {
+    expect(within(tabs).getByRole('tab', { name: 'Following' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+  expect(screen.getByText('You are not following anyone yet.')).toBeInTheDocument();
+
+  await user.click(within(tabs).getByRole('tab', { name: 'Followed' }));
+  await waitFor(() => {
+    expect(within(tabs).getByRole('tab', { name: 'Followed' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+  expect(
+    screen.getAllByText('Followed shows only followers already observed on this device.').length
+  ).toBeGreaterThan(0);
+
+  let bobConnectionCard = screen.getByText(mutedAuthorPubkey).closest('article');
+  if (!(bobConnectionCard instanceof HTMLElement)) {
+    throw new Error('followed author card not found');
+  }
+  await user.click(within(bobConnectionCard).getByRole('button', { name: 'Follow' }));
+  await waitFor(() => {
+    const refreshedCard = screen.getByText(mutedAuthorPubkey).closest('article');
+    expect(refreshedCard).toBeInstanceOf(HTMLElement);
+    expect(
+      within(refreshedCard as HTMLElement).getByRole('button', { name: 'Unfollow' })
+    ).toBeInTheDocument();
+  });
+
+  bobConnectionCard = screen.getByText(mutedAuthorPubkey).closest('article');
+  if (!(bobConnectionCard instanceof HTMLElement)) {
+    throw new Error('refreshed followed author card not found');
+  }
+  await user.click(within(bobConnectionCard).getByRole('button', { name: 'Mute' }));
+  await waitFor(() => {
+    const refreshedCard = screen.getByText(mutedAuthorPubkey).closest('article');
+    expect(refreshedCard).toBeInstanceOf(HTMLElement);
+    expect(within(refreshedCard as HTMLElement).getByText('Muted')).toBeInTheDocument();
+    expect(
+      within(refreshedCard as HTMLElement).getByRole('button', { name: 'Unmute' })
+    ).toBeInTheDocument();
+  });
+
+  await user.click(within(tabs).getByRole('tab', { name: 'Following' }));
+  await waitFor(() => {
+    expect(within(tabs).getByRole('tab', { name: 'Following' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+  bobConnectionCard = screen.getByText(mutedAuthorPubkey).closest('article');
+  if (!(bobConnectionCard instanceof HTMLElement)) {
+    throw new Error('following author card not found');
+  }
+  expect(within(bobConnectionCard).getByRole('button', { name: 'Unfollow' })).toBeInTheDocument();
+
+  await user.click(within(tabs).getByRole('tab', { name: 'Muted' }));
+  await waitFor(() => {
+    expect(within(tabs).getByRole('tab', { name: 'Muted' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+  bobConnectionCard = screen.getByText(mutedAuthorPubkey).closest('article');
+  if (!(bobConnectionCard instanceof HTMLElement)) {
+    throw new Error('muted author card not found');
+  }
+  expect(within(bobConnectionCard).getByRole('button', { name: 'Unmute' })).toBeInTheDocument();
+  expect(within(bobConnectionCard).getByText('Muted')).toBeInTheDocument();
+
+  await selectWorkspace(user, 'Timeline');
+  await waitFor(() => {
+    expect(screen.queryByText('mute this post')).not.toBeInTheDocument();
+  });
+  expect(screen.getByText('keep this post')).toBeInTheDocument();
+
+  await selectTimelineView(user, 'Bookmarks');
+  await waitFor(() => {
+    expect(screen.getByText('No bookmarked posts yet.')).toBeInTheDocument();
+  });
+
+  await selectWorkspace(user, 'Live');
+  await waitFor(() => {
+    expect(screen.queryByText('Muted Live')).not.toBeInTheDocument();
+  });
+  expect(screen.getByText('Visible Live')).toBeInTheDocument();
+
+  await selectWorkspace(user, 'Game');
+  await waitFor(() => {
+    expect(screen.queryByText('Muted Room')).not.toBeInTheDocument();
+  });
+  expect(screen.getByText('Visible Room')).toBeInTheDocument();
+});
+
 test('author detail shows via authors and follow action updates relationship', async () => {
   const authorPubkey = 'b'.repeat(64);
   const viaA = 'c'.repeat(64);
@@ -2296,6 +2610,58 @@ test('author detail shows via authors and follow action updates relationship', a
     expect(screen.getByRole('button', { name: 'Unfollow' })).toBeInTheDocument();
   });
   expect(screen.getAllByText('following').length).toBeGreaterThan(0);
+});
+
+test('author detail mute toggle updates the selected author state', async () => {
+  const authorPubkey = 'b'.repeat(64);
+  const user = userEvent.setup();
+  render(
+    <App
+      api={createDesktopMockApi({
+        seedPosts: {
+          'kukuri:topic:demo': [
+            {
+              object_id: 'post-author-mute',
+              envelope_id: 'envelope-author-mute',
+              author_pubkey: authorPubkey,
+              author_name: 'bob',
+              author_display_name: null,
+              following: false,
+              followed_by: false,
+              mutual: false,
+              friend_of_friend: false,
+              object_kind: 'post',
+              content: 'author mute target',
+              content_status: 'Available',
+              attachments: [],
+              created_at: 1,
+              reply_to: null,
+              root_id: 'post-author-mute',
+              audience_label: 'Public',
+            },
+          ],
+        },
+        authorSocialViews: {
+          [authorPubkey]: {
+            name: 'bob',
+            about: 'author detail stays visible while muted',
+          },
+        },
+      })}
+    />
+  );
+
+  await user.click(await screen.findByRole('button', { name: 'bob' }));
+
+  const authorPane = await screen.findByRole('complementary', { name: 'Author' });
+  expect(within(authorPane).getByRole('button', { name: 'Mute' })).toBeInTheDocument();
+
+  await user.click(within(authorPane).getByRole('button', { name: 'Mute' }));
+
+  await waitFor(() => {
+    expect(within(authorPane).getByRole('button', { name: 'Unmute' })).toBeInTheDocument();
+  });
+  expect(within(authorPane).getByText('author detail stays visible while muted')).toBeInTheDocument();
 });
 
 test('author detail mutual action opens the direct message pane and sends a local message', async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -119,7 +119,6 @@ import {
   ReactionKeyInput,
   ReactionStateView,
   RecentReactionView,
-  SocialConnectionKind,
   SyncStatus,
   TimelineScope,
   TopicSyncStatus,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/components/core/types';
 import { ProfileOverviewPanel } from '@/components/extended/ProfileOverviewPanel';
 import { ProfileEditorPanel } from '@/components/extended/ProfileEditorPanel';
+import { ProfileConnectionsPanel } from '@/components/extended/ProfileConnectionsPanel';
 import { PrivateChannelPanel } from '@/components/extended/PrivateChannelPanel';
 import { AppearancePanel } from '@/components/settings/AppearancePanel';
 import { CommunityNodePanel } from '@/components/settings/CommunityNodePanel';
@@ -65,6 +66,7 @@ import { SettingsDrawer } from '@/components/shell/SettingsDrawer';
 import { ShellTopBar } from '@/components/shell/ShellTopBar';
 import {
   type PrimarySection,
+  type ProfileConnectionsView,
   type ProfileWorkspaceMode,
   type SettingsSection,
   type ShellChromeState,
@@ -117,6 +119,7 @@ import {
   ReactionKeyInput,
   ReactionStateView,
   RecentReactionView,
+  SocialConnectionKind,
   SyncStatus,
   TimelineScope,
   TopicSyncStatus,
@@ -154,6 +157,8 @@ type AsyncPanelState = {
   error: string | null;
 };
 
+type SocialConnectionsState = Record<ProfileConnectionsView, AuthorSocialView[]>;
+
 type DesktopShellState = {
   trackedTopics: string[];
   activeTopic: string;
@@ -189,6 +194,8 @@ type DesktopShellState = {
   syncStatus: SyncStatus;
   localProfile: Profile | null;
   profileTimeline: PostView[];
+  socialConnections: SocialConnectionsState;
+  socialConnectionsPanelState: AsyncPanelState;
   ownedReactionAssets: CustomReactionAssetView[];
   bookmarkedReactionAssets: BookmarkedCustomReactionView[];
   bookmarkedPosts: BookmarkedPostView[];
@@ -259,6 +266,7 @@ type DesktopShellRouteOverrides = {
   composeTarget?: ChannelRef;
   primarySection?: PrimarySection;
   profileMode?: ProfileWorkspaceMode;
+  profileConnectionsView?: ProfileConnectionsView;
   selectedAuthorPubkey?: string | null;
   directMessagePaneOpen?: boolean;
   selectedDirectMessagePeerPubkey?: string | null;
@@ -314,6 +322,11 @@ const DEFAULT_DISCOVERY_CONFIG: DiscoveryConfig = {
 };
 const DEFAULT_COMMUNITY_NODE_CONFIG: CommunityNodeConfig = {
   nodes: [],
+};
+const DEFAULT_SOCIAL_CONNECTIONS: SocialConnectionsState = {
+  following: [],
+  followed: [],
+  muted: [],
 };
 const DEFAULT_SYNC_STATUS: SyncStatus = {
   connected: false,
@@ -391,6 +404,8 @@ function createInitialShellState(): DesktopShellState {
     syncStatus: DEFAULT_SYNC_STATUS,
     localProfile: null,
     profileTimeline: [],
+    socialConnections: DEFAULT_SOCIAL_CONNECTIONS,
+    socialConnectionsPanelState: DEFAULT_ASYNC_PANEL_STATE,
     ownedReactionAssets: [],
     bookmarkedReactionAssets: [],
     bookmarkedPosts: [],
@@ -451,6 +466,7 @@ function createInitialShellState(): DesktopShellState {
       timelineView: 'feed',
       activeSettingsSection: 'connectivity',
       profileMode: 'overview',
+      profileConnectionsView: 'following',
       navOpen: false,
       settingsOpen: false,
     },
@@ -551,6 +567,10 @@ function isSettingsSection(value: string | null): value is SettingsSection {
     value === 'community-node' ||
     value === 'reactions'
   );
+}
+
+function isProfileConnectionsView(value: string | null): value is ProfileConnectionsView {
+  return value === 'following' || value === 'followed' || value === 'muted';
 }
 
 const PRIMARY_SECTION_PATHS: Record<PrimarySection, string> = {
@@ -1408,6 +1428,8 @@ function DesktopShellPage({
     syncStatus,
     localProfile,
     profileTimeline,
+    socialConnections,
+    socialConnectionsPanelState,
     ownedReactionAssets,
     bookmarkedReactionAssets,
     bookmarkedPosts,
@@ -1598,6 +1620,14 @@ function DesktopShellPage({
   const setSyncStatus = useMemo(() => makeFieldSetter('syncStatus'), [makeFieldSetter]);
   const setLocalProfile = useMemo(() => makeFieldSetter('localProfile'), [makeFieldSetter]);
   const setProfileTimeline = useMemo(() => makeFieldSetter('profileTimeline'), [makeFieldSetter]);
+  const setSocialConnections = useMemo(
+    () => makeFieldSetter('socialConnections'),
+    [makeFieldSetter]
+  );
+  const setSocialConnectionsPanelState = useMemo(
+    () => makeFieldSetter('socialConnectionsPanelState'),
+    [makeFieldSetter]
+  );
   const setOwnedReactionAssets = useMemo(
     () => makeFieldSetter('ownedReactionAssets'),
     [makeFieldSetter]
@@ -1817,6 +1847,8 @@ function DesktopShellPage({
     return audienceLabelForChannelRef(activeComposeChannel, activeJoinedChannels);
   }, [activeComposeChannel, activeJoinedChannels, replyTarget, repostTarget]);
   const profileMode = shellChromeState.profileMode;
+  const profileConnectionsView = shellChromeState.profileConnectionsView;
+  const activeSocialConnections = socialConnections[profileConnectionsView] ?? [];
   const activePrivateChannel = useMemo(
     () =>
       selectedPrivateChannelId
@@ -1911,6 +1943,8 @@ function DesktopShellPage({
     const resolvedPrimarySection = nextPrimarySection;
     const nextTimelineView = overrides?.timelineView ?? shellChromeState.timelineView;
     const nextProfileMode = overrides?.profileMode ?? shellChromeState.profileMode;
+    const nextProfileConnectionsView =
+      overrides?.profileConnectionsView ?? shellChromeState.profileConnectionsView;
     const nextSelectedThread = hasOverride('selectedThread')
       ? overrides?.selectedThread ?? null
       : selectedThread;
@@ -1968,6 +2002,10 @@ function DesktopShellPage({
     if (resolvedPrimarySection === 'profile' && nextProfileMode === 'edit') {
       search.set('profileMode', 'edit');
     }
+    if (resolvedPrimarySection === 'profile' && nextProfileMode === 'connections') {
+      search.set('profileMode', 'connections');
+      search.set('connectionsView', nextProfileConnectionsView);
+    }
     if (nextSettingsOpen) {
       search.set('settings', nextSettingsSection);
     }
@@ -1996,6 +2034,7 @@ function DesktopShellPage({
     shellChromeState.timelineView,
     shellChromeState.activeSettingsSection,
     shellChromeState.profileMode,
+    shellChromeState.profileConnectionsView,
     shellChromeState.settingsOpen,
   ]);
   const liveSessionListItems = useMemo(
@@ -2238,6 +2277,9 @@ function DesktopShellPage({
           bookmarkedReactionAssetsResult,
           bookmarkedPostsResult,
           recentReactionsResult,
+          followingConnectionsResult,
+          followedConnectionsResult,
+          mutedConnectionsResult,
         ] = await Promise.allSettled([
           api.getDiscoveryConfig(),
           api.getCommunityNodeConfig(),
@@ -2261,6 +2303,9 @@ function DesktopShellPage({
           api.listBookmarkedCustomReactions(),
           api.listBookmarkedPosts(),
           api.listRecentReactions(8),
+          api.listSocialConnections('following'),
+          api.listSocialConnections('followed'),
+          api.listSocialConnections('muted'),
         ]);
         if (requestId !== loadTopicsRequestRef.current) {
           return;
@@ -2394,6 +2439,43 @@ function DesktopShellPage({
           }
           if (recentReactionsResult.status === 'fulfilled') {
             setRecentReactions(recentReactionsResult.value);
+          }
+          if (
+            followingConnectionsResult.status === 'fulfilled' &&
+            followedConnectionsResult.status === 'fulfilled' &&
+            mutedConnectionsResult.status === 'fulfilled'
+          ) {
+            setSocialConnections({
+              following: followingConnectionsResult.value,
+              followed: followedConnectionsResult.value,
+              muted: mutedConnectionsResult.value,
+            });
+            setSocialConnectionsPanelState({
+              status: 'ready',
+              error: null,
+            });
+          } else {
+            setSocialConnections(DEFAULT_SOCIAL_CONNECTIONS);
+            setSocialConnectionsPanelState({
+              status: 'error',
+              error:
+                followingConnectionsResult.status === 'rejected'
+                  ? messageFromError(
+                      followingConnectionsResult.reason,
+                      translate('common:errors.failedToLoadSocialConnections')
+                    )
+                  : followedConnectionsResult.status === 'rejected'
+                    ? messageFromError(
+                        followedConnectionsResult.reason,
+                        translate('common:errors.failedToLoadSocialConnections')
+                      )
+                    : mutedConnectionsResult.status === 'rejected'
+                      ? messageFromError(
+                          mutedConnectionsResult.reason,
+                          translate('common:errors.failedToLoadSocialConnections')
+                        )
+                      : null,
+            });
           }
           setReactionPanelState({
             status:
@@ -2563,6 +2645,8 @@ function DesktopShellPage({
       setBookmarkedPosts,
       setRecentReactions,
       setReactionPanelState,
+      setSocialConnections,
+      setSocialConnectionsPanelState,
       setSelectedAuthor,
       setSelectedAuthorTimeline,
       setSyncStatus,
@@ -2791,6 +2875,7 @@ function DesktopShellPage({
       ...current,
       activePrimarySection: section,
       profileMode: section === 'profile' ? 'overview' : current.profileMode,
+      profileConnectionsView: section === 'profile' ? 'following' : current.profileConnectionsView,
       navOpen: false,
     }));
     setSelectedThread(null);
@@ -2804,6 +2889,7 @@ function DesktopShellPage({
     syncRoute('push', {
       primarySection: section,
       profileMode: section === 'profile' ? 'overview' : undefined,
+      profileConnectionsView: section === 'profile' ? 'following' : undefined,
       selectedAuthorPubkey: null,
       selectedThread: null,
     });
@@ -3238,6 +3324,23 @@ function DesktopShellPage({
       profileMode: 'edit',
     });
   }, [setShellChromeState, syncRoute]);
+
+  const openProfileConnections = useCallback(
+    (view: ProfileConnectionsView = 'following') => {
+      setShellChromeState((current) => ({
+        ...current,
+        activePrimarySection: 'profile',
+        profileMode: 'connections',
+        profileConnectionsView: view,
+      }));
+      syncRoute('push', {
+        primarySection: 'profile',
+        profileMode: 'connections',
+        profileConnectionsView: view,
+      });
+    },
+    [setShellChromeState, syncRoute]
+  );
 
   function handleSelectPrivateChannel(topicId: string, channelId: string) {
     setSelectedChannelIdByTopic((current) => ({
@@ -4176,15 +4279,35 @@ function DesktopShellPage({
       const nextView = following
         ? await api.unfollowAuthor(authorPubkey)
         : await api.followAuthor(authorPubkey);
-      setSelectedAuthorPubkey(authorPubkey);
-      setSelectedAuthor(nextView);
-      setAuthorError(null);
+      if (selectedAuthorPubkey === authorPubkey) {
+        setSelectedAuthor(nextView);
+        setAuthorError(null);
+      }
       await loadTopics(trackedTopics, activeTopic, selectedThread);
     } catch (relationshipError) {
       setAuthorError(
         relationshipError instanceof Error
           ? relationshipError.message
           : translate('common:errors.failedToUpdateFollowState')
+      );
+    }
+  }
+
+  async function handleMuteAction(authorPubkey: string, muted: boolean) {
+    try {
+      const nextView = muted
+        ? await api.unmuteAuthor(authorPubkey)
+        : await api.muteAuthor(authorPubkey);
+      if (selectedAuthorPubkey === authorPubkey) {
+        setSelectedAuthor(nextView);
+        setAuthorError(null);
+      }
+      await loadTopics(trackedTopics, activeTopic, selectedThread);
+    } catch (muteError) {
+      setAuthorError(
+        muteError instanceof Error
+          ? muteError.message
+          : translate('common:errors.failedToUpdateMuteState')
       );
     }
   }
@@ -4577,6 +4700,7 @@ function DesktopShellPage({
     const requestedSettingsSection = params.get('settings');
     const requestedContext = params.get('context');
     const requestedProfileMode = params.get('profileMode');
+    const requestedConnectionsView = params.get('connectionsView');
     const requestedThreadId = params.get('threadId');
     const requestedAuthorPubkey = params.get('authorPubkey');
     const requestedPeerPubkey = params.get('peerPubkey');
@@ -4656,14 +4780,27 @@ function DesktopShellPage({
       ? requestedSettingsSection
       : shellChromeState.activeSettingsSection;
     const nextProfileMode =
-      routeSection === 'profile' && requestedProfileMode === 'edit' ? 'edit' : 'overview';
+      routeSection === 'profile'
+        ? requestedProfileMode === 'edit'
+          ? 'edit'
+          : requestedProfileMode === 'connections'
+            ? 'connections'
+            : 'overview'
+        : 'overview';
+    const nextProfileConnectionsView =
+      routeSection === 'profile' && requestedProfileMode === 'connections'
+        ? isProfileConnectionsView(requestedConnectionsView)
+          ? requestedConnectionsView
+          : 'following'
+        : shellChromeState.profileConnectionsView;
 
     if (
       shellChromeState.activePrimarySection !== routeSection ||
       shellChromeState.timelineView !== nextTimelineView ||
       shellChromeState.activeSettingsSection !== nextSettingsSection ||
       shellChromeState.settingsOpen !== nextSettingsOpen ||
-      shellChromeState.profileMode !== nextProfileMode
+      shellChromeState.profileMode !== nextProfileMode ||
+      shellChromeState.profileConnectionsView !== nextProfileConnectionsView
     ) {
       setShellChromeState((current) => ({
         ...current,
@@ -4672,6 +4809,7 @@ function DesktopShellPage({
         activeSettingsSection: nextSettingsSection,
         settingsOpen: nextSettingsOpen,
         profileMode: nextProfileMode,
+        profileConnectionsView: nextProfileConnectionsView,
       }));
     }
 
@@ -4684,10 +4822,21 @@ function DesktopShellPage({
     if (requestedSettingsSection && !isSettingsSection(requestedSettingsSection)) {
       shouldNormalize = true;
     }
-    if (requestedProfileMode && requestedProfileMode !== 'edit') {
+    if (
+      requestedProfileMode &&
+      requestedProfileMode !== 'edit' &&
+      requestedProfileMode !== 'connections'
+    ) {
       shouldNormalize = true;
     }
     if (requestedProfileMode && routeSection !== 'profile') {
+      shouldNormalize = true;
+    }
+    if (
+      requestedConnectionsView &&
+      (requestedProfileMode !== 'connections' ||
+        !isProfileConnectionsView(requestedConnectionsView))
+    ) {
       shouldNormalize = true;
     }
 
@@ -4918,6 +5067,7 @@ function DesktopShellPage({
     shellChromeState.timelineView,
     shellChromeState.activeSettingsSection,
     shellChromeState.profileMode,
+    shellChromeState.profileConnectionsView,
     shellChromeState.settingsOpen,
     syncRoute,
     thread.length,
@@ -5194,10 +5344,12 @@ function DesktopShellPage({
             followedBy: selectedAuthor.followed_by,
             mutual: selectedAuthor.mutual,
             friendOfFriend: selectedAuthor.friend_of_friend,
+            muted: selectedAuthor.muted,
             viaPubkeys: selectedAuthor.friend_of_friend_via_pubkeys.map(shortPubkey),
             isSelf: selectedAuthor.author_pubkey === syncStatus.local_author_pubkey,
             canFollow: selectedAuthor.author_pubkey !== syncStatus.local_author_pubkey,
             followActionLabel: selectedAuthor.following ? 'Unfollow' : 'Follow',
+            muteActionLabel: selectedAuthor.muted ? 'Unmute' : 'Mute',
           }
         : null,
       canMessage: Boolean(
@@ -5989,6 +6141,7 @@ function DesktopShellPage({
               onToggleRelationship={(authorPubkey, following) =>
                 void handleRelationshipAction(authorPubkey, following)
               }
+              onToggleMute={(authorPubkey, muted) => void handleMuteAction(authorPubkey, muted)}
               onOpenDirectMessage={(authorPubkey) => void openDirectMessagePane(authorPubkey)}
             />
             <Card className='shell-workspace-card'>
@@ -6412,6 +6565,22 @@ function DesktopShellPage({
                       onSave={handleSaveProfile}
                       onReset={resetProfileDraft}
                     />
+                  ) : profileMode === 'connections' ? (
+                    <ProfileConnectionsPanel
+                      activeView={profileConnectionsView}
+                      items={activeSocialConnections}
+                      localAuthorPubkey={syncStatus.local_author_pubkey}
+                      status={socialConnectionsPanelState.status}
+                      error={socialConnectionsPanelState.error}
+                      onSelectView={openProfileConnections}
+                      onToggleRelationship={(authorPubkey, following) =>
+                        void handleRelationshipAction(authorPubkey, following)
+                      }
+                      onToggleMute={(authorPubkey, muted) =>
+                        void handleMuteAction(authorPubkey, muted)
+                      }
+                      onBack={openProfileOverview}
+                    />
                   ) : (
                     <ProfileOverviewPanel
                       authorLabel={profileAuthorLabel}
@@ -6421,20 +6590,23 @@ function DesktopShellPage({
                       error={profileError ?? profilePanelState.error}
                       postCount={profileTimelinePostViews.length}
                       onEdit={openProfileEditor}
+                      onManageConnections={() => openProfileConnections('following')}
                     />
                   )}
-                  <Card className='shell-workspace-card'>
-                    <TimelineFeed
-                      posts={profileTimelinePostViews}
-                      emptyCopy={t('profile:feed.noOwnPosts')}
-                      onOpenAuthor={(authorPubkey) => void openAuthorDetail(authorPubkey)}
-                      onOpenThread={(threadId) => void openThread(threadId)}
-                      onOpenThreadInTopic={(threadId, topicId) => void openThread(threadId, { topic: topicId })}
-                      onReply={beginReply}
-                      readOnly={true}
-                      onOpenOriginalTopic={(topicId) => void handleOpenOriginalTopic(topicId)}
-                    />
-                  </Card>
+                  {profileMode !== 'connections' ? (
+                    <Card className='shell-workspace-card'>
+                      <TimelineFeed
+                        posts={profileTimelinePostViews}
+                        emptyCopy={t('profile:feed.noOwnPosts')}
+                        onOpenAuthor={(authorPubkey) => void openAuthorDetail(authorPubkey)}
+                        onOpenThread={(threadId) => void openThread(threadId)}
+                        onOpenThreadInTopic={(threadId, topicId) => void openThread(threadId, { topic: topicId })}
+                        onReply={beginReply}
+                        readOnly={true}
+                        onOpenOriginalTopic={(topicId) => void handleOpenOriginalTopic(topicId)}
+                      />
+                    </Card>
+                  ) : null}
                 </>
               ) : null}
             </section>

--- a/apps/desktop/src/components/core/AuthorDetailCard.stories.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.stories.tsx
@@ -21,6 +21,7 @@ const meta = {
     view: authorDetailView,
     localAuthorPubkey: 'f'.repeat(64),
     onToggleRelationship: () => undefined,
+    onToggleMute: () => undefined,
   },
 } satisfies Meta<typeof AuthorDetailCard>;
 

--- a/apps/desktop/src/components/core/AuthorDetailCard.test.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.test.tsx
@@ -26,6 +26,7 @@ test('author detail marks long unbroken values as wrappable content', () => {
       }}
       localAuthorPubkey={'f'.repeat(64)}
       onToggleRelationship={vi.fn()}
+      onToggleMute={vi.fn()}
     />
   );
 
@@ -41,5 +42,6 @@ test('author detail marks long unbroken values as wrappable content', () => {
   expect(screen.queryByText('following: yes')).not.toBeInTheDocument();
   expect(screen.queryByText('followed by: yes')).not.toBeInTheDocument();
   const followButton = screen.getByRole('button', { name: 'Unfollow' });
+  expect(screen.getByRole('button', { name: 'Mute' })).toBeInTheDocument();
   expect(screen.getByText('mutual').closest('.author-detail-actions')).toContainElement(followButton);
 });

--- a/apps/desktop/src/components/core/AuthorDetailCard.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.tsx
@@ -10,6 +10,7 @@ type AuthorDetailCardProps = {
   view: AuthorDetailView;
   localAuthorPubkey: string;
   onToggleRelationship: (authorPubkey: string, following: boolean) => void;
+  onToggleMute: (authorPubkey: string, muted: boolean) => void;
   onOpenDirectMessage?: (authorPubkey: string) => void;
 };
 
@@ -17,6 +18,7 @@ export function AuthorDetailCard({
   view,
   localAuthorPubkey,
   onToggleRelationship,
+  onToggleMute,
   onOpenDirectMessage,
 }: AuthorDetailCardProps) {
   const { t } = useTranslation(['common']);
@@ -29,6 +31,7 @@ export function AuthorDetailCard({
       view.canMessage &&
       onOpenDirectMessage
   );
+  const showMuteAction = Boolean(author && author.author_pubkey !== localAuthorPubkey);
 
   return (
     <Card className='author-detail'>
@@ -63,7 +66,7 @@ export function AuthorDetailCard({
             </div>
           ) : null}
 
-          {relationshipLabel || showFollowAction || showMessageAction ? (
+          {relationshipLabel || showFollowAction || showMuteAction || showMessageAction ? (
             <div className='author-detail-actions'>
               {relationshipLabel ? <RelationshipBadge label={relationshipLabel} /> : <span />}
               <div className='post-actions'>
@@ -85,6 +88,17 @@ export function AuthorDetailCard({
                     {view.summary?.followActionLabel === 'Unfollow'
                       ? t('actions.unfollow')
                       : t('actions.follow')}
+                  </button>
+                ) : null}
+                {showMuteAction ? (
+                  <button
+                    className='button button-secondary'
+                    type='button'
+                    onClick={() => onToggleMute(author.author_pubkey, author.muted)}
+                  >
+                    {view.summary?.muteActionLabel === 'Unmute'
+                      ? t('actions.unmute', { defaultValue: 'Unmute' })
+                      : t('actions.mute', { defaultValue: 'Mute' })}
                   </button>
                 ) : null}
               </div>

--- a/apps/desktop/src/components/core/CoreProductFlow.stories.tsx
+++ b/apps/desktop/src/components/core/CoreProductFlow.stories.tsx
@@ -222,6 +222,7 @@ const AUTHOR_VIEW: AuthorDetailView = {
     mutual: true,
     friend_of_friend: false,
     friend_of_friend_via_pubkeys: [],
+    muted: false,
   },
   displayLabel: 'bob',
   summary: {
@@ -230,10 +231,12 @@ const AUTHOR_VIEW: AuthorDetailView = {
     followedBy: true,
     mutual: true,
     friendOfFriend: false,
+    muted: false,
     viaPubkeys: [],
     isSelf: false,
     canFollow: true,
     followActionLabel: 'Unfollow',
+    muteActionLabel: 'Mute',
   },
   authorError: null,
 };

--- a/apps/desktop/src/components/core/CoreProductFlow.stories.tsx
+++ b/apps/desktop/src/components/core/CoreProductFlow.stories.tsx
@@ -365,6 +365,7 @@ function CoreProductFlowStory({ width }: { width: number }) {
                 view={AUTHOR_VIEW}
                 localAuthorPubkey={'f'.repeat(64)}
                 onToggleRelationship={() => undefined}
+                onToggleMute={() => undefined}
               />
             </ContextPane>
           </>

--- a/apps/desktop/src/components/core/types.ts
+++ b/apps/desktop/src/components/core/types.ts
@@ -75,10 +75,12 @@ export type AuthorRelationshipSummary = {
   followedBy: boolean;
   mutual: boolean;
   friendOfFriend: boolean;
+  muted: boolean;
   viaPubkeys: string[];
   isSelf: boolean;
   canFollow: boolean;
   followActionLabel: 'Follow' | 'Unfollow';
+  muteActionLabel: 'Mute' | 'Unmute';
 };
 
 export type AuthorDetailView = {

--- a/apps/desktop/src/components/extended/ProfileConnectionsPanel.tsx
+++ b/apps/desktop/src/components/extended/ProfileConnectionsPanel.tsx
@@ -1,0 +1,161 @@
+import { useTranslation } from 'react-i18next';
+
+import { AuthorAvatar } from '@/components/core/AuthorAvatar';
+import { RelationshipBadge } from '@/components/core/RelationshipBadge';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader } from '@/components/ui/card';
+import { Notice } from '@/components/ui/notice';
+import type { ProfileConnectionsView } from '@/components/shell/types';
+import type { ExtendedPanelStatus } from '@/components/extended/types';
+import type { AuthorSocialView } from '@/lib/api';
+
+type ProfileConnectionsPanelProps = {
+  activeView: ProfileConnectionsView;
+  items: AuthorSocialView[];
+  localAuthorPubkey: string;
+  status: ExtendedPanelStatus;
+  error: string | null;
+  onSelectView: (view: ProfileConnectionsView) => void;
+  onToggleRelationship: (authorPubkey: string, following: boolean) => void;
+  onToggleMute: (authorPubkey: string, muted: boolean) => void;
+  onBack: () => void;
+};
+
+const CONNECTION_VIEWS: ProfileConnectionsView[] = ['following', 'followed', 'muted'];
+
+function displayLabel(author: AuthorSocialView): string {
+  return author.display_name?.trim() || author.name?.trim() || author.author_pubkey;
+}
+
+function strongestRelationshipLabel(author: AuthorSocialView): string | null {
+  if (author.mutual) {
+    return 'mutual';
+  }
+  if (author.following) {
+    return 'following';
+  }
+  if (author.followed_by) {
+    return 'follows you';
+  }
+  if (author.friend_of_friend) {
+    return 'friend of friend';
+  }
+  return null;
+}
+
+export function ProfileConnectionsPanel({
+  activeView,
+  items,
+  localAuthorPubkey,
+  status,
+  error,
+  onSelectView,
+  onToggleRelationship,
+  onToggleMute,
+  onBack,
+}: ProfileConnectionsPanelProps) {
+  const { t } = useTranslation(['profile', 'common']);
+  const noteKey =
+    activeView === 'followed'
+      ? 'connections.notes.followed'
+      : activeView === 'muted'
+        ? 'connections.notes.muted'
+        : 'connections.notes.following';
+
+  return (
+    <Card className='panel-subsection'>
+      <CardHeader>
+        <div>
+          <h3>{t('connections.title')}</h3>
+          <small>{t(noteKey)}</small>
+        </div>
+        <Button variant='secondary' type='button' onClick={onBack}>
+          {t('connections.back')}
+        </Button>
+      </CardHeader>
+
+      <div className='shell-workspace-tabs' role='tablist' aria-label={t('connections.tabsLabel')}>
+        {CONNECTION_VIEWS.map((view) => (
+          <button
+            key={view}
+            className={`shell-tab${activeView === view ? ' shell-tab-active' : ''}`}
+            role='tab'
+            type='button'
+            aria-selected={activeView === view}
+            onClick={() => onSelectView(view)}
+          >
+            {t(`connections.tabs.${view}`)}
+          </button>
+        ))}
+      </div>
+
+      {status === 'loading' ? <Notice>{t('connections.loading')}</Notice> : null}
+      {status === 'error' && error ? <Notice tone='destructive'>{error}</Notice> : null}
+      {status === 'ready' ? <Notice>{t(noteKey)}</Notice> : null}
+
+      {status === 'ready' && items.length === 0 ? (
+        <p className='empty-state'>{t(`connections.empty.${activeView}`)}</p>
+      ) : null}
+
+      {items.length > 0 ? (
+        <ul className='post-list'>
+          {items.map((author) => {
+            const label = displayLabel(author);
+            const relationshipLabel = strongestRelationshipLabel(author);
+            const showActions = author.author_pubkey !== localAuthorPubkey;
+
+            return (
+              <li key={author.author_pubkey}>
+                <article className='post-card'>
+                  <div className='post-meta'>
+                    <span>{label}</span>
+                    <span>{author.author_pubkey}</span>
+                  </div>
+                  <div className='post-body'>
+                    <div className='author-detail-hero'>
+                      <AuthorAvatar label={label} picture={author.picture ?? null} size='sm' />
+                      <div className='author-detail-copy-stack'>
+                        <strong className='post-title'>{label}</strong>
+                        <p className='author-detail-copy author-detail-break'>
+                          {author.about?.trim() || t('common:fallbacks.noBio')}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <div className='post-actions'>
+                    {relationshipLabel ? <RelationshipBadge label={relationshipLabel} /> : null}
+                    {author.muted ? (
+                      <span className='relationship-badge relationship-badge-direct'>
+                        {t('connections.mutedBadge')}
+                      </span>
+                    ) : null}
+                  </div>
+                  {showActions ? (
+                    <div className='post-actions'>
+                      <Button
+                        variant='secondary'
+                        type='button'
+                        onClick={() => onToggleRelationship(author.author_pubkey, author.following)}
+                      >
+                        {author.following ? t('common:actions.unfollow') : t('common:actions.follow')}
+                      </Button>
+                      <Button
+                        variant='secondary'
+                        type='button'
+                        onClick={() => onToggleMute(author.author_pubkey, author.muted)}
+                      >
+                        {author.muted
+                          ? t('common:actions.unmute', { defaultValue: 'Unmute' })
+                          : t('common:actions.mute', { defaultValue: 'Mute' })}
+                      </Button>
+                    </div>
+                  ) : null}
+                </article>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </Card>
+  );
+}

--- a/apps/desktop/src/components/extended/ProfileOverviewPanel.tsx
+++ b/apps/desktop/src/components/extended/ProfileOverviewPanel.tsx
@@ -12,6 +12,7 @@ type ProfileOverviewPanelProps = {
   error: string | null;
   postCount: number;
   onEdit: () => void;
+  onManageConnections: () => void;
 };
 
 export function ProfileOverviewPanel({
@@ -22,6 +23,7 @@ export function ProfileOverviewPanel({
   error,
   postCount,
   onEdit,
+  onManageConnections,
 }: ProfileOverviewPanelProps) {
   const { t } = useTranslation('profile');
 
@@ -41,9 +43,14 @@ export function ProfileOverviewPanel({
             <small>{authorLabel}</small>
           </div>
         </div>
-        <Button variant='secondary' type='button' onClick={onEdit}>
-          {t('overview.edit')}
-        </Button>
+        <div className='post-actions'>
+          <Button variant='secondary' type='button' onClick={onManageConnections}>
+            {t('overview.connections')}
+          </Button>
+          <Button variant='secondary' type='button' onClick={onEdit}>
+            {t('overview.edit')}
+          </Button>
+        </div>
       </CardHeader>
 
       {status === 'loading' ? <Notice>{t('overview.loading')}</Notice> : null}

--- a/apps/desktop/src/components/review/DesktopShellWorkspaceGallery.stories.tsx
+++ b/apps/desktop/src/components/review/DesktopShellWorkspaceGallery.stories.tsx
@@ -474,6 +474,7 @@ function ProfileOverviewWorkspace() {
         error={null}
         postCount={PROFILE_TIMELINE_POSTS.length}
         onEdit={() => undefined}
+        onManageConnections={() => undefined}
       />
       <Card className='shell-workspace-card'>
         <TimelineFeed

--- a/apps/desktop/src/components/shell/ContextPane.stories.tsx
+++ b/apps/desktop/src/components/shell/ContextPane.stories.tsx
@@ -25,6 +25,7 @@ const meta = {
         view={authorDetailView}
         localAuthorPubkey={'f'.repeat(64)}
         onToggleRelationship={() => undefined}
+        onToggleMute={() => undefined}
       />
     ),
   },

--- a/apps/desktop/src/components/shell/types.ts
+++ b/apps/desktop/src/components/shell/types.ts
@@ -1,5 +1,6 @@
 export type PrimarySection = 'timeline' | 'live' | 'game' | 'profile';
 export type TimelineWorkspaceView = 'feed' | 'bookmarks';
+export type ProfileConnectionsView = 'following' | 'followed' | 'muted';
 
 export type SettingsSection =
   | 'appearance'
@@ -8,13 +9,14 @@ export type SettingsSection =
   | 'community-node'
   | 'reactions';
 
-export type ProfileWorkspaceMode = 'overview' | 'edit';
+export type ProfileWorkspaceMode = 'overview' | 'edit' | 'connections';
 
 export type ShellChromeState = {
   activePrimarySection: PrimarySection;
   timelineView: TimelineWorkspaceView;
   activeSettingsSection: SettingsSection;
   profileMode: ProfileWorkspaceMode;
+  profileConnectionsView: ProfileConnectionsView;
   navOpen: boolean;
   settingsOpen: boolean;
 };

--- a/apps/desktop/src/components/storyFixtures.ts
+++ b/apps/desktop/src/components/storyFixtures.ts
@@ -234,6 +234,7 @@ export function createStoryAuthorDetailView(): AuthorDetailView {
       mutual: true,
       friend_of_friend: false,
       friend_of_friend_via_pubkeys: [],
+      muted: false,
     },
     displayLabel: 'bob',
     summary: {
@@ -242,10 +243,12 @@ export function createStoryAuthorDetailView(): AuthorDetailView {
       followedBy: true,
       mutual: true,
       friendOfFriend: false,
+      muted: false,
       viaPubkeys: [],
       isSelf: false,
       canFollow: true,
       followActionLabel: 'Unfollow',
+      muteActionLabel: 'Mute',
     },
     authorError: null,
   };

--- a/apps/desktop/src/i18n/locales/en/common.json
+++ b/apps/desktop/src/i18n/locales/en/common.json
@@ -12,6 +12,7 @@
     "importPeer": "Import Peer",
     "join": "Join",
     "leave": "Leave",
+    "mute": "Mute",
     "publish": "Publish",
     "quoteRepost": "Quote Repost",
     "react": "React",
@@ -23,6 +24,7 @@
     "reset": "Reset",
     "rotate": "Rotate",
     "save": "Save",
+    "unmute": "Unmute",
     "unfollow": "Unfollow"
   },
   "composer": {
@@ -55,6 +57,7 @@
     "failedToLoadLiveSessions": "failed to load live sessions",
     "failedToLoadPrivateChannels": "failed to load private channels",
     "failedToLoadProfile": "failed to load profile",
+    "failedToLoadSocialConnections": "failed to load social connections",
     "failedToLoadSettings": "failed to load settings",
     "failedToLoadThread": "failed to load thread",
     "failedToLoadTopic": "failed to load topic",
@@ -65,6 +68,7 @@
     "failedToUpdateCommunityNodes": "failed to update community nodes",
     "failedToUpdateDiscoverySeeds": "failed to update discovery seeds",
     "failedToUpdateFollowState": "failed to update follow state",
+    "failedToUpdateMuteState": "failed to update mute state",
     "quoteRepostRequiresCommentary": "quote repost requires commentary",
     "unsupportedAttachmentType": "unsupported attachment type: {{name}}"
   },

--- a/apps/desktop/src/i18n/locales/en/profile.json
+++ b/apps/desktop/src/i18n/locales/en/profile.json
@@ -16,11 +16,34 @@
     "title": "My Profile"
   },
   "overview": {
+    "connections": "Manage Follows & Mutes",
     "edit": "Edit Profile",
     "loading": "Loading profile…",
     "noBio": "No profile bio published yet.",
     "postCount": "Public posts",
     "title": "Profile"
+  },
+  "connections": {
+    "back": "Back to profile",
+    "empty": {
+      "followed": "No local-known followers yet.",
+      "following": "You are not following anyone yet.",
+      "muted": "No muted authors yet."
+    },
+    "loading": "Loading follows and mutes…",
+    "mutedBadge": "Muted",
+    "notes": {
+      "followed": "Followed shows only followers already observed on this device.",
+      "following": "Following lists authors you actively follow.",
+      "muted": "Muted is local-only and is not shared with other devices."
+    },
+    "tabs": {
+      "followed": "Followed",
+      "following": "Following",
+      "muted": "Muted"
+    },
+    "tabsLabel": "Social connections",
+    "title": "Follow & Mute"
   },
   "feed": {
     "noAuthorPosts": "No public posts from this author yet.",

--- a/apps/desktop/src/i18n/locales/ja/common.json
+++ b/apps/desktop/src/i18n/locales/ja/common.json
@@ -12,6 +12,7 @@
     "importPeer": "ピアを追加",
     "join": "参加",
     "leave": "退出",
+    "mute": "ミュート",
     "publish": "投稿",
     "quoteRepost": "引用リポスト",
     "react": "リアクション",
@@ -23,6 +24,7 @@
     "reset": "リセット",
     "rotate": "ローテーション",
     "save": "保存",
+    "unmute": "ミュート解除",
     "unfollow": "フォロー解除"
   },
   "composer": {
@@ -55,6 +57,7 @@
     "failedToLoadLiveSessions": "ライブセッションの読み込みに失敗しました",
     "failedToLoadPrivateChannels": "プライベートチャンネルの読み込みに失敗しました",
     "failedToLoadProfile": "プロフィールの読み込みに失敗しました",
+    "failedToLoadSocialConnections": "ソーシャル一覧の読み込みに失敗しました",
     "failedToLoadSettings": "設定の読み込みに失敗しました",
     "failedToLoadThread": "スレッドの読み込みに失敗しました",
     "failedToLoadTopic": "トピックの読み込みに失敗しました",
@@ -65,6 +68,7 @@
     "failedToUpdateCommunityNodes": "コミュニティノードの更新に失敗しました",
     "failedToUpdateDiscoverySeeds": "ディスカバリーシードの更新に失敗しました",
     "failedToUpdateFollowState": "フォロー状態の更新に失敗しました",
+    "failedToUpdateMuteState": "ミュート状態の更新に失敗しました",
     "quoteRepostRequiresCommentary": "引用リポストにはコメントが必要です",
     "unsupportedAttachmentType": "未対応の添付タイプです: {{name}}"
   },

--- a/apps/desktop/src/i18n/locales/ja/profile.json
+++ b/apps/desktop/src/i18n/locales/ja/profile.json
@@ -16,11 +16,34 @@
     "title": "マイプロフィール"
   },
   "overview": {
+    "connections": "フォローとミュートを管理",
     "edit": "プロフィールを編集",
     "loading": "プロフィールを読み込み中…",
     "noBio": "まだプロフィール文が公開されていません。",
     "postCount": "公開投稿",
     "title": "プロフィール"
+  },
+  "connections": {
+    "back": "プロフィールに戻る",
+    "empty": {
+      "followed": "この端末で把握している follower はまだいません。",
+      "following": "まだ誰もフォローしていません。",
+      "muted": "ミュート中の著者はいません。"
+    },
+    "loading": "フォローとミュートを読み込み中…",
+    "mutedBadge": "ミュート中",
+    "notes": {
+      "followed": "Followed はこの端末で観測済みの follower のみを表示します。",
+      "following": "Following には現在フォロー中の著者だけを表示します。",
+      "muted": "Muted はローカル専用で、他の端末には共有されません。"
+    },
+    "tabs": {
+      "followed": "Followed",
+      "following": "Following",
+      "muted": "Muted"
+    },
+    "tabsLabel": "ソーシャル一覧",
+    "title": "フォローとミュート"
   },
   "feed": {
     "noAuthorPosts": "この著者にはまだ公開投稿がありません。",

--- a/apps/desktop/src/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/common.json
@@ -11,6 +11,7 @@
     "importPeer": "导入 Peer",
     "join": "加入",
     "leave": "离开",
+    "mute": "静音",
     "publish": "发布",
     "quoteRepost": "引用转发",
     "react": "回应",
@@ -21,6 +22,7 @@
     "reset": "重置",
     "rotate": "轮换",
     "save": "保存",
+    "unmute": "取消静音",
     "unfollow": "取消关注"
   },
   "composer": {
@@ -53,6 +55,7 @@
     "failedToLoadLiveSessions": "加载直播会话失败",
     "failedToLoadPrivateChannels": "加载私密频道失败",
     "failedToLoadProfile": "加载资料失败",
+    "failedToLoadSocialConnections": "加载社交列表失败",
     "failedToLoadSettings": "加载设置失败",
     "failedToLoadThread": "加载线程失败",
     "failedToLoadTopic": "加载主题失败",
@@ -62,6 +65,7 @@
     "failedToUpdateCommunityNodes": "更新社区节点失败",
     "failedToUpdateDiscoverySeeds": "更新发现种子失败",
     "failedToUpdateFollowState": "更新关注状态失败",
+    "failedToUpdateMuteState": "更新静音状态失败",
     "quoteRepostRequiresCommentary": "引用转发需要评论内容",
     "unsupportedAttachmentType": "不支持的附件类型: {{name}}"
   },

--- a/apps/desktop/src/i18n/locales/zh-CN/profile.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/profile.json
@@ -16,11 +16,34 @@
     "title": "我的资料"
   },
   "overview": {
+    "connections": "管理关注与静音",
     "edit": "编辑资料",
     "loading": "正在加载资料…",
     "noBio": "尚未发布个人简介。",
     "postCount": "公开帖子",
     "title": "资料"
+  },
+  "connections": {
+    "back": "返回资料",
+    "empty": {
+      "followed": "这个设备上还没有已知的关注者。",
+      "following": "你还没有关注任何人。",
+      "muted": "还没有静音任何作者。"
+    },
+    "loading": "正在加载关注与静音…",
+    "mutedBadge": "已静音",
+    "notes": {
+      "followed": "Followed 只显示这个设备上已经观测到的关注者。",
+      "following": "Following 仅显示你当前关注的作者。",
+      "muted": "Muted 仅保存在本地，不会同步到其他设备。"
+    },
+    "tabs": {
+      "followed": "Followed",
+      "following": "Following",
+      "muted": "Muted"
+    },
+    "tabsLabel": "社交列表",
+    "title": "关注与静音"
   },
   "feed": {
     "noAuthorPosts": "这位作者还没有公开帖子。",

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -147,7 +147,10 @@ export type AuthorSocialView = {
   mutual: boolean;
   friend_of_friend: boolean;
   friend_of_friend_via_pubkeys: string[];
+  muted: boolean;
 };
+
+export type SocialConnectionKind = 'following' | 'followed' | 'muted';
 
 export type DirectMessageStatusView = {
   peer_pubkey: string;
@@ -483,6 +486,9 @@ export interface DesktopApi {
   followAuthor(pubkey: string): Promise<AuthorSocialView>;
   unfollowAuthor(pubkey: string): Promise<AuthorSocialView>;
   getAuthorSocialView(pubkey: string): Promise<AuthorSocialView>;
+  muteAuthor(pubkey: string): Promise<AuthorSocialView>;
+  unmuteAuthor(pubkey: string): Promise<AuthorSocialView>;
+  listSocialConnections(kind: SocialConnectionKind): Promise<AuthorSocialView[]>;
   openDirectMessage(pubkey: string): Promise<DirectMessageConversationView>;
   listDirectMessages(): Promise<DirectMessageConversationView[]>;
   listDirectMessageMessages(
@@ -844,6 +850,30 @@ export const runtimeApi: DesktopApi = {
     }
     return invokeDesktop<AuthorSocialView>('get_author_social_view', {
       request: { pubkey },
+    });
+  },
+  muteAuthor: async (pubkey) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.muteAuthor(pubkey);
+    }
+    return invokeDesktop<AuthorSocialView>('mute_author', {
+      request: { pubkey },
+    });
+  },
+  unmuteAuthor: async (pubkey) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.unmuteAuthor(pubkey);
+    }
+    return invokeDesktop<AuthorSocialView>('unmute_author', {
+      request: { pubkey },
+    });
+  },
+  listSocialConnections: async (kind) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.listSocialConnections(kind);
+    }
+    return invokeDesktop<AuthorSocialView[]>('list_social_connections', {
+      request: { kind },
     });
   },
   openDirectMessage: async (pubkey) => {

--- a/apps/desktop/src/mocks/desktopApiMock.ts
+++ b/apps/desktop/src/mocks/desktopApiMock.ts
@@ -30,6 +30,7 @@ import {
   type ReactionStateView,
   type RecentReactionView,
   type SyncStatus,
+  type SocialConnectionKind,
   type TimelineScope,
   type TimelineView,
 } from '@/lib/api';
@@ -139,7 +140,16 @@ function withDefaultAuthorView(
     mutual: false,
     friend_of_friend: false,
     friend_of_friend_via_pubkeys: [],
+    muted: false,
     ...view,
+  };
+}
+
+function cloneAuthorView(view: AuthorSocialView): AuthorSocialView {
+  return {
+    ...view,
+    picture_asset: view.picture_asset ? { ...view.picture_asset } : null,
+    friend_of_friend_via_pubkeys: [...view.friend_of_friend_via_pubkeys],
   };
 }
 
@@ -179,6 +189,33 @@ function filterChannelScopedItems<T extends { channel_id?: string | null }>(
     return items.filter((item) => !item.channel_id || joinedIds.has(item.channel_id));
   }
   return items.filter((item) => !item.channel_id);
+}
+
+function compareAuthorViews(left: AuthorSocialView, right: AuthorSocialView) {
+  const normalize = (value?: string | null) => value?.trim().toLocaleLowerCase() ?? '';
+  const leftDisplay = normalize(left.display_name);
+  const rightDisplay = normalize(right.display_name);
+  if (leftDisplay !== rightDisplay) {
+    if (!leftDisplay) {
+      return 1;
+    }
+    if (!rightDisplay) {
+      return -1;
+    }
+    return leftDisplay.localeCompare(rightDisplay);
+  }
+  const leftName = normalize(left.name);
+  const rightName = normalize(right.name);
+  if (leftName !== rightName) {
+    if (!leftName) {
+      return 1;
+    }
+    if (!rightName) {
+      return -1;
+    }
+    return leftName.localeCompare(rightName);
+  }
+  return left.author_pubkey.localeCompare(right.author_pubkey);
 }
 
 function normalizedReactionKey(reactionKey: ReactionKeyInput): string {
@@ -345,6 +382,56 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
   const bookmarkedCustomReactionAssets: BookmarkedCustomReactionView[] = [];
   const bookmarkedPosts: BookmarkedPostView[] = [];
   let recentReactions: RecentReactionView[] = [];
+
+  function mutedAuthorPubkeys() {
+    return new Set(
+      Object.values(authorSocialViews)
+        .filter((view) => view.muted)
+        .map((view) => view.author_pubkey)
+    );
+  }
+
+  function withCurrentRelationship(post: PostView): PostView {
+    const author = authorSocialViews[post.author_pubkey];
+    if (!author) {
+      return withSocialPostDefaults(post);
+    }
+    return withSocialPostDefaults({
+      ...post,
+      following: author.following ?? post.following,
+      followed_by: author.followed_by ?? post.followed_by,
+      mutual: author.mutual ?? post.mutual,
+      friend_of_friend: author.friend_of_friend ?? post.friend_of_friend,
+    });
+  }
+
+  function isVisiblePost(post: PostView): boolean {
+    const muted = mutedAuthorPubkeys();
+    return (
+      !muted.has(post.author_pubkey) &&
+      !(post.repost_of && muted.has(post.repost_of.source_author_pubkey))
+    );
+  }
+
+  function visibleTimelineItems(items: PostView[]): PostView[] {
+    return items.map(withCurrentRelationship).filter(isVisiblePost);
+  }
+
+  function listConnections(kind: SocialConnectionKind): AuthorSocialView[] {
+    const items = Object.values(authorSocialViews)
+      .filter((view) => {
+        if (kind === 'following') {
+          return view.following;
+        }
+        if (kind === 'followed') {
+          return view.followed_by;
+        }
+        return view.muted;
+      })
+      .map(cloneAuthorView);
+    items.sort(compareAuthorViews);
+    return items;
+  }
 
   function directMessageStatusFor(pubkey: string): DirectMessageStatusView {
     const author = withDefaultAuthorView(pubkey, authorSocialViews[pubkey]);
@@ -637,7 +724,14 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       }
     },
     async listBookmarkedPosts() {
-      return bookmarkedPosts.map((item) => cloneBookmarkedPost(item));
+      return bookmarkedPosts
+        .filter((item) => isVisiblePost(item.post))
+        .map((item) =>
+          cloneBookmarkedPost({
+            ...item,
+            post: withCurrentRelationship(item.post),
+          })
+        );
     },
     async bookmarkPost(topic, objectId) {
       const existing = bookmarkedPosts.find((item) => item.post.object_id === objectId);
@@ -695,10 +789,8 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
         });
       }
       return {
-        items: filterChannelScopedItems(
-          postsByTopic[topic] ?? [],
-          scope,
-          joinedChannelsByTopic[topic] ?? []
+        items: visibleTimelineItems(
+          filterChannelScopedItems(postsByTopic[topic] ?? [], scope, joinedChannelsByTopic[topic] ?? [])
         ),
         next_cursor: null,
       };
@@ -706,13 +798,15 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
     async listThread(topic, threadId) {
       const posts = postsByTopic[topic] ?? [];
       return {
-        items: posts.filter((post) => post.root_id === threadId || post.object_id === threadId),
+        items: visibleTimelineItems(
+          posts.filter((post) => post.root_id === threadId || post.object_id === threadId)
+        ),
         next_cursor: null,
       };
     },
     async listProfileTimeline(pubkey) {
       return {
-        items: [...(authorProfileTimelines[pubkey] ?? [])],
+        items: visibleTimelineItems([...(authorProfileTimelines[pubkey] ?? [])]),
         next_cursor: null,
       };
     },
@@ -755,40 +849,41 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       const existing = withDefaultAuthorView(pubkey, authorSocialViews[pubkey]);
       const next = { ...existing, following: true, mutual: existing.followed_by };
       authorSocialViews[pubkey] = next;
-      for (const topic of Object.keys(postsByTopic)) {
-        postsByTopic[topic] = postsByTopic[topic].map((post) =>
-          post.author_pubkey === pubkey
-            ? { ...post, following: true, mutual: next.mutual, friend_of_friend: false }
-            : post
-        );
-      }
-      return next;
+      return cloneAuthorView(next);
     },
     async unfollowAuthor(pubkey) {
       const existing = withDefaultAuthorView(pubkey, authorSocialViews[pubkey]);
       const next = { ...existing, following: false, mutual: false };
       authorSocialViews[pubkey] = next;
-      for (const topic of Object.keys(postsByTopic)) {
-        postsByTopic[topic] = postsByTopic[topic].map((post) =>
-          post.author_pubkey === pubkey
-            ? { ...post, following: false, mutual: false }
-            : post
-        );
-      }
-      return next;
+      return cloneAuthorView(next);
     },
     async getAuthorSocialView(pubkey) {
       if (pubkey === myProfile.pubkey) {
-        return withDefaultAuthorView(myProfile.pubkey, {
+        return cloneAuthorView(withDefaultAuthorView(myProfile.pubkey, {
           name: myProfile.name ?? null,
           display_name: myProfile.display_name ?? null,
           about: myProfile.about ?? null,
           picture: myProfile.picture ?? null,
           picture_asset: myProfile.picture_asset ?? null,
           updated_at: myProfile.updated_at,
-        });
+        }));
       }
-      return withDefaultAuthorView(pubkey, authorSocialViews[pubkey]);
+      return cloneAuthorView(withDefaultAuthorView(pubkey, authorSocialViews[pubkey]));
+    },
+    async muteAuthor(pubkey) {
+      const existing = withDefaultAuthorView(pubkey, authorSocialViews[pubkey]);
+      const next = { ...existing, muted: true };
+      authorSocialViews[pubkey] = next;
+      return cloneAuthorView(next);
+    },
+    async unmuteAuthor(pubkey) {
+      const existing = withDefaultAuthorView(pubkey, authorSocialViews[pubkey]);
+      const next = { ...existing, muted: false };
+      authorSocialViews[pubkey] = next;
+      return cloneAuthorView(next);
+    },
+    async listSocialConnections(kind) {
+      return listConnections(kind);
     },
     async openDirectMessage(pubkey) {
       const status = directMessageStatusFor(pubkey);
@@ -866,11 +961,12 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       return directMessageStatusFor(pubkey);
     },
     async listLiveSessions(topic, scope: TimelineScope = { kind: 'public' }) {
+      const muted = mutedAuthorPubkeys();
       return filterChannelScopedItems(
         liveSessionsByTopic[topic] ?? [],
         scope,
         joinedChannelsByTopic[topic] ?? []
-      );
+      ).filter((session) => !muted.has(session.host_pubkey));
     },
     async createLiveSession(topic, title, description, channelRef = { kind: 'public' }) {
       sequence += 1;
@@ -920,11 +1016,12 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       );
     },
     async listGameRooms(topic, scope: TimelineScope = { kind: 'public' }) {
+      const muted = mutedAuthorPubkeys();
       return filterChannelScopedItems(
         gameRoomsByTopic[topic] ?? [],
         scope,
         joinedChannelsByTopic[topic] ?? []
-      );
+      ).filter((room) => !muted.has(room.host_pubkey));
     },
     async createGameRoom(topic, title, description, participants, channelRef = { kind: 'public' }) {
       sequence += 1;

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -50,8 +50,8 @@ use kukuri_store::{
     AuthorRelationshipProjectionRow, BlobCacheStatus, BookmarkedCustomReactionRow,
     BookmarkedPostRow, DirectMessageConversationRow, DirectMessageMessageRow,
     DirectMessageOutboxRow, DirectMessageTombstoneRow, GameRoomProjectionRow,
-    LiveSessionProjectionRow, ObjectProjectionRow, Page, ProjectionStore, ReactionProjectionRow,
-    Store, TimelineCursor,
+    LiveSessionProjectionRow, MutedAuthorRow, ObjectProjectionRow, Page, ProjectionStore,
+    ReactionProjectionRow, Store, TimelineCursor,
 };
 use kukuri_transport::{
     ConnectMode, DiscoveryMode, DiscoverySnapshot, HintTransport, PeerSnapshot, SeedPeer,
@@ -232,6 +232,16 @@ pub struct AuthorSocialView {
     pub mutual: bool,
     pub friend_of_friend: bool,
     pub friend_of_friend_via_pubkeys: Vec<String>,
+    #[serde(default)]
+    pub muted: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SocialConnectionKind {
+    Following,
+    Followed,
+    Muted,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -712,6 +722,71 @@ impl AppService {
         self.build_author_social_view(author_pubkey.as_str()).await
     }
 
+    pub async fn mute_author(&self, pubkey: &str) -> Result<AuthorSocialView> {
+        let author_pubkey = normalize_author_pubkey(pubkey)?;
+        self.ensure_author_subscription(author_pubkey.as_str())
+            .await?;
+        self.projection_store
+            .put_muted_author(MutedAuthorRow {
+                author_pubkey: author_pubkey.clone(),
+                muted_at: Utc::now().timestamp_millis(),
+            })
+            .await?;
+        self.build_author_social_view(author_pubkey.as_str()).await
+    }
+
+    pub async fn unmute_author(&self, pubkey: &str) -> Result<AuthorSocialView> {
+        let author_pubkey = normalize_author_pubkey(pubkey)?;
+        self.ensure_author_subscription(author_pubkey.as_str())
+            .await?;
+        self.projection_store
+            .remove_muted_author(author_pubkey.as_str())
+            .await?;
+        self.build_author_social_view(author_pubkey.as_str()).await
+    }
+
+    pub async fn list_social_connections(
+        &self,
+        kind: SocialConnectionKind,
+    ) -> Result<Vec<AuthorSocialView>> {
+        self.rebuild_author_relationships().await?;
+        let local_author_pubkey = self.current_author_pubkey();
+        let pubkeys = match kind {
+            SocialConnectionKind::Following => self
+                .store
+                .list_follow_edges_by_subject(local_author_pubkey.as_str())
+                .await?
+                .into_iter()
+                .filter(|edge| edge.status == FollowEdgeStatus::Active)
+                .map(|edge| edge.target_pubkey.as_str().to_string())
+                .collect::<BTreeSet<_>>(),
+            SocialConnectionKind::Followed => self
+                .store
+                .list_follow_edges_by_target(local_author_pubkey.as_str())
+                .await?
+                .into_iter()
+                .filter(|edge| edge.status == FollowEdgeStatus::Active)
+                .map(|edge| edge.subject_pubkey.as_str().to_string())
+                .collect::<BTreeSet<_>>(),
+            SocialConnectionKind::Muted => self
+                .projection_store
+                .list_muted_authors()
+                .await?
+                .into_iter()
+                .map(|row| row.author_pubkey)
+                .collect::<BTreeSet<_>>(),
+        };
+        let mut items = Vec::with_capacity(pubkeys.len());
+        for author_pubkey in pubkeys {
+            items.push(
+                self.build_author_social_view(author_pubkey.as_str())
+                    .await?,
+            );
+        }
+        items.sort_by(author_social_view_sort_key);
+        Ok(items)
+    }
+
     pub async fn resume_direct_message_state(&self) -> Result<()> {
         let mut peers = self
             .projection_store
@@ -950,6 +1025,8 @@ impl AppService {
                 .cmp(&left.created_at())
                 .then_with(|| right.object_id().cmp(left.object_id()))
         });
+        let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
+        items.retain(|item| !profile_timeline_item_is_muted(item, &muted_author_pubkeys));
         let page = profile_timeline_page(items, cursor, limit);
         let mut views = Vec::with_capacity(page.items.len());
         for item in page.items {
@@ -1250,7 +1327,14 @@ impl AppService {
     }
 
     pub async fn list_bookmarked_posts(&self) -> Result<Vec<BookmarkedPostView>> {
-        let rows = self.projection_store.list_bookmarked_posts().await?;
+        let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
+        let rows = self
+            .projection_store
+            .list_bookmarked_posts()
+            .await?
+            .into_iter()
+            .filter(|row| !bookmarked_post_row_is_muted(row, &muted_author_pubkeys))
+            .collect::<Vec<_>>();
         let mut items = Vec::with_capacity(rows.len());
         for row in rows {
             items.push(self.bookmarked_post_view_from_row(row).await?);
@@ -1673,12 +1757,14 @@ impl AppService {
         limit: usize,
     ) -> Result<TimelineView> {
         self.ensure_scope_subscriptions(topic_id, &scope).await?;
+        let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
         let mut page = filtered_timeline_page(
             self.projection_store.as_ref(),
             topic_id,
             cursor.clone(),
             limit,
             &self.allowed_channel_ids_for_scope(topic_id, &scope).await?,
+            &muted_author_pubkeys,
         )
         .await?;
         if page.items.is_empty()
@@ -1698,6 +1784,7 @@ impl AppService {
                 cursor,
                 limit,
                 &self.allowed_channel_ids_for_scope(topic_id, &scope).await?,
+                &muted_author_pubkeys,
             )
             .await?;
         }
@@ -1720,6 +1807,7 @@ impl AppService {
     ) -> Result<TimelineView> {
         self.ensure_scope_subscriptions(topic_id, &TimelineScope::AllJoined)
             .await?;
+        let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
         let thread_root = EnvelopeId::from(thread_id);
         let mut page = filtered_thread_page(
             self.projection_store.as_ref(),
@@ -1728,6 +1816,7 @@ impl AppService {
             cursor.clone(),
             limit,
             None,
+            &muted_author_pubkeys,
         )
         .await?;
         if page.items.is_empty() || projection_page_needs_hydration(&page) {
@@ -1752,6 +1841,7 @@ impl AppService {
                 cursor,
                 limit,
                 root_channel.as_deref(),
+                &muted_author_pubkeys,
             )
             .await?;
         }
@@ -1776,6 +1866,7 @@ impl AppService {
         scope: TimelineScope,
     ) -> Result<Vec<LiveSessionView>> {
         self.ensure_scope_subscriptions(topic_id, &scope).await?;
+        let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
         self.projection_store
             .clear_expired_live_presence(Utc::now().timestamp_millis())
             .await?;
@@ -1786,7 +1877,10 @@ impl AppService {
                 .await?,
             &allowed,
             |row| row.channel_id.as_str(),
-        );
+        )
+        .into_iter()
+        .filter(|row| !muted_author_pubkeys.contains(row.host_pubkey.as_str()))
+        .collect::<Vec<_>>();
         let needs_refresh = rows
             .iter()
             .any(|row| row.status == LiveSessionStatus::Live && row.viewer_count == 0);
@@ -1803,7 +1897,10 @@ impl AppService {
                     .await?,
                 &allowed,
                 |row| row.channel_id.as_str(),
-            );
+            )
+            .into_iter()
+            .filter(|row| !muted_author_pubkeys.contains(row.host_pubkey.as_str()))
+            .collect();
         }
         self.cleanup_ended_live_presence_tasks(&rows).await;
         let joined_sessions = self.live_presence_tasks.lock().await;
@@ -2085,6 +2182,7 @@ impl AppService {
         scope: TimelineScope,
     ) -> Result<Vec<GameRoomView>> {
         self.ensure_scope_subscriptions(topic_id, &scope).await?;
+        let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
         let allowed = self.allowed_channel_ids_for_scope(topic_id, &scope).await?;
         let mut rows = filter_channel_rows(
             self.projection_store
@@ -2092,7 +2190,10 @@ impl AppService {
                 .await?,
             &allowed,
             |row| row.channel_id.as_str(),
-        );
+        )
+        .into_iter()
+        .filter(|row| !muted_author_pubkeys.contains(row.host_pubkey.as_str()))
+        .collect::<Vec<_>>();
         if rows.is_empty() {
             self.hydrate_scope_projection(topic_id, &scope).await?;
             rows = filter_channel_rows(
@@ -2101,7 +2202,10 @@ impl AppService {
                     .await?,
                 &allowed,
                 |row| row.channel_id.as_str(),
-            );
+            )
+            .into_iter()
+            .filter(|row| !muted_author_pubkeys.contains(row.host_pubkey.as_str()))
+            .collect();
         }
         let mut items = Vec::with_capacity(rows.len());
         for row in rows {
@@ -4451,10 +4555,16 @@ impl AppService {
             .projection_store
             .get_author_relationship(self.current_author_pubkey().as_str(), author_pubkey)
             .await?;
+        let muted = self
+            .projection_store
+            .get_muted_author(author_pubkey)
+            .await?
+            .is_some();
         Ok(author_social_view_from_parts(
             author_pubkey,
             profile.as_ref(),
             relationship.as_ref(),
+            muted,
         ))
     }
 
@@ -4465,6 +4575,16 @@ impl AppService {
             self.current_author_pubkey().as_str(),
         )
         .await
+    }
+
+    async fn current_muted_author_pubkeys(&self) -> Result<BTreeSet<String>> {
+        Ok(self
+            .projection_store
+            .list_muted_authors()
+            .await?
+            .into_iter()
+            .map(|row| row.author_pubkey)
+            .collect())
     }
 
     async fn ensure_author_subscriptions_for_rows(
@@ -6029,6 +6149,7 @@ fn author_social_view_from_parts(
     author_pubkey: &str,
     profile: Option<&Profile>,
     relationship: Option<&AuthorRelationshipProjectionRow>,
+    muted: bool,
 ) -> AuthorSocialView {
     AuthorSocialView {
         author_pubkey: author_pubkey.to_string(),
@@ -6047,7 +6168,29 @@ fn author_social_view_from_parts(
         friend_of_friend_via_pubkeys: relationship
             .map(|relationship| relationship.friend_of_friend_via_pubkeys.clone())
             .unwrap_or_default(),
+        muted,
     }
+}
+
+fn author_social_view_sort_key(
+    left: &AuthorSocialView,
+    right: &AuthorSocialView,
+) -> std::cmp::Ordering {
+    fn key(value: Option<&str>) -> (u8, String) {
+        let normalized = value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_ascii_lowercase());
+        match normalized {
+            Some(value) => (0, value),
+            None => (1, String::new()),
+        }
+    }
+
+    key(left.display_name.as_deref())
+        .cmp(&key(right.display_name.as_deref()))
+        .then_with(|| key(left.name.as_deref()).cmp(&key(right.name.as_deref())))
+        .then_with(|| left.author_pubkey.cmp(&right.author_pubkey))
 }
 
 async fn rebuild_author_relationships_with_services(
@@ -7596,6 +7739,7 @@ async fn filtered_timeline_page(
     cursor: Option<TimelineCursor>,
     limit: usize,
     allowed_channels: &BTreeSet<String>,
+    muted_author_pubkeys: &BTreeSet<String>,
 ) -> Result<Page<ObjectProjectionRow>> {
     if limit == 0 {
         return Ok(Page {
@@ -7616,7 +7760,9 @@ async fn filtered_timeline_page(
         .await?;
         let next_cursor = page.next_cursor.clone();
         for row in page.items {
-            if allowed_channels.contains(row.channel_id.as_str()) {
+            if allowed_channels.contains(row.channel_id.as_str())
+                && !object_projection_row_is_muted(&row, muted_author_pubkeys)
+            {
                 items.push(row);
                 if items.len() >= limit {
                     return Ok(Page { items, next_cursor });
@@ -7637,6 +7783,7 @@ async fn filtered_thread_page(
     cursor: Option<TimelineCursor>,
     limit: usize,
     allowed_channel: Option<&str>,
+    muted_author_pubkeys: &BTreeSet<String>,
 ) -> Result<Page<ObjectProjectionRow>> {
     if limit == 0 {
         return Ok(Page {
@@ -7658,7 +7805,9 @@ async fn filtered_thread_page(
         .await?;
         let next_cursor = page.next_cursor.clone();
         for row in page.items {
-            if allowed_channel.is_none_or(|channel_id| row.channel_id == channel_id) {
+            if allowed_channel.is_none_or(|channel_id| row.channel_id == channel_id)
+                && !object_projection_row_is_muted(&row, muted_author_pubkeys)
+            {
                 items.push(row);
                 if items.len() >= limit {
                     return Ok(Page { items, next_cursor });
@@ -7680,6 +7829,41 @@ fn filter_channel_rows<T>(
     rows.into_iter()
         .filter(|row| allowed_channels.contains(channel_id(row)))
         .collect()
+}
+
+fn object_projection_row_is_muted(
+    row: &ObjectProjectionRow,
+    muted_author_pubkeys: &BTreeSet<String>,
+) -> bool {
+    muted_author_pubkeys.contains(row.author_pubkey.as_str())
+        || row.repost_of.as_ref().is_some_and(|snapshot| {
+            muted_author_pubkeys.contains(snapshot.source_author_pubkey.as_str())
+        })
+}
+
+fn bookmarked_post_row_is_muted(
+    row: &BookmarkedPostRow,
+    muted_author_pubkeys: &BTreeSet<String>,
+) -> bool {
+    muted_author_pubkeys.contains(row.author_pubkey.as_str())
+        || row.repost_of.as_ref().is_some_and(|snapshot| {
+            muted_author_pubkeys.contains(snapshot.source_author_pubkey.as_str())
+        })
+}
+
+fn profile_timeline_item_is_muted(
+    item: &ProfileTimelineItem,
+    muted_author_pubkeys: &BTreeSet<String>,
+) -> bool {
+    match item {
+        ProfileTimelineItem::Post(post) => {
+            muted_author_pubkeys.contains(post.author_pubkey.as_str())
+        }
+        ProfileTimelineItem::Repost(repost) => {
+            muted_author_pubkeys.contains(repost.author_pubkey.as_str())
+                || muted_author_pubkeys.contains(repost.repost_of.source_author_pubkey.as_str())
+        }
+    }
 }
 
 async fn fetch_post_object_for_projection(
@@ -9172,6 +9356,50 @@ mod tests {
         (app, store, docs_sync, blob_service)
     }
 
+    fn shared_apps_with_memory_services() -> (
+        AppService,
+        KukuriKeys,
+        AppService,
+        KukuriKeys,
+        Arc<MemoryStore>,
+        Arc<MemoryDocsSync>,
+        Arc<MemoryBlobService>,
+    ) {
+        let store = Arc::new(MemoryStore::default());
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let local_keys = generate_keys();
+        let remote_keys = generate_keys();
+        let local_app = AppService::new_with_services(
+            store.clone(),
+            store.clone(),
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync.clone(),
+            blob_service.clone(),
+            local_keys.clone(),
+        );
+        let remote_app = AppService::new_with_services(
+            store.clone(),
+            store.clone(),
+            transport,
+            Arc::new(NoopHintTransport),
+            docs_sync.clone(),
+            blob_service.clone(),
+            remote_keys.clone(),
+        );
+        (
+            local_app,
+            local_keys,
+            remote_app,
+            remote_keys,
+            store,
+            docs_sync,
+            blob_service,
+        )
+    }
+
     async fn author_profile_post_docs(
         docs_sync: &dyn DocsSync,
         author_pubkey: &str,
@@ -10287,6 +10515,309 @@ mod tests {
         assert_eq!(repost_of.source_object_id, source_object_id);
         assert_eq!(repost_of.source_topic_id, source_topic);
         assert_eq!(repost_of.content, "source body");
+    }
+
+    #[tokio::test]
+    async fn mute_author_restores_after_restart() {
+        let dir = tempdir().expect("tempdir");
+        let database_path = dir.path().join("mute-restart.sqlite");
+        let store = Arc::new(
+            SqliteStore::connect_file(&database_path)
+                .await
+                .expect("connect sqlite store"),
+        );
+        let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
+        let docs_sync = Arc::new(MemoryDocsSync::default());
+        let blob_service = Arc::new(MemoryBlobService::default());
+        let keys = generate_keys();
+        let author_pubkey = generate_keys().public_key_hex();
+
+        let app = AppService::new_with_services(
+            store.clone(),
+            store.clone(),
+            transport.clone(),
+            Arc::new(NoopHintTransport),
+            docs_sync.clone(),
+            blob_service.clone(),
+            keys.clone(),
+        );
+        let muted = app
+            .mute_author(author_pubkey.as_str())
+            .await
+            .expect("mute author");
+        assert!(muted.muted);
+
+        drop(app);
+        store.close().await;
+
+        let reopened = Arc::new(
+            SqliteStore::connect_file(&database_path)
+                .await
+                .expect("reopen sqlite store"),
+        );
+        let reopened_app = AppService::new_with_services(
+            reopened.clone(),
+            reopened.clone(),
+            transport,
+            Arc::new(NoopHintTransport),
+            docs_sync,
+            blob_service,
+            keys,
+        );
+
+        let restored = reopened_app
+            .get_author_social_view(author_pubkey.as_str())
+            .await
+            .expect("get author after restart");
+        let muted_authors = reopened_app
+            .list_social_connections(SocialConnectionKind::Muted)
+            .await
+            .expect("list muted authors");
+
+        assert!(restored.muted);
+        assert_eq!(muted_authors.len(), 1);
+        assert_eq!(muted_authors[0].author_pubkey, author_pubkey);
+        assert!(muted_authors[0].muted);
+    }
+
+    #[tokio::test]
+    async fn muted_author_is_filtered_from_timeline_thread_profile_and_bookmarks() {
+        let (local_app, _local_keys, remote_app, remote_keys, _store, _docs_sync, _blob_service) =
+            shared_apps_with_memory_services();
+        let topic = "kukuri:topic:mute-filter";
+        let remote_pubkey = remote_keys.public_key_hex();
+        let root_id = remote_app
+            .create_post(topic, "muted root", None)
+            .await
+            .expect("create root post");
+        let reply_id = remote_app
+            .create_post(topic, "muted reply", Some(root_id.as_str()))
+            .await
+            .expect("create reply post");
+
+        let timeline_before = local_app
+            .list_timeline(topic, None, 20)
+            .await
+            .expect("timeline before mute");
+        let thread_before = local_app
+            .list_thread(topic, root_id.as_str(), None, 20)
+            .await
+            .expect("thread before mute");
+        let profile_before = local_app
+            .list_profile_timeline(remote_pubkey.as_str(), None, 20)
+            .await
+            .expect("profile before mute");
+
+        local_app
+            .bookmark_post(topic, root_id.as_str())
+            .await
+            .expect("bookmark muted author post");
+        let bookmarks_before = local_app
+            .list_bookmarked_posts()
+            .await
+            .expect("bookmarks before mute");
+
+        assert!(
+            timeline_before
+                .items
+                .iter()
+                .any(|post| post.object_id == root_id)
+        );
+        assert!(
+            timeline_before
+                .items
+                .iter()
+                .any(|post| post.object_id == reply_id)
+        );
+        assert!(
+            thread_before
+                .items
+                .iter()
+                .any(|post| post.object_id == root_id)
+        );
+        assert!(
+            thread_before
+                .items
+                .iter()
+                .any(|post| post.object_id == reply_id)
+        );
+        assert!(
+            profile_before
+                .items
+                .iter()
+                .any(|post| post.object_id == root_id)
+        );
+        assert_eq!(bookmarks_before.len(), 1);
+        assert_eq!(bookmarks_before[0].post.object_id, root_id);
+
+        local_app
+            .mute_author(remote_pubkey.as_str())
+            .await
+            .expect("mute remote author");
+
+        let timeline_after = local_app
+            .list_timeline(topic, None, 20)
+            .await
+            .expect("timeline after mute");
+        let thread_after = local_app
+            .list_thread(topic, root_id.as_str(), None, 20)
+            .await
+            .expect("thread after mute");
+        let profile_after = local_app
+            .list_profile_timeline(remote_pubkey.as_str(), None, 20)
+            .await
+            .expect("profile after mute");
+        let bookmarks_after = local_app
+            .list_bookmarked_posts()
+            .await
+            .expect("bookmarks after mute");
+
+        assert!(timeline_after.items.is_empty());
+        assert!(thread_after.items.is_empty());
+        assert!(profile_after.items.is_empty());
+        assert!(bookmarks_after.is_empty());
+    }
+
+    #[tokio::test]
+    async fn repost_of_muted_author_is_hidden() {
+        let (local_app, _local_keys, remote_app, remote_keys, _store, _docs_sync, _blob_service) =
+            shared_apps_with_memory_services();
+        let topic = "kukuri:topic:mute-repost";
+        let remote_pubkey = remote_keys.public_key_hex();
+        let source_id = remote_app
+            .create_post(topic, "muted source", None)
+            .await
+            .expect("create muted source post");
+        let visible_local_id = local_app
+            .create_post(topic, "visible local post", None)
+            .await
+            .expect("create visible local post");
+        let repost_id = local_app
+            .create_repost(topic, topic, source_id.as_str(), Some("quote muted source"))
+            .await
+            .expect("create quote repost");
+
+        let timeline_before = local_app
+            .list_timeline(topic, None, 20)
+            .await
+            .expect("timeline before mute");
+        assert!(
+            timeline_before
+                .items
+                .iter()
+                .any(|post| post.object_id == repost_id)
+        );
+
+        local_app
+            .mute_author(remote_pubkey.as_str())
+            .await
+            .expect("mute source author");
+
+        let timeline_after = local_app
+            .list_timeline(topic, None, 20)
+            .await
+            .expect("timeline after mute");
+
+        assert!(
+            timeline_after
+                .items
+                .iter()
+                .all(|post| post.object_id != source_id)
+        );
+        assert!(
+            timeline_after
+                .items
+                .iter()
+                .all(|post| post.object_id != repost_id)
+        );
+        assert!(
+            timeline_after
+                .items
+                .iter()
+                .any(|post| post.object_id == visible_local_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn list_social_connections_followed_is_local_known_only() {
+        let (local_app, local_keys, remote_app, remote_keys, _store, _docs_sync, _blob_service) =
+            shared_apps_with_memory_services();
+        let local_pubkey = local_keys.public_key_hex();
+        let remote_pubkey = remote_keys.public_key_hex();
+        let unseen_pubkey = generate_keys().public_key_hex();
+
+        remote_app
+            .follow_author(local_pubkey.as_str())
+            .await
+            .expect("remote follows local");
+
+        let followed = local_app
+            .list_social_connections(SocialConnectionKind::Followed)
+            .await
+            .expect("list followed authors");
+
+        assert_eq!(followed.len(), 1);
+        assert_eq!(followed[0].author_pubkey, remote_pubkey);
+        assert!(followed[0].followed_by);
+        assert!(
+            followed
+                .iter()
+                .all(|author| author.author_pubkey != unseen_pubkey)
+        );
+    }
+
+    #[tokio::test]
+    async fn unmute_restores_visibility() {
+        let (local_app, _local_keys, remote_app, remote_keys, _store, _docs_sync, _blob_service) =
+            shared_apps_with_memory_services();
+        let topic = "kukuri:topic:unmute-restore";
+        let remote_pubkey = remote_keys.public_key_hex();
+        let object_id = remote_app
+            .create_post(topic, "restored after unmute", None)
+            .await
+            .expect("create remote post");
+
+        let timeline_before = local_app
+            .list_timeline(topic, None, 20)
+            .await
+            .expect("timeline before mute");
+        assert!(
+            timeline_before
+                .items
+                .iter()
+                .any(|post| post.object_id == object_id)
+        );
+
+        local_app
+            .mute_author(remote_pubkey.as_str())
+            .await
+            .expect("mute remote author");
+        let muted_timeline = local_app
+            .list_timeline(topic, None, 20)
+            .await
+            .expect("timeline while muted");
+        assert!(
+            muted_timeline
+                .items
+                .iter()
+                .all(|post| post.object_id != object_id)
+        );
+
+        local_app
+            .unmute_author(remote_pubkey.as_str())
+            .await
+            .expect("unmute remote author");
+        let restored_timeline = local_app
+            .list_timeline(topic, None, 20)
+            .await
+            .expect("timeline after unmute");
+
+        assert!(
+            restored_timeline
+                .items
+                .iter()
+                .any(|post| post.object_id == object_id)
+        );
     }
 
     #[test]
@@ -13534,6 +14065,128 @@ mod tests {
             .await
             .expect_err("ended room update should fail");
         assert!(error.to_string().contains("ended game room"));
+    }
+
+    #[tokio::test]
+    async fn muted_author_is_filtered_from_live_and_game_lists() {
+        let (local_app, _local_keys, remote_app, remote_keys, _store, _docs_sync, _blob_service) =
+            shared_apps_with_memory_services();
+        let topic = "kukuri:topic:mute-live-game";
+        let remote_pubkey = remote_keys.public_key_hex();
+
+        let session_id = remote_app
+            .create_live_session(
+                topic,
+                CreateLiveSessionInput {
+                    title: "muted live".into(),
+                    description: "hidden".into(),
+                },
+            )
+            .await
+            .expect("create live session");
+        let room_id = remote_app
+            .create_game_room(
+                topic,
+                CreateGameRoomInput {
+                    title: "muted room".into(),
+                    description: "hidden".into(),
+                    participants: vec!["Alice".into(), "Bob".into()],
+                },
+            )
+            .await
+            .expect("create game room");
+
+        let live_before = local_app
+            .list_live_sessions(topic)
+            .await
+            .expect("list live sessions before mute");
+        let games_before = local_app
+            .list_game_rooms(topic)
+            .await
+            .expect("list game rooms before mute");
+        assert!(
+            live_before
+                .iter()
+                .any(|session| session.session_id == session_id)
+        );
+        assert!(games_before.iter().any(|room| room.room_id == room_id));
+
+        local_app
+            .mute_author(remote_pubkey.as_str())
+            .await
+            .expect("mute live/game host");
+
+        let live_after = local_app
+            .list_live_sessions(topic)
+            .await
+            .expect("list live sessions after mute");
+        let games_after = local_app
+            .list_game_rooms(topic)
+            .await
+            .expect("list game rooms after mute");
+
+        assert!(
+            live_after
+                .iter()
+                .all(|session| session.session_id != session_id)
+        );
+        assert!(games_after.iter().all(|room| room.room_id != room_id));
+    }
+
+    #[tokio::test]
+    async fn mute_does_not_change_follow_mutual_or_friend_gating() {
+        let (local_app, local_keys, remote_app, remote_keys, _store, _docs_sync, _blob_service) =
+            shared_apps_with_memory_services();
+        let topic = "kukuri:topic:mute-friend-gating";
+        let local_pubkey = local_keys.public_key_hex();
+        let remote_pubkey = remote_keys.public_key_hex();
+
+        local_app
+            .follow_author(remote_pubkey.as_str())
+            .await
+            .expect("local follows remote");
+        remote_app
+            .follow_author(local_pubkey.as_str())
+            .await
+            .expect("remote follows local");
+
+        local_app
+            .mute_author(remote_pubkey.as_str())
+            .await
+            .expect("mute mutual author");
+
+        let social_view = local_app
+            .get_author_social_view(remote_pubkey.as_str())
+            .await
+            .expect("load muted mutual author");
+        let dm_status = local_app
+            .get_direct_message_status(remote_pubkey.as_str())
+            .await
+            .expect("get direct message status");
+        let channel = local_app
+            .create_private_channel(CreatePrivateChannelInput {
+                topic_id: TopicId::new(topic),
+                label: "friends".into(),
+                audience_kind: ChannelAudienceKind::FriendOnly,
+            })
+            .await
+            .expect("create friend-only channel");
+        let grant = local_app
+            .export_friend_only_grant(topic, channel.channel_id.as_str(), None)
+            .await
+            .expect("export friend-only grant after mute");
+        let preview = remote_app
+            .import_friend_only_grant(grant.as_str())
+            .await
+            .expect("import friend-only grant after mute");
+
+        assert!(social_view.following);
+        assert!(social_view.followed_by);
+        assert!(social_view.mutual);
+        assert!(social_view.muted);
+        assert!(dm_status.mutual);
+        assert!(dm_status.send_enabled);
+        assert_eq!(preview.channel_id.as_str(), channel.channel_id);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -718,6 +718,8 @@ impl AppService {
         let author_pubkey = normalize_author_pubkey(pubkey)?;
         self.ensure_author_subscription(author_pubkey.as_str())
             .await?;
+        self.maybe_restart_author_subscription(author_pubkey.as_str())
+            .await;
         self.rebuild_author_relationships().await?;
         self.build_author_social_view(author_pubkey.as_str()).await
     }
@@ -4630,6 +4632,32 @@ impl AppService {
             handle.abort();
         }
         self.spawn_author_subscription(author_pubkey.as_str()).await
+    }
+
+    async fn maybe_restart_author_subscription(&self, author_pubkey: &str) {
+        let Ok(author_pubkey) = normalize_author_pubkey(author_pubkey) else {
+            return;
+        };
+        let key = format!("author-subscription:{author_pubkey}");
+        let now = Utc::now().timestamp();
+        {
+            let mut deadlines = self.replica_sync_restart_deadlines.lock().await;
+            let next_due_at = deadlines.get(key.as_str()).copied().unwrap_or_default();
+            if next_due_at > now {
+                return;
+            }
+            deadlines.insert(key, now.saturating_add(REPLICA_SYNC_RESTART_RETRY_SECONDS));
+        }
+        if let Err(error) = self
+            .restart_author_subscription(author_pubkey.as_str())
+            .await
+        {
+            warn!(
+                author_pubkey = %author_pubkey,
+                error = %error,
+                "failed to restart author subscription"
+            );
+        }
     }
 
     async fn spawn_author_subscription(&self, author_pubkey: &str) -> Result<()> {

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -19,7 +19,7 @@ use kukuri_app_api::{
     CustomReactionAssetView, DirectMessageConversationView, DirectMessageStatusView,
     DirectMessageTimelineView, GameRoomView, GameScoreView, JoinedPrivateChannelView,
     LiveSessionView, PendingAttachment, PrivateChannelCapability, ProfileInput, ReactionStateView,
-    RecentReactionView, SyncStatus, TimelineView, UpdateGameRoomInput,
+    RecentReactionView, SocialConnectionKind, SyncStatus, TimelineView, UpdateGameRoomInput,
 };
 use kukuri_blob_service::{BlobService, BlobStatus, IrohBlobService, StoredBlob};
 use kukuri_cn_core::{
@@ -214,6 +214,11 @@ pub struct GetBlobMediaRequest {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthorRequest {
     pub pubkey: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ListSocialConnectionsRequest {
+    pub kind: SocialConnectionKind,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1048,6 +1053,23 @@ impl DesktopRuntime {
         self.app_service
             .get_author_social_view(request.pubkey.as_str())
             .await
+    }
+
+    pub async fn mute_author(&self, request: AuthorRequest) -> Result<AuthorSocialView> {
+        self.app_service.mute_author(request.pubkey.as_str()).await
+    }
+
+    pub async fn unmute_author(&self, request: AuthorRequest) -> Result<AuthorSocialView> {
+        self.app_service
+            .unmute_author(request.pubkey.as_str())
+            .await
+    }
+
+    pub async fn list_social_connections(
+        &self,
+        request: ListSocialConnectionsRequest,
+    ) -> Result<Vec<AuthorSocialView>> {
+        self.app_service.list_social_connections(request.kind).await
     }
 
     pub async fn open_direct_message(

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -3256,12 +3256,12 @@ mod tests {
         }
     }
 
-    async fn wait_for_profile_timeline_posts(
+    async fn wait_for_profile_timeline_posts_result(
         runtime: &DesktopRuntime,
         author_pubkey: &str,
         object_ids: &[String],
         timeout_label: &str,
-    ) -> TimelineView {
+    ) -> Result<TimelineView> {
         match timeout(runtime_replication_timeout(), async {
             loop {
                 let timeline = runtime
@@ -3285,7 +3285,7 @@ mod tests {
         })
         .await
         {
-            Ok(timeline) => timeline,
+            Ok(timeline) => Ok(timeline),
             Err(_) => {
                 let status = runtime.get_sync_status().await.expect("sync status");
                 let visible_items = runtime
@@ -3304,7 +3304,7 @@ mod tests {
                             .collect::<Vec<_>>()
                     })
                     .unwrap_or_default();
-                panic!(
+                bail!(
                     "{timeout_label}: {}; visible_items={visible_items:?}",
                     format_sync_snapshot(&status, "")
                 );
@@ -4256,11 +4256,15 @@ mod tests {
             .expect("ticket b value");
 
         runtime_a
-            .import_peer_ticket(ImportPeerTicketRequest { ticket: ticket_b })
+            .import_peer_ticket(ImportPeerTicketRequest {
+                ticket: ticket_b.clone(),
+            })
             .await
             .expect("import b");
         runtime_b
-            .import_peer_ticket(ImportPeerTicketRequest { ticket: ticket_a })
+            .import_peer_ticket(ImportPeerTicketRequest {
+                ticket: ticket_a.clone(),
+            })
             .await
             .expect("import a");
         wait_for_connected_peer_count(&runtime_a, 1, "profile topic owner peer readiness timeout")
@@ -4353,13 +4357,83 @@ mod tests {
                 .all(|topic| topic != untracked_topic)
         );
 
-        let profile_timeline = wait_for_profile_timeline_posts(
+        let profile_object_ids = vec![tracked_object_id.clone(), untracked_object_id.clone()];
+        let (runtime_b, profile_timeline) = match wait_for_profile_timeline_posts_result(
             &runtime_b,
             author_pubkey.as_str(),
-            &[tracked_object_id.clone(), untracked_object_id.clone()],
+            &profile_object_ids,
             "profile timeline visibility timeout",
         )
-        .await;
+        .await
+        {
+            Ok(timeline) => (runtime_b, timeline),
+            Err(first_error) => {
+                timeout(runtime_shutdown_timeout(), runtime_b.shutdown())
+                    .await
+                    .expect("profile viewer restart shutdown timeout");
+                drop(runtime_b);
+
+                let restarted_b = DesktopRuntime::new_with_config_and_identity(
+                    &db_b,
+                    TransportNetworkConfig::loopback(),
+                    IdentityStorageMode::FileOnly,
+                )
+                .await
+                .expect("restart runtime b");
+                let restarted_ticket_b = restarted_b
+                    .local_peer_ticket()
+                    .await
+                    .expect("restarted ticket b")
+                    .expect("restarted ticket b value");
+                runtime_a
+                    .import_peer_ticket(ImportPeerTicketRequest {
+                        ticket: restarted_ticket_b,
+                    })
+                    .await
+                    .expect("import restarted b");
+                restarted_b
+                    .import_peer_ticket(ImportPeerTicketRequest {
+                        ticket: ticket_a.clone(),
+                    })
+                    .await
+                    .expect("import a after restart");
+                wait_for_connected_peer_count(
+                    &restarted_b,
+                    1,
+                    "profile viewer peer restart readiness timeout",
+                )
+                .await;
+                let _ = restarted_b
+                    .list_timeline(ListTimelineRequest {
+                        topic: tracked_topic.into(),
+                        scope: public_scope.clone(),
+                        cursor: None,
+                        limit: Some(20),
+                    })
+                    .await
+                    .expect("resubscribe restarted b tracked topic");
+                wait_for_connected_topic_peer_count(
+                    &restarted_b,
+                    tracked_topic,
+                    1,
+                    "profile tracked topic restart readiness timeout b",
+                )
+                .await;
+                let timeline = wait_for_profile_timeline_posts_result(
+                    &restarted_b,
+                    author_pubkey.as_str(),
+                    &profile_object_ids,
+                    "profile timeline visibility timeout after restart",
+                )
+                .await
+                .unwrap_or_else(|second_error| {
+                    panic!(
+                        "profile timeline visibility timeout after viewer restart: first_error={first_error:#}; second_error={second_error:#}"
+                    )
+                });
+                (restarted_b, timeline)
+            }
+        };
         assert!(
             profile_timeline
                 .items

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -2728,8 +2728,6 @@ mod tests {
     use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
     use image::{AnimationDecoder, Delay, Frame, GenericImageView, ImageFormat, Rgba, RgbaImage};
     use iroh::address_lookup::EndpointInfo;
-    use kukuri_core::AuthorProfilePostDocV1;
-    use kukuri_docs_sync::author_replica_id;
     use pkarr::errors::{ConcurrencyError, PublishError};
     use pkarr::{Client as PkarrClient, SignedPacket, Timestamp, mainline::Testnet};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -3308,72 +3306,6 @@ mod tests {
                     .unwrap_or_default();
                 panic!(
                     "{timeout_label}: {}; visible_items={visible_items:?}",
-                    format_sync_snapshot(&status, "")
-                );
-            }
-        }
-    }
-
-    async fn wait_for_profile_post_doc(
-        runtime: &DesktopRuntime,
-        author_pubkey: &str,
-        object_id: &str,
-        timeout_label: &str,
-    ) {
-        let author_replica = author_replica_id(author_pubkey);
-        match timeout(runtime_replication_timeout(), async {
-            loop {
-                let _ = runtime
-                    .list_profile_timeline(ListProfileTimelineRequest {
-                        pubkey: author_pubkey.to_string(),
-                        cursor: None,
-                        limit: Some(20),
-                    })
-                    .await
-                    .expect("profile timeline");
-                let current = runtime.iroh_stack.current.lock().await;
-                let docs_sync = current.as_ref().expect("current stack").docs_sync.clone();
-                drop(current);
-                let docs = docs_sync
-                    .query_replica(&author_replica, DocQuery::Prefix("profile/posts/".into()))
-                    .await
-                    .expect("profile post docs");
-                if docs.into_iter().any(|record| {
-                    serde_json::from_slice::<AuthorProfilePostDocV1>(record.value.as_slice())
-                        .map(|doc| doc.object_id.as_str() == object_id)
-                        .unwrap_or(false)
-                }) {
-                    return;
-                }
-                sleep(Duration::from_millis(50)).await;
-            }
-        })
-        .await
-        {
-            Ok(()) => {}
-            Err(_) => {
-                let status = runtime.get_sync_status().await.expect("sync status");
-                let current = runtime.iroh_stack.current.lock().await;
-                let docs_sync = current.as_ref().expect("current stack").docs_sync.clone();
-                drop(current);
-                let visible_doc_ids = docs_sync
-                    .query_replica(&author_replica, DocQuery::Prefix("profile/posts/".into()))
-                    .await
-                    .ok()
-                    .map(|docs| {
-                        docs.into_iter()
-                            .filter_map(|record| {
-                                serde_json::from_slice::<AuthorProfilePostDocV1>(
-                                    record.value.as_slice(),
-                                )
-                                .ok()
-                                .map(|doc| doc.object_id.as_str().to_string())
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default();
-                panic!(
-                    "{timeout_label}: {}; visible_doc_ids={visible_doc_ids:?}",
                     format_sync_snapshot(&status, "")
                 );
             }
@@ -4404,14 +4336,6 @@ mod tests {
             })
             .await
             .expect("untracked public post");
-        wait_for_profile_post_doc(
-            &runtime_b,
-            author_pubkey.as_str(),
-            untracked_object_id.as_str(),
-            "profile post doc visibility timeout",
-        )
-        .await;
-
         let before_profile = runtime_b
             .get_sync_status()
             .await

--- a/crates/harness/src/lib.rs
+++ b/crates/harness/src/lib.rs
@@ -971,6 +971,7 @@ async fn run_community_node_connectivity(
                 })
                 .await
                 .context("failed to create live session on desktop a")?;
+            wait_for_live_session(&runtime_a, topic, session_id.as_str(), step_timeout).await?;
             let mut live_session_error = None;
             for attempt in 1..=public_feature_attempts {
                 match wait_for_live_session(
@@ -1046,6 +1047,7 @@ async fn run_community_node_connectivity(
                 })
                 .await
                 .context("failed to end live session on desktop a")?;
+            wait_for_live_ended(&runtime_a, topic, session_id.as_str(), step_timeout).await?;
             let mut live_ended_error = None;
             for attempt in 1..=public_feature_attempts {
                 match wait_for_live_ended(
@@ -3517,6 +3519,30 @@ async fn refresh_public_pair(
             scope: TimelineScope::Public,
             cursor: None,
             limit: Some(20),
+        })
+        .await;
+    let _ = runtime_a
+        .list_live_sessions(ListLiveSessionsRequest {
+            topic: topic.to_string(),
+            scope: TimelineScope::Public,
+        })
+        .await;
+    let _ = runtime_b
+        .list_live_sessions(ListLiveSessionsRequest {
+            topic: topic.to_string(),
+            scope: TimelineScope::Public,
+        })
+        .await;
+    let _ = runtime_a
+        .list_game_rooms(ListGameRoomsRequest {
+            topic: topic.to_string(),
+            scope: TimelineScope::Public,
+        })
+        .await;
+    let _ = runtime_b
+        .list_game_rooms(ListGameRoomsRequest {
+            topic: topic.to_string(),
+            scope: TimelineScope::Public,
         })
         .await;
     wait_for_topic_peer_count(runtime_a, topic, 1, step_timeout).await?;

--- a/crates/store/migrations/20260331000000_muted_authors.down.sql
+++ b/crates/store/migrations/20260331000000_muted_authors.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_muted_authors_muted_at;
+DROP TABLE IF EXISTS muted_authors;

--- a/crates/store/migrations/20260331000000_muted_authors.up.sql
+++ b/crates/store/migrations/20260331000000_muted_authors.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS muted_authors (
+    author_pubkey TEXT PRIMARY KEY,
+    muted_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_muted_authors_muted_at
+    ON muted_authors(muted_at DESC, author_pubkey ASC);

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -163,6 +163,12 @@ pub struct AuthorRelationshipProjectionRow {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MutedAuthorRow {
+    pub author_pubkey: String,
+    pub muted_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirectMessageConversationRow {
     pub dm_id: String,
     pub peer_pubkey: String,
@@ -268,6 +274,10 @@ pub trait ProjectionStore: Send + Sync {
         local_author_pubkey: &str,
         rows: Vec<AuthorRelationshipProjectionRow>,
     ) -> Result<()>;
+    async fn put_muted_author(&self, row: MutedAuthorRow) -> Result<()>;
+    async fn get_muted_author(&self, author_pubkey: &str) -> Result<Option<MutedAuthorRow>>;
+    async fn list_muted_authors(&self) -> Result<Vec<MutedAuthorRow>>;
+    async fn remove_muted_author(&self, author_pubkey: &str) -> Result<()>;
     async fn upsert_live_presence(
         &self,
         topic_id: &str,
@@ -858,6 +868,7 @@ pub struct MemoryStore {
     game_room_rows: Arc<RwLock<HashMap<String, GameRoomProjectionRow>>>,
     author_relationship_rows:
         Arc<RwLock<HashMap<(String, String), AuthorRelationshipProjectionRow>>>,
+    muted_authors: Arc<RwLock<HashMap<String, MutedAuthorRow>>>,
     live_presence: Arc<RwLock<HashMap<LivePresenceKey, LivePresenceValue>>>,
     blob_statuses: Arc<RwLock<HashMap<String, BlobCacheStatus>>>,
     reaction_projection_rows: Arc<RwLock<MemoryReactionProjectionRows>>,
@@ -1479,6 +1490,62 @@ impl ProjectionStore for SqliteStore {
             .await?;
         }
 
+        Ok(())
+    }
+
+    async fn put_muted_author(&self, row: MutedAuthorRow) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO muted_authors (author_pubkey, muted_at)
+            VALUES (?1, ?2)
+            ON CONFLICT(author_pubkey) DO UPDATE SET
+              muted_at = excluded.muted_at
+            "#,
+        )
+        .bind(row.author_pubkey.as_str())
+        .bind(row.muted_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn get_muted_author(&self, author_pubkey: &str) -> Result<Option<MutedAuthorRow>> {
+        let row = sqlx::query(
+            r#"
+            SELECT author_pubkey, muted_at
+            FROM muted_authors
+            WHERE author_pubkey = ?1
+            "#,
+        )
+        .bind(author_pubkey)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(row_to_muted_author).transpose()
+    }
+
+    async fn list_muted_authors(&self) -> Result<Vec<MutedAuthorRow>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT author_pubkey, muted_at
+            FROM muted_authors
+            ORDER BY muted_at DESC, author_pubkey ASC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(row_to_muted_author).collect()
+    }
+
+    async fn remove_muted_author(&self, author_pubkey: &str) -> Result<()> {
+        sqlx::query(
+            r#"
+            DELETE FROM muted_authors
+            WHERE author_pubkey = ?1
+            "#,
+        )
+        .bind(author_pubkey)
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 
@@ -2461,6 +2528,40 @@ impl ProjectionStore for MemoryStore {
         Ok(())
     }
 
+    async fn put_muted_author(&self, row: MutedAuthorRow) -> Result<()> {
+        self.muted_authors
+            .write()
+            .await
+            .insert(row.author_pubkey.clone(), row);
+        Ok(())
+    }
+
+    async fn get_muted_author(&self, author_pubkey: &str) -> Result<Option<MutedAuthorRow>> {
+        Ok(self.muted_authors.read().await.get(author_pubkey).cloned())
+    }
+
+    async fn list_muted_authors(&self) -> Result<Vec<MutedAuthorRow>> {
+        let mut items = self
+            .muted_authors
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        items.sort_by(|left, right| {
+            right
+                .muted_at
+                .cmp(&left.muted_at)
+                .then_with(|| left.author_pubkey.cmp(&right.author_pubkey))
+        });
+        Ok(items)
+    }
+
+    async fn remove_muted_author(&self, author_pubkey: &str) -> Result<()> {
+        self.muted_authors.write().await.remove(author_pubkey);
+        Ok(())
+    }
+
     async fn upsert_live_presence(
         &self,
         topic_id: &str,
@@ -3191,6 +3292,13 @@ fn row_to_author_relationship_projection(
     })
 }
 
+fn row_to_muted_author(row: sqlx::sqlite::SqliteRow) -> Result<MutedAuthorRow> {
+    Ok(MutedAuthorRow {
+        author_pubkey: row.get("author_pubkey"),
+        muted_at: row.get("muted_at"),
+    })
+}
+
 fn follow_edge_status_name(status: &FollowEdgeStatus) -> &'static str {
     match status {
         FollowEdgeStatus::Active => "active",
@@ -3735,6 +3843,55 @@ mod tests {
             vec!["c".repeat(64)]
         );
         assert!(relationship.followed_by);
+    }
+
+    #[tokio::test]
+    async fn muted_authors_restore_after_restart() {
+        let tempdir = tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("store.db");
+        let author_pubkey = "b".repeat(64);
+
+        {
+            let store = SqliteStore::connect_file(&db_path)
+                .await
+                .expect("open sqlite store");
+            ProjectionStore::put_muted_author(
+                &store,
+                MutedAuthorRow {
+                    author_pubkey: author_pubkey.clone(),
+                    muted_at: 42,
+                },
+            )
+            .await
+            .expect("store muted author");
+            store.close().await;
+        }
+
+        let reopened = SqliteStore::connect_file(&db_path)
+            .await
+            .expect("reopen sqlite store");
+        let muted = ProjectionStore::get_muted_author(&reopened, author_pubkey.as_str())
+            .await
+            .expect("get muted author")
+            .expect("muted author exists");
+        assert_eq!(muted.author_pubkey, author_pubkey);
+        assert_eq!(muted.muted_at, 42);
+        assert_eq!(
+            ProjectionStore::list_muted_authors(&reopened)
+                .await
+                .expect("list muted authors"),
+            vec![muted.clone()]
+        );
+
+        ProjectionStore::remove_muted_author(&reopened, author_pubkey.as_str())
+            .await
+            .expect("remove muted author");
+        assert!(
+            ProjectionStore::get_muted_author(&reopened, author_pubkey.as_str())
+                .await
+                .expect("get muted author after delete")
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/docs/adr/0022-local-author-mute-and-social-management.md
+++ b/docs/adr/0022-local-author-mute-and-social-management.md
@@ -1,0 +1,76 @@
+# ADR 0022: Local Author Mute And Social Management
+
+## Status
+Proposed
+
+## Date
+2026-03-31
+
+## Base Branch
+`main`
+
+## Related
+- `docs/adr/0002-feature-data-classification-template.md`
+- `docs/adr/0013-social-graph-foundation-draft.md`
+- `docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md`
+- `docs/adr/0021-local-post-bookmark-data-classification.md`
+
+## Feature Data Classification
+- Feature 名: local author mute + profile social management
+- Durable / Transient: durable local-only mute state + local route/UI state
+- Canonical Source: local SQLite `muted_authors`
+- Replicated?: No
+- Rebuildable From: local mute record, follow edges, local profile cache
+- Public Replica / Private Replica / Local Only:
+  - mute collection: local only
+  - following / followed projection: 既存 author replica + local projection
+- Gossip Hint 必要有無: No
+- Blob 必要有無: No
+- SQLite projection 必要有無: Yes
+- 必須 contract:
+  - `mute_author_restores_after_restart`
+  - `muted_author_is_filtered_from_timeline_thread_profile_and_bookmarks`
+  - `muted_author_is_filtered_from_live_and_game_lists`
+  - `repost_of_muted_author_is_hidden`
+  - `mute_does_not_change_follow_mutual_or_friend_gating`
+  - `list_social_connections_followed_is_local_known_only`
+  - `unmute_restores_visibility`
+- 必須 scenario:
+  - `follow -> local mute on one device -> muted device only hides post/live/game -> restart restore`
+  - 別 device では mute state が共有されないこと
+
+## Decision
+- author mute v1 は特定 author の `post / live / game` を current device だけで非表示にする local visibility preference とする。
+- mute の canonical source は `ProjectionStore` の `muted_authors` で、docs sync、gossip、community-node、他 device には複製しない。
+- mute は social graph 本体には入れず、follow edge、mutual、friend-only / friend-plus gating、DM 可否、private channel access を変更しない。
+- Following / Followed / Muted の管理 UI は新しい primary section を増やさず、`#/profile` 配下の `profileMode=connections` として持つ。
+- `connectionsView` は `following | followed | muted` を持ち、invalid 値は `following` に normalize する。
+- `Followed` 一覧は full follower inventory ではなく、この端末で hydrate 済みの incoming follow だけを表示する local-known list とする。
+- mute 対象 author は `list_timeline`, `list_thread`, `list_profile_timeline`, `list_bookmarked_posts`, `list_live_sessions_scoped`, `list_game_rooms_scoped` から除外する。
+- repost / quote repost は card author が未ミュートでも `repost_of.source_author_pubkey` が muted なら非表示にする。
+- author detail と profile social management page では muted author を表示し、unmute 導線を失わないようにする。
+- Following / Followed / Muted の一覧は `display_name -> name -> pubkey` の昇順に固定する。
+
+## Public Interfaces
+- `kukuri-store`
+  - `MutedAuthorRow`
+  - `put_muted_author`
+  - `get_muted_author`
+  - `list_muted_authors`
+  - `remove_muted_author`
+- `kukuri-app-api`
+  - `AuthorSocialView.muted`
+  - `SocialConnectionKind`
+  - `mute_author(pubkey)`
+  - `unmute_author(pubkey)`
+  - `list_social_connections(kind)`
+- `desktop-runtime` / Tauri / `apps/desktop/src/lib/api.ts`
+  - mute/list social connection APIs をそのまま公開する
+- desktop shell route
+  - `#/profile?topic=<topic>&profileMode=connections&connectionsView=following|followed|muted`
+
+## Consequences
+- mute は local-only preference なので cross-device sync されず、端末ごとに異なる visibility が成立する。
+- content surface では muted author を完全に隠す一方、management surface では表示するため、解除導線は維持される。
+- `Followed` は observed-only list なので UI に不完全性の説明が必要になる。
+- bookmark 一覧も mute filter の対象に入るため、保存済み post であっても muted author なら通常の content surface からは見えなくなる。


### PR DESCRIPTION
## Summary
- add ADR 0022 for local-only author mute and profile social management
- persist muted authors in the projection store and filter muted authors from post, live, and game surfaces
- add Following / Followed / Muted management under `#/profile` and expose mute toggles in author detail

## Testing
- cargo fmt --all
- cargo test -p kukuri-store muted_authors_restore_after_restart -- --nocapture
- cargo test -p kukuri-app-api mute_ -- --nocapture
- cargo test -p kukuri-app-api muted_ -- --nocapture
- cargo test -p kukuri-app-api list_social_connections_followed_is_local_known_only -- --nocapture
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
- cd apps/desktop && npx pnpm@10.16.1 vitest run src/App.test.tsx