### PR TITLE
Implement desktop UI follow-up fixes

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -240,7 +240,7 @@ function getSocialConnectionsTabs() {
 
 async function selectWorkspace(
   user: ReturnType<typeof userEvent.setup>,
-  label: 'Timeline' | 'Live' | 'Game' | 'Profile'
+  label: 'Timeline' | 'Live' | 'Game' | 'Messages' | 'Profile'
 ) {
   await user.click(within(getWorkspaceTabs()).getByRole('tab', { name: label }));
   await waitFor(() => {
@@ -303,7 +303,7 @@ async function openGameCreateDialog(user: ReturnType<typeof userEvent.setup>) {
   return await screen.findByRole('dialog', { name: 'Create Room' });
 }
 
-function getDetailPane(name: 'Thread' | 'Author' | 'Messages') {
+function getDetailPane(name: 'Thread' | 'Author') {
   return screen.getByRole('complementary', { name });
 }
 
@@ -350,6 +350,11 @@ test.each([
     path: '#/game',
     workspaceLabel: 'Game',
     expectedControl: () => screen.getByRole('button', { name: 'Create Room' }),
+  },
+  {
+    path: '#/messages',
+    workspaceLabel: 'Messages',
+    expectedControl: () => screen.getByText('No direct messages yet.'),
   },
   {
     path: '#/profile',
@@ -657,8 +662,8 @@ test('profile connections route restores the requested view', async () => {
     );
   });
   expect(
-    screen.getAllByText('Muted is local-only and is not shared with other devices.').length
-  ).toBeGreaterThan(0);
+    screen.queryByText('Muted is local-only and is not shared with other devices.')
+  ).not.toBeInTheDocument();
   expect(screen.getByText(authorPubkey)).toBeInTheDocument();
 });
 
@@ -2458,7 +2463,7 @@ test('profile social management updates follow and mute lists and muted authors 
   });
 
   await selectWorkspace(user, 'Profile');
-  await user.click(screen.getByRole('button', { name: 'Manage Follows & Mutes' }));
+  await user.click(screen.getByRole('button', { name: '0 Following' }));
 
   const tabs = getSocialConnectionsTabs();
   await waitFor(() => {
@@ -2477,8 +2482,8 @@ test('profile social management updates follow and mute lists and muted authors 
     );
   });
   expect(
-    screen.getAllByText('Followed shows only followers already observed on this device.').length
-  ).toBeGreaterThan(0);
+    screen.queryByText('Followed shows only followers already observed on this device.')
+  ).not.toBeInTheDocument();
 
   let bobConnectionCard = screen.getByText(mutedAuthorPubkey).closest('article');
   if (!(bobConnectionCard instanceof HTMLElement)) {
@@ -2664,7 +2669,7 @@ test('author detail mute toggle updates the selected author state', async () => 
   expect(within(authorPane).getByText('author detail stays visible while muted')).toBeInTheDocument();
 });
 
-test('author detail mutual action opens the direct message pane and sends a local message', async () => {
+test('author detail mutual action opens the messages workspace and sends a local message', async () => {
   const authorPubkey = 'b'.repeat(64);
   const api = createDesktopMockApi({
     seedPosts: {
@@ -2711,7 +2716,13 @@ test('author detail mutual action opens the direct message pane and sends a loca
   await user.click(screen.getByRole('button', { name: 'Message' }));
 
   await waitFor(() => {
-    expect(getDetailPane('Messages')).toBeInTheDocument();
+    expect(within(getWorkspaceTabs()).getByRole('tab', { name: 'Messages' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(window.location.hash).toBe(
+      `#/messages?topic=kukuri%3Atopic%3Ademo&peerPubkey=${authorPubkey}`
+    );
   });
 
   await user.type(screen.getByPlaceholderText('Write a message'), 'hello dm');
@@ -2719,6 +2730,121 @@ test('author detail mutual action opens the direct message pane and sends a loca
 
   await waitFor(() => {
     expect(screen.getAllByText('hello dm').length).toBeGreaterThan(0);
+  });
+});
+
+test('author avatar blob stays visible on the timeline after the author pane closes', async () => {
+  installObjectUrlMocks();
+
+  const authorPubkey = 'b'.repeat(64);
+  const user = userEvent.setup();
+
+  render(
+    <App
+      api={createDesktopMockApi({
+        seedPosts: {
+          'kukuri:topic:demo': [
+            {
+              object_id: 'post-author-avatar',
+              envelope_id: 'envelope-author-avatar',
+              author_pubkey: authorPubkey,
+              author_name: 'bob',
+              author_display_name: null,
+              following: false,
+              followed_by: false,
+              mutual: false,
+              friend_of_friend: false,
+              object_kind: 'post',
+              content: 'avatar persistence',
+              content_status: 'Available',
+              attachments: [],
+              created_at: 1,
+              reply_to: null,
+              root_id: 'post-author-avatar',
+              audience_label: 'Public',
+            },
+          ],
+        },
+        authorSocialViews: {
+          [authorPubkey]: {
+            name: 'bob',
+            picture_asset: {
+              hash: 'avatar-hash',
+              mime: 'image/png',
+              bytes: 64,
+              role: 'profile_avatar',
+            },
+          },
+        },
+      })}
+    />
+  );
+
+  await user.click(await screen.findByRole('button', { name: 'bob' }));
+
+  const timelineAvatars = await screen.findAllByTestId('post-author-avatar-author-avatar');
+  await waitFor(() => {
+    expect(
+      timelineAvatars.some((avatar) => avatar.querySelector('img')?.getAttribute('src') === 'blob:mock-1')
+    ).toBe(true);
+  });
+
+  const authorPane = getDetailPane('Author');
+  await user.click(within(authorPane).getByRole('button', { name: 'Close Author' }));
+
+  await waitFor(() => {
+    expect(screen.queryByRole('complementary', { name: 'Author' })).not.toBeInTheDocument();
+    expect(
+      screen
+        .getAllByTestId('post-author-avatar-author-avatar')
+        .some((avatar) => avatar.querySelector('img')?.getAttribute('src') === 'blob:mock-1')
+    ).toBe(true);
+  });
+});
+
+test('profile overview connection count buttons open the requested connections tab', async () => {
+  const followedPubkey = 'b'.repeat(64);
+  const mutedPubkey = 'c'.repeat(64);
+  const user = userEvent.setup();
+
+  render(
+    <App
+      api={createDesktopMockApi({
+        authorSocialViews: {
+          [followedPubkey]: {
+            name: 'bob',
+            followed_by: true,
+          },
+          [mutedPubkey]: {
+            name: 'carol',
+            muted: true,
+          },
+        },
+      })}
+    />
+  );
+
+  await selectWorkspace(user, 'Profile');
+  await user.click(screen.getByRole('button', { name: '1 Followers' }));
+
+  await waitFor(() => {
+    expect(within(getSocialConnectionsTabs()).getByRole('tab', { name: 'Followed' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+  expect(
+    screen.queryByText('Followed shows only followers already observed on this device.')
+  ).not.toBeInTheDocument();
+
+  await user.click(screen.getByRole('button', { name: 'Back to profile' }));
+  await user.click(screen.getByRole('button', { name: '1 Muted' }));
+
+  await waitFor(() => {
+    expect(within(getSocialConnectionsTabs()).getByRole('tab', { name: 'Muted' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
   });
 });
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -19,7 +19,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useStore } from 'zustand';
 import { createStore } from 'zustand/vanilla';
-import { Lock, MessageSquare, PanelLeftOpen, Plus, Settings } from 'lucide-react';
+import { Lock, PanelLeftOpen, Plus, Settings } from 'lucide-react';
 
 import { AuthorDetailCard } from '@/components/core/AuthorDetailCard';
 import { ComposerDraftPreviewList } from '@/components/core/ComposerDraftPreviewList';
@@ -157,6 +157,7 @@ type AsyncPanelState = {
 };
 
 type SocialConnectionsState = Record<ProfileConnectionsView, AuthorSocialView[]>;
+type KnownAuthorsByPubkey = Record<string, AuthorSocialView>;
 
 type DesktopShellState = {
   trackedTopics: string[];
@@ -193,6 +194,7 @@ type DesktopShellState = {
   syncStatus: SyncStatus;
   localProfile: Profile | null;
   profileTimeline: PostView[];
+  knownAuthorsByPubkey: KnownAuthorsByPubkey;
   socialConnections: SocialConnectionsState;
   socialConnectionsPanelState: AsyncPanelState;
   ownedReactionAssets: CustomReactionAssetView[];
@@ -403,6 +405,7 @@ function createInitialShellState(): DesktopShellState {
     syncStatus: DEFAULT_SYNC_STATUS,
     localProfile: null,
     profileTimeline: [],
+    knownAuthorsByPubkey: {},
     socialConnections: DEFAULT_SOCIAL_CONNECTIONS,
     socialConnectionsPanelState: DEFAULT_ASYNC_PANEL_STATE,
     ownedReactionAssets: [],
@@ -521,6 +524,10 @@ const PRIMARY_SECTION_ITEMS: Array<{
     label: 'Game',
   },
   {
+    id: 'messages',
+    label: 'Messages',
+  },
+  {
     id: 'profile',
     label: 'Profile',
   },
@@ -576,6 +583,7 @@ const PRIMARY_SECTION_PATHS: Record<PrimarySection, string> = {
   timeline: '/timeline',
   live: '/live',
   game: '/game',
+  messages: '/messages',
   profile: '/profile',
 };
 
@@ -726,6 +734,66 @@ function strongestRelationshipLabel(relationship: {
     return 'friend of friend';
   }
   return null;
+}
+
+function mergeAuthorView(
+  current: AuthorSocialView | null | undefined,
+  incoming: Partial<AuthorSocialView> & { author_pubkey: string }
+): AuthorSocialView {
+  return {
+    author_pubkey: incoming.author_pubkey,
+    name: incoming.name ?? current?.name ?? null,
+    display_name: incoming.display_name ?? current?.display_name ?? null,
+    about: incoming.about ?? current?.about ?? null,
+    picture: incoming.picture ?? current?.picture ?? null,
+    picture_asset: incoming.picture_asset ?? current?.picture_asset ?? null,
+    updated_at: incoming.updated_at ?? current?.updated_at ?? null,
+    following: incoming.following ?? current?.following ?? false,
+    followed_by: incoming.followed_by ?? current?.followed_by ?? false,
+    mutual: incoming.mutual ?? current?.mutual ?? false,
+    friend_of_friend: incoming.friend_of_friend ?? current?.friend_of_friend ?? false,
+    friend_of_friend_via_pubkeys:
+      incoming.friend_of_friend_via_pubkeys ?? current?.friend_of_friend_via_pubkeys ?? [],
+    muted: incoming.muted ?? current?.muted ?? false,
+  };
+}
+
+function mergeKnownAuthors(
+  current: KnownAuthorsByPubkey,
+  incoming: Array<(Partial<AuthorSocialView> & { author_pubkey: string }) | null | undefined>
+): KnownAuthorsByPubkey {
+  let next = current;
+  for (const view of incoming) {
+    if (!view) {
+      continue;
+    }
+    const merged = mergeAuthorView(next[view.author_pubkey], view);
+    if (next === current) {
+      next = { ...current };
+    }
+    next[view.author_pubkey] = merged;
+  }
+  return next;
+}
+
+function authorViewFromDirectMessageConversation(
+  conversation: DirectMessageConversationView
+): AuthorSocialView {
+  return {
+    author_pubkey: conversation.peer_pubkey,
+    name: conversation.peer_name ?? null,
+    display_name: conversation.peer_display_name ?? null,
+    about: null,
+    picture: conversation.peer_picture ?? null,
+    picture_asset: conversation.peer_picture_asset ?? null,
+    updated_at: null,
+    following: false,
+    followed_by: false,
+    mutual: conversation.status.mutual,
+    friend_of_friend: false,
+    friend_of_friend_via_pubkeys: [],
+    muted: false,
+  };
 }
 
 function privateTimelineScope(channelId: string | null): TimelineScope {
@@ -1427,6 +1495,7 @@ function DesktopShellPage({
     syncStatus,
     localProfile,
     profileTimeline,
+    knownAuthorsByPubkey,
     socialConnections,
     socialConnectionsPanelState,
     ownedReactionAssets,
@@ -1619,6 +1688,10 @@ function DesktopShellPage({
   const setSyncStatus = useMemo(() => makeFieldSetter('syncStatus'), [makeFieldSetter]);
   const setLocalProfile = useMemo(() => makeFieldSetter('localProfile'), [makeFieldSetter]);
   const setProfileTimeline = useMemo(() => makeFieldSetter('profileTimeline'), [makeFieldSetter]);
+  const setKnownAuthorsByPubkey = useMemo(
+    () => makeFieldSetter('knownAuthorsByPubkey'),
+    [makeFieldSetter]
+  );
   const setSocialConnections = useMemo(
     () => makeFieldSetter('socialConnections'),
     [makeFieldSetter]
@@ -1787,6 +1860,7 @@ function DesktopShellPage({
     timeline: null,
     live: null,
     game: null,
+    messages: null,
     profile: null,
   });
   const location = useLocation();
@@ -1848,6 +1922,17 @@ function DesktopShellPage({
   const profileMode = shellChromeState.profileMode;
   const profileConnectionsView = shellChromeState.profileConnectionsView;
   const activeSocialConnections = socialConnections[profileConnectionsView] ?? [];
+  const activeSocialConnectionViews = useMemo(
+    () =>
+      activeSocialConnections.map((author) => {
+        const knownAuthor = knownAuthorsByPubkey[author.author_pubkey] ?? author;
+        return {
+          ...author,
+          picture_src: resolveProfilePictureSrc(knownAuthor, mediaObjectUrls),
+        };
+      }),
+    [activeSocialConnections, knownAuthorsByPubkey, mediaObjectUrls]
+  );
   const activePrivateChannel = useMemo(
     () =>
       selectedPrivateChannelId
@@ -1926,6 +2011,7 @@ function DesktopShellPage({
   }, [shellChromeState.activePrimarySection, t]);
   const showFloatingActionButton =
     shellChromeState.activePrimarySection !== 'profile' &&
+    shellChromeState.activePrimarySection !== 'messages' &&
     !(
       shellChromeState.activePrimarySection === 'timeline' &&
       shellChromeState.timelineView === 'bookmarks'
@@ -1950,9 +2036,6 @@ function DesktopShellPage({
     const nextSelectedAuthorPubkey = hasOverride('selectedAuthorPubkey')
       ? overrides?.selectedAuthorPubkey ?? null
       : selectedAuthorPubkey;
-    const nextDirectMessagePaneOpen = hasOverride('directMessagePaneOpen')
-      ? overrides?.directMessagePaneOpen ?? false
-      : directMessagePaneOpen;
     const nextSelectedDirectMessagePeerPubkey = hasOverride('selectedDirectMessagePeerPubkey')
       ? overrides?.selectedDirectMessagePeerPubkey ?? null
       : selectedDirectMessagePeerPubkey;
@@ -1975,6 +2058,7 @@ function DesktopShellPage({
 
     search.set('topic', nextTopic);
     if (
+      resolvedPrimarySection !== 'messages' &&
       nextSelectedChannelId &&
       !(resolvedPrimarySection === 'timeline' && nextTimelineView === 'bookmarks')
     ) {
@@ -1983,8 +2067,7 @@ function DesktopShellPage({
     if (resolvedPrimarySection === 'timeline' && nextTimelineView === 'bookmarks') {
       search.set('timelineView', 'bookmarks');
     }
-    if (nextDirectMessagePaneOpen) {
-      search.set('context', 'dm');
+    if (resolvedPrimarySection === 'messages') {
       if (nextSelectedDirectMessagePeerPubkey) {
         search.set('peerPubkey', nextSelectedDirectMessagePeerPubkey);
       }
@@ -2024,7 +2107,6 @@ function DesktopShellPage({
     location.pathname,
     location.search,
     navigate,
-    directMessagePaneOpen,
     selectedDirectMessagePeerPubkey,
     selectedAuthorPubkey,
     selectedThread,
@@ -2162,7 +2244,7 @@ function DesktopShellPage({
     }
     for (const pictureAsset of [
       localProfile?.picture_asset ?? null,
-      selectedAuthor?.picture_asset ?? null,
+      ...Object.values(knownAuthorsByPubkey).map((author) => author.picture_asset ?? null),
     ]) {
       tryAddAttachment(
         pictureAsset
@@ -2181,11 +2263,11 @@ function DesktopShellPage({
     activePublicTimeline,
     activeTimeline,
     bookmarkedReactionAssets,
+    knownAuthorsByPubkey,
     localProfile?.picture_asset,
     ownedReactionAssets,
     profileTimeline,
     selectedDirectMessageTimeline,
-    selectedAuthor?.picture_asset,
     selectedAuthorTimeline,
     thread,
   ]);
@@ -2406,6 +2488,9 @@ function DesktopShellPage({
             return next;
           });
           setDirectMessages(directMessagesView);
+          setKnownAuthorsByPubkey((current) =>
+            mergeKnownAuthors(current, directMessagesView.map(authorViewFromDirectMessageConversation))
+          );
           setSyncStatus(status);
           if (discoveryResult.status === 'fulfilled') {
             setDiscoveryConfig(discoveryResult.value);
@@ -2449,6 +2534,13 @@ function DesktopShellPage({
               followed: followedConnectionsResult.value,
               muted: mutedConnectionsResult.value,
             });
+            setKnownAuthorsByPubkey((current) =>
+              mergeKnownAuthors(current, [
+                ...followingConnectionsResult.value,
+                ...followedConnectionsResult.value,
+                ...mutedConnectionsResult.value,
+              ])
+            );
             setSocialConnectionsPanelState({
               status: 'ready',
               error: null,
@@ -2548,6 +2640,11 @@ function DesktopShellPage({
             setSelectedAuthor(authorViewResult.value);
             setSelectedAuthorTimeline(authorTimelineResult.value?.items ?? []);
             setAuthorError(null);
+            if (authorViewResult.value) {
+              setKnownAuthorsByPubkey((current) =>
+                mergeKnownAuthors(current, [authorViewResult.value])
+              );
+            }
           } else {
             setSelectedAuthorTimeline([]);
             setAuthorError(
@@ -2635,6 +2732,7 @@ function DesktopShellPage({
       setLiveSessionsByTopic,
       setLocalPeerTicket,
       setLocalProfile,
+      setKnownAuthorsByPubkey,
       setOwnedReactionAssets,
       setProfileTimeline,
       setProfileDraft,
@@ -2882,6 +2980,9 @@ function DesktopShellPage({
     setSelectedAuthorPubkey(null);
     setSelectedAuthor(null);
     setAuthorError(null);
+    setDirectMessagePaneOpen(section === 'messages');
+    setSelectedDirectMessagePeerPubkey(null);
+    setDirectMessageError(null);
     window.requestAnimationFrame(() => {
       primarySectionRefs.current[section]?.focus();
     });
@@ -2890,6 +2991,7 @@ function DesktopShellPage({
       profileMode: section === 'profile' ? 'overview' : undefined,
       profileConnectionsView: section === 'profile' ? 'following' : undefined,
       selectedAuthorPubkey: null,
+      selectedDirectMessagePeerPubkey: null,
       selectedThread: null,
     });
   }
@@ -2922,7 +3024,6 @@ function DesktopShellPage({
       timelineView: view,
       selectedAuthorPubkey: view === 'bookmarks' ? null : undefined,
       selectedThread: view === 'bookmarks' ? null : undefined,
-      directMessagePaneOpen: view === 'bookmarks' ? false : undefined,
       selectedDirectMessagePeerPubkey: view === 'bookmarks' ? null : undefined,
     });
   }
@@ -2962,21 +3063,6 @@ function DesktopShellPage({
     syncRoute,
   ]);
 
-  const closeDirectMessagePane = useCallback(() => {
-    setDirectMessagePaneOpen(false);
-    setSelectedDirectMessagePeerPubkey(null);
-    setDirectMessageError(null);
-    syncRoute('replace', {
-      directMessagePaneOpen: false,
-      selectedDirectMessagePeerPubkey: null,
-    });
-  }, [
-    setDirectMessageError,
-    setDirectMessagePaneOpen,
-    setSelectedDirectMessagePeerPubkey,
-    syncRoute,
-  ]);
-
   const openDirectMessageList = useCallback((historyMode: 'push' | 'replace' = 'push') => {
     setReplyTarget(null);
     setRepostTarget(null);
@@ -2986,11 +3072,16 @@ function DesktopShellPage({
     setSelectedAuthor(null);
     setSelectedAuthorTimeline([]);
     setAuthorError(null);
+    setShellChromeState((current) => ({
+      ...current,
+      activePrimarySection: 'messages',
+      navOpen: false,
+    }));
     setDirectMessagePaneOpen(true);
     setSelectedDirectMessagePeerPubkey(null);
     setDirectMessageError(null);
     syncRoute(historyMode, {
-      directMessagePaneOpen: true,
+      primarySection: 'messages',
       selectedAuthorPubkey: null,
       selectedDirectMessagePeerPubkey: null,
       selectedThread: null,
@@ -3001,6 +3092,7 @@ function DesktopShellPage({
     setDirectMessagePaneOpen,
     setReplyTarget,
     setRepostTarget,
+    setShellChromeState,
     setSelectedAuthor,
     setSelectedAuthorPubkey,
     setSelectedAuthorTimeline,
@@ -3040,11 +3132,19 @@ function DesktopShellPage({
         ...current,
         [peerPubkey]: status,
       }));
+      setKnownAuthorsByPubkey((current) =>
+        mergeKnownAuthors(current, [authorViewFromDirectMessageConversation(conversation)])
+      );
+      setShellChromeState((current) => ({
+        ...current,
+        activePrimarySection: 'messages',
+        navOpen: false,
+      }));
       setDirectMessagePaneOpen(true);
       setSelectedDirectMessagePeerPubkey(peerPubkey);
       setDirectMessageError(null);
       syncRoute(options?.historyMode ?? 'push', {
-        directMessagePaneOpen: true,
+        primarySection: 'messages',
         selectedAuthorPubkey: null,
         selectedDirectMessagePeerPubkey: peerPubkey,
         selectedThread: null,
@@ -3053,10 +3153,10 @@ function DesktopShellPage({
       const nextError = messageFromError(openError, 'failed to open direct message');
       setDirectMessageError(nextError);
       if (options?.normalizeOnError) {
-        setDirectMessagePaneOpen(false);
+        setDirectMessagePaneOpen(true);
         setSelectedDirectMessagePeerPubkey(null);
         syncRoute('replace', {
-          directMessagePaneOpen: false,
+          primarySection: 'messages',
           selectedDirectMessagePeerPubkey: null,
         });
       }
@@ -3069,8 +3169,10 @@ function DesktopShellPage({
     setDirectMessages,
     setDirectMessageStatusByPeer,
     setDirectMessageTimelineByPeer,
+    setKnownAuthorsByPubkey,
     setReplyTarget,
     setRepostTarget,
+    setShellChromeState,
     setSelectedAuthor,
     setSelectedAuthorPubkey,
     setSelectedAuthorTimeline,
@@ -3088,11 +3190,6 @@ function DesktopShellPage({
       if (shellChromeState.settingsOpen) {
         event.preventDefault();
         setSettingsOpen(false, true);
-        return;
-      }
-      if (directMessagePaneOpen) {
-        event.preventDefault();
-        closeDirectMessagePane();
         return;
       }
       if (selectedAuthorPubkey) {
@@ -3117,9 +3214,7 @@ function DesktopShellPage({
     };
   }, [
     closeAuthorPane,
-    closeDirectMessagePane,
     closeThreadPane,
-    directMessagePaneOpen,
     setNavOpen,
     setSettingsOpen,
     shellChromeState.navOpen,
@@ -4224,6 +4319,7 @@ function DesktopShellPage({
       const nextThreadId = options?.fromThread ? (options.threadId ?? selectedThread) : null;
       setSelectedAuthorPubkey(authorPubkey);
       setSelectedAuthor(socialView);
+      setKnownAuthorsByPubkey((current) => mergeKnownAuthors(current, [socialView]));
       setSelectedAuthorTimeline([]);
       setAuthorError(null);
       setDirectMessagePaneOpen(false);
@@ -4234,7 +4330,6 @@ function DesktopShellPage({
         setThread([]);
       }
       syncRoute(options?.historyMode ?? 'push', {
-        directMessagePaneOpen: false,
         selectedThread: nextThreadId,
         selectedAuthorPubkey: authorPubkey,
       });
@@ -4261,6 +4356,7 @@ function DesktopShellPage({
   }, [
     api,
     setAuthorError,
+    setKnownAuthorsByPubkey,
     setSelectedAuthor,
     setSelectedAuthorTimeline,
     setSelectedAuthorPubkey,
@@ -4278,6 +4374,7 @@ function DesktopShellPage({
       const nextView = following
         ? await api.unfollowAuthor(authorPubkey)
         : await api.followAuthor(authorPubkey);
+      setKnownAuthorsByPubkey((current) => mergeKnownAuthors(current, [nextView]));
       if (selectedAuthorPubkey === authorPubkey) {
         setSelectedAuthor(nextView);
         setAuthorError(null);
@@ -4297,6 +4394,7 @@ function DesktopShellPage({
       const nextView = muted
         ? await api.unmuteAuthor(authorPubkey)
         : await api.muteAuthor(authorPubkey);
+      setKnownAuthorsByPubkey((current) => mergeKnownAuthors(current, [nextView]));
       if (selectedAuthorPubkey === authorPubkey) {
         setSelectedAuthor(nextView);
         setAuthorError(null);
@@ -4774,6 +4872,20 @@ function DesktopShellPage({
       shouldReload = true;
     }
 
+    if (requestedContext === 'dm' && routeSection !== 'messages') {
+      window.requestAnimationFrame(() => {
+        syncRoute('replace', {
+          activeTopic: nextTopic,
+          primarySection: 'messages',
+          selectedAuthorPubkey: null,
+          selectedDirectMessagePeerPubkey:
+            requestedPeerPubkey && isHex64(requestedPeerPubkey) ? requestedPeerPubkey : null,
+          selectedThread: null,
+        });
+      });
+      return;
+    }
+
     const nextSettingsOpen = isSettingsSection(requestedSettingsSection);
     const nextSettingsSection = isSettingsSection(requestedSettingsSection)
       ? requestedSettingsSection
@@ -4838,6 +4950,9 @@ function DesktopShellPage({
     ) {
       shouldNormalize = true;
     }
+    if (routeSection === 'messages' && requestedContext) {
+      shouldNormalize = true;
+    }
 
     if (nextTimelineView === 'bookmarks') {
       if (requestedContext) {
@@ -4862,8 +4977,7 @@ function DesktopShellPage({
       }
       setDirectMessageError(null);
     }
-
-    if (nextTimelineView !== 'bookmarks' && requestedContext === 'dm') {
+    if (routeSection === 'messages') {
       if (requestedThreadId || requestedAuthorPubkey) {
         shouldNormalize = true;
       }
@@ -5158,6 +5272,10 @@ function DesktopShellPage({
         post.object_kind === 'repost' && !isQuoteRepost(post) && post.repost_of
           ? post.repost_of.source_topic_id
           : publishedTopicId;
+      const knownAuthor =
+        post.author_pubkey === syncStatus.local_author_pubkey
+          ? localProfile
+          : knownAuthorsByPubkey[post.author_pubkey] ?? null;
 
       return {
         post,
@@ -5168,11 +5286,9 @@ function DesktopShellPage({
           post.author_name
         ),
         authorPicture:
-          post.author_pubkey === syncStatus.local_author_pubkey
-            ? resolveProfilePictureSrc(localProfile, mediaObjectUrls)
-            : selectedAuthor?.author_pubkey === post.author_pubkey
-              ? resolveProfilePictureSrc(selectedAuthor, mediaObjectUrls)
-              : null,
+          post.author_pubkey === syncStatus.local_author_pubkey || knownAuthor
+            ? resolveProfilePictureSrc(knownAuthor, mediaObjectUrls)
+            : null,
         relationshipLabel: strongestRelationshipLabel(post),
         audienceChipLabel: post.channel_id
           ? activeJoinedChannels.find((channel) => channel.channel_id === post.channel_id)?.label ??
@@ -5220,10 +5336,10 @@ function DesktopShellPage({
     },
     [
       activeJoinedChannels,
+      knownAuthorsByPubkey,
       localProfile,
       locale,
       mediaObjectUrls,
-      selectedAuthor,
       setUnsupportedVideoManifests,
       syncStatus.local_author_pubkey,
       unsupportedVideoManifests,
@@ -5325,40 +5441,47 @@ function DesktopShellPage({
     }),
     [selectedThread, t, thread.length]
   );
+  const resolvedSelectedAuthor = useMemo(
+    () =>
+      selectedAuthor
+        ? knownAuthorsByPubkey[selectedAuthor.author_pubkey] ?? selectedAuthor
+        : null,
+    [knownAuthorsByPubkey, selectedAuthor]
+  );
   const authorDetailView = useMemo<AuthorDetailView>(
     () => ({
-      author: selectedAuthor,
-      displayLabel: selectedAuthor
+      author: resolvedSelectedAuthor,
+      displayLabel: resolvedSelectedAuthor
         ? authorDisplayLabel(
-            selectedAuthor.author_pubkey,
-            selectedAuthor.display_name,
-            selectedAuthor.name
+            resolvedSelectedAuthor.author_pubkey,
+            resolvedSelectedAuthor.display_name,
+            resolvedSelectedAuthor.name
           )
         : t('common:fallbacks.authorDetail'),
-      pictureSrc: resolveProfilePictureSrc(selectedAuthor, mediaObjectUrls),
-      summary: selectedAuthor
+      pictureSrc: resolveProfilePictureSrc(resolvedSelectedAuthor, mediaObjectUrls),
+      summary: resolvedSelectedAuthor
         ? {
-            label: strongestRelationshipLabel(selectedAuthor),
-            following: selectedAuthor.following,
-            followedBy: selectedAuthor.followed_by,
-            mutual: selectedAuthor.mutual,
-            friendOfFriend: selectedAuthor.friend_of_friend,
-            muted: selectedAuthor.muted,
-            viaPubkeys: selectedAuthor.friend_of_friend_via_pubkeys.map(shortPubkey),
-            isSelf: selectedAuthor.author_pubkey === syncStatus.local_author_pubkey,
-            canFollow: selectedAuthor.author_pubkey !== syncStatus.local_author_pubkey,
-            followActionLabel: selectedAuthor.following ? 'Unfollow' : 'Follow',
-            muteActionLabel: selectedAuthor.muted ? 'Unmute' : 'Mute',
+            label: strongestRelationshipLabel(resolvedSelectedAuthor),
+            following: resolvedSelectedAuthor.following,
+            followedBy: resolvedSelectedAuthor.followed_by,
+            mutual: resolvedSelectedAuthor.mutual,
+            friendOfFriend: resolvedSelectedAuthor.friend_of_friend,
+            muted: resolvedSelectedAuthor.muted,
+            viaPubkeys: resolvedSelectedAuthor.friend_of_friend_via_pubkeys.map(shortPubkey),
+            isSelf: resolvedSelectedAuthor.author_pubkey === syncStatus.local_author_pubkey,
+            canFollow: resolvedSelectedAuthor.author_pubkey !== syncStatus.local_author_pubkey,
+            followActionLabel: resolvedSelectedAuthor.following ? 'Unfollow' : 'Follow',
+            muteActionLabel: resolvedSelectedAuthor.muted ? 'Unmute' : 'Mute',
           }
         : null,
       canMessage: Boolean(
-        selectedAuthor &&
-          selectedAuthor.author_pubkey !== syncStatus.local_author_pubkey &&
-          selectedAuthor.mutual
+        resolvedSelectedAuthor &&
+          resolvedSelectedAuthor.author_pubkey !== syncStatus.local_author_pubkey &&
+          resolvedSelectedAuthor.mutual
       ),
       authorError,
     }),
-    [authorError, mediaObjectUrls, selectedAuthor, syncStatus.local_author_pubkey, t]
+    [authorError, mediaObjectUrls, resolvedSelectedAuthor, syncStatus.local_author_pubkey, t]
   );
   const navRailHeader = (
     <div className='shell-nav-status'>
@@ -5414,17 +5537,7 @@ function DesktopShellPage({
     />
   );
   const channelAction = (
-    <div className='post-actions'>
-      <Button
-        className='shell-icon-button shell-nav-channel-action'
-        variant='secondary'
-        size='icon'
-        type='button'
-        aria-label='Messages'
-        onClick={() => openDirectMessageList()}
-      >
-        <MessageSquare className='size-4' aria-hidden='true' />
-      </Button>
+    <div className='shell-nav-channel-actions'>
       <Button
         className='shell-icon-button shell-nav-channel-action'
         variant='secondary'
@@ -5821,272 +5934,244 @@ function DesktopShellPage({
     localProfile?.display_name,
     localProfile?.name
   );
-  const detailPaneStack = (
+  const messagesWorkspace = (
     <>
-      {directMessagePaneOpen ? (
-        <ContextPane
-          paneId={`${SHELL_CONTEXT_ID}-direct-message`}
-          title='Messages'
-          summary={
-            selectedDirectMessageConversation
-              ? authorDisplayLabel(
-                  selectedDirectMessageConversation.peer_pubkey,
-                  selectedDirectMessageConversation.peer_display_name,
-                  selectedDirectMessageConversation.peer_name
-                )
-              : 'Direct messages'
-          }
-          showBackdrop={true}
-          stackIndex={0}
-          onClose={closeDirectMessagePane}
-        >
-          <div className='shell-main-stack'>
-            <Card className='shell-workspace-card'>
-              <div className='panel-header'>
-                <div>
-                  <h3>Messages</h3>
-                  <small>{formatCount(directMessages.length)} conversations</small>
-                </div>
-                {selectedDirectMessagePeerPubkey ? (
-                  <Button
-                    variant='secondary'
-                    type='button'
-                    onClick={() => openDirectMessageList('replace')}
-                  >
-                    All
-                  </Button>
-                ) : null}
-              </div>
-              {directMessageError ? <Notice tone='destructive'>{directMessageError}</Notice> : null}
-              {directMessages.length === 0 ? (
-                <p className='empty'>No direct messages yet.</p>
-              ) : (
-                <ul className='post-list'>
-                  {directMessages.map((conversation) => {
-                    const label = authorDisplayLabel(
-                      conversation.peer_pubkey,
-                      conversation.peer_display_name,
-                      conversation.peer_name
-                    );
-                    const selected =
-                      conversation.peer_pubkey === selectedDirectMessagePeerPubkey;
-                    return (
-                      <li key={conversation.peer_pubkey}>
-                        <article className='post-card'>
-                          <div className='post-meta'>
-                            <span>{label}</span>
-                            <span>
-                              {conversation.last_message_at
-                                ? formatLocalizedTime(conversation.last_message_at, locale)
-                                : t('common:fallbacks.noEvents')}
-                            </span>
-                          </div>
-                          <div className='post-body'>
-                            <strong className='post-title'>
-                              {conversation.last_message_preview ?? t('common:fallbacks.none')}
-                            </strong>
-                          </div>
-                          <div className='post-actions'>
-                            <Button
-                              variant={selected ? 'primary' : 'secondary'}
-                              type='button'
-                              onClick={() => void openDirectMessagePane(conversation.peer_pubkey)}
-                            >
-                              Open
-                            </Button>
-                          </div>
-                        </article>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </Card>
-
-            {selectedDirectMessagePeerPubkey ? (
-              <>
-                <Card className='shell-workspace-card'>
-                  <div className='shell-workspace-header'>
-                    <div className='shell-workspace-summary'>
-                      <span className='relationship-badge'>
-                        {selectedDirectMessageConversation
-                          ? authorDisplayLabel(
-                              selectedDirectMessageConversation.peer_pubkey,
-                              selectedDirectMessageConversation.peer_display_name,
-                              selectedDirectMessageConversation.peer_name
-                            )
-                          : selectedDirectMessagePeerPubkey}
+      <Card className='shell-workspace-card'>
+        <div className='panel-header'>
+          <div>
+            <h3>Messages</h3>
+            <small>{formatCount(directMessages.length)} conversations</small>
+          </div>
+          {selectedDirectMessagePeerPubkey ? (
+            <Button variant='secondary' type='button' onClick={() => openDirectMessageList('replace')}>
+              All
+            </Button>
+          ) : null}
+        </div>
+        {directMessageError ? <Notice tone='destructive'>{directMessageError}</Notice> : null}
+        {directMessages.length === 0 ? (
+          <p className='empty'>No direct messages yet.</p>
+        ) : (
+          <ul className='post-list'>
+            {directMessages.map((conversation) => {
+              const label = authorDisplayLabel(
+                conversation.peer_pubkey,
+                conversation.peer_display_name,
+                conversation.peer_name
+              );
+              const selected = conversation.peer_pubkey === selectedDirectMessagePeerPubkey;
+              return (
+                <li key={conversation.peer_pubkey}>
+                  <article className='post-card'>
+                    <div className='post-meta'>
+                      <span>{label}</span>
+                      <span>
+                        {conversation.last_message_at
+                          ? formatLocalizedTime(conversation.last_message_at, locale)
+                          : t('common:fallbacks.noEvents')}
                       </span>
-                      {selectedDirectMessageStatus ? (
-                        <span className='relationship-badge relationship-badge-direct'>
-                          {selectedDirectMessageStatus.send_enabled
-                            ? `peers ${formatCount(selectedDirectMessageStatus.peer_count)}`
-                            : 'send disabled'}
-                        </span>
-                      ) : null}
+                    </div>
+                    <div className='post-body'>
+                      <strong className='post-title'>
+                        {conversation.last_message_preview ?? t('common:fallbacks.none')}
+                      </strong>
                     </div>
                     <div className='post-actions'>
                       <Button
-                        variant='secondary'
+                        variant={selected ? 'primary' : 'secondary'}
                         type='button'
-                        onClick={() =>
-                          void openDirectMessagePane(selectedDirectMessagePeerPubkey, {
-                            historyMode: 'replace',
-                          })
-                        }
+                        onClick={() => void openDirectMessagePane(conversation.peer_pubkey)}
                       >
-                        {t('common:actions.refresh')}
-                      </Button>
-                      <Button
-                        variant='secondary'
-                        type='button'
-                        disabled={selectedDirectMessageTimeline.length === 0}
-                        onClick={() => void handleClearDirectMessage(selectedDirectMessagePeerPubkey)}
-                      >
-                        {t('common:actions.clear')}
+                        Open
                       </Button>
                     </div>
-                  </div>
-                </Card>
+                  </article>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Card>
 
-                <Card className='shell-workspace-card'>
-                  {selectedDirectMessageTimeline.length === 0 ? (
-                    <p className='empty'>No messages yet.</p>
-                  ) : (
-                    <ul className='post-list'>
-                      {selectedDirectMessageTimeline.map((message) => {
-                        const image = selectPrimaryImageAttachment(message.attachments);
-                        const poster = selectVideoPosterAttachment(message.attachments);
-                        const video = selectVideoManifestAttachment(message.attachments);
-                        const imageSrc = image ? mediaObjectUrls[image.hash] ?? null : null;
-                        const posterSrc = poster ? mediaObjectUrls[poster.hash] ?? null : null;
-                        const videoSrc = video ? mediaObjectUrls[video.hash] ?? null : null;
-                        const videoUnsupported = Boolean(
-                          video && unsupportedVideoManifests[video.hash]
-                        );
-                        return (
-                          <li key={message.message_id}>
-                            <article className='post-card'>
-                              <div className='post-meta'>
-                                <span>
-                                  {message.outgoing ? 'You' : 'Peer'}
-                                </span>
-                                <span>{formatLocalizedTime(message.created_at, locale)}</span>
-                                <span className='reply-chip'>
-                                  {message.delivered ? 'Delivered' : 'Pending'}
-                                </span>
-                              </div>
-                              {message.text ? (
-                                <div className='post-body'>
-                                  <strong className='post-title'>{message.text}</strong>
-                                </div>
-                              ) : null}
-                              {image ? (
-                                imageSrc ? (
-                                  <div className='draft-preview-frame'>
-                                    <img
-                                      className='draft-preview-image'
-                                      src={imageSrc}
-                                      alt={t('common:media.imageAlt')}
-                                    />
-                                  </div>
-                                ) : (
-                                  <small>{t('common:media.syncingImage')}</small>
-                                )
-                              ) : null}
-                              {video ? (
-                                videoSrc && !videoUnsupported ? (
-                                  <video
-                                    className='post-card-video'
-                                    controls
-                                    playsInline
-                                    poster={posterSrc ?? undefined}
-                                    src={videoSrc}
-                                  />
-                                ) : posterSrc ? (
-                                  <div className='draft-preview-frame'>
-                                    <img
-                                      className='draft-preview-image'
-                                      src={posterSrc}
-                                      alt={t('common:media.videoPosterAlt')}
-                                    />
-                                  </div>
-                                ) : (
-                                  <small>{t('common:media.syncingPoster')}</small>
-                                )
-                              ) : null}
-                              <div className='post-actions'>
-                                <Button
-                                  variant='secondary'
-                                  type='button'
-                                  onClick={() =>
-                                    void handleDeleteDirectMessageMessage(
-                                      selectedDirectMessagePeerPubkey,
-                                      message.message_id
-                                    )
-                                  }
-                                >
-                                  {t('common:actions.clear')}
-                                </Button>
-                              </div>
-                            </article>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  )}
-                </Card>
+      {selectedDirectMessagePeerPubkey ? (
+        <>
+          <Card className='shell-workspace-card'>
+            <div className='shell-workspace-header'>
+              <div className='shell-workspace-summary'>
+                <span className='relationship-badge'>
+                  {selectedDirectMessageConversation
+                    ? authorDisplayLabel(
+                        selectedDirectMessageConversation.peer_pubkey,
+                        selectedDirectMessageConversation.peer_display_name,
+                        selectedDirectMessageConversation.peer_name
+                      )
+                    : selectedDirectMessagePeerPubkey}
+                </span>
+                {selectedDirectMessageStatus ? (
+                  <span className='relationship-badge relationship-badge-direct'>
+                    {selectedDirectMessageStatus.send_enabled
+                      ? `peers ${formatCount(selectedDirectMessageStatus.peer_count)}`
+                      : 'send disabled'}
+                  </span>
+                ) : null}
+              </div>
+              <div className='post-actions'>
+                <Button
+                  variant='secondary'
+                  type='button'
+                  onClick={() =>
+                    void openDirectMessagePane(selectedDirectMessagePeerPubkey, {
+                      historyMode: 'replace',
+                    })
+                  }
+                >
+                  {t('common:actions.refresh')}
+                </Button>
+                <Button
+                  variant='secondary'
+                  type='button'
+                  disabled={selectedDirectMessageTimeline.length === 0}
+                  onClick={() => void handleClearDirectMessage(selectedDirectMessagePeerPubkey)}
+                >
+                  {t('common:actions.clear')}
+                </Button>
+              </div>
+            </div>
+          </Card>
 
-                <Card className='shell-workspace-card'>
-                  {selectedDirectMessageStatus && !selectedDirectMessageStatus.send_enabled ? (
-                    <Notice tone='warning'>
-                      Direct message send is disabled until the relationship is mutual again.
-                    </Notice>
-                  ) : null}
-                  <form className='composer' onSubmit={(event) => void handleSendDirectMessage(event)}>
-                    <Textarea
-                      value={directMessageComposer}
-                      onChange={(event) => setDirectMessageComposer(event.target.value)}
-                      placeholder='Write a message'
-                      disabled={directMessageSending || !selectedDirectMessageStatus?.send_enabled}
-                    />
-                    <Label className='file-field file-field-compact'>
-                      <span>{t('common:fallbacks.attachment')}</span>
-                      <Input
-                        key={directMessageAttachmentInputKey}
-                        aria-label={t('common:fallbacks.attachment')}
-                        type='file'
-                        accept='image/*,video/*'
-                        disabled={
-                          directMessageSending || !selectedDirectMessageStatus?.send_enabled
-                        }
-                        onChange={(event) => {
-                          void handleDirectMessageAttachmentSelection(event);
-                        }}
-                      />
-                    </Label>
-                    <ComposerDraftPreviewList
-                      items={directMessageDraftViews}
-                      onRemove={handleRemoveDirectMessageDraftAttachment}
-                    />
-                    <div className='topic-diagnostic topic-diagnostic-secondary'>
-                      <span>
-                        pending outbox {formatCount(selectedDirectMessageStatus?.pending_outbox_count ?? 0)}
-                      </span>
-                    </div>
-                    <Button
-                      type='submit'
-                      disabled={directMessageSending || !selectedDirectMessageStatus?.send_enabled}
-                    >
-                      {directMessageSending ? 'Sending...' : 'Send'}
-                    </Button>
-                  </form>
-                </Card>
-              </>
+          <Card className='shell-workspace-card'>
+            {selectedDirectMessageTimeline.length === 0 ? (
+              <p className='empty'>No messages yet.</p>
+            ) : (
+              <ul className='post-list'>
+                {selectedDirectMessageTimeline.map((message) => {
+                  const image = selectPrimaryImageAttachment(message.attachments);
+                  const poster = selectVideoPosterAttachment(message.attachments);
+                  const video = selectVideoManifestAttachment(message.attachments);
+                  const imageSrc = image ? mediaObjectUrls[image.hash] ?? null : null;
+                  const posterSrc = poster ? mediaObjectUrls[poster.hash] ?? null : null;
+                  const videoSrc = video ? mediaObjectUrls[video.hash] ?? null : null;
+                  const videoUnsupported = Boolean(video && unsupportedVideoManifests[video.hash]);
+                  return (
+                    <li key={message.message_id}>
+                      <article className='post-card'>
+                        <div className='post-meta'>
+                          <span>{message.outgoing ? 'You' : 'Peer'}</span>
+                          <span>{formatLocalizedTime(message.created_at, locale)}</span>
+                          <span className='reply-chip'>
+                            {message.delivered ? 'Delivered' : 'Pending'}
+                          </span>
+                        </div>
+                        {message.text ? (
+                          <div className='post-body'>
+                            <strong className='post-title'>{message.text}</strong>
+                          </div>
+                        ) : null}
+                        {image ? (
+                          imageSrc ? (
+                            <div className='draft-preview-frame'>
+                              <img
+                                className='draft-preview-image'
+                                src={imageSrc}
+                                alt={t('common:media.imageAlt')}
+                              />
+                            </div>
+                          ) : (
+                            <small>{t('common:media.syncingImage')}</small>
+                          )
+                        ) : null}
+                        {video ? (
+                          videoSrc && !videoUnsupported ? (
+                            <video
+                              className='post-card-video'
+                              controls
+                              playsInline
+                              poster={posterSrc ?? undefined}
+                              src={videoSrc}
+                            />
+                          ) : posterSrc ? (
+                            <div className='draft-preview-frame'>
+                              <img
+                                className='draft-preview-image'
+                                src={posterSrc}
+                                alt={t('common:media.videoPosterAlt')}
+                              />
+                            </div>
+                          ) : (
+                            <small>{t('common:media.syncingPoster')}</small>
+                          )
+                        ) : null}
+                        <div className='post-actions'>
+                          <Button
+                            variant='secondary'
+                            type='button'
+                            onClick={() =>
+                              void handleDeleteDirectMessageMessage(
+                                selectedDirectMessagePeerPubkey,
+                                message.message_id
+                              )
+                            }
+                          >
+                            {t('common:actions.clear')}
+                          </Button>
+                        </div>
+                      </article>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </Card>
+
+          <Card className='shell-workspace-card'>
+            {selectedDirectMessageStatus && !selectedDirectMessageStatus.send_enabled ? (
+              <Notice tone='warning'>
+                Direct message send is disabled until the relationship is mutual again.
+              </Notice>
             ) : null}
-          </div>
-        </ContextPane>
+            <form className='composer' onSubmit={(event) => void handleSendDirectMessage(event)}>
+              <Textarea
+                value={directMessageComposer}
+                onChange={(event) => setDirectMessageComposer(event.target.value)}
+                placeholder='Write a message'
+                disabled={directMessageSending || !selectedDirectMessageStatus?.send_enabled}
+              />
+              <Label className='file-field file-field-compact'>
+                <span>{t('common:fallbacks.attachment')}</span>
+                <Input
+                  key={directMessageAttachmentInputKey}
+                  aria-label={t('common:fallbacks.attachment')}
+                  type='file'
+                  accept='image/*,video/*'
+                  disabled={directMessageSending || !selectedDirectMessageStatus?.send_enabled}
+                  onChange={(event) => {
+                    void handleDirectMessageAttachmentSelection(event);
+                  }}
+                />
+              </Label>
+              <ComposerDraftPreviewList
+                items={directMessageDraftViews}
+                onRemove={handleRemoveDirectMessageDraftAttachment}
+              />
+              <div className='topic-diagnostic topic-diagnostic-secondary'>
+                <span>
+                  pending outbox {formatCount(selectedDirectMessageStatus?.pending_outbox_count ?? 0)}
+                </span>
+              </div>
+              <Button
+                type='submit'
+                disabled={directMessageSending || !selectedDirectMessageStatus?.send_enabled}
+              >
+                {directMessageSending ? 'Sending...' : 'Send'}
+              </Button>
+            </form>
+          </Card>
+        </>
       ) : null}
+    </>
+  );
+  const detailPaneStack = (
+    <>
       {selectedThread ? (
         <ContextPane
           paneId={`${SHELL_CONTEXT_ID}-thread`}
@@ -6542,6 +6627,8 @@ function DesktopShellPage({
                 </>
               ) : null}
 
+              {shellChromeState.activePrimarySection === 'messages' ? messagesWorkspace : null}
+
               {shellChromeState.activePrimarySection === 'profile' ? (
                 <>
                   {profileMode === 'edit' ? (
@@ -6567,7 +6654,7 @@ function DesktopShellPage({
                   ) : profileMode === 'connections' ? (
                     <ProfileConnectionsPanel
                       activeView={profileConnectionsView}
-                      items={activeSocialConnections}
+                      items={activeSocialConnectionViews}
                       localAuthorPubkey={syncStatus.local_author_pubkey}
                       status={socialConnectionsPanelState.status}
                       error={socialConnectionsPanelState.error}
@@ -6588,8 +6675,13 @@ function DesktopShellPage({
                       status={profilePanelState.status}
                       error={profileError ?? profilePanelState.error}
                       postCount={profileTimelinePostViews.length}
+                      followingCount={socialConnections.following.length}
+                      followedCount={socialConnections.followed.length}
+                      mutedCount={socialConnections.muted.length}
                       onEdit={openProfileEditor}
-                      onManageConnections={() => openProfileConnections('following')}
+                      onOpenFollowing={() => openProfileConnections('following')}
+                      onOpenFollowed={() => openProfileConnections('followed')}
+                      onOpenMuted={() => openProfileConnections('muted')}
                     />
                   )}
                   {profileMode !== 'connections' ? (
@@ -6612,9 +6704,7 @@ function DesktopShellPage({
           </div>
         }
         detailPaneStack={detailPaneStack}
-        detailPaneCount={
-          (directMessagePaneOpen ? 1 : 0) + (selectedThread ? 1 : 0) + (selectedAuthorPubkey ? 1 : 0)
-        }
+        detailPaneCount={(selectedThread ? 1 : 0) + (selectedAuthorPubkey ? 1 : 0)}
         mobileFooter={
           <Button
             ref={navTriggerRef}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1921,7 +1921,10 @@ function DesktopShellPage({
   }, [activeComposeChannel, activeJoinedChannels, replyTarget, repostTarget]);
   const profileMode = shellChromeState.profileMode;
   const profileConnectionsView = shellChromeState.profileConnectionsView;
-  const activeSocialConnections = socialConnections[profileConnectionsView] ?? [];
+  const activeSocialConnections = useMemo(
+    () => socialConnections[profileConnectionsView] ?? [],
+    [profileConnectionsView, socialConnections]
+  );
   const activeSocialConnectionViews = useMemo(
     () =>
       activeSocialConnections.map((author) => {

--- a/apps/desktop/src/components/core/AuthorDetailCard.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.tsx
@@ -68,8 +68,10 @@ export function AuthorDetailCard({
 
           {relationshipLabel || showFollowAction || showMuteAction || showMessageAction ? (
             <div className='author-detail-actions'>
-              {relationshipLabel ? <RelationshipBadge label={relationshipLabel} /> : <span />}
-              <div className='post-actions'>
+              <div className='author-detail-action-meta'>
+                {relationshipLabel ? <RelationshipBadge label={relationshipLabel} /> : null}
+              </div>
+              <div className='author-detail-action-buttons'>
                 {showMessageAction ? (
                   <button
                     className='button button-secondary'

--- a/apps/desktop/src/components/core/PostCard.test.tsx
+++ b/apps/desktop/src/components/core/PostCard.test.tsx
@@ -323,3 +323,27 @@ test('read-only post card hides reaction affordances and keeps the original topi
   await user.click(screen.getByRole('button', { name: 'Open original topic' }));
   expect(onOpenOriginalTopic).toHaveBeenCalledWith('kukuri:topic:source');
 });
+
+test('post card renders bookmark as an icon-only action with an accessible label', async () => {
+  const user = userEvent.setup();
+  const onToggleBookmark = vi.fn();
+
+  render(
+    <PostCard
+      view={createView()}
+      onOpenAuthor={() => undefined}
+      onOpenThread={() => undefined}
+      onReply={() => undefined}
+      showBookmarkAction
+      isBookmarked
+      onToggleBookmark={onToggleBookmark}
+    />
+  );
+
+  const bookmarkButton = screen.getByRole('button', { name: 'Remove bookmark' });
+  expect(bookmarkButton).toHaveAttribute('aria-pressed', 'true');
+  expect(bookmarkButton).not.toHaveTextContent(/bookmark/i);
+
+  await user.click(bookmarkButton);
+  expect(onToggleBookmark).toHaveBeenCalledWith(createView().post);
+});

--- a/apps/desktop/src/components/core/PostCard.tsx
+++ b/apps/desktop/src/components/core/PostCard.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Reply, Repeat2 } from 'lucide-react';
+import { BookCopy, Reply, Repeat2 } from 'lucide-react';
 
 import { formatLocalizedTime } from '@/i18n/format';
 import type {
@@ -367,11 +367,17 @@ export function PostCard({
             ) : null}
             {showBookmarkAction && onToggleBookmark ? (
               <Button
-                variant='secondary'
+                variant={isBookmarked ? 'primary' : 'secondary'}
+                size='icon'
+                className='post-action-button'
                 type='button'
+                aria-label={
+                  isBookmarked ? t('common:actions.removeBookmark') : t('common:actions.bookmark')
+                }
+                aria-pressed={isBookmarked}
                 onClick={() => onToggleBookmark(post)}
               >
-                {isBookmarked ? t('common:actions.removeBookmark') : t('common:actions.bookmark')}
+                <BookCopy className='size-4' aria-hidden='true' />
               </Button>
             ) : null}
           </>

--- a/apps/desktop/src/components/extended/ProfileConnectionsPanel.tsx
+++ b/apps/desktop/src/components/extended/ProfileConnectionsPanel.tsx
@@ -11,7 +11,7 @@ import type { AuthorSocialView } from '@/lib/api';
 
 type ProfileConnectionsPanelProps = {
   activeView: ProfileConnectionsView;
-  items: AuthorSocialView[];
+  items: Array<AuthorSocialView & { picture_src?: string | null }>;
   localAuthorPubkey: string;
   status: ExtendedPanelStatus;
   error: string | null;
@@ -55,20 +55,11 @@ export function ProfileConnectionsPanel({
   onBack,
 }: ProfileConnectionsPanelProps) {
   const { t } = useTranslation(['profile', 'common']);
-  const noteKey =
-    activeView === 'followed'
-      ? 'connections.notes.followed'
-      : activeView === 'muted'
-        ? 'connections.notes.muted'
-        : 'connections.notes.following';
 
   return (
     <Card className='panel-subsection'>
       <CardHeader>
-        <div>
-          <h3>{t('connections.title')}</h3>
-          <small>{t(noteKey)}</small>
-        </div>
+        <h3>{t('connections.title')}</h3>
         <Button variant='secondary' type='button' onClick={onBack}>
           {t('connections.back')}
         </Button>
@@ -91,7 +82,6 @@ export function ProfileConnectionsPanel({
 
       {status === 'loading' ? <Notice>{t('connections.loading')}</Notice> : null}
       {status === 'error' && error ? <Notice tone='destructive'>{error}</Notice> : null}
-      {status === 'ready' ? <Notice>{t(noteKey)}</Notice> : null}
 
       {status === 'ready' && items.length === 0 ? (
         <p className='empty-state'>{t(`connections.empty.${activeView}`)}</p>
@@ -113,7 +103,7 @@ export function ProfileConnectionsPanel({
                   </div>
                   <div className='post-body'>
                     <div className='author-detail-hero'>
-                      <AuthorAvatar label={label} picture={author.picture ?? null} size='sm' />
+                      <AuthorAvatar label={label} picture={author.picture_src ?? author.picture ?? null} size='sm' />
                       <div className='author-detail-copy-stack'>
                         <strong className='post-title'>{label}</strong>
                         <p className='author-detail-copy author-detail-break'>

--- a/apps/desktop/src/components/extended/ProfileOverviewPanel.tsx
+++ b/apps/desktop/src/components/extended/ProfileOverviewPanel.tsx
@@ -11,8 +11,13 @@ type ProfileOverviewPanelProps = {
   status: 'loading' | 'ready' | 'error';
   error: string | null;
   postCount: number;
+  followingCount: number;
+  followedCount: number;
+  mutedCount: number;
   onEdit: () => void;
-  onManageConnections: () => void;
+  onOpenFollowing: () => void;
+  onOpenFollowed: () => void;
+  onOpenMuted: () => void;
 };
 
 export function ProfileOverviewPanel({
@@ -22,8 +27,13 @@ export function ProfileOverviewPanel({
   status,
   error,
   postCount,
+  followingCount,
+  followedCount,
+  mutedCount,
   onEdit,
-  onManageConnections,
+  onOpenFollowing,
+  onOpenFollowed,
+  onOpenMuted,
 }: ProfileOverviewPanelProps) {
   const { t } = useTranslation('profile');
 
@@ -44,9 +54,6 @@ export function ProfileOverviewPanel({
           </div>
         </div>
         <div className='post-actions'>
-          <Button variant='secondary' type='button' onClick={onManageConnections}>
-            {t('overview.connections')}
-          </Button>
           <Button variant='secondary' type='button' onClick={onEdit}>
             {t('overview.edit')}
           </Button>
@@ -57,6 +64,17 @@ export function ProfileOverviewPanel({
       {status === 'error' && error ? <Notice tone='destructive'>{error}</Notice> : null}
 
       <div className='shell-main-stack'>
+        <div className='profile-overview-connections'>
+          <Button variant='secondary' type='button' onClick={onOpenFollowing}>
+            {t('overview.followingCount', { count: followingCount })}
+          </Button>
+          <Button variant='secondary' type='button' onClick={onOpenFollowed}>
+            {t('overview.followedCount', { count: followedCount })}
+          </Button>
+          <Button variant='secondary' type='button' onClick={onOpenMuted}>
+            {t('overview.mutedCount', { count: mutedCount })}
+          </Button>
+        </div>
         <p className='lede'>{about?.trim() || t('overview.noBio')}</p>
         <div className='topic-diagnostic topic-diagnostic-secondary'>
           <span>{t('overview.postCount')}</span>

--- a/apps/desktop/src/components/review/DesktopShellWorkspaceGallery.stories.tsx
+++ b/apps/desktop/src/components/review/DesktopShellWorkspaceGallery.stories.tsx
@@ -473,8 +473,13 @@ function ProfileOverviewWorkspace() {
         status='ready'
         error={null}
         postCount={PROFILE_TIMELINE_POSTS.length}
+        followingCount={12}
+        followedCount={8}
+        mutedCount={1}
         onEdit={() => undefined}
-        onManageConnections={() => undefined}
+        onOpenFollowing={() => undefined}
+        onOpenFollowed={() => undefined}
+        onOpenMuted={() => undefined}
       />
       <Card className='shell-workspace-card'>
         <TimelineFeed

--- a/apps/desktop/src/components/shell/types.ts
+++ b/apps/desktop/src/components/shell/types.ts
@@ -1,4 +1,4 @@
-export type PrimarySection = 'timeline' | 'live' | 'game' | 'profile';
+export type PrimarySection = 'timeline' | 'live' | 'game' | 'messages' | 'profile';
 export type TimelineWorkspaceView = 'feed' | 'bookmarks';
 export type ProfileConnectionsView = 'following' | 'followed' | 'muted';
 

--- a/apps/desktop/src/i18n/locales/en/common.json
+++ b/apps/desktop/src/i18n/locales/en/common.json
@@ -12,6 +12,7 @@
     "importPeer": "Import Peer",
     "join": "Join",
     "leave": "Leave",
+    "message": "Message",
     "mute": "Mute",
     "publish": "Publish",
     "quoteRepost": "Quote Repost",

--- a/apps/desktop/src/i18n/locales/en/profile.json
+++ b/apps/desktop/src/i18n/locales/en/profile.json
@@ -16,9 +16,11 @@
     "title": "My Profile"
   },
   "overview": {
-    "connections": "Manage Follows & Mutes",
     "edit": "Edit Profile",
+    "followedCount": "{{count}} Followers",
+    "followingCount": "{{count}} Following",
     "loading": "Loading profile…",
+    "mutedCount": "{{count}} Muted",
     "noBio": "No profile bio published yet.",
     "postCount": "Public posts",
     "title": "Profile"
@@ -32,11 +34,6 @@
     },
     "loading": "Loading follows and mutes…",
     "mutedBadge": "Muted",
-    "notes": {
-      "followed": "Followed shows only followers already observed on this device.",
-      "following": "Following lists authors you actively follow.",
-      "muted": "Muted is local-only and is not shared with other devices."
-    },
     "tabs": {
       "followed": "Followed",
       "following": "Following",

--- a/apps/desktop/src/i18n/locales/en/shell.json
+++ b/apps/desktop/src/i18n/locales/en/shell.json
@@ -27,6 +27,7 @@
   "primarySections": {
     "game": "Game",
     "live": "Live",
+    "messages": "Messages",
     "profile": "Profile",
     "timeline": "Timeline"
   },

--- a/apps/desktop/src/i18n/locales/ja/common.json
+++ b/apps/desktop/src/i18n/locales/ja/common.json
@@ -12,6 +12,7 @@
     "importPeer": "ピアを追加",
     "join": "参加",
     "leave": "退出",
+    "message": "メッセージ",
     "mute": "ミュート",
     "publish": "投稿",
     "quoteRepost": "引用リポスト",

--- a/apps/desktop/src/i18n/locales/ja/profile.json
+++ b/apps/desktop/src/i18n/locales/ja/profile.json
@@ -16,9 +16,11 @@
     "title": "マイプロフィール"
   },
   "overview": {
-    "connections": "フォローとミュートを管理",
     "edit": "プロフィールを編集",
+    "followedCount": "{{count}} フォロワー",
+    "followingCount": "{{count}} フォロー中",
     "loading": "プロフィールを読み込み中…",
+    "mutedCount": "{{count}} ミュート中",
     "noBio": "まだプロフィール文が公開されていません。",
     "postCount": "公開投稿",
     "title": "プロフィール"
@@ -32,11 +34,6 @@
     },
     "loading": "フォローとミュートを読み込み中…",
     "mutedBadge": "ミュート中",
-    "notes": {
-      "followed": "Followed はこの端末で観測済みの follower のみを表示します。",
-      "following": "Following には現在フォロー中の著者だけを表示します。",
-      "muted": "Muted はローカル専用で、他の端末には共有されません。"
-    },
     "tabs": {
       "followed": "Followed",
       "following": "Following",

--- a/apps/desktop/src/i18n/locales/ja/shell.json
+++ b/apps/desktop/src/i18n/locales/ja/shell.json
@@ -27,6 +27,7 @@
   "primarySections": {
     "game": "ゲーム",
     "live": "ライブ",
+    "messages": "メッセージ",
     "profile": "プロフィール",
     "timeline": "タイムライン"
   },

--- a/apps/desktop/src/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/common.json
@@ -11,6 +11,7 @@
     "importPeer": "导入 Peer",
     "join": "加入",
     "leave": "离开",
+    "message": "消息",
     "mute": "静音",
     "publish": "发布",
     "quoteRepost": "引用转发",

--- a/apps/desktop/src/i18n/locales/zh-CN/profile.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/profile.json
@@ -16,9 +16,11 @@
     "title": "我的资料"
   },
   "overview": {
-    "connections": "管理关注与静音",
     "edit": "编辑资料",
+    "followedCount": "{{count}} 位关注者",
+    "followingCount": "已关注 {{count}} 位",
     "loading": "正在加载资料…",
+    "mutedCount": "已静音 {{count}} 位",
     "noBio": "尚未发布个人简介。",
     "postCount": "公开帖子",
     "title": "资料"
@@ -32,11 +34,6 @@
     },
     "loading": "正在加载关注与静音…",
     "mutedBadge": "已静音",
-    "notes": {
-      "followed": "Followed 只显示这个设备上已经观测到的关注者。",
-      "following": "Following 仅显示你当前关注的作者。",
-      "muted": "Muted 仅保存在本地，不会同步到其他设备。"
-    },
     "tabs": {
       "followed": "Followed",
       "following": "Following",

--- a/apps/desktop/src/i18n/locales/zh-CN/shell.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/shell.json
@@ -27,6 +27,7 @@
   "primarySections": {
     "game": "游戏",
     "live": "直播",
+    "messages": "消息",
     "profile": "资料",
     "timeline": "时间线"
   },

--- a/apps/desktop/src/styles/shell-phase1-legacy.css
+++ b/apps/desktop/src/styles/shell-phase1-legacy.css
@@ -705,6 +705,7 @@
   align-items: center;
   gap: 0.75rem;
   min-width: 0;
+  flex: 1 1 auto;
 }
 
 .shell-phase1 .post-meta-trailing, .shell-phase1 .post-actions-inline {
@@ -712,6 +713,9 @@
   align-items: center;
   flex-wrap: wrap;
   gap: 0.55rem;
+  margin-left: auto;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
 .shell-phase1 .post-meta-chip {
@@ -748,6 +752,8 @@
   padding: 0.2rem 0.55rem;
   color: var(--foreground);
   background: var(--surface-badge-neutral);
+  white-space: nowrap;
+  flex: none;
 }
 
 .shell-phase1 .relationship-badge-direct {
@@ -825,8 +831,20 @@
   gap: 0.75rem;
 }
 
-.shell-phase1 .author-detail-actions .button {
-  margin-left: auto;
+.shell-phase1 .author-detail-action-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.shell-phase1 .author-detail-action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin: 0;
 }
 
 .shell-phase1 .author-detail-break,

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -675,6 +675,7 @@
   align-items: center;
   gap: 0.75rem;
   min-width: 0;
+  flex: 1 1 auto;
 }
 
 .post-meta-trailing,
@@ -684,6 +685,8 @@
   flex-wrap: wrap;
   gap: 0.55rem;
   min-width: 0;
+  margin-left: auto;
+  justify-content: flex-end;
 }
 
 .post-meta-chip {
@@ -720,6 +723,8 @@
   padding: 0.2rem 0.55rem;
   color: var(--foreground);
   background: var(--surface-badge-neutral);
+  white-space: nowrap;
+  flex: none;
 }
 
 .relationship-badge-direct {
@@ -1051,6 +1056,13 @@
   flex: none;
 }
 
+.shell-nav-channel-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+}
+
 .shell-nav-accordion {
   gap: 0.65rem;
 }
@@ -1296,6 +1308,16 @@
   align-items: center;
   gap: 0.9rem;
   min-width: 0;
+}
+
+.profile-overview-connections {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.profile-overview-connections .button {
+  min-height: 2.75rem;
 }
 
 .profile-overview-avatar {


### PR DESCRIPTION
## Summary
- add a top-level Messages workspace and route author DM actions into it
- persist resolved author avatars by pubkey so blob-backed icons remain visible after closing the author pane
- replace the profile social management entry with connection count buttons and remove the old explanatory copy
- convert bookmark actions to icon-only buttons and tighten the related sidebar and author badge layout fixes

## Testing
- `cd apps/desktop && npx pnpm@10.16.1 test -- --run App.test.tsx src/components/core/PostCard.test.tsx`
- `cd apps/desktop && npx pnpm@10.16.1 exec tsc --noEmit`