### PR TITLE
[codex] Improve desktop UX responsiveness

### DIFF
--- a/apps/desktop/src/components/core/PostCard.tsx
+++ b/apps/desktop/src/components/core/PostCard.tsx
@@ -51,6 +51,8 @@ type PostCardProps = {
   showBookmarkAction?: boolean;
   isBookmarked?: boolean;
   onToggleBookmark?: (post: PostCardView['post']) => void;
+  onRetryLocalPost?: (post: PostCardView['post']) => void;
+  onRestoreLocalPost?: (post: PostCardView['post']) => void;
 };
 
 function reactionKeyInputFromView(reaction: ReactionKeyView): ReactionKeyInput | null {
@@ -83,17 +85,29 @@ export function PostCard({
   showBookmarkAction = false,
   isBookmarked = false,
   onToggleBookmark,
+  onRetryLocalPost,
+  onRestoreLocalPost,
 }: PostCardProps) {
   const { t } = useTranslation(['common', 'profile']);
   const { post, context } = view;
   const [repostMenuOpen, setRepostMenuOpen] = useState(false);
   const isPendingText = post.content_status === 'Missing' && post.content === '[blob pending]';
+  const localState = post.local_state ?? null;
+  const interactionDisabled = localState !== null;
   const audienceChipLabel = view.audienceChipLabel ?? post.audience_label;
   const publishedTopicId = post.published_topic_id?.trim() || post.origin_topic_id?.trim() || null;
   const repostSource = post.repost_of ?? null;
   const isQuoteRepost = post.object_kind === 'repost' && Boolean(post.repost_commentary?.trim());
   const canReply = view.canReply ?? true;
   const canRepost = view.canRepost ?? false;
+  const localStateLabel =
+    localState === 'pending'
+      ? t('feed.localPosting')
+      : localState === 'syncing'
+        ? t('feed.localSyncing')
+        : localState === 'failed'
+          ? t('feed.localFailed')
+          : null;
   const hasPrimaryContent = isPendingText || post.content.trim().length > 0;
   const reactionSummary = post.reaction_summary ?? [];
   const myReactionKeys = useMemo(
@@ -124,6 +138,7 @@ export function PostCard({
   return (
     <article
       className={context === 'thread' ? 'post-card post-card-thread post-layout-safe' : 'post-card post-layout-safe'}
+      aria-busy={localState === 'pending' || localState === 'syncing'}
     >
       <div className='post-meta'>
         <AuthorIdentityButton
@@ -229,6 +244,23 @@ export function PostCard({
         </button>
       )}
 
+      {localStateLabel ? (
+        <div className='topic-diagnostic topic-diagnostic-secondary' aria-live='polite'>
+          <span>{localStateLabel}</span>
+          {post.local_error ? <span>{post.local_error}</span> : null}
+          {localState === 'failed' && onRetryLocalPost ? (
+            <Button variant='secondary' type='button' onClick={() => onRetryLocalPost(post)}>
+              {t('actions.retry')}
+            </Button>
+          ) : null}
+          {localState === 'failed' && onRestoreLocalPost ? (
+            <Button variant='secondary' type='button' onClick={() => onRestoreLocalPost(post)}>
+              {t('actions.restoreDraft')}
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+
       <div className='post-actions'>
         {readOnly ? (
           publishedTopicId && onOpenOriginalTopic ? (
@@ -242,7 +274,7 @@ export function PostCard({
           ) : null
         ) : (
           <>
-            {reactionSummary.length > 0 ? (
+            {reactionSummary.length > 0 && !interactionDisabled ? (
               <div className='post-reaction-summary'>
                 {reactionSummary.map((reaction) => {
                   const reactionKey = reactionKeyInputFromView(reaction);
@@ -294,14 +326,16 @@ export function PostCard({
                 })}
               </div>
             ) : null}
-            <ReactionPickerPopover
-              post={post}
-              recentReactions={recentReactions}
-              assets={pickerAssets}
-              mediaObjectUrls={mediaObjectUrls}
-              onToggleReaction={onToggleReaction}
-            />
-            {canRepost && (onRepost || onQuoteRepost) ? (
+            {!interactionDisabled ? (
+              <ReactionPickerPopover
+                post={post}
+                recentReactions={recentReactions}
+                assets={pickerAssets}
+                mediaObjectUrls={mediaObjectUrls}
+                onToggleReaction={onToggleReaction}
+              />
+            ) : null}
+            {!interactionDisabled && canRepost && (onRepost || onQuoteRepost) ? (
               <Popover open={repostMenuOpen} onOpenChange={setRepostMenuOpen}>
                 <PopoverTrigger asChild>
                   <Button
@@ -344,7 +378,7 @@ export function PostCard({
                 </PopoverContent>
               </Popover>
             ) : null}
-            {canReply ? (
+            {!interactionDisabled && canReply ? (
               <Button
                 variant='secondary'
                 size='icon'
@@ -356,7 +390,7 @@ export function PostCard({
                 <Reply className='size-4' aria-hidden='true' />
               </Button>
             ) : null}
-            {showBookmarkAction && onToggleBookmark ? (
+            {!interactionDisabled && showBookmarkAction && onToggleBookmark ? (
               <Button
                 variant={isBookmarked ? 'primary' : 'secondary'}
                 size='icon'

--- a/apps/desktop/src/components/core/ThreadPanel.tsx
+++ b/apps/desktop/src/components/core/ThreadPanel.tsx
@@ -24,6 +24,11 @@ type ThreadPanelProps = {
   recentReactions?: RecentReactionView[];
   onToggleReaction?: (post: PostCardView['post'], reactionKey: ReactionKeyInput) => void;
   onBookmarkCustomReaction?: (asset: CustomReactionAssetView) => void;
+  onRetryLocalPost?: (post: PostCardView['post']) => void;
+  onRestoreLocalPost?: (post: PostCardView['post']) => void;
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?: () => void;
 };
 
 export function ThreadPanel({
@@ -42,6 +47,11 @@ export function ThreadPanel({
   recentReactions,
   onToggleReaction,
   onBookmarkCustomReaction,
+  onRetryLocalPost,
+  onRestoreLocalPost,
+  hasMore = false,
+  loadingMore = false,
+  onLoadMore,
 }: ThreadPanelProps) {
   return (
     <div className='shell-main-stack'>
@@ -63,6 +73,11 @@ export function ThreadPanel({
         recentReactions={recentReactions}
         onToggleReaction={onToggleReaction}
         onBookmarkCustomReaction={onBookmarkCustomReaction}
+        onRetryLocalPost={onRetryLocalPost}
+        onRestoreLocalPost={onRestoreLocalPost}
+        hasMore={hasMore}
+        loadingMore={loadingMore}
+        onLoadMore={onLoadMore}
       />
     </div>
   );

--- a/apps/desktop/src/components/core/TimelineFeed.tsx
+++ b/apps/desktop/src/components/core/TimelineFeed.tsx
@@ -1,9 +1,13 @@
+import { useEffect, useRef } from 'react';
+
 import type {
   BookmarkedCustomReactionView,
   CustomReactionAssetView,
   ReactionKeyInput,
   RecentReactionView,
 } from '@/lib/api';
+
+import { Button } from '@/components/ui/button';
 
 import { PostCard } from './PostCard';
 import { type PostCardView } from './types';
@@ -31,6 +35,11 @@ type TimelineFeedProps = {
   showBookmarkAction?: boolean;
   bookmarkedPostIds?: Set<string>;
   onToggleBookmark?: (post: PostCardView['post']) => void;
+  onRetryLocalPost?: (post: PostCardView['post']) => void;
+  onRestoreLocalPost?: (post: PostCardView['post']) => void;
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?: () => void;
 };
 
 export function TimelineFeed({
@@ -56,7 +65,34 @@ export function TimelineFeed({
   showBookmarkAction = false,
   bookmarkedPostIds,
   onToggleBookmark,
+  onRetryLocalPost,
+  onRestoreLocalPost,
+  hasMore = false,
+  loadingMore = false,
+  onLoadMore,
 }: TimelineFeedProps) {
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const canAutoLoad =
+    typeof window !== 'undefined' &&
+    'IntersectionObserver' in window &&
+    typeof onLoadMore === 'function';
+
+  useEffect(() => {
+    if (!canAutoLoad || !hasMore || loadingMore || !loadMoreRef.current) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          onLoadMore?.();
+        }
+      },
+      { rootMargin: '200px 0px' }
+    );
+    observer.observe(loadMoreRef.current);
+    return () => observer.disconnect();
+  }, [canAutoLoad, hasMore, loadingMore, onLoadMore]);
+
   if (posts.length === 0) {
     return <p className='empty'>{emptyCopy}</p>;
   }
@@ -85,9 +121,22 @@ export function TimelineFeed({
             showBookmarkAction={showBookmarkAction}
             isBookmarked={bookmarkedPostIds?.has(view.post.object_id) ?? false}
             onToggleBookmark={onToggleBookmark}
+            onRetryLocalPost={onRetryLocalPost}
+            onRestoreLocalPost={onRestoreLocalPost}
           />
         </li>
       ))}
+      {hasMore ? (
+        <li className={itemClassName}>
+          {canAutoLoad ? <div ref={loadMoreRef} aria-hidden='true' /> : null}
+          {!canAutoLoad && onLoadMore ? (
+            <Button variant='secondary' type='button' onClick={() => onLoadMore()}>
+              {loadingMore ? 'Loading...' : 'Load more'}
+            </Button>
+          ) : null}
+          {canAutoLoad && loadingMore ? <p className='empty'>Loading more…</p> : null}
+        </li>
+      ) : null}
     </ul>
   );
 }

--- a/apps/desktop/src/i18n/locales/en/common.json
+++ b/apps/desktop/src/i18n/locales/en/common.json
@@ -20,8 +20,10 @@
     "refresh": "Refresh",
     "manageReactions": "Manage reactions",
     "removeBookmark": "Remove bookmark",
+    "restoreDraft": "Restore draft",
     "repost": "Repost",
     "reply": "Reply",
+    "retry": "Retry",
     "reset": "Reset",
     "rotate": "Rotate",
     "save": "Save",
@@ -74,6 +76,9 @@
     "unsupportedAttachmentType": "unsupported attachment type: {{name}}"
   },
   "feed": {
+    "localFailed": "Publish failed",
+    "localPosting": "Posting…",
+    "localSyncing": "Syncing…",
     "quoteRepost": "Quote repost",
     "reposted": "Reposted"
   },

--- a/apps/desktop/src/i18n/locales/ja/common.json
+++ b/apps/desktop/src/i18n/locales/ja/common.json
@@ -20,8 +20,10 @@
     "refresh": "更新",
     "manageReactions": "リアクション管理",
     "removeBookmark": "ブックマーク解除",
+    "restoreDraft": "下書きを復元",
     "repost": "リポスト",
     "reply": "返信",
+    "retry": "再試行",
     "reset": "リセット",
     "rotate": "ローテーション",
     "save": "保存",
@@ -74,6 +76,9 @@
     "unsupportedAttachmentType": "未対応の添付タイプです: {{name}}"
   },
   "feed": {
+    "localFailed": "投稿に失敗しました",
+    "localPosting": "投稿中…",
+    "localSyncing": "同期中…",
     "quoteRepost": "引用リポスト",
     "reposted": "リポスト"
   },

--- a/apps/desktop/src/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/common.json
@@ -18,8 +18,10 @@
     "react": "回应",
     "refresh": "刷新",
     "manageReactions": "管理回应",
+    "restoreDraft": "恢复草稿",
     "repost": "转发",
     "reply": "回复",
+    "retry": "重试",
     "reset": "重置",
     "rotate": "轮换",
     "save": "保存",
@@ -71,6 +73,9 @@
     "unsupportedAttachmentType": "不支持的附件类型: {{name}}"
   },
   "feed": {
+    "localFailed": "发布失败",
+    "localPosting": "发布中…",
+    "localSyncing": "同步中…",
     "quoteRepost": "引用转发",
     "reposted": "已转发"
   },

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -17,6 +17,24 @@ export type TimelineScope =
 export type ChannelAudienceKind = 'invite_only' | 'friend_only' | 'friend_plus';
 export type ChannelSharingState = 'open' | 'frozen';
 
+export type LocalPostDraft = {
+  kind: 'post' | 'repost';
+  topic: string;
+  content: string;
+  reply_to?: string | null;
+  source_topic?: string | null;
+  source_object_id?: string | null;
+  channel_ref?: ChannelRef | null;
+  attachments?: CreateAttachmentInput[];
+};
+
+export type LocalDraftMediaItem = {
+  id: string;
+  source_name: string;
+  preview_url: string;
+  attachments: CreateAttachmentInput[];
+};
+
 export type PostView = {
   object_id: string;
   envelope_id: string;
@@ -43,6 +61,12 @@ export type PostView = {
   audience_label: string;
   reaction_summary?: ReactionSummaryView[];
   my_reactions?: ReactionKeyView[];
+  local_id?: string | null;
+  local_state?: 'pending' | 'syncing' | 'failed' | null;
+  local_error?: string | null;
+  server_object_id?: string | null;
+  local_draft?: LocalPostDraft | null;
+  local_draft_media_items?: LocalDraftMediaItem[] | null;
 };
 
 export type CustomReactionAssetView = {

--- a/apps/desktop/src/mocks/desktopApiMock.ts
+++ b/apps/desktop/src/mocks/desktopApiMock.ts
@@ -72,6 +72,23 @@ function withSocialPostDefaults(post: PostView): PostView {
     attachments: [...post.attachments],
     reaction_summary: [...(post.reaction_summary ?? [])],
     my_reactions: [...(post.my_reactions ?? [])],
+    local_id: post.local_id ?? null,
+    local_state: post.local_state ?? null,
+    local_error: post.local_error ?? null,
+    server_object_id: post.server_object_id ?? null,
+    local_draft: post.local_draft
+      ? {
+          ...post.local_draft,
+          channel_ref: post.local_draft.channel_ref ?? null,
+          attachments: [...(post.local_draft.attachments ?? [])],
+        }
+      : null,
+    local_draft_media_items: post.local_draft_media_items
+      ? post.local_draft_media_items.map((item) => ({
+          ...item,
+          attachments: [...item.attachments],
+        }))
+      : null,
   };
 }
 

--- a/apps/desktop/src/shell/DesktopShellPage.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.test.tsx
@@ -1395,6 +1395,9 @@ test('timeline polling does not overlap refreshes while a refresh is in flight',
 
   await Promise.resolve();
   await vi.advanceTimersByTimeAsync(0);
+  expect(listTimelineSpy).toHaveBeenCalledTimes(2);
+
+  await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL_MS);
   expect(listTimelineSpy).toHaveBeenCalledTimes(4);
 
   await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL_MS * 2);
@@ -1434,7 +1437,7 @@ test('publish refreshes the active timeline without reloading full shell data', 
   render(<App api={api} />);
 
   await waitFor(() => {
-    expect(listDirectMessagesSpy).toHaveBeenCalledTimes(1);
+    expect(listDirectMessagesSpy).toHaveBeenCalledTimes(0);
   });
 
   const publishDialog = await openPublishDialog(user);
@@ -1444,7 +1447,7 @@ test('publish refreshes the active timeline without reloading full shell data', 
   await waitFor(() => {
     expect(screen.getByText('local refresh post')).toBeInTheDocument();
   });
-  expect(listDirectMessagesSpy).toHaveBeenCalledTimes(1);
+  expect(listDirectMessagesSpy).toHaveBeenCalledTimes(0);
 });
 
 test('desktop shell can create a simple repost from timeline', async () => {
@@ -3240,8 +3243,10 @@ test('messages dm headers use resolved author labels instead of You and Peer', a
   );
 
   await screen.findByText('hello dm');
-  expect(screen.getAllByRole('button', { name: 'Local Author' }).length).toBeGreaterThan(0);
-  expect(screen.getAllByRole('button', { name: 'Bob Display' }).length).toBeGreaterThan(0);
+  await waitFor(() => {
+    expect(screen.getAllByRole('button', { name: 'Local Author' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: 'Bob Display' }).length).toBeGreaterThan(0);
+  });
   expect(screen.queryByText('You')).not.toBeInTheDocument();
   expect(screen.queryByText('Peer')).not.toBeInTheDocument();
 });
@@ -3399,7 +3404,7 @@ test('messages workspace keeps the last successful DM state when status refresh 
   });
 
   failNextStatusRefresh = true;
-  await new Promise((resolve) => window.setTimeout(resolve, 2300));
+  await new Promise((resolve) => window.setTimeout(resolve, REFRESH_INTERVAL_MS + 300));
 
   await waitFor(() => {
     expect(screen.getAllByText('hello dm').length).toBeGreaterThan(0);

--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -114,7 +114,11 @@ export function DesktopShellPage({
     topicInput,
     composer,
     attachmentInputKey,
+    timelineNextCursorByTopic,
+    timelineLoadingMoreByTopic,
     selectedThread,
+    threadNextCursorById,
+    threadLoadingMoreById,
     replyTarget,
     repostTarget,
     discoveryConfig,
@@ -264,7 +268,10 @@ export function DesktopShellPage({
 
   const {
     loadTopics,
+    refreshVisibleShellData,
     refreshVisibleTimelineAfterPublish,
+    loadMoreTimeline,
+    loadMoreThread,
     rememberDraftPreview,
     releaseDraftPreview,
     releaseAllDraftPreviews,
@@ -345,6 +352,8 @@ export function DesktopShellPage({
     clearRepost,
     openFloatingActionDialog,
     handleSimpleRepost,
+    handleRetryLocalPost,
+    handleRestoreLocalPost,
     beginQuoteRepost,
     handleRelationshipAction,
     handleMuteAction,
@@ -443,6 +452,14 @@ export function DesktopShellPage({
     () => new Set(bookmarkedPosts.map((item) => item.post.object_id)),
     [bookmarkedPosts]
   );
+  const activeTimelineHasMore = Boolean(timelineNextCursorByTopic[activeTopic]);
+  const activeTimelineLoadingMore = timelineLoadingMoreByTopic[activeTopic] ?? false;
+  const selectedThreadHasMore = selectedThread
+    ? Boolean(threadNextCursorById[selectedThread])
+    : false;
+  const selectedThreadLoadingMore = selectedThread
+    ? (threadLoadingMoreById[selectedThread] ?? false)
+    : false;
   const notificationBadgeLabel =
     notificationStatus.unread_count > 99 ? '99+' : formatCount(notificationStatus.unread_count);
   const notificationItems = useMemo(
@@ -1058,14 +1075,19 @@ export function DesktopShellPage({
           summary={threadPanelState.summary}
           showBackdrop={!selectedAuthorPubkey}
           stackIndex={0}
-          onClose={closeThreadPane}
-        >
-          <ThreadPanel
-            state={threadPanelState}
-            posts={threadPostViews}
-            onOpenAuthor={(authorPubkey) =>
-              void openAuthorDetail(authorPubkey, {
-                fromThread: true,
+            onClose={closeThreadPane}
+          >
+            <ThreadPanel
+              state={threadPanelState}
+              posts={threadPostViews}
+              hasMore={selectedThreadHasMore}
+              loadingMore={selectedThreadLoadingMore}
+              onLoadMore={
+                selectedThread ? () => void loadMoreThread(activeTopic, selectedThread) : undefined
+              }
+              onOpenAuthor={(authorPubkey) =>
+                void openAuthorDetail(authorPubkey, {
+                  fromThread: true,
                 threadId: selectedThread,
               })
             }
@@ -1073,8 +1095,10 @@ export function DesktopShellPage({
             onOpenThreadInTopic={(threadId, topicId) => void openThread(threadId, { topic: topicId })}
             onReply={beginReply}
             onRepost={(post) => void handleSimpleRepost(post)}
-            onQuoteRepost={beginQuoteRepost}
-            localAuthorPubkey={syncStatus.local_author_pubkey}
+                onQuoteRepost={beginQuoteRepost}
+                onRetryLocalPost={handleRetryLocalPost}
+                onRestoreLocalPost={handleRestoreLocalPost}
+                localAuthorPubkey={syncStatus.local_author_pubkey}
             mediaObjectUrls={mediaObjectUrls}
             ownedReactionAssets={ownedReactionAssets}
             bookmarkedReactionAssets={bookmarkedReactionAssets}
@@ -1233,11 +1257,7 @@ export function DesktopShellPage({
                       <Button
                         variant='secondary'
                         type='button'
-                        onClick={() =>
-                          void loadTopics(trackedTopics, activeTopic, selectedThread).catch(
-                            () => undefined
-                          )
-                        }
+                        onClick={() => void refreshVisibleShellData(activeTopic, selectedThread)}
                       >
                         {t('common:actions.refresh')}
                       </Button>
@@ -1255,6 +1275,8 @@ export function DesktopShellPage({
                         onReply={beginReply}
                         onRepost={(post) => void handleSimpleRepost(post)}
                         onQuoteRepost={beginQuoteRepost}
+                        onRetryLocalPost={handleRetryLocalPost}
+                        onRestoreLocalPost={handleRestoreLocalPost}
                         localAuthorPubkey={syncStatus.local_author_pubkey}
                         mediaObjectUrls={mediaObjectUrls}
                         ownedReactionAssets={ownedReactionAssets}
@@ -1265,6 +1287,9 @@ export function DesktopShellPage({
                         showBookmarkAction={true}
                         bookmarkedPostIds={bookmarkedPostIds}
                         onToggleBookmark={(post) => void handleToggleBookmarkedPost(post)}
+                        hasMore={activeTimelineHasMore}
+                        loadingMore={activeTimelineLoadingMore}
+                        onLoadMore={() => void loadMoreTimeline(activeTopic)}
                       />
                     ) : (
                       <TimelineFeed
@@ -1276,6 +1301,8 @@ export function DesktopShellPage({
                         onReply={beginReply}
                         onRepost={(post) => void handleSimpleRepost(post)}
                         onQuoteRepost={beginQuoteRepost}
+                        onRetryLocalPost={handleRetryLocalPost}
+                        onRestoreLocalPost={handleRestoreLocalPost}
                         localAuthorPubkey={syncStatus.local_author_pubkey}
                         mediaObjectUrls={mediaObjectUrls}
                         ownedReactionAssets={ownedReactionAssets}

--- a/apps/desktop/src/shell/store.ts
+++ b/apps/desktop/src/shell/store.ts
@@ -38,6 +38,7 @@ import {
   type ProfileInput,
   type RecentReactionView,
   type SyncStatus,
+  type TimelineCursor,
   type TimelineScope,
 } from '@/lib/api';
 import type { DesktopTheme } from '@/lib/theme';
@@ -75,7 +76,11 @@ export type DesktopShellState = {
   draftMediaItems: DraftMediaItem[];
   attachmentInputKey: number;
   timelinesByTopic: Record<string, PostView[]>;
+  timelineNextCursorByTopic: Record<string, TimelineCursor | null>;
+  timelineLoadingMoreByTopic: Record<string, boolean>;
   publicTimelinesByTopic: Record<string, PostView[]>;
+  publicTimelineNextCursorByTopic: Record<string, TimelineCursor | null>;
+  publicTimelineLoadingMoreByTopic: Record<string, boolean>;
   liveSessionsByTopic: Record<string, LiveSessionView[]>;
   gameRoomsByTopic: Record<string, GameRoomView[]>;
   joinedChannelsByTopic: Record<string, JoinedPrivateChannelView[]>;
@@ -83,6 +88,8 @@ export type DesktopShellState = {
   timelineScopeByTopic: Record<string, TimelineScope>;
   composeChannelByTopic: Record<string, ChannelRef>;
   thread: PostView[];
+  threadNextCursorById: Record<string, TimelineCursor | null>;
+  threadLoadingMoreById: Record<string, boolean>;
   selectedThread: string | null;
   replyTarget: PostView | null;
   repostTarget: PostView | null;
@@ -102,6 +109,8 @@ export type DesktopShellState = {
   syncStatus: SyncStatus;
   localProfile: Profile | null;
   profileTimeline: PostView[];
+  profileTimelineNextCursor: TimelineCursor | null;
+  profileTimelineLoadingMore: boolean;
   knownAuthorsByPubkey: KnownAuthorsByPubkey;
   socialConnections: SocialConnectionsState;
   socialConnectionsPanelState: AsyncPanelState;
@@ -117,6 +126,8 @@ export type DesktopShellState = {
   selectedAuthorPubkey: string | null;
   selectedAuthor: AuthorSocialView | null;
   selectedAuthorTimeline: PostView[];
+  selectedAuthorTimelineNextCursor: TimelineCursor | null;
+  selectedAuthorTimelineLoadingMore: boolean;
   authorError: string | null;
   notifications: NotificationView[];
   notificationStatus: NotificationStatusView;
@@ -126,6 +137,8 @@ export type DesktopShellState = {
   selectedDirectMessagePeerPubkey: string | null;
   directMessages: DirectMessageConversationView[];
   directMessageTimelineByPeer: Record<string, DirectMessageMessageView[]>;
+  directMessageTimelineNextCursorByPeer: Record<string, TimelineCursor | null>;
+  directMessageTimelineLoadingMoreByPeer: Record<string, boolean>;
   directMessageStatusByPeer: Record<string, DirectMessageStatusView>;
   directMessageComposer: string;
   directMessageDraftMediaItems: DraftMediaItem[];
@@ -182,7 +195,8 @@ export type DesktopShellPageProps = AppProps & {
 export const DEFAULT_TOPIC = 'kukuri:topic:demo';
 export const PUBLIC_CHANNEL_REF: ChannelRef = { kind: 'public' };
 export const PUBLIC_TIMELINE_SCOPE: TimelineScope = { kind: 'public' };
-export const REFRESH_INTERVAL_MS = 2000;
+export const REFRESH_INTERVAL_MS = 3000;
+export const STATUS_REFRESH_INTERVAL_MS = 10000;
 export const VIDEO_POSTER_TIMEOUT_MS = 5000;
 export const MEDIA_DEBUG_STORAGE_KEY = 'kukuri:media-debug';
 export const SHELL_WORKSPACE_ID = 'shell-primary-workspace';
@@ -296,8 +310,20 @@ export function createInitialShellState(): DesktopShellState {
     timelinesByTopic: {
       [DEFAULT_TOPIC]: [],
     },
+    timelineNextCursorByTopic: {
+      [DEFAULT_TOPIC]: null,
+    },
+    timelineLoadingMoreByTopic: {
+      [DEFAULT_TOPIC]: false,
+    },
     publicTimelinesByTopic: {
       [DEFAULT_TOPIC]: [],
+    },
+    publicTimelineNextCursorByTopic: {
+      [DEFAULT_TOPIC]: null,
+    },
+    publicTimelineLoadingMoreByTopic: {
+      [DEFAULT_TOPIC]: false,
     },
     liveSessionsByTopic: {
       [DEFAULT_TOPIC]: [],
@@ -318,6 +344,8 @@ export function createInitialShellState(): DesktopShellState {
       [DEFAULT_TOPIC]: PUBLIC_CHANNEL_REF,
     },
     thread: [],
+    threadNextCursorById: {},
+    threadLoadingMoreById: {},
     selectedThread: null,
     replyTarget: null,
     repostTarget: null,
@@ -337,6 +365,8 @@ export function createInitialShellState(): DesktopShellState {
     syncStatus: DEFAULT_SYNC_STATUS,
     localProfile: null,
     profileTimeline: [],
+    profileTimelineNextCursor: null,
+    profileTimelineLoadingMore: false,
     knownAuthorsByPubkey: {},
     socialConnections: DEFAULT_SOCIAL_CONNECTIONS,
     socialConnectionsPanelState: DEFAULT_ASYNC_PANEL_STATE,
@@ -352,6 +382,8 @@ export function createInitialShellState(): DesktopShellState {
     selectedAuthorPubkey: null,
     selectedAuthor: null,
     selectedAuthorTimeline: [],
+    selectedAuthorTimelineNextCursor: null,
+    selectedAuthorTimelineLoadingMore: false,
     authorError: null,
     notifications: [],
     notificationStatus: DEFAULT_NOTIFICATION_STATUS,
@@ -361,6 +393,8 @@ export function createInitialShellState(): DesktopShellState {
     selectedDirectMessagePeerPubkey: null,
     directMessages: [],
     directMessageTimelineByPeer: {},
+    directMessageTimelineNextCursorByPeer: {},
+    directMessageTimelineLoadingMoreByPeer: {},
     directMessageStatusByPeer: {},
     directMessageComposer: '',
     directMessageDraftMediaItems: [],

--- a/apps/desktop/src/shell/useDesktopShellActions.ts
+++ b/apps/desktop/src/shell/useDesktopShellActions.ts
@@ -7,7 +7,6 @@ import {
 
 import type {
   AttachmentView,
-  ChannelRef,
   CustomReactionCropRect,
   DesktopApi,
   DirectMessageConversationView,

--- a/apps/desktop/src/shell/useDesktopShellActions.ts
+++ b/apps/desktop/src/shell/useDesktopShellActions.ts
@@ -7,12 +7,15 @@ import {
 
 import type {
   AttachmentView,
+  ChannelRef,
   CustomReactionCropRect,
   DesktopApi,
   DirectMessageConversationView,
   DirectMessageMessageView,
   GameScoreView,
   JoinedPrivateChannelView,
+  LocalDraftMediaItem,
+  LocalPostDraft,
   NotificationView,
   PostView,
   ProfileInput,
@@ -161,6 +164,7 @@ export function useDesktopShellActions({
     nextJoinedChannels.find((channel) => channel.channel_id === nextSelectedChannelId) ?? null;
   const bookmarkedPostIds = new Set(state.bookmarkedPosts.map((item) => item.post.object_id));
   const activeGameRooms = state.gameRoomsByTopic[nextActiveTopic] ?? [];
+  const localAuthorPubkey = state.syncStatus.local_author_pubkey;
 
   const setTrackedTopics = useDesktopShellFieldSetter('trackedTopics');
   const setActiveTopic = useDesktopShellFieldSetter('activeTopic');
@@ -242,6 +246,289 @@ export function useDesktopShellActions({
   const setReactionCreatePending = useDesktopShellFieldSetter('reactionCreatePending');
   const setShellChromeState = useDesktopShellFieldSetter('shellChromeState');
   const setError = useDesktopShellFieldSetter('error');
+
+  function cloneDraftMediaItems(items: DraftMediaItem[]): LocalDraftMediaItem[] {
+    return items.map((item) => ({
+      id: item.id,
+      source_name: item.source_name,
+      preview_url: item.preview_url,
+      attachments: item.attachments.map((attachment) => ({ ...attachment })),
+    }));
+  }
+
+  function attachmentViewsFromDraftMediaItems(
+    localId: string,
+    items: LocalDraftMediaItem[]
+  ): AttachmentView[] {
+    let attachmentIndex = 0;
+    return items.flatMap((item) =>
+      item.attachments.map((attachment) => ({
+        hash: `${localId}-attachment-${attachmentIndex++}`,
+        mime: attachment.mime,
+        bytes: attachment.byte_size,
+        role: attachment.role ?? 'image_original',
+        status: 'Available',
+      }))
+    );
+  }
+
+  function prependPost(posts: PostView[], post: PostView) {
+    return [post, ...posts.filter((current) => current.object_id !== post.object_id)];
+  }
+
+  function patchLocalPosts(
+    localId: string,
+    updater: (post: PostView) => PostView,
+    topicId: string = activeTopic
+  ) {
+    const patch = (posts: PostView[]) =>
+      posts.map((post) => (post.local_id === localId ? updater(post) : post));
+
+    setTimelinesByTopic((current) => ({
+      ...current,
+      [topicId]: patch(current[topicId] ?? []),
+    }));
+    setPublicTimelinesByTopic((current) => ({
+      ...current,
+      [topicId]: patch(current[topicId] ?? []),
+    }));
+    setThread((current) => patch(current));
+    setProfileTimeline((current) => patch(current));
+    setSelectedAuthorTimeline((current) => patch(current));
+  }
+
+  function findKnownPost(objectId: string): PostView | null {
+    const currentState = storeApi.getState();
+    const lists = [
+      currentState.thread,
+      currentState.timelinesByTopic[currentState.activeTopic] ?? [],
+      currentState.publicTimelinesByTopic[currentState.activeTopic] ?? [],
+      currentState.profileTimeline,
+      currentState.selectedAuthorTimeline,
+    ];
+    for (const posts of lists) {
+      const match = posts.find((post) => post.object_id === objectId);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+
+  function restoreLocalDraft(post: PostView) {
+    const draft = post.local_draft;
+    if (!draft) {
+      return;
+    }
+    const draftMedia = cloneDraftMediaItems(post.local_draft_media_items ?? []);
+    for (const item of draftMedia) {
+      rememberDraftPreview(item as DraftMediaItem);
+    }
+    if (draft.topic !== activeTopic) {
+      setActiveTopic(draft.topic);
+    }
+    setComposer(draft.content);
+    setDraftMediaItems(draftMedia as DraftMediaItem[]);
+    setAttachmentInputKey((value) => value + 1);
+    setComposeChannelByTopic((current) => ({
+      ...current,
+      [draft.topic]:
+        draft.kind === 'repost' ? PUBLIC_CHANNEL_REF : (draft.channel_ref ?? PUBLIC_CHANNEL_REF),
+    }));
+    if (draft.kind === 'repost' && draft.source_object_id) {
+      setRepostTarget(findKnownPost(draft.source_object_id));
+      setReplyTarget(null);
+    } else if (draft.reply_to) {
+      setReplyTarget(findKnownPost(draft.reply_to));
+      setRepostTarget(null);
+      setSelectedThread(post.root_id ?? draft.reply_to);
+    } else {
+      setReplyTarget(null);
+      setRepostTarget(null);
+      const channelRef = draft.channel_ref;
+      if (channelRef && channelRef.kind === 'private_channel') {
+        setSelectedChannelIdByTopic((current) => ({
+          ...current,
+          [draft.topic]: channelRef.channel_id,
+        }));
+      }
+    }
+    setComposerError(post.local_error ?? null);
+    setComposeDialogOpen(true);
+    setShellChromeState((current) => ({
+      ...current,
+      activePrimarySection: 'timeline',
+    }));
+    syncRoute('replace', {
+      activeTopic: draft.topic,
+      primarySection: 'timeline',
+      selectedThread: draft.reply_to ? post.root_id ?? draft.reply_to : null,
+    });
+  }
+
+  function createOptimisticPost(args: {
+    localId: string;
+    draft: LocalPostDraft;
+    draftMedia: LocalDraftMediaItem[];
+    replyPost?: PostView | null;
+    repostPost?: PostView | null;
+  }): PostView {
+    const { localId, draft, draftMedia, replyPost = null, repostPost = null } = args;
+    const isRepost = draft.kind === 'repost' && repostPost;
+    const channelId =
+      draft.kind === 'post' && draft.channel_ref?.kind === 'private_channel'
+        ? draft.channel_ref.channel_id
+        : null;
+    const rootId = replyPost ? replyPost.root_id ?? replyPost.object_id : localId;
+    return {
+      object_id: localId,
+      envelope_id: localId,
+      author_pubkey: localAuthorPubkey,
+      author_name: localProfile?.name ?? null,
+      author_display_name: localProfile?.display_name ?? null,
+      following: false,
+      followed_by: false,
+      mutual: false,
+      friend_of_friend: false,
+      object_kind: isRepost ? 'repost' : replyPost ? 'comment' : 'post',
+      content: draft.content,
+      content_status: 'Available',
+      attachments: attachmentViewsFromDraftMediaItems(localId, draftMedia),
+      created_at: Math.floor(Date.now() / 1000),
+      reply_to: replyPost?.object_id ?? null,
+      root_id: isRepost ? null : rootId,
+      published_topic_id: draft.topic,
+      origin_topic_id: draft.topic,
+      repost_of: repostPost
+        ? {
+            source_object_id: repostPost.object_id,
+            source_topic_id: publishedTopicIdForPost(repostPost) ?? draft.topic,
+            source_author_pubkey: repostPost.author_pubkey,
+            source_author_name: repostPost.author_name ?? null,
+            source_author_display_name: repostPost.author_display_name ?? null,
+            source_object_kind: repostPost.object_kind,
+            content: repostPost.content,
+            attachments: repostPost.attachments.map((attachment) => ({ ...attachment })),
+            reply_to: repostPost.reply_to ?? null,
+            root_id: repostPost.root_id ?? null,
+          }
+        : null,
+      repost_commentary: repostPost ? (draft.content.trim() || null) : null,
+      is_threadable: repostPost ? Boolean(draft.content.trim()) : true,
+      channel_id: channelId,
+      audience_label:
+        replyPost?.audience_label ??
+        (channelId ? activePrivateChannel?.label ?? 'Private channel' : 'Public'),
+      reaction_summary: [],
+      my_reactions: [],
+      local_id: localId,
+      local_state: 'pending',
+      local_error: null,
+      server_object_id: null,
+      local_draft: {
+        ...draft,
+        attachments: draft.attachments?.map((attachment) => ({ ...attachment })) ?? [],
+      },
+      local_draft_media_items: draftMedia,
+    };
+  }
+
+  function insertOptimisticPost(post: PostView) {
+    const currentState = storeApi.getState();
+    const selectedChannelId = currentState.selectedChannelIdByTopic[post.published_topic_id ?? activeTopic] ?? null;
+    const topicId = post.published_topic_id ?? activeTopic;
+    const belongsToActiveTimeline = post.channel_id
+      ? selectedChannelId === post.channel_id
+      : selectedChannelId === null;
+
+    if (belongsToActiveTimeline) {
+      setTimelinesByTopic((current) => ({
+        ...current,
+        [topicId]: prependPost(current[topicId] ?? [], post),
+      }));
+    }
+    if (!post.channel_id) {
+      setPublicTimelinesByTopic((current) => ({
+        ...current,
+        [topicId]: prependPost(current[topicId] ?? [], post),
+      }));
+    }
+    if (post.root_id && currentState.selectedThread === post.root_id) {
+      setThread((current) => prependPost(current, post));
+    }
+    if (!post.channel_id && localProfile && currentState.shellChromeState.activePrimarySection === 'profile') {
+      setProfileTimeline((current) => prependPost(current, post));
+    }
+    if (
+      !post.channel_id &&
+      currentState.selectedAuthorPubkey === localAuthorPubkey &&
+      currentState.shellChromeState.activePrimarySection === 'timeline'
+    ) {
+      setSelectedAuthorTimeline((current) => prependPost(current, post));
+    }
+  }
+
+  async function submitOptimisticPost(post: PostView) {
+    const draft = post.local_draft;
+    const draftMedia = cloneDraftMediaItems(post.local_draft_media_items ?? []);
+    if (!draft || !post.local_id) {
+      return;
+    }
+    patchLocalPosts(post.local_id, (current) => ({
+      ...current,
+      local_state: 'pending',
+      local_error: null,
+    }), draft.topic);
+    try {
+      const serverObjectId =
+        draft.kind === 'repost' && draft.source_topic && draft.source_object_id
+          ? await api.createRepost(
+              draft.topic,
+              draft.source_topic,
+              draft.source_object_id,
+              draft.content.trim() || null
+            )
+          : await api.createPost(
+              draft.topic,
+              draft.content,
+              draft.reply_to ?? null,
+              draft.attachments ?? [],
+              draft.channel_ref ?? PUBLIC_CHANNEL_REF
+            );
+      for (const item of draftMedia) {
+        releaseDraftPreview(item.id);
+      }
+      patchLocalPosts(
+        post.local_id,
+        (current) => ({
+          ...current,
+          local_state: 'syncing',
+          local_error: null,
+          server_object_id: serverObjectId,
+        }),
+        draft.topic
+      );
+      void refreshVisibleTimelineAfterPublish(
+        draft.topic,
+        draft.reply_to ? post.root_id ?? draft.reply_to : null
+      );
+    } catch (publishError) {
+      const message =
+        publishError instanceof Error
+          ? publishError.message
+          : translate('common:errors.failedToPublish');
+      patchLocalPosts(
+        post.local_id,
+        (current) => ({
+          ...current,
+          local_state: 'failed',
+          local_error: message,
+        }),
+        draft.topic
+      );
+      setComposerError(message);
+    }
+  }
 
   function clearThreadContext() {
     setSelectedThread(null);
@@ -698,7 +985,8 @@ export function useDesktopShellActions({
   async function handlePublish(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const trimmedComposer = composer.trim();
-    const attachments = draftMediaItems.flatMap((item) => item.attachments);
+    const draftMediaSnapshot = cloneDraftMediaItems(draftMediaItems);
+    const attachments = draftMediaSnapshot.flatMap((item) => item.attachments);
     if (repostTarget) {
       const sourceTopic = publishedTopicIdForPost(repostTarget);
       if (!sourceTopic) {
@@ -709,35 +997,39 @@ export function useDesktopShellActions({
         setComposerError(translate('common:errors.quoteRepostRequiresCommentary'));
         return;
       }
-
-      try {
-        await api.createRepost(activeTopic, sourceTopic, repostTarget.object_id, trimmedComposer);
-        releaseAllDraftPreviews();
-        setComposer('');
-        setDraftMediaItems([]);
-        setAttachmentInputKey((value) => value + 1);
-        setComposerError(null);
-        setReplyTarget(null);
-        setRepostTarget(null);
-        setComposeDialogOpen(false);
-        setSelectedThread(null);
-        setThread([]);
-        setShellChromeState((current) => ({
-          ...current,
-          activePrimarySection: 'timeline',
-        }));
-        syncRoute('replace', {
-          primarySection: 'timeline',
-          selectedThread: null,
-        });
-        void refreshVisibleTimelineAfterPublish(activeTopic, null);
-      } catch (publishError) {
-        setComposerError(
-          publishError instanceof Error
-            ? publishError.message
-            : translate('common:errors.failedToPublish')
-        );
-      }
+      const localId = `local-post:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+      const optimisticPost = createOptimisticPost({
+        localId,
+        draft: {
+          kind: 'repost',
+          topic: activeTopic,
+          content: trimmedComposer,
+          source_topic: sourceTopic,
+          source_object_id: repostTarget.object_id,
+          channel_ref: PUBLIC_CHANNEL_REF,
+        },
+        draftMedia: [],
+        repostPost: repostTarget,
+      });
+      insertOptimisticPost(optimisticPost);
+      setComposer('');
+      setDraftMediaItems([]);
+      setAttachmentInputKey((value) => value + 1);
+      setComposerError(null);
+      setReplyTarget(null);
+      setRepostTarget(null);
+      setComposeDialogOpen(false);
+      setSelectedThread(null);
+      setThread([]);
+      setShellChromeState((current) => ({
+        ...current,
+        activePrimarySection: 'timeline',
+      }));
+      syncRoute('replace', {
+        primarySection: 'timeline',
+        selectedThread: null,
+      });
+      void submitOptimisticPost(optimisticPost);
       return;
     }
 
@@ -745,37 +1037,36 @@ export function useDesktopShellActions({
       return;
     }
 
-    try {
-      await api.createPost(
-        activeTopic,
-        trimmedComposer,
-        replyTarget?.object_id ?? null,
+    const localId = `local-post:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+    const optimisticPost = createOptimisticPost({
+      localId,
+      draft: {
+        kind: 'post',
+        topic: activeTopic,
+        content: trimmedComposer,
+        reply_to: replyTarget?.object_id ?? null,
+        channel_ref: activeComposeChannel,
         attachments,
-        activeComposeChannel
-      );
-      releaseAllDraftPreviews();
-      setComposer('');
-      setDraftMediaItems([]);
-      setAttachmentInputKey((value) => value + 1);
-      setComposerError(null);
-      setComposeDialogOpen(false);
-      setReplyTarget(null);
-      setRepostTarget(null);
-      setShellChromeState((current) => ({
-        ...current,
-        activePrimarySection: 'timeline',
-      }));
-      syncRoute('replace', {
-        primarySection: 'timeline',
-      });
-      void refreshVisibleTimelineAfterPublish(activeTopic, selectedThread);
-    } catch (publishError) {
-      setComposerError(
-        publishError instanceof Error
-          ? publishError.message
-          : translate('common:errors.failedToPublish')
-      );
-    }
+      },
+      draftMedia: draftMediaSnapshot,
+      replyPost: replyTarget,
+    });
+    insertOptimisticPost(optimisticPost);
+    setComposer('');
+    setDraftMediaItems([]);
+    setAttachmentInputKey((value) => value + 1);
+    setComposerError(null);
+    setComposeDialogOpen(false);
+    setReplyTarget(null);
+    setRepostTarget(null);
+    setShellChromeState((current) => ({
+      ...current,
+      activePrimarySection: 'timeline',
+    }));
+    syncRoute('replace', {
+      primarySection: 'timeline',
+    });
+    void submitOptimisticPost(optimisticPost);
   }
 
   async function handleAttachmentSelection(event: ChangeEvent<HTMLInputElement>) {
@@ -1245,30 +1536,47 @@ export function useDesktopShellActions({
       setComposerError(translate('common:errors.failedToPublish'));
       return;
     }
+    const localId = `local-post:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+    const optimisticPost = createOptimisticPost({
+      localId,
+      draft: {
+        kind: 'repost',
+        topic: activeTopic,
+        content: '',
+        source_topic: sourceTopic,
+        source_object_id: post.object_id,
+        channel_ref: PUBLIC_CHANNEL_REF,
+      },
+      draftMedia: [],
+      repostPost: post,
+    });
+    insertOptimisticPost(optimisticPost);
+    setComposerError(null);
+    setReplyTarget(null);
+    setRepostTarget(null);
+    setSelectedThread(null);
+    setThread([]);
+    setShellChromeState((current) => ({
+      ...current,
+      activePrimarySection: 'timeline',
+    }));
+    syncRoute('replace', {
+      primarySection: 'timeline',
+      selectedThread: null,
+    });
+    void submitOptimisticPost(optimisticPost);
+  }
 
-    try {
-      await api.createRepost(activeTopic, sourceTopic, post.object_id, null);
-      setComposerError(null);
-      setReplyTarget(null);
-      setRepostTarget(null);
-      setSelectedThread(null);
-      setThread([]);
-      setShellChromeState((current) => ({
-        ...current,
-        activePrimarySection: 'timeline',
-      }));
-      syncRoute('replace', {
-        primarySection: 'timeline',
-        selectedThread: null,
-      });
-      void refreshVisibleTimelineAfterPublish(activeTopic, null);
-    } catch (repostError) {
-      setComposerError(
-        repostError instanceof Error
-          ? repostError.message
-          : translate('common:errors.failedToPublish')
-      );
+  function handleRestoreLocalPost(post: PostView) {
+    restoreLocalDraft(post);
+  }
+
+  function handleRetryLocalPost(post: PostView) {
+    if (post.local_state !== 'failed') {
+      return;
     }
+    setComposerError(null);
+    void submitOptimisticPost(post);
   }
 
   function beginQuoteRepost(post: PostView) {
@@ -1729,6 +2037,8 @@ export function useDesktopShellActions({
     openNewPostDialog,
     openFloatingActionDialog,
     handleSimpleRepost,
+    handleRetryLocalPost,
+    handleRestoreLocalPost,
     beginQuoteRepost,
     handleRelationshipAction,
     handleMuteAction,

--- a/apps/desktop/src/shell/useDesktopShellData.ts
+++ b/apps/desktop/src/shell/useDesktopShellData.ts
@@ -34,6 +34,7 @@ import {
   PUBLIC_CHANNEL_REF,
   PUBLIC_TIMELINE_SCOPE,
   REFRESH_INTERVAL_MS,
+  STATUS_REFRESH_INTERVAL_MS,
   type DraftMediaItem,
   useDesktopShellFieldSetter,
   useDesktopShellStore,
@@ -66,6 +67,8 @@ const EMPTY_POSTS: PostView[] = [];
 const EMPTY_GAME_ROOMS: GameRoomView[] = [];
 const EMPTY_JOINED_CHANNELS: JoinedPrivateChannelView[] = [];
 const EMPTY_DIRECT_MESSAGE_TIMELINE: DirectMessageMessageView[] = [];
+const VISIBLE_TIMELINE_LIMIT = 20;
+const THREAD_TIMELINE_LIMIT = 30;
 type LoadTopicsArgs = readonly [string[], string, string | null];
 type LoadTopicsWaiter = {
   resolve: () => void;
@@ -114,9 +117,15 @@ export function useDesktopShellData({
   const loadTopicsInFlightRef = useRef(false);
   const queuedLoadTopicsArgsRef = useRef<LoadTopicsArgs | null>(null);
   const loadTopicsWaitersRef = useRef<LoadTopicsWaiter[]>([]);
+  const visibleRefreshInFlightRef = useRef(false);
 
   const setTimelinesByTopic = useDesktopShellFieldSetter('timelinesByTopic');
+  const setTimelineNextCursorByTopic = useDesktopShellFieldSetter('timelineNextCursorByTopic');
+  const setTimelineLoadingMoreByTopic = useDesktopShellFieldSetter('timelineLoadingMoreByTopic');
   const setPublicTimelinesByTopic = useDesktopShellFieldSetter('publicTimelinesByTopic');
+  const setPublicTimelineNextCursorByTopic = useDesktopShellFieldSetter(
+    'publicTimelineNextCursorByTopic'
+  );
   const setLiveSessionsByTopic = useDesktopShellFieldSetter('liveSessionsByTopic');
   const setGameRoomsByTopic = useDesktopShellFieldSetter('gameRoomsByTopic');
   const setJoinedChannelsByTopic = useDesktopShellFieldSetter('joinedChannelsByTopic');
@@ -124,16 +133,21 @@ export function useDesktopShellData({
   const setTimelineScopeByTopic = useDesktopShellFieldSetter('timelineScopeByTopic');
   const setComposeChannelByTopic = useDesktopShellFieldSetter('composeChannelByTopic');
   const setThread = useDesktopShellFieldSetter('thread');
+  const setThreadNextCursorById = useDesktopShellFieldSetter('threadNextCursorById');
+  const setThreadLoadingMoreById = useDesktopShellFieldSetter('threadLoadingMoreById');
   const setLocalPeerTicket = useDesktopShellFieldSetter('localPeerTicket');
   const setDiscoveryConfig = useDesktopShellFieldSetter('discoveryConfig');
   const setDiscoverySeedInput = useDesktopShellFieldSetter('discoverySeedInput');
+  const setDiscoveryError = useDesktopShellFieldSetter('discoveryError');
   const setCommunityNodeConfig = useDesktopShellFieldSetter('communityNodeConfig');
   const setCommunityNodeStatuses = useDesktopShellFieldSetter('communityNodeStatuses');
   const setCommunityNodeInput = useDesktopShellFieldSetter('communityNodeInput');
+  const setCommunityNodeError = useDesktopShellFieldSetter('communityNodeError');
   const setMediaObjectUrls = useDesktopShellFieldSetter('mediaObjectUrls');
   const setSyncStatus = useDesktopShellFieldSetter('syncStatus');
   const setLocalProfile = useDesktopShellFieldSetter('localProfile');
   const setProfileTimeline = useDesktopShellFieldSetter('profileTimeline');
+  const setProfileTimelineNextCursor = useDesktopShellFieldSetter('profileTimelineNextCursor');
   const setKnownAuthorsByPubkey = useDesktopShellFieldSetter('knownAuthorsByPubkey');
   const setSocialConnections = useDesktopShellFieldSetter('socialConnections');
   const setSocialConnectionsPanelState = useDesktopShellFieldSetter('socialConnectionsPanelState');
@@ -146,6 +160,9 @@ export function useDesktopShellData({
   const setProfilePanelState = useDesktopShellFieldSetter('profilePanelState');
   const setSelectedAuthor = useDesktopShellFieldSetter('selectedAuthor');
   const setSelectedAuthorTimeline = useDesktopShellFieldSetter('selectedAuthorTimeline');
+  const setSelectedAuthorTimelineNextCursor = useDesktopShellFieldSetter(
+    'selectedAuthorTimelineNextCursor'
+  );
   const setAuthorError = useDesktopShellFieldSetter('authorError');
   const setNotifications = useDesktopShellFieldSetter('notifications');
   const setNotificationStatus = useDesktopShellFieldSetter('notificationStatus');
@@ -156,6 +173,9 @@ export function useDesktopShellData({
   );
   const setDirectMessages = useDesktopShellFieldSetter('directMessages');
   const setDirectMessageTimelineByPeer = useDesktopShellFieldSetter('directMessageTimelineByPeer');
+  const setDirectMessageTimelineNextCursorByPeer = useDesktopShellFieldSetter(
+    'directMessageTimelineNextCursorByPeer'
+  );
   const setDirectMessageStatusByPeer = useDesktopShellFieldSetter('directMessageStatusByPeer');
   const setDirectMessageError = useDesktopShellFieldSetter('directMessageError');
   const setLivePanelStateByTopic = useDesktopShellFieldSetter('livePanelStateByTopic');
@@ -258,547 +278,548 @@ export function useDesktopShellData({
     thread,
   ]);
 
-  const runLoadTopics = useCallback(
-    async (currentTopics: string[], currentActiveTopic: string, currentThread: string | null) => {
+  const mergeUniquePosts = useCallback((current: PostView[], incoming: PostView[]) => {
+    const seen = new Set(current.map((post) => post.object_id));
+    return [...current, ...incoming.filter((post) => !seen.has(post.object_id))];
+  }, []);
+
+  const mergeLocalPosts = useCallback((current: PostView[], incoming: PostView[]) => {
+    const authoritativeIds = new Set(incoming.map((post) => post.object_id));
+    const localPosts = current.filter((post) => {
+      if (!post.local_state) {
+        return false;
+      }
+      const authoritativeId = post.server_object_id ?? post.object_id;
+      return !authoritativeIds.has(authoritativeId);
+    });
+    const localObjectIds = new Set(localPosts.map((post) => post.object_id));
+    return [...localPosts, ...incoming.filter((post) => !localObjectIds.has(post.object_id))];
+  }, []);
+
+  const mergeUniqueMessages = useCallback(
+    (current: DirectMessageMessageView[], incoming: DirectMessageMessageView[]) => {
+      const seen = new Set(current.map((message) => message.message_id));
+      return [...current, ...incoming.filter((message) => !seen.has(message.message_id))];
+    },
+    []
+  );
+
+  const refreshVisibleShellData = useCallback(
+    async (topic: string, currentThread: string | null) => {
       const requestId = loadTopicsRequestRef.current + 1;
       loadTopicsRequestRef.current = requestId;
       const currentState = storeApi.getState();
-      const currentSelectedChannelIdByTopic = currentState.selectedChannelIdByTopic;
-      const currentSelectedAuthorPubkey = currentState.selectedAuthorPubkey;
-      const currentDirectMessagePaneOpen = currentState.directMessagePaneOpen;
-      const currentSelectedDirectMessagePeerPubkey = currentState.selectedDirectMessagePeerPubkey;
-      const currentActivePrimarySection = currentState.shellChromeState.activePrimarySection;
-      const currentDiscoveryEditorDirty = currentState.discoveryEditorDirty;
-      const currentCommunityNodeEditorDirty = currentState.communityNodeEditorDirty;
-      const currentProfileDirty = currentState.profileDirty;
-      const shouldLoadNotifications = currentActivePrimarySection === 'notifications';
+      const selectedChannelId = currentState.selectedChannelIdByTopic[topic] ?? null;
 
       try {
-        const [
-          timelineViews,
-          publicTimelineViews,
-          liveViewsResult,
-          gameViewsResult,
-          joinedChannelViewsResult,
-          threadView,
-          directMessagesView,
-          status,
-        ] = await Promise.all([
-          Promise.all(
-            currentTopics.map(async (topic) => ({
-              topic,
-              timeline: await api.listTimeline(
-                topic,
-                null,
-                50,
-                privateTimelineScope(currentSelectedChannelIdByTopic[topic] ?? null)
-              ),
-            }))
+        const [timeline, publicTimeline, joinedChannels, threadView, status] = await Promise.all([
+          api.listTimeline(
+            topic,
+            null,
+            VISIBLE_TIMELINE_LIMIT,
+            privateTimelineScope(selectedChannelId)
           ),
-          Promise.all(
-            currentTopics.map(async (topic) => ({
-              topic,
-              timeline: await api.listTimeline(topic, null, 50, PUBLIC_TIMELINE_SCOPE),
-            }))
-          ),
-          Promise.allSettled(
-            currentTopics.map(async (topic) => ({
-              topic,
-              sessions: await api.listLiveSessions(
-                topic,
-                privateTimelineScope(currentSelectedChannelIdByTopic[topic] ?? null)
-              ),
-            }))
-          ),
-          Promise.allSettled(
-            currentTopics.map(async (topic) => ({
-              topic,
-              rooms: await api.listGameRooms(
-                topic,
-                privateTimelineScope(currentSelectedChannelIdByTopic[topic] ?? null)
-              ),
-            }))
-          ),
-          Promise.allSettled(
-            currentTopics.map(async (topic) => ({
-              topic,
-              channels: await api.listJoinedPrivateChannels(topic),
-            }))
-          ),
+          api.listTimeline(topic, null, VISIBLE_TIMELINE_LIMIT, PUBLIC_TIMELINE_SCOPE),
+          api.listJoinedPrivateChannels(topic),
           currentThread
-            ? api.listThread(currentActiveTopic, currentThread, null, 50)
+            ? api.listThread(topic, currentThread, null, THREAD_TIMELINE_LIMIT)
             : Promise.resolve(null),
-          api.listDirectMessages(),
           api.getSyncStatus(),
         ]);
-        const [
-          discoveryResult,
-          communityConfigResult,
-          communityStatusesResult,
-          ticketResult,
-          profileResult,
-          authorViewResult,
-          profileTimelineResult,
-          authorTimelineResult,
-          directMessageTimelineResult,
-          directMessageStatusResult,
-          ownedReactionAssetsResult,
-          bookmarkedReactionAssetsResult,
-          bookmarkedPostsResult,
-          recentReactionsResult,
-          followingConnectionsResult,
-          followedConnectionsResult,
-          mutedConnectionsResult,
-          notificationStatusResult,
-          notificationsResult,
-        ] = await Promise.allSettled([
-          api.getDiscoveryConfig(),
-          api.getCommunityNodeConfig(),
-          api.getCommunityNodeStatuses(),
-          api.getLocalPeerTicket(),
-          api.getMyProfile(),
-          currentSelectedAuthorPubkey
-            ? api.getAuthorSocialView(currentSelectedAuthorPubkey)
-            : Promise.resolve(null),
-          api.listProfileTimeline(status.local_author_pubkey, null, 50),
-          currentSelectedAuthorPubkey
-            ? api.listProfileTimeline(currentSelectedAuthorPubkey, null, 50)
-            : Promise.resolve(null),
-          currentDirectMessagePaneOpen && currentSelectedDirectMessagePeerPubkey
-            ? api.listDirectMessageMessages(currentSelectedDirectMessagePeerPubkey, null, 100)
-            : Promise.resolve(null),
-          currentDirectMessagePaneOpen && currentSelectedDirectMessagePeerPubkey
-            ? api.getDirectMessageStatus(currentSelectedDirectMessagePeerPubkey)
-            : Promise.resolve(null),
-          api.listMyCustomReactionAssets(),
-          api.listBookmarkedCustomReactions(),
-          api.listBookmarkedPosts(),
-          api.listRecentReactions(8),
-          api.listSocialConnections('following'),
-          api.listSocialConnections('followed'),
-          api.listSocialConnections('muted'),
-          api.getNotificationStatus(),
-          shouldLoadNotifications ? api.listNotifications() : Promise.resolve(null),
-        ]);
-        if (requestId !== loadTopicsRequestRef.current) {
-          return;
-        }
-        let nextNotifications: NotificationView[] | null =
-          shouldLoadNotifications && notificationsResult.status === 'fulfilled'
-            ? notificationsResult.value ?? []
-            : null;
-        let nextNotificationStatus =
-          notificationStatusResult.status === 'fulfilled'
-            ? notificationStatusResult.value
-            : nextNotifications
-              ? {
-                  unread_count: nextNotifications.filter((notification) => !notification.read_at)
-                    .length,
-                }
-              : null;
-        let nextNotificationAutoReadError: string | null = null;
 
-        if (shouldLoadNotifications && nextNotifications) {
-          const hasUnreadNotifications = nextNotifications.some((notification) => !notification.read_at);
-          if (hasUnreadNotifications) {
-            try {
-              nextNotificationStatus = await api.markAllNotificationsRead();
-              const readAt = Date.now();
-              nextNotifications = nextNotifications.map((notification) =>
-                notification.read_at ? notification : { ...notification, read_at: readAt }
-              );
-            } catch (notificationReadError) {
-              nextNotificationAutoReadError = messageFromError(
-                notificationReadError,
-                translate('shell:notifications.errors.failedAutoRead')
-              );
-            }
-          }
-        }
         if (requestId !== loadTopicsRequestRef.current) {
           return;
         }
-        const latestState = storeApi.getState();
-        const matchesSelectedAuthorContext =
-          latestState.selectedAuthorPubkey === currentSelectedAuthorPubkey;
-        const matchesDirectMessageContext =
-          latestState.directMessagePaneOpen === currentDirectMessagePaneOpen &&
-          latestState.selectedDirectMessagePeerPubkey === currentSelectedDirectMessagePeerPubkey;
-        const matchesThreadContext = latestState.selectedThread === currentThread;
 
         startTransition(() => {
-          setTimelinesByTopic(
-            Object.fromEntries(timelineViews.map(({ topic, timeline }) => [topic, timeline.items]))
-          );
-          setPublicTimelinesByTopic(
-            Object.fromEntries(
-              publicTimelineViews.map(({ topic, timeline }) => [topic, timeline.items])
-            )
-          );
-          setLiveSessionsByTopic((current) => {
-            const next = { ...current };
-            for (const result of liveViewsResult) {
-              if (result.status === 'fulfilled') {
-                next[result.value.topic] = result.value.sessions;
-              }
-            }
-            return next;
-          });
-          setGameRoomsByTopic((current) => {
-            const next = { ...current };
-            for (const result of gameViewsResult) {
-              if (result.status === 'fulfilled') {
-                next[result.value.topic] = result.value.rooms;
-              }
-            }
-            return next;
-          });
-          setJoinedChannelsByTopic((current) => {
-            const next = { ...current };
-            for (const result of joinedChannelViewsResult) {
-              if (result.status === 'fulfilled') {
-                next[result.value.topic] = result.value.channels;
-              }
-            }
-            return next;
-          });
-          setLivePanelStateByTopic((current) => {
-            const next = { ...current };
-            for (const [index, result] of liveViewsResult.entries()) {
-              if (result.status === 'fulfilled') {
-                next[result.value.topic] = {
-                  status: 'ready',
-                  error: null,
-                };
-              } else {
-                next[currentTopics[index]] = {
-                  status: 'error',
-                  error: messageFromError(
-                    result.reason,
-                    translate('common:errors.failedToLoadLiveSessions')
-                  ),
-                };
-              }
-            }
-            return next;
-          });
-          setGamePanelStateByTopic((current) => {
-            const next = { ...current };
-            for (const [index, result] of gameViewsResult.entries()) {
-              if (result.status === 'fulfilled') {
-                next[result.value.topic] = {
-                  status: 'ready',
-                  error: null,
-                };
-              } else {
-                next[currentTopics[index]] = {
-                  status: 'error',
-                  error: messageFromError(
-                    result.reason,
-                    translate('common:errors.failedToLoadGameRooms')
-                  ),
-                };
-              }
-            }
-            return next;
-          });
-          setChannelPanelStateByTopic((current) => {
-            const next = { ...current };
-            for (const [index, result] of joinedChannelViewsResult.entries()) {
-              if (result.status === 'fulfilled') {
-                next[result.value.topic] = {
-                  status: 'ready',
-                  error: null,
-                };
-              } else {
-                next[currentTopics[index]] = {
-                  status: 'error',
-                  error: messageFromError(
-                    result.reason,
-                    translate('common:errors.failedToLoadPrivateChannels')
-                  ),
-                };
-              }
-            }
-            return next;
-          });
-          setDirectMessages(directMessagesView);
-          setKnownAuthorsByPubkey((current) =>
-            mergeKnownAuthors(current, directMessagesView.map(authorViewFromDirectMessageConversation))
-          );
+          setTimelinesByTopic((current) => ({
+            ...current,
+            [topic]: mergeLocalPosts(current[topic] ?? EMPTY_POSTS, timeline.items),
+          }));
+          setTimelineNextCursorByTopic((current) => ({
+            ...current,
+            [topic]: timeline.next_cursor ?? null,
+          }));
+          setPublicTimelinesByTopic((current) => ({
+            ...current,
+            [topic]: mergeLocalPosts(current[topic] ?? EMPTY_POSTS, publicTimeline.items),
+          }));
+          setPublicTimelineNextCursorByTopic((current) => ({
+            ...current,
+            [topic]: publicTimeline.next_cursor ?? null,
+          }));
+          setJoinedChannelsByTopic((current) => ({
+            ...current,
+            [topic]: joinedChannels,
+          }));
+          if (currentThread) {
+            setThread((current) => mergeLocalPosts(current, threadView?.items ?? []));
+            setThreadNextCursorById((current) => ({
+              ...current,
+              [currentThread]: threadView?.next_cursor ?? null,
+            }));
+          } else {
+            setThread([]);
+          }
           setSyncStatus(status);
-          if (nextNotificationStatus) {
-            setNotificationStatus(nextNotificationStatus);
-          }
-          if (shouldLoadNotifications) {
-            if (notificationsResult.status === 'fulfilled' && nextNotifications) {
-              setNotifications(nextNotifications);
-              setNotificationPanelState({
-                status: 'ready',
-                error: null,
-              });
-            } else {
-              setNotifications([]);
-              setNotificationPanelState({
-                status: 'error',
-                error: messageFromError(
-                  notificationsResult.status === 'rejected' ? notificationsResult.reason : null,
-                  translate('shell:notifications.errors.failedToLoad')
-                ),
-              });
-            }
-            setNotificationAutoReadError(nextNotificationAutoReadError);
-          } else {
-            setNotificationAutoReadError(null);
-          }
-          if (discoveryResult.status === 'fulfilled') {
-            setDiscoveryConfig(discoveryResult.value);
-            if (!currentDiscoveryEditorDirty) {
-              setDiscoverySeedInput(seedPeersToEditorValue(discoveryResult.value));
-            }
-          }
-          if (communityConfigResult.status === 'fulfilled') {
-            setCommunityNodeConfig(communityConfigResult.value);
-            if (!currentCommunityNodeEditorDirty) {
-              setCommunityNodeInput(communityNodesToEditorValue(communityConfigResult.value));
-            }
-          }
-          if (communityStatusesResult.status === 'fulfilled') {
-            setCommunityNodeStatuses((current) =>
-              mergeCommunityNodeStatuses(current, communityStatusesResult.value)
-            );
-          }
-          if (ticketResult.status === 'fulfilled') {
-            setLocalPeerTicket(ticketResult.value);
-          }
-          if (ownedReactionAssetsResult.status === 'fulfilled') {
-            setOwnedReactionAssets(ownedReactionAssetsResult.value);
-          }
-          if (bookmarkedReactionAssetsResult.status === 'fulfilled') {
-            setBookmarkedReactionAssets(bookmarkedReactionAssetsResult.value);
-          }
-          if (bookmarkedPostsResult.status === 'fulfilled') {
-            setBookmarkedPosts(bookmarkedPostsResult.value);
-          }
-          if (recentReactionsResult.status === 'fulfilled') {
-            setRecentReactions(recentReactionsResult.value);
-          }
-          if (
-            followingConnectionsResult.status === 'fulfilled' &&
-            followedConnectionsResult.status === 'fulfilled' &&
-            mutedConnectionsResult.status === 'fulfilled'
-          ) {
-            setSocialConnections({
-              following: followingConnectionsResult.value,
-              followed: followedConnectionsResult.value,
-              muted: mutedConnectionsResult.value,
-            });
-            setKnownAuthorsByPubkey((current) =>
-              mergeKnownAuthors(current, [
-                ...followingConnectionsResult.value,
-                ...followedConnectionsResult.value,
-                ...mutedConnectionsResult.value,
-              ])
-            );
-            setSocialConnectionsPanelState({
-              status: 'ready',
-              error: null,
-            });
-          } else {
-            setSocialConnections(DEFAULT_SOCIAL_CONNECTIONS);
-            setSocialConnectionsPanelState({
-              status: 'error',
-              error:
-                followingConnectionsResult.status === 'rejected'
-                  ? messageFromError(
-                      followingConnectionsResult.reason,
-                      translate('common:errors.failedToLoadSocialConnections')
-                    )
-                  : followedConnectionsResult.status === 'rejected'
-                    ? messageFromError(
-                        followedConnectionsResult.reason,
-                        translate('common:errors.failedToLoadSocialConnections')
-                      )
-                    : mutedConnectionsResult.status === 'rejected'
-                      ? messageFromError(
-                          mutedConnectionsResult.reason,
-                          translate('common:errors.failedToLoadSocialConnections')
-                        )
-                      : null,
-            });
-          }
-          setReactionPanelState({
-            status:
-              ownedReactionAssetsResult.status === 'fulfilled' &&
-              bookmarkedReactionAssetsResult.status === 'fulfilled' &&
-              recentReactionsResult.status === 'fulfilled'
-                ? 'ready'
-                : 'error',
-            error:
-              ownedReactionAssetsResult.status === 'rejected'
-                ? messageFromError(
-                    ownedReactionAssetsResult.reason,
-                    translate('common:errors.failedToLoadSettings')
-                  )
-                : bookmarkedReactionAssetsResult.status === 'rejected'
-                  ? messageFromError(
-                      bookmarkedReactionAssetsResult.reason,
-                      translate('common:errors.failedToLoadSettings')
-                    )
-                  : recentReactionsResult.status === 'rejected'
-                    ? messageFromError(
-                        recentReactionsResult.reason,
-                        translate('common:errors.failedToLoadSettings')
-                      )
-                    : null,
-          });
-          if (profileResult.status === 'fulfilled') {
-            setLocalProfile(profileResult.value);
-            if (!currentProfileDirty) {
-              setProfileDraft(profileInputFromProfile(profileResult.value));
-            }
-            if (profileTimelineResult.status === 'fulfilled') {
-              setProfileTimeline(profileTimelineResult.value.items);
-              setProfileError(null);
-              setProfilePanelState({
-                status: 'ready',
-                error: null,
-              });
-            } else {
-              const nextProfileError = messageFromError(
-                profileTimelineResult.reason,
-                translate('common:errors.failedToLoadProfile')
-              );
-              setProfileTimeline([]);
-              setProfileError(nextProfileError);
-              setProfilePanelState({
-                status: 'error',
-                error: nextProfileError,
-              });
-            }
-          } else {
-            const nextProfileError = messageFromError(
-              profileResult.reason,
-              translate('common:errors.failedToLoadProfile')
-            );
-            setProfileTimeline([]);
-            setProfileError(nextProfileError);
-            setProfilePanelState({
-              status: 'error',
-              error: nextProfileError,
-            });
-          }
-          if (matchesSelectedAuthorContext) {
-            if (!currentSelectedAuthorPubkey) {
-              setSelectedAuthor(null);
-              setSelectedAuthorTimeline([]);
-              setAuthorError(null);
-            } else if (
-              authorViewResult.status === 'fulfilled' &&
-              authorTimelineResult.status === 'fulfilled'
-            ) {
-              setSelectedAuthor(authorViewResult.value);
-              setSelectedAuthorTimeline(authorTimelineResult.value?.items ?? []);
-              setAuthorError(null);
-              if (authorViewResult.value) {
-                setKnownAuthorsByPubkey((current) =>
-                  mergeKnownAuthors(current, [authorViewResult.value])
-                );
-              }
-            } else {
-              setSelectedAuthorTimeline([]);
-              setAuthorError(
-                messageFromError(
-                  authorViewResult.status === 'rejected'
-                    ? authorViewResult.reason
-                    : authorTimelineResult.status === 'rejected'
-                      ? authorTimelineResult.reason
-                      : null,
-                  translate('common:errors.failedToLoadAuthor')
-                )
-              );
-            }
-          }
-          if (matchesDirectMessageContext) {
-            if (!currentDirectMessagePaneOpen) {
-              setSelectedDirectMessagePeerPubkey(null);
-              setDirectMessageError(null);
-            } else if (!currentSelectedDirectMessagePeerPubkey) {
-              setDirectMessageError(null);
-            } else {
-              if (directMessageTimelineResult.status === 'fulfilled') {
-                setDirectMessageTimelineByPeer((current) => ({
-                  ...current,
-                  [currentSelectedDirectMessagePeerPubkey]:
-                    directMessageTimelineResult.value?.items ?? [],
-                }));
-              }
-              if (directMessageStatusResult.status === 'fulfilled') {
-                setDirectMessageStatusByPeer((current) => ({
-                  ...current,
-                  [currentSelectedDirectMessagePeerPubkey]: directMessageStatusResult.value!,
-                }));
-              }
-              if (
-                directMessageTimelineResult.status === 'fulfilled' &&
-                directMessageStatusResult.status === 'fulfilled'
-              ) {
-                setDirectMessageError(null);
-              } else {
-                setDirectMessageError(
-                  messageFromError(
-                    directMessageTimelineResult.status === 'rejected'
-                      ? directMessageTimelineResult.reason
-                      : directMessageStatusResult.status === 'rejected'
-                        ? directMessageStatusResult.reason
-                        : null,
-                    'failed to load direct messages'
-                  )
-                );
-              }
-            }
-          }
-          if (matchesThreadContext) {
-            if (threadView) {
-              setThread(threadView.items);
-            } else if (!currentThread) {
-              setThread([]);
-            }
-          }
           setError(null);
         });
-      } catch (loadError) {
+      } catch (refreshError) {
         if (requestId !== loadTopicsRequestRef.current) {
           return;
         }
         setError(
-          loadError instanceof Error
-            ? loadError.message
+          refreshError instanceof Error
+            ? refreshError.message
             : translate('common:errors.failedToLoadTopic')
         );
-        throw loadError;
       }
     },
     [
       api,
+      mergeLocalPosts,
       loadTopicsRequestRef,
+      setError,
+      setJoinedChannelsByTopic,
+      setPublicTimelineNextCursorByTopic,
+      setPublicTimelinesByTopic,
+      setSyncStatus,
+      setThread,
+      setThreadNextCursorById,
+      setTimelineNextCursorByTopic,
+      setTimelinesByTopic,
+      storeApi,
+      translate,
+    ]
+  );
+
+  const loadMoreTimeline = useCallback(
+    async (topic: string) => {
+      const currentState = storeApi.getState();
+      const cursor = currentState.timelineNextCursorByTopic[topic] ?? null;
+      if (!cursor || currentState.timelineLoadingMoreByTopic[topic]) {
+        return;
+      }
+      const selectedChannelId = currentState.selectedChannelIdByTopic[topic] ?? null;
+      setTimelineLoadingMoreByTopic((current) => ({
+        ...current,
+        [topic]: true,
+      }));
+      try {
+        const timeline = await api.listTimeline(
+          topic,
+          cursor,
+          VISIBLE_TIMELINE_LIMIT,
+          privateTimelineScope(selectedChannelId)
+        );
+        startTransition(() => {
+          setTimelinesByTopic((current) => ({
+            ...current,
+            [topic]: mergeUniquePosts(current[topic] ?? EMPTY_POSTS, timeline.items),
+          }));
+          setTimelineNextCursorByTopic((current) => ({
+            ...current,
+            [topic]: timeline.next_cursor ?? null,
+          }));
+        });
+      } finally {
+        setTimelineLoadingMoreByTopic((current) => ({
+          ...current,
+          [topic]: false,
+        }));
+      }
+    },
+    [
+      api,
+      mergeUniquePosts,
+      setTimelineLoadingMoreByTopic,
+      setTimelineNextCursorByTopic,
+      setTimelinesByTopic,
+      storeApi,
+    ]
+  );
+
+  const loadMoreThread = useCallback(
+    async (topic: string, threadId: string) => {
+      const currentState = storeApi.getState();
+      const cursor = currentState.threadNextCursorById[threadId] ?? null;
+      if (!cursor || currentState.threadLoadingMoreById[threadId]) {
+        return;
+      }
+      setThreadLoadingMoreById((current) => ({
+        ...current,
+        [threadId]: true,
+      }));
+      try {
+        const threadView = await api.listThread(topic, threadId, cursor, THREAD_TIMELINE_LIMIT);
+        startTransition(() => {
+          setThread((current) => mergeUniquePosts(current, threadView.items));
+          setThreadNextCursorById((current) => ({
+            ...current,
+            [threadId]: threadView.next_cursor ?? null,
+          }));
+        });
+      } finally {
+        setThreadLoadingMoreById((current) => ({
+          ...current,
+          [threadId]: false,
+        }));
+      }
+    },
+    [
+      api,
+      mergeUniquePosts,
+      setThread,
+      setThreadLoadingMoreById,
+      setThreadNextCursorById,
+      storeApi,
+    ]
+  );
+
+  const runLoadTopics = useCallback(
+    async (_currentTopics: string[], currentActiveTopic: string, currentThread: string | null) => {
+      await refreshVisibleShellData(currentActiveTopic, currentThread);
+
+      const currentState = storeApi.getState();
+      const selectedChannelId = currentState.selectedChannelIdByTopic[currentActiveTopic] ?? null;
+      const selectedAuthorPubkey = currentState.selectedAuthorPubkey;
+      const selectedDirectMessagePeerPubkey = currentState.selectedDirectMessagePeerPubkey;
+      const {
+        activePrimarySection,
+        activeSettingsSection,
+        settingsOpen,
+        timelineView,
+      } = currentState.shellChromeState;
+
+      const tasks: Promise<void>[] = [];
+
+      if (activePrimarySection === 'live') {
+        tasks.push(
+          api
+            .listLiveSessions(currentActiveTopic, privateTimelineScope(selectedChannelId))
+            .then((sessions) => {
+              startTransition(() => {
+                setLiveSessionsByTopic((current) => ({
+                  ...current,
+                  [currentActiveTopic]: sessions,
+                }));
+                setLivePanelStateByTopic((current) => ({
+                  ...current,
+                  [currentActiveTopic]: { status: 'ready', error: null },
+                }));
+              });
+            })
+            .catch((error) => {
+              setLivePanelStateByTopic((current) => ({
+                ...current,
+                [currentActiveTopic]: {
+                  status: 'error',
+                  error: messageFromError(
+                    error,
+                    translate('common:errors.failedToLoadLiveSessions')
+                  ),
+                },
+              }));
+            })
+        );
+      }
+
+      if (activePrimarySection === 'game') {
+        tasks.push(
+          api
+            .listGameRooms(currentActiveTopic, privateTimelineScope(selectedChannelId))
+            .then((rooms) => {
+              startTransition(() => {
+                setGameRoomsByTopic((current) => ({
+                  ...current,
+                  [currentActiveTopic]: rooms,
+                }));
+                setGamePanelStateByTopic((current) => ({
+                  ...current,
+                  [currentActiveTopic]: { status: 'ready', error: null },
+                }));
+              });
+            })
+            .catch((error) => {
+              setGamePanelStateByTopic((current) => ({
+                ...current,
+                [currentActiveTopic]: {
+                  status: 'error',
+                  error: messageFromError(error, translate('common:errors.failedToLoadGameRooms')),
+                },
+              }));
+            })
+        );
+      }
+
+      if (activePrimarySection === 'profile') {
+        tasks.push(
+          Promise.all([
+            api.getMyProfile(),
+            api.listSocialConnections('following'),
+            api.listSocialConnections('followed'),
+            api.listSocialConnections('muted'),
+          ])
+            .then(async ([profile, following, followed, muted]) => {
+              const timeline = await api.listProfileTimeline(profile.pubkey, null, VISIBLE_TIMELINE_LIMIT);
+              startTransition(() => {
+                setLocalProfile(profile);
+                if (!storeApi.getState().profileDirty) {
+                  setProfileDraft(profileInputFromProfile(profile));
+                }
+                setProfileTimeline(timeline.items);
+                setProfileTimelineNextCursor(timeline.next_cursor ?? null);
+                setProfileError(null);
+                setProfilePanelState({ status: 'ready', error: null });
+                setSocialConnections({ following, followed, muted });
+                setKnownAuthorsByPubkey((current) =>
+                  mergeKnownAuthors(current, [...following, ...followed, ...muted])
+                );
+                setSocialConnectionsPanelState({ status: 'ready', error: null });
+              });
+            })
+            .catch((error) => {
+              const message = messageFromError(error, translate('common:errors.failedToLoadProfile'));
+              setProfileError(message);
+              setProfilePanelState({ status: 'error', error: message });
+            })
+        );
+      }
+
+      if (selectedAuthorPubkey) {
+        tasks.push(
+          Promise.all([
+            api.getAuthorSocialView(selectedAuthorPubkey),
+            api.listProfileTimeline(selectedAuthorPubkey, null, VISIBLE_TIMELINE_LIMIT),
+          ])
+            .then(([author, timeline]) => {
+              startTransition(() => {
+                setSelectedAuthor(author);
+                setSelectedAuthorTimeline(timeline.items);
+                setSelectedAuthorTimelineNextCursor(timeline.next_cursor ?? null);
+                setAuthorError(null);
+                if (author) {
+                  setKnownAuthorsByPubkey((current) => mergeKnownAuthors(current, [author]));
+                }
+              });
+            })
+            .catch((error) => {
+              setAuthorError(messageFromError(error, translate('common:errors.failedToLoadAuthor')));
+            })
+        );
+      }
+
+      if (activePrimarySection === 'messages' || currentState.directMessagePaneOpen) {
+        tasks.push(
+          api
+            .listDirectMessages()
+            .then(async (directMessages) => {
+              startTransition(() => {
+                setDirectMessages(directMessages);
+                setKnownAuthorsByPubkey((current) =>
+                  mergeKnownAuthors(
+                    current,
+                    directMessages.map(authorViewFromDirectMessageConversation)
+                  )
+                );
+              });
+              const selectedPeerPubkey = storeApi.getState().selectedDirectMessagePeerPubkey;
+              if (!selectedPeerPubkey) {
+                setDirectMessageError(null);
+                return;
+              }
+              const [timelineResult, statusResult] = await Promise.allSettled([
+                api.listDirectMessageMessages(selectedPeerPubkey, null, VISIBLE_TIMELINE_LIMIT),
+                api.getDirectMessageStatus(selectedPeerPubkey),
+              ]);
+              startTransition(() => {
+                if (timelineResult.status === 'fulfilled') {
+                  setDirectMessageTimelineByPeer((current) => ({
+                    ...current,
+                    [selectedPeerPubkey]: timelineResult.value.items,
+                  }));
+                  setDirectMessageTimelineNextCursorByPeer((current) => ({
+                    ...current,
+                    [selectedPeerPubkey]: timelineResult.value.next_cursor ?? null,
+                  }));
+                }
+                if (statusResult.status === 'fulfilled') {
+                  setDirectMessageStatusByPeer((current) => ({
+                    ...current,
+                    [selectedPeerPubkey]: statusResult.value,
+                  }));
+                }
+                setDirectMessageError(
+                  timelineResult.status === 'fulfilled' && statusResult.status === 'fulfilled'
+                    ? null
+                    : messageFromError(
+                        timelineResult.status === 'rejected'
+                          ? timelineResult.reason
+                          : statusResult.status === 'rejected'
+                            ? statusResult.reason
+                            : null,
+                        'failed to load direct messages'
+                      )
+                );
+              });
+            })
+            .catch((error) => {
+              setDirectMessageError(messageFromError(error, 'failed to load direct messages'));
+            })
+        );
+      }
+
+      if (activePrimarySection === 'notifications') {
+        tasks.push(
+          Promise.all([api.getNotificationStatus(), api.listNotifications()])
+            .then(async ([status, notificationItems]) => {
+              let nextNotifications: NotificationView[] = notificationItems;
+              let nextStatus = status;
+              if (notificationItems.some((notification) => !notification.read_at)) {
+                try {
+                  nextStatus = await api.markAllNotificationsRead();
+                  const readAt = Date.now();
+                  nextNotifications = notificationItems.map((notification) =>
+                    notification.read_at ? notification : { ...notification, read_at: readAt }
+                  );
+                  setNotificationAutoReadError(null);
+                } catch (notificationReadError) {
+                  setNotificationAutoReadError(
+                    messageFromError(
+                      notificationReadError,
+                      translate('shell:notifications.errors.failedAutoRead')
+                    )
+                  );
+                }
+              }
+              startTransition(() => {
+                setNotificationStatus(nextStatus);
+                setNotifications(nextNotifications);
+                setNotificationPanelState({ status: 'ready', error: null });
+              });
+            })
+            .catch((error) => {
+              setNotificationPanelState({
+                status: 'error',
+                error: messageFromError(error, translate('shell:notifications.errors.failedToLoad')),
+              });
+            })
+        );
+      }
+
+      if (activePrimarySection === 'timeline' && timelineView === 'bookmarks') {
+        tasks.push(
+          api
+            .listBookmarkedPosts()
+            .then((bookmarks) => {
+              setBookmarkedPosts(bookmarks);
+            })
+            .catch(() => undefined)
+        );
+      }
+
+      if (settingsOpen) {
+        if (activeSettingsSection === 'connectivity') {
+          tasks.push(
+            api
+              .getLocalPeerTicket()
+              .then((ticket) => {
+                setLocalPeerTicket(ticket);
+              })
+              .catch(() => undefined)
+          );
+        }
+
+        if (activeSettingsSection === 'discovery') {
+          tasks.push(
+            api
+              .getDiscoveryConfig()
+              .then((config) => {
+                setDiscoveryConfig(config);
+                if (!storeApi.getState().discoveryEditorDirty) {
+                  setDiscoverySeedInput(seedPeersToEditorValue(config));
+                }
+                setDiscoveryError(null);
+              })
+              .catch((error) => {
+                setDiscoveryError(
+                  messageFromError(error, translate('common:errors.failedToLoadSettings'))
+                );
+              })
+          );
+        }
+
+        if (activeSettingsSection === 'community-node') {
+          tasks.push(
+            Promise.all([api.getCommunityNodeConfig(), api.getCommunityNodeStatuses()])
+              .then(([config, statuses]) => {
+                startTransition(() => {
+                  setCommunityNodeConfig(config);
+                  if (!storeApi.getState().communityNodeEditorDirty) {
+                    setCommunityNodeInput(communityNodesToEditorValue(config));
+                  }
+                  setCommunityNodeStatuses((current) =>
+                    mergeCommunityNodeStatuses(current, statuses)
+                  );
+                  setCommunityNodeError(null);
+                });
+              })
+              .catch((error) => {
+                setCommunityNodeError(
+                  messageFromError(error, translate('common:errors.failedToLoadSettings'))
+                );
+              })
+          );
+        }
+
+        if (activeSettingsSection === 'reactions') {
+          tasks.push(
+            Promise.all([
+              api.listMyCustomReactionAssets(),
+              api.listBookmarkedCustomReactions(),
+              api.listBookmarkedPosts(),
+              api.listRecentReactions(8),
+            ])
+              .then(([ownedAssets, bookmarkedAssets, bookmarkedPosts, recent]) => {
+                startTransition(() => {
+                  setOwnedReactionAssets(ownedAssets);
+                  setBookmarkedReactionAssets(bookmarkedAssets);
+                  setBookmarkedPosts(bookmarkedPosts);
+                  setRecentReactions(recent);
+                  setReactionPanelState({ status: 'ready', error: null });
+                });
+              })
+              .catch((error) => {
+                setReactionPanelState({
+                  status: 'error',
+                  error: messageFromError(error, translate('common:errors.failedToLoadSettings')),
+                });
+              })
+          );
+        }
+      }
+
+      await Promise.allSettled(tasks);
+    },
+    [
+      api,
       setAuthorError,
       setBookmarkedPosts,
       setBookmarkedReactionAssets,
-      setChannelPanelStateByTopic,
       setCommunityNodeConfig,
+      setCommunityNodeError,
       setCommunityNodeInput,
       setCommunityNodeStatuses,
-      setDirectMessageError,
       setDirectMessages,
-      setDirectMessageStatusByPeer,
+      setDirectMessageError,
+      setDirectMessageTimelineNextCursorByPeer,
       setDirectMessageTimelineByPeer,
+      setDirectMessageStatusByPeer,
       setDiscoveryConfig,
+      setDiscoveryError,
       setDiscoverySeedInput,
-      setError,
       setGamePanelStateByTopic,
       setGameRoomsByTopic,
-      setJoinedChannelsByTopic,
       setKnownAuthorsByPubkey,
       setLivePanelStateByTopic,
       setLiveSessionsByTopic,
@@ -812,18 +833,16 @@ export function useDesktopShellData({
       setProfileDraft,
       setProfileError,
       setProfilePanelState,
+      setProfileTimelineNextCursor,
       setProfileTimeline,
-      setPublicTimelinesByTopic,
       setReactionPanelState,
       setRecentReactions,
       setSelectedAuthor,
+      setSelectedAuthorTimelineNextCursor,
       setSelectedAuthorTimeline,
-      setSelectedDirectMessagePeerPubkey,
       setSocialConnections,
       setSocialConnectionsPanelState,
-      setSyncStatus,
-      setThread,
-      setTimelinesByTopic,
+      refreshVisibleShellData,
       storeApi,
       translate,
     ]
@@ -877,76 +896,27 @@ export function useDesktopShellData({
 
   const refreshVisibleTimelineAfterPublish = useCallback(
     async (topic: string, currentThread: string | null) => {
-      const requestId = loadTopicsRequestRef.current + 1;
-      loadTopicsRequestRef.current = requestId;
-      const currentState = storeApi.getState();
-      const selectedChannelId = currentState.selectedChannelIdByTopic[topic] ?? null;
-
-      try {
-        const [timeline, publicTimeline, threadView, status] = await Promise.all([
-          api.listTimeline(topic, null, 50, privateTimelineScope(selectedChannelId)),
-          api.listTimeline(topic, null, 50, PUBLIC_TIMELINE_SCOPE),
-          currentThread ? api.listThread(topic, currentThread, null, 50) : Promise.resolve(null),
-          api.getSyncStatus(),
-        ]);
-
-        if (requestId !== loadTopicsRequestRef.current) {
-          return;
-        }
-
-        const latestState = storeApi.getState();
-        const matchesThreadContext = latestState.selectedThread === currentThread;
-
-        startTransition(() => {
-          setTimelinesByTopic((current) => ({
-            ...current,
-            [topic]: timeline.items,
-          }));
-          setPublicTimelinesByTopic((current) => ({
-            ...current,
-            [topic]: publicTimeline.items,
-          }));
-          if (matchesThreadContext) {
-            setThread(threadView?.items ?? []);
-          }
-          setSyncStatus(status);
-          setError(null);
-        });
-      } catch (refreshError) {
-        if (requestId !== loadTopicsRequestRef.current) {
-          return;
-        }
-        setError(
-          refreshError instanceof Error
-            ? refreshError.message
-            : translate('common:errors.failedToLoadTopic')
-        );
-      }
+      await refreshVisibleShellData(topic, currentThread);
     },
-    [
-      api,
-      loadTopicsRequestRef,
-      setError,
-      setPublicTimelinesByTopic,
-      setSyncStatus,
-      setThread,
-      setTimelinesByTopic,
-      storeApi,
-      translate,
-    ]
+    [refreshVisibleShellData]
   );
 
   useEffect(() => {
     let disposed = false;
 
     const refresh = async () => {
-      if (disposed) {
+      if (
+        disposed ||
+        visibleRefreshInFlightRef.current ||
+        (typeof document !== 'undefined' && document.visibilityState === 'hidden')
+      ) {
         return;
       }
+      visibleRefreshInFlightRef.current = true;
       try {
-        await loadTopics(trackedTopics, activeTopic, selectedThread);
-      } catch {
-        // loadTopics already writes the visible error state
+        await refreshVisibleShellData(activeTopic, selectedThread);
+      } finally {
+        visibleRefreshInFlightRef.current = false;
       }
     };
 
@@ -954,18 +924,406 @@ export function useDesktopShellData({
     const intervalId = window.setInterval(() => {
       void refresh();
     }, REFRESH_INTERVAL_MS);
+    const handleFocus = () => {
+      void refresh();
+    };
+    const handleVisibility = () => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+        void refresh();
+      }
+    };
+    window.addEventListener('focus', handleFocus);
+    document.addEventListener('visibilitychange', handleVisibility);
 
+    return () => {
+      disposed = true;
+      visibleRefreshInFlightRef.current = false;
+      window.clearInterval(intervalId);
+      window.removeEventListener('focus', handleFocus);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [activeTopic, refreshVisibleShellData, selectedThread]);
+
+  useEffect(() => {
+    let disposed = false;
+
+    const refreshStatus = async () => {
+      if (
+        disposed ||
+        (typeof document !== 'undefined' && document.visibilityState === 'hidden')
+      ) {
+        return;
+      }
+      try {
+        const status = await api.getNotificationStatus();
+        if (!disposed) {
+          setNotificationStatus(status);
+        }
+      } catch {
+        // best effort badge refresh
+      }
+    };
+
+    void refreshStatus();
+    const intervalId = window.setInterval(() => {
+      void refreshStatus();
+    }, STATUS_REFRESH_INTERVAL_MS);
     return () => {
       disposed = true;
       window.clearInterval(intervalId);
     };
+  }, [api, setNotificationStatus]);
+
+  useEffect(() => {
+    let disposed = false;
+    void (async () => {
+      try {
+        const profile = await api.getMyProfile();
+        if (disposed) {
+          return;
+        }
+        setLocalProfile(profile);
+        if (!storeApi.getState().profileDirty) {
+          setProfileDraft(profileInputFromProfile(profile));
+        }
+      } catch {
+        // best effort background bootstrap
+      }
+    })();
+    return () => {
+      disposed = true;
+    };
+  }, [api, setLocalProfile, setProfileDraft, storeApi]);
+
+  useEffect(() => {
+    if (shellChromeState.activePrimarySection !== 'live') {
+      return;
+    }
+    void loadTopics(trackedTopics, activeTopic, selectedThread).catch(() => undefined);
+  }, [activeTopic, loadTopics, selectedThread, shellChromeState.activePrimarySection, trackedTopics]);
+
+  useEffect(() => {
+    if (shellChromeState.activePrimarySection !== 'game') {
+      return;
+    }
+    void loadTopics(trackedTopics, activeTopic, selectedThread).catch(() => undefined);
+  }, [activeTopic, loadTopics, selectedThread, shellChromeState.activePrimarySection, trackedTopics]);
+
+  useEffect(() => {
+    if (
+      shellChromeState.activePrimarySection !== 'timeline' ||
+      shellChromeState.timelineView !== 'bookmarks'
+    ) {
+      return;
+    }
+    void loadTopics(trackedTopics, activeTopic, selectedThread).catch(() => undefined);
   }, [
     activeTopic,
     loadTopics,
-    shellChromeState.activePrimarySection,
-    selectedAuthorPubkey,
     selectedThread,
+    shellChromeState.activePrimarySection,
+    shellChromeState.timelineView,
     trackedTopics,
+  ]);
+
+  useEffect(() => {
+    if (!shellChromeState.settingsOpen) {
+      return;
+    }
+    void loadTopics(trackedTopics, activeTopic, selectedThread).catch(() => undefined);
+  }, [
+    activeTopic,
+    loadTopics,
+    selectedThread,
+    shellChromeState.activeSettingsSection,
+    shellChromeState.settingsOpen,
+    trackedTopics,
+  ]);
+
+  useEffect(() => {
+    if (shellChromeState.activePrimarySection !== 'profile') {
+      return;
+    }
+    let disposed = false;
+    void (async () => {
+      try {
+        const profile = await api.getMyProfile();
+        if (disposed) {
+          return;
+        }
+        setLocalProfile(profile);
+        if (!storeApi.getState().profileDirty) {
+          setProfileDraft(profileInputFromProfile(profile));
+        }
+        const [timeline, following, followed, muted] = await Promise.all([
+          api.listProfileTimeline(profile.pubkey, null, VISIBLE_TIMELINE_LIMIT),
+          api.listSocialConnections('following'),
+          api.listSocialConnections('followed'),
+          api.listSocialConnections('muted'),
+        ]);
+        if (disposed) {
+          return;
+        }
+        startTransition(() => {
+          setProfileTimeline(timeline.items);
+          setProfileTimelineNextCursor(timeline.next_cursor ?? null);
+          setProfilePanelState({ status: 'ready', error: null });
+          setProfileError(null);
+          setSocialConnections({
+            following,
+            followed,
+            muted,
+          });
+          setKnownAuthorsByPubkey((current) =>
+            mergeKnownAuthors(current, [...following, ...followed, ...muted])
+          );
+          setSocialConnectionsPanelState({ status: 'ready', error: null });
+        });
+      } catch (error) {
+        if (!disposed) {
+          const message = messageFromError(
+            error,
+            translate('common:errors.failedToLoadProfile')
+          );
+          setProfileError(message);
+          setProfilePanelState({ status: 'error', error: message });
+        }
+      }
+    })();
+    return () => {
+      disposed = true;
+    };
+  }, [
+    api,
+    setKnownAuthorsByPubkey,
+    setLocalProfile,
+    setProfileDraft,
+    setProfileError,
+    setProfilePanelState,
+    setProfileTimeline,
+    setProfileTimelineNextCursor,
+    setSocialConnections,
+    setSocialConnectionsPanelState,
+    shellChromeState.activePrimarySection,
+    storeApi,
+    translate,
+  ]);
+
+  useEffect(() => {
+    if (!selectedAuthorPubkey) {
+      return;
+    }
+    let disposed = false;
+    void (async () => {
+      try {
+        const [author, timeline] = await Promise.all([
+          api.getAuthorSocialView(selectedAuthorPubkey),
+          api.listProfileTimeline(selectedAuthorPubkey, null, VISIBLE_TIMELINE_LIMIT),
+        ]);
+        if (disposed) {
+          return;
+        }
+        startTransition(() => {
+          setSelectedAuthor(author);
+          setSelectedAuthorTimeline(timeline.items);
+          setSelectedAuthorTimelineNextCursor(timeline.next_cursor ?? null);
+          setAuthorError(null);
+          if (author) {
+            setKnownAuthorsByPubkey((current) => mergeKnownAuthors(current, [author]));
+          }
+        });
+      } catch (error) {
+        if (!disposed) {
+          setAuthorError(
+            messageFromError(error, translate('common:errors.failedToLoadAuthor'))
+          );
+        }
+      }
+    })();
+    return () => {
+      disposed = true;
+    };
+  }, [
+    api,
+    selectedAuthorPubkey,
+    setAuthorError,
+    setKnownAuthorsByPubkey,
+    setSelectedAuthor,
+    setSelectedAuthorTimeline,
+    setSelectedAuthorTimelineNextCursor,
+    translate,
+  ]);
+
+  useEffect(() => {
+    if (
+      shellChromeState.activePrimarySection !== 'messages' &&
+      !storeApi.getState().directMessagePaneOpen
+    ) {
+      return;
+    }
+    let disposed = false;
+    const refresh = async () => {
+      if (
+        disposed ||
+        (typeof document !== 'undefined' && document.visibilityState === 'hidden')
+      ) {
+        return;
+      }
+      try {
+        const directMessages = await api.listDirectMessages();
+        if (disposed) {
+          return;
+        }
+        setDirectMessages(directMessages);
+        setKnownAuthorsByPubkey((current) =>
+          mergeKnownAuthors(current, directMessages.map(authorViewFromDirectMessageConversation))
+        );
+        const selectedPeerPubkey = storeApi.getState().selectedDirectMessagePeerPubkey;
+        if (!selectedPeerPubkey) {
+          setDirectMessageError(null);
+          return;
+        }
+        const [timelineResult, statusResult] = await Promise.allSettled([
+          api.listDirectMessageMessages(selectedPeerPubkey, null, VISIBLE_TIMELINE_LIMIT),
+          api.getDirectMessageStatus(selectedPeerPubkey),
+        ]);
+        if (disposed) {
+          return;
+        }
+        startTransition(() => {
+          if (timelineResult.status === 'fulfilled') {
+            setDirectMessageTimelineByPeer((current) => ({
+              ...current,
+              [selectedPeerPubkey]: timelineResult.value.items,
+            }));
+            setDirectMessageTimelineNextCursorByPeer((current) => ({
+              ...current,
+              [selectedPeerPubkey]: timelineResult.value.next_cursor ?? null,
+            }));
+          }
+          if (statusResult.status === 'fulfilled') {
+            setDirectMessageStatusByPeer((current) => ({
+              ...current,
+              [selectedPeerPubkey]: statusResult.value,
+            }));
+          }
+          setDirectMessageError(
+            timelineResult.status === 'fulfilled' && statusResult.status === 'fulfilled'
+              ? null
+              : messageFromError(
+                  timelineResult.status === 'rejected'
+                    ? timelineResult.reason
+                    : statusResult.status === 'rejected'
+                      ? statusResult.reason
+                      : null,
+                  'failed to load direct messages'
+                )
+          );
+        });
+      } catch (error) {
+        if (!disposed) {
+          setDirectMessageError(messageFromError(error, 'failed to load direct messages'));
+        }
+      }
+    };
+
+    void refresh();
+    const intervalId = window.setInterval(() => {
+      void refresh();
+    }, REFRESH_INTERVAL_MS);
+    const handleFocus = () => {
+      void refresh();
+    };
+    const handleVisibility = () => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+        void refresh();
+      }
+    };
+    window.addEventListener('focus', handleFocus);
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      disposed = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener('focus', handleFocus);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [
+    api,
+    setDirectMessageError,
+    setDirectMessages,
+    setDirectMessageStatusByPeer,
+    setDirectMessageTimelineByPeer,
+    setDirectMessageTimelineNextCursorByPeer,
+    setKnownAuthorsByPubkey,
+    shellChromeState.activePrimarySection,
+    storeApi,
+  ]);
+
+  useEffect(() => {
+    if (shellChromeState.activePrimarySection !== 'notifications') {
+      return;
+    }
+    let disposed = false;
+    void (async () => {
+      try {
+        const [status, notificationItems] = await Promise.all([
+          api.getNotificationStatus(),
+          api.listNotifications(),
+        ]);
+        if (disposed) {
+          return;
+        }
+        let nextNotifications = notificationItems;
+        let nextStatus = status;
+        if (notificationItems.some((notification) => !notification.read_at)) {
+          try {
+            nextStatus = await api.markAllNotificationsRead();
+            const readAt = Date.now();
+            nextNotifications = notificationItems.map((notification) =>
+              notification.read_at ? notification : { ...notification, read_at: readAt }
+            );
+            if (!disposed) {
+              setNotificationAutoReadError(null);
+            }
+          } catch (notificationReadError) {
+            if (!disposed) {
+              setNotificationAutoReadError(
+                messageFromError(
+                  notificationReadError,
+                  translate('shell:notifications.errors.failedAutoRead')
+                )
+              );
+            }
+          }
+        }
+        if (disposed) {
+          return;
+        }
+        startTransition(() => {
+          setNotificationStatus(nextStatus);
+          setNotifications(nextNotifications);
+          setNotificationPanelState({ status: 'ready', error: null });
+        });
+      } catch (error) {
+        if (!disposed) {
+          setNotificationPanelState({
+            status: 'error',
+            error: messageFromError(error, translate('shell:notifications.errors.failedToLoad')),
+          });
+        }
+      }
+    })();
+    return () => {
+      disposed = true;
+    };
+  }, [
+    api,
+    setNotificationAutoReadError,
+    setNotificationPanelState,
+    setNotifications,
+    setNotificationStatus,
+    shellChromeState.activePrimarySection,
+    translate,
   ]);
 
   useEffect(() => {
@@ -1205,7 +1563,10 @@ export function useDesktopShellData({
 
   return {
     loadTopics,
+    refreshVisibleShellData,
     refreshVisibleTimelineAfterPublish,
+    loadMoreTimeline,
+    loadMoreThread,
     rememberDraftPreview,
     releaseDraftPreview,
     releaseAllDraftPreviews,

--- a/apps/desktop/src/shell/useDesktopShellData.ts
+++ b/apps/desktop/src/shell/useDesktopShellData.ts
@@ -30,7 +30,6 @@ import {
   selectVideoPosterAttachment,
 } from '@/shell/media';
 import {
-  DEFAULT_SOCIAL_CONNECTIONS,
   PUBLIC_CHANNEL_REF,
   PUBLIC_TIMELINE_SCOPE,
   REFRESH_INTERVAL_MS,
@@ -168,9 +167,6 @@ export function useDesktopShellData({
   const setNotificationStatus = useDesktopShellFieldSetter('notificationStatus');
   const setNotificationPanelState = useDesktopShellFieldSetter('notificationPanelState');
   const setNotificationAutoReadError = useDesktopShellFieldSetter('notificationAutoReadError');
-  const setSelectedDirectMessagePeerPubkey = useDesktopShellFieldSetter(
-    'selectedDirectMessagePeerPubkey'
-  );
   const setDirectMessages = useDesktopShellFieldSetter('directMessages');
   const setDirectMessageTimelineByPeer = useDesktopShellFieldSetter('directMessageTimelineByPeer');
   const setDirectMessageTimelineNextCursorByPeer = useDesktopShellFieldSetter(
@@ -179,7 +175,6 @@ export function useDesktopShellData({
   const setDirectMessageStatusByPeer = useDesktopShellFieldSetter('directMessageStatusByPeer');
   const setDirectMessageError = useDesktopShellFieldSetter('directMessageError');
   const setLivePanelStateByTopic = useDesktopShellFieldSetter('livePanelStateByTopic');
-  const setChannelPanelStateByTopic = useDesktopShellFieldSetter('channelPanelStateByTopic');
   const setGamePanelStateByTopic = useDesktopShellFieldSetter('gamePanelStateByTopic');
   const setGameDrafts = useDesktopShellFieldSetter('gameDrafts');
   const setReactionPanelState = useDesktopShellFieldSetter('reactionPanelState');
@@ -295,14 +290,6 @@ export function useDesktopShellData({
     const localObjectIds = new Set(localPosts.map((post) => post.object_id));
     return [...localPosts, ...incoming.filter((post) => !localObjectIds.has(post.object_id))];
   }, []);
-
-  const mergeUniqueMessages = useCallback(
-    (current: DirectMessageMessageView[], incoming: DirectMessageMessageView[]) => {
-      const seen = new Set(current.map((message) => message.message_id));
-      return [...current, ...incoming.filter((message) => !seen.has(message.message_id))];
-    },
-    []
-  );
 
   const refreshVisibleShellData = useCallback(
     async (topic: string, currentThread: string | null) => {
@@ -483,7 +470,6 @@ export function useDesktopShellData({
       const currentState = storeApi.getState();
       const selectedChannelId = currentState.selectedChannelIdByTopic[currentActiveTopic] ?? null;
       const selectedAuthorPubkey = currentState.selectedAuthorPubkey;
-      const selectedDirectMessagePeerPubkey = currentState.selectedDirectMessagePeerPubkey;
       const {
         activePrimarySection,
         activeSettingsSection,

--- a/crates/app-api/src/direct_messages.rs
+++ b/crates/app-api/src/direct_messages.rs
@@ -62,11 +62,6 @@ impl AppService {
             .await?;
         let mut items = Vec::with_capacity(rows.len());
         for row in rows {
-            // Re-establish DM subscriptions for mutual peers when the conversation list is polled
-            // after a restart. This keeps queued outbox delivery progressing even if the UI only
-            // reopens the conversation list first.
-            self.ensure_direct_message_subscription(row.peer_pubkey.as_str())
-                .await?;
             items.push(
                 self.direct_message_conversation_view(row.peer_pubkey.as_str())
                     .await?,

--- a/crates/app-api/src/service.rs
+++ b/crates/app-api/src/service.rs
@@ -457,33 +457,12 @@ impl AppService {
             .projection_store
             .list_reaction_cache_for_target(source_replica_id, target_object_id)
             .await?;
-        let current_author = self.current_author_pubkey();
-        let mut summary = BTreeMap::<String, ReactionSummaryView>::new();
-        let mut my_reactions = Vec::new();
-        for row in rows {
-            let key_view = reaction_key_view_from_projection(&row);
-            if row.status == ObjectStatus::Active {
-                summary
-                    .entry(row.normalized_reaction_key.clone())
-                    .and_modify(|value| value.count += 1)
-                    .or_insert_with(|| ReactionSummaryView {
-                        reaction_key_kind: key_view.reaction_key_kind.clone(),
-                        normalized_reaction_key: key_view.normalized_reaction_key.clone(),
-                        emoji: key_view.emoji.clone(),
-                        custom_asset: key_view.custom_asset.clone(),
-                        count: 1,
-                    });
-                if row.author_pubkey == current_author {
-                    my_reactions.push(key_view);
-                }
-            }
-        }
-        Ok(ReactionStateView {
-            target_object_id: target_object_id.as_str().to_string(),
-            source_replica_id: source_replica_id.as_str().to_string(),
-            reaction_summary: summary.into_values().collect(),
-            my_reactions,
-        })
+        Ok(reaction_state_view_from_rows(
+            source_replica_id,
+            target_object_id,
+            rows,
+            self.current_author_pubkey().as_str(),
+        ))
     }
 
     pub(crate) async fn maybe_redeem_rotation_grants_for_scope(
@@ -3101,9 +3080,43 @@ impl AppService {
         &self,
         page: Page<ObjectProjectionRow>,
     ) -> Result<TimelineView> {
+        let local_author = self.current_author_pubkey();
+        let mut author_pubkeys = BTreeSet::new();
+        let mut targets_by_replica = BTreeMap::<String, Vec<EnvelopeId>>::new();
+        for row in &page.items {
+            author_pubkeys.insert(row.author_pubkey.clone());
+            if let Some(repost_of) = row.repost_of.as_ref() {
+                author_pubkeys.insert(repost_of.source_author_pubkey.as_str().to_string());
+            }
+            targets_by_replica
+                .entry(row.source_replica_id.as_str().to_string())
+                .or_default()
+                .push(row.object_id.clone());
+        }
+
+        let author_pubkeys = author_pubkeys.into_iter().collect::<Vec<_>>();
+        let profiles = self.store.get_profiles(&author_pubkeys).await?;
+        let relationships = self
+            .projection_store
+            .list_author_relationships(local_author.as_str(), &author_pubkeys)
+            .await?;
+        let mut reactions_by_target = HashMap::<String, Vec<ReactionProjectionRow>>::new();
+        for (replica_id, object_ids) in targets_by_replica {
+            let grouped = self
+                .projection_store
+                .list_reaction_cache_for_targets(&ReplicaId::new(replica_id.clone()), &object_ids)
+                .await?;
+            for (object_id, rows) in grouped {
+                reactions_by_target.insert(format!("{replica_id}:{object_id}"), rows);
+            }
+        }
+
         let mut items = Vec::with_capacity(page.items.len());
         for row in page.items {
-            items.push(self.row_to_view(row).await?);
+            items.push(
+                self.row_to_view_with_cache(row, &profiles, &relationships, &reactions_by_target)
+                    .await?,
+            );
         }
         Ok(TimelineView {
             items,
@@ -3111,59 +3124,52 @@ impl AppService {
         })
     }
 
-    pub(crate) async fn row_to_view(&self, row: ObjectProjectionRow) -> Result<PostView> {
-        let post_object = fetch_post_object_for_projection(
-            self.docs_sync.as_ref(),
-            &row.source_replica_id,
-            row.source_key.as_str(),
-        )
-        .await?;
-        let profile = self.store.get_profile(row.author_pubkey.as_str()).await?;
-        let relationship = self
-            .projection_store
-            .get_author_relationship(
-                self.current_author_pubkey().as_str(),
-                row.author_pubkey.as_str(),
-            )
-            .await?;
+    pub(crate) async fn row_to_view_with_cache(
+        &self,
+        row: ObjectProjectionRow,
+        profiles: &HashMap<String, Profile>,
+        relationships: &HashMap<String, AuthorRelationshipProjectionRow>,
+        reactions_by_target: &HashMap<String, Vec<ReactionProjectionRow>>,
+    ) -> Result<PostView> {
+        let profile = profiles.get(row.author_pubkey.as_str());
+        let relationship = relationships.get(row.author_pubkey.as_str());
         let repost_commentary = normalize_repost_commentary(row.content.clone());
         let content_status = if row.object_kind == "repost" {
             BlobViewStatus::Available
         } else {
             blob_view_status_for_payload(self.blob_service.as_ref(), &row.payload_ref).await?
         };
-        let attachments = if row.object_kind == "repost" {
-            Vec::new()
-        } else if let Some(post_object) = post_object {
-            attachment_views(self.blob_service.as_ref(), &post_object).await?
-        } else {
-            Vec::new()
-        };
+        let attachments = self.attachment_views_for_projection_row(&row).await?;
         let repost_of = match row.repost_of.clone() {
-            Some(snapshot) => Some(self.repost_snapshot_to_view(snapshot).await?),
+            Some(snapshot) => Some(
+                self.repost_snapshot_to_view_with_profiles(snapshot, profiles)
+                    .await?,
+            ),
             None => None,
         };
         let audience_label = self
             .audience_label_for_storage(row.topic_id.as_str(), row.channel_id.as_str())
             .await;
-        let reaction_state = self
-            .reaction_state_for_target(&row.source_replica_id, &row.object_id)
-            .await?;
+        let reaction_state = reaction_state_view_from_rows(
+            &row.source_replica_id,
+            &row.object_id,
+            reactions_by_target
+                .get(reaction_cache_key(&row.source_replica_id, &row.object_id).as_str())
+                .cloned()
+                .unwrap_or_default(),
+            self.current_author_pubkey().as_str(),
+        );
 
         Ok(PostView {
             object_id: row.object_id.0.clone(),
             envelope_id: row.source_envelope_id.0.clone(),
             author_pubkey: row.author_pubkey.clone(),
-            author_name: profile.as_ref().and_then(|profile| profile.name.clone()),
-            author_display_name: profile
-                .as_ref()
-                .and_then(|profile| profile.display_name.clone()),
-            following: relationship.as_ref().is_some_and(|value| value.following),
-            followed_by: relationship.as_ref().is_some_and(|value| value.followed_by),
-            mutual: relationship.as_ref().is_some_and(|value| value.mutual),
-            friend_of_friend: relationship
-                .as_ref()
-                .is_some_and(|value| value.friend_of_friend),
+            author_name: profile.and_then(|profile| profile.name.clone()),
+            author_display_name: profile.and_then(|profile| profile.display_name.clone()),
+            following: relationship.is_some_and(|value| value.following),
+            followed_by: relationship.is_some_and(|value| value.followed_by),
+            mutual: relationship.is_some_and(|value| value.mutual),
+            friend_of_friend: relationship.is_some_and(|value| value.friend_of_friend),
             content: row.content.unwrap_or_else(|| "[blob pending]".to_string()),
             content_status,
             attachments,
@@ -3181,6 +3187,29 @@ impl AppService {
             reaction_summary: reaction_state.reaction_summary,
             my_reactions: reaction_state.my_reactions,
         })
+    }
+
+    pub(crate) async fn attachment_views_for_projection_row(
+        &self,
+        row: &ObjectProjectionRow,
+    ) -> Result<Vec<AttachmentView>> {
+        if row.object_kind == "repost" {
+            return Ok(Vec::new());
+        }
+        if !row.attachments.is_empty() || row.projection_version >= 2 {
+            return attachment_views_from_refs(self.blob_service.as_ref(), &row.attachments).await;
+        }
+
+        let post_object = fetch_post_object_for_projection(
+            self.docs_sync.as_ref(),
+            &row.source_replica_id,
+            row.source_key.as_str(),
+        )
+        .await?;
+        if let Some(post_object) = post_object {
+            return attachment_views(self.blob_service.as_ref(), &post_object).await;
+        }
+        Ok(Vec::new())
     }
 
     pub(crate) async fn bookmarked_post_view_from_row(
@@ -3359,18 +3388,26 @@ impl AppService {
         &self,
         snapshot: RepostSourceSnapshotV1,
     ) -> Result<RepostSourceView> {
-        let source_profile = self
+        let profiles = self
             .store
-            .get_profile(snapshot.source_author_pubkey.as_str())
+            .get_profiles(&[snapshot.source_author_pubkey.as_str().to_string()])
             .await?;
+        self.repost_snapshot_to_view_with_profiles(snapshot, &profiles)
+            .await
+    }
+
+    pub(crate) async fn repost_snapshot_to_view_with_profiles(
+        &self,
+        snapshot: RepostSourceSnapshotV1,
+        profiles: &HashMap<String, Profile>,
+    ) -> Result<RepostSourceView> {
+        let source_profile = profiles.get(snapshot.source_author_pubkey.as_str());
         Ok(RepostSourceView {
             source_object_id: snapshot.source_object_id.as_str().to_string(),
             source_topic_id: snapshot.source_topic_id.as_str().to_string(),
             source_author_pubkey: snapshot.source_author_pubkey.as_str().to_string(),
-            source_author_name: source_profile.as_ref().and_then(|value| value.name.clone()),
-            source_author_display_name: source_profile
-                .as_ref()
-                .and_then(|value| value.display_name.clone()),
+            source_author_name: source_profile.and_then(|value| value.name.clone()),
+            source_author_display_name: source_profile.and_then(|value| value.display_name.clone()),
             source_object_kind: snapshot.source_object_kind,
             content: snapshot.content,
             attachments: attachment_views_from_refs(
@@ -5065,13 +5102,14 @@ pub(crate) fn projection_row_from_header(
         reply_to_object_id: header.reply_to.clone(),
         payload_ref: header.payload_ref.clone(),
         content,
+        attachments: header.attachments.clone(),
         repost_of: header.repost_of.clone(),
         source_replica_id: source_replica_id.clone(),
         source_key: stable_key("objects", &format!("{}/state", header.object_id.as_str())),
         source_envelope_id: header.envelope_id.clone(),
         source_blob_hash,
         derived_at: Utc::now().timestamp_millis(),
-        projection_version: 1,
+        projection_version: 2,
     }
 }
 
@@ -5189,6 +5227,51 @@ pub(crate) fn reaction_key_view_from_projection(row: &ReactionProjectionRow) -> 
     }
 }
 
+pub(crate) fn reaction_cache_key(
+    source_replica_id: &ReplicaId,
+    target_object_id: &EnvelopeId,
+) -> String {
+    format!(
+        "{}:{}",
+        source_replica_id.as_str(),
+        target_object_id.as_str()
+    )
+}
+
+pub(crate) fn reaction_state_view_from_rows(
+    source_replica_id: &ReplicaId,
+    target_object_id: &EnvelopeId,
+    rows: Vec<ReactionProjectionRow>,
+    current_author: &str,
+) -> ReactionStateView {
+    let mut summary = BTreeMap::<String, ReactionSummaryView>::new();
+    let mut my_reactions = Vec::new();
+    for row in rows {
+        let key_view = reaction_key_view_from_projection(&row);
+        if row.status == ObjectStatus::Active {
+            summary
+                .entry(row.normalized_reaction_key.clone())
+                .and_modify(|value| value.count += 1)
+                .or_insert_with(|| ReactionSummaryView {
+                    reaction_key_kind: key_view.reaction_key_kind.clone(),
+                    normalized_reaction_key: key_view.normalized_reaction_key.clone(),
+                    emoji: key_view.emoji.clone(),
+                    custom_asset: key_view.custom_asset.clone(),
+                    count: 1,
+                });
+            if row.author_pubkey == current_author {
+                my_reactions.push(key_view);
+            }
+        }
+    }
+    ReactionStateView {
+        target_object_id: target_object_id.as_str().to_string(),
+        source_replica_id: source_replica_id.as_str().to_string(),
+        reaction_summary: summary.into_values().collect(),
+        my_reactions,
+    }
+}
+
 pub(crate) fn search_key_or_asset_id(search_key: &str, asset_id: &str) -> String {
     let normalized = search_key.trim();
     if normalized.is_empty() {
@@ -5207,6 +5290,8 @@ pub(crate) async fn hydrate_object_projection_from_replica(
         .query_replica(replica, DocQuery::Prefix("objects/".into()))
         .await?;
     let mut hydrated = 0usize;
+    let mut blob_statuses = Vec::new();
+    let mut projections = Vec::new();
     for record in records {
         if !record.key.ends_with("/state") {
             continue;
@@ -5216,29 +5301,25 @@ pub(crate) async fn hydrate_object_projection_from_replica(
             PayloadRef::InlineText { text } => Some(text.clone()),
             PayloadRef::BlobText { hash, .. } => {
                 let payload = fetch_projection_blob_text(blob_service, hash).await;
-                projection_store
-                    .mark_blob_status(
-                        hash,
-                        match payload {
-                            Some(_) => BlobCacheStatus::Available,
-                            None => BlobCacheStatus::Missing,
-                        },
-                    )
-                    .await?;
+                blob_statuses.push((
+                    hash.clone(),
+                    match payload {
+                        Some(_) => BlobCacheStatus::Available,
+                        None => BlobCacheStatus::Missing,
+                    },
+                ));
                 payload
             }
         };
         for attachment in &header.attachments {
             let status = best_effort_blob_cache_status(blob_service, &attachment.hash).await;
-            projection_store
-                .mark_blob_status(&attachment.hash, status)
-                .await?;
+            blob_statuses.push((attachment.hash.clone(), status));
         }
-        projection_store
-            .put_object_projection(projection_row_from_header(&header, content, replica))
-            .await?;
+        projections.push(projection_row_from_header(&header, content, replica));
         hydrated += 1;
     }
+    projection_store.mark_blob_statuses(blob_statuses).await?;
+    projection_store.put_object_projections(projections).await?;
     Ok(hydrated)
 }
 
@@ -5858,18 +5939,17 @@ pub(crate) async fn filtered_timeline_page(
     let mut items = Vec::new();
     let page_size = limit.max(20);
     loop {
-        let page = ProjectionStore::list_topic_timeline(
+        let page = ProjectionStore::list_topic_timeline_filtered(
             projection_store,
             topic_id,
+            allowed_channels,
             current_cursor.clone(),
             page_size,
         )
         .await?;
         let next_cursor = page.next_cursor.clone();
         for row in page.items {
-            if allowed_channels.contains(row.channel_id.as_str())
-                && !object_projection_row_is_muted(&row, muted_author_pubkeys)
-            {
+            if !object_projection_row_is_muted(&row, muted_author_pubkeys) {
                 items.push(row);
                 if items.len() >= limit {
                     return Ok(Page { items, next_cursor });
@@ -5902,19 +5982,18 @@ pub(crate) async fn filtered_thread_page(
     let mut items = Vec::new();
     let page_size = limit.max(20);
     loop {
-        let page = ProjectionStore::list_thread(
+        let page = ProjectionStore::list_thread_filtered(
             projection_store,
             topic_id,
             thread_root_object_id,
+            allowed_channel,
             current_cursor.clone(),
             page_size,
         )
         .await?;
         let next_cursor = page.next_cursor.clone();
         for row in page.items {
-            if allowed_channel.is_none_or(|channel_id| row.channel_id == channel_id)
-                && !object_projection_row_is_muted(&row, muted_author_pubkeys)
-            {
+            if !object_projection_row_is_muted(&row, muted_author_pubkeys) {
                 items.push(row);
                 if items.len() >= limit {
                     return Ok(Page { items, next_cursor });

--- a/crates/app-api/src/social.rs
+++ b/crates/app-api/src/social.rs
@@ -153,7 +153,6 @@ impl AppService {
         &self,
         kind: SocialConnectionKind,
     ) -> Result<Vec<AuthorSocialView>> {
-        self.rebuild_author_relationships().await?;
         let local_author_pubkey = self.current_author_pubkey();
         let pubkeys = match kind {
             SocialConnectionKind::Following => self

--- a/crates/app-api/src/tests/direct_messages.rs
+++ b/crates/app-api/src/tests/direct_messages.rs
@@ -216,6 +216,80 @@ async fn dm_open_does_not_duplicate_active_subscription_when_mutual_auto_subscri
 }
 
 #[tokio::test]
+async fn dm_list_does_not_restart_active_subscription_after_open() {
+    let transport = Arc::new(StaticTransport::new(PeerSnapshot {
+        connected: true,
+        peer_count: 1,
+        connected_peers: vec!["peer-b".into()],
+        configured_peers: vec!["peer-b".into()],
+        subscribed_topics: Vec::new(),
+        pending_events: 0,
+        status_detail: "connected".into(),
+        last_error: None,
+        topic_diagnostics: Vec::new(),
+    }));
+    let hint_transport = Arc::new(CountingClosingHintTransport::default());
+    let docs_sync = Arc::new(MemoryDocsSync::default());
+    let blob_service = Arc::new(MemoryBlobService::default());
+    let store = Arc::new(MemoryStore::default());
+    let keys_local = generate_keys();
+    let keys_peer = generate_keys();
+    let local_pubkey = keys_local.public_key_hex();
+    let peer_pubkey = keys_peer.public_key_hex();
+    let follow_local_to_peer = parse_follow_edge(
+        &build_follow_edge_envelope(
+            &keys_local,
+            &Pubkey::from(peer_pubkey.as_str()),
+            FollowEdgeStatus::Active,
+        )
+        .expect("build follow edge local->peer"),
+    )
+    .expect("parse follow edge local->peer")
+    .expect("follow edge local->peer");
+    let follow_peer_to_local = parse_follow_edge(
+        &build_follow_edge_envelope(
+            &keys_peer,
+            &Pubkey::from(local_pubkey.as_str()),
+            FollowEdgeStatus::Active,
+        )
+        .expect("build follow edge peer->local"),
+    )
+    .expect("parse follow edge peer->local")
+    .expect("follow edge peer->local");
+    store
+        .upsert_follow_edge(follow_local_to_peer)
+        .await
+        .expect("seed local->peer follow edge");
+    store
+        .upsert_follow_edge(follow_peer_to_local)
+        .await
+        .expect("seed peer->local follow edge");
+
+    let app = AppService::new_with_services(
+        store.clone(),
+        store.clone(),
+        transport,
+        hint_transport.clone(),
+        docs_sync,
+        blob_service,
+        keys_local,
+    );
+
+    app.open_direct_message(peer_pubkey.as_str())
+        .await
+        .expect("open direct message");
+    sleep(Duration::from_millis(50)).await;
+    app.list_direct_messages()
+        .await
+        .expect("list direct messages first time");
+    app.list_direct_messages()
+        .await
+        .expect("list direct messages second time");
+
+    assert_eq!(*hint_transport.subscribe_count.lock().await, 1);
+}
+
+#[tokio::test]
 async fn dm_import_peer_ticket_restarts_active_mutual_subscription() {
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let hint_transport = Arc::new(TrackingHintTransport::default());

--- a/crates/app-api/src/tests/social.rs
+++ b/crates/app-api/src/tests/social.rs
@@ -233,6 +233,10 @@ async fn list_social_connections_followed_is_local_known_only() {
         .follow_author(local_pubkey.as_str())
         .await
         .expect("remote follows local");
+    local_app
+        .warm_social_graph()
+        .await
+        .expect("warm local social graph");
 
     let followed = local_app
         .list_social_connections(SocialConnectionKind::Followed)

--- a/crates/app-api/src/timeline.rs
+++ b/crates/app-api/src/timeline.rs
@@ -8,9 +8,6 @@ impl AppService {
         limit: usize,
     ) -> Result<TimelineView> {
         let author_pubkey = normalize_author_pubkey(author_pubkey)?;
-        self.ensure_author_subscription(author_pubkey.as_str())
-            .await?;
-        self.rebuild_author_relationships().await?;
         let mut posts =
             load_profile_posts_from_author_replica(self.docs_sync.as_ref(), author_pubkey.as_str())
                 .await?;

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -968,6 +968,32 @@ async fn replicate_private_post_with_retry(
                     .await
                     .context("failed to read publisher private channel state before write")?
                     .map(|entry| entry.current_epoch_id);
+            if let Some(pre_write_epoch) = pre_write_epoch.as_deref() {
+                wait_for_joined_private_channel_epoch_result(
+                    publisher,
+                    topic,
+                    channel_id.as_str(),
+                    pre_write_epoch,
+                    subscribers.len() + 1,
+                    attempt_timeout,
+                )
+                .await
+                .context(
+                    "publisher was not synced to the current private channel participant set before write",
+                )?;
+                for subscriber in subscribers {
+                    wait_for_joined_private_channel_epoch_result(
+                        subscriber,
+                        topic,
+                        channel_id.as_str(),
+                        pre_write_epoch,
+                        1,
+                        attempt_timeout,
+                    )
+                    .await
+                    .context("subscriber was not synced to the current private channel epoch before write")?;
+                }
+            }
             let object_id = publisher
                 .create_post(CreatePostRequest {
                     topic: topic.to_string(),

--- a/crates/harness/src/scenarios/community_node.rs
+++ b/crates/harness/src/scenarios/community_node.rs
@@ -478,26 +478,31 @@ pub(crate) async fn run_community_node_connectivity(
                 public_replication_retry_schedule(step_timeout, false);
 
             let started_at = Instant::now();
-            let (live_owner, live_viewer, live_owner_label, live_viewer_label) =
-                select_public_feature_pair(
-                    &runtime_a,
-                    &runtime_b,
-                    topic,
-                    public_feature_timeout,
-                )
-                .await?;
-            let session_id = live_owner
-                .create_live_session(kukuri_desktop_runtime::CreateLiveSessionRequest {
-                    topic: topic.to_string(),
-                    channel_ref: ChannelRef::Public,
-                    title: "community live".to_string(),
-                    description: "live session".to_string(),
-                })
-                .await
-                .with_context(|| format!("failed to create live session on {live_owner_label}"))?;
-            wait_for_live_session(live_owner, topic, session_id.as_str(), step_timeout).await?;
+            let mut live_session = None;
             let mut live_session_error = None;
             for attempt in 1..=public_feature_attempts {
+                let (live_owner, live_viewer, live_owner_label, live_viewer_label) =
+                    select_public_feature_pair(
+                        &runtime_a,
+                        &runtime_b,
+                        topic,
+                        public_feature_timeout,
+                        attempt,
+                    )
+                    .await?;
+                let session_id = live_owner
+                    .create_live_session(kukuri_desktop_runtime::CreateLiveSessionRequest {
+                        topic: topic.to_string(),
+                        channel_ref: ChannelRef::Public,
+                        title: "community live".to_string(),
+                        description: "live session".to_string(),
+                    })
+                    .await
+                    .with_context(|| {
+                        format!("failed to create live session on {live_owner_label}")
+                    })?;
+                wait_for_live_session(live_owner, topic, session_id.as_str(), step_timeout)
+                    .await?;
                 match wait_for_live_session(
                     live_viewer,
                     topic,
@@ -508,10 +513,23 @@ pub(crate) async fn run_community_node_connectivity(
                 {
                     Ok(()) => {
                         live_session_error = None;
+                        live_session = Some((
+                            live_owner,
+                            live_viewer,
+                            live_owner_label,
+                            live_viewer_label,
+                            session_id,
+                        ));
                         break;
                     }
                     Err(error) if attempt < public_feature_attempts => {
                         live_session_error = Some(format!("{error:#}"));
+                        let _ = live_owner
+                            .end_live_session(kukuri_desktop_runtime::LiveSessionCommandRequest {
+                                topic: topic.to_string(),
+                                session_id: session_id.clone(),
+                            })
+                            .await;
                         refresh_public_pair(&runtime_a, &runtime_b, topic, public_feature_timeout)
                             .await
                             .context("failed to refresh public topic after live-session timeout")?;
@@ -523,6 +541,11 @@ pub(crate) async fn run_community_node_connectivity(
                     }
                 }
             }
+            let Some((live_owner, live_viewer, live_owner_label, live_viewer_label, session_id)) =
+                live_session
+            else {
+                anyhow::bail!("community live session did not establish");
+            };
             if let Some(error) = live_session_error {
                 anyhow::bail!(
                     "{live_viewer_label} did not receive community live session from {live_owner_label}: {error}"
@@ -611,28 +634,30 @@ pub(crate) async fn run_community_node_connectivity(
             push_named_step(&mut steps, "live", started_at);
 
             let started_at = Instant::now();
-            let (game_owner, game_observer, game_owner_label, game_observer_label) =
-                select_public_feature_pair(
-                    &runtime_a,
-                    &runtime_b,
-                    topic,
-                    public_feature_timeout,
-                )
-                .await?;
-            let room_id = game_owner
-                .create_game_room(kukuri_desktop_runtime::CreateGameRoomRequest {
-                    topic: topic.to_string(),
-                    channel_ref: ChannelRef::Public,
-                    title: "community finals".to_string(),
-                    description: "set".to_string(),
-                    participants: vec!["Alice".to_string(), "Bob".to_string()],
-                })
-                .await
-                .with_context(|| format!("failed to create game room on {game_owner_label}"))?;
-            let room_owner =
-                wait_for_game_room(game_owner, topic, room_id.as_str(), step_timeout).await?;
+            let mut game_room = None;
             let mut game_room_error = None;
             for attempt in 1..=public_feature_attempts {
+                let (game_owner, game_observer, game_owner_label, game_observer_label) =
+                    select_public_feature_pair(
+                        &runtime_a,
+                        &runtime_b,
+                        topic,
+                        public_feature_timeout,
+                        attempt,
+                    )
+                    .await?;
+                let room_id = game_owner
+                    .create_game_room(kukuri_desktop_runtime::CreateGameRoomRequest {
+                        topic: topic.to_string(),
+                        channel_ref: ChannelRef::Public,
+                        title: "community finals".to_string(),
+                        description: "set".to_string(),
+                        participants: vec!["Alice".to_string(), "Bob".to_string()],
+                    })
+                    .await
+                    .with_context(|| format!("failed to create game room on {game_owner_label}"))?;
+                let room_owner =
+                    wait_for_game_room(game_owner, topic, room_id.as_str(), step_timeout).await?;
                 match wait_for_game_room(
                     game_observer,
                     topic,
@@ -643,6 +668,14 @@ pub(crate) async fn run_community_node_connectivity(
                 {
                     Ok(_) => {
                         game_room_error = None;
+                        game_room = Some((
+                            game_owner,
+                            game_observer,
+                            game_owner_label,
+                            game_observer_label,
+                            room_id,
+                            room_owner,
+                        ));
                         break;
                     }
                     Err(error) if attempt < public_feature_attempts => {
@@ -658,6 +691,17 @@ pub(crate) async fn run_community_node_connectivity(
                     }
                 }
             }
+            let Some((
+                game_owner,
+                game_observer,
+                game_owner_label,
+                game_observer_label,
+                room_id,
+                room_owner,
+            )) = game_room
+            else {
+                anyhow::bail!("community game room did not establish");
+            };
             if let Some(error) = game_room_error {
                 anyhow::bail!(
                     "{game_observer_label} did not receive community game room from {game_owner_label}: {error}"
@@ -755,6 +799,17 @@ pub(crate) async fn run_community_node_connectivity(
             })
             .await
             .context("failed to resubscribe desktop b to scenario topic after reconnect")?;
+        refresh_public_pair(&runtime_a, &runtime_b, topic, reconnect_timeout)
+            .await
+            .context("failed to refresh public topic after desktop b restart")?;
+        wait_for_direct_topic_peer_count_without_pending_join(
+            &runtime_b,
+            topic,
+            1,
+            reconnect_timeout,
+        )
+        .await
+        .context("desktop b did not clear reconnect topic-join pending state")?;
         wait_for_topic_peer_count(&runtime_a, topic, 1, reconnect_timeout)
             .await
             .context("desktop a did not restore topic peer connectivity after desktop b restart")?;

--- a/crates/harness/src/scenarios/community_node.rs
+++ b/crates/harness/src/scenarios/community_node.rs
@@ -315,8 +315,12 @@ pub(crate) async fn run_community_node_connectivity(
                 })
                 .await
                 .context("desktop a failed to send direct message in community-node lane")?;
-            let delivered = wait_for_direct_message_result(
+            let delivered = wait_for_direct_message_result_with_pair_refresh(
+                &runtime_a,
+                ticket_a.as_str(),
+                sync_b.local_author_pubkey.as_str(),
                 &runtime_b,
+                ticket_b.as_str(),
                 sync_a.local_author_pubkey.as_str(),
                 message_id.as_str(),
                 step_timeout,

--- a/crates/harness/src/scenarios/community_node.rs
+++ b/crates/harness/src/scenarios/community_node.rs
@@ -316,12 +316,14 @@ pub(crate) async fn run_community_node_connectivity(
                 .await
                 .context("desktop a failed to send direct message in community-node lane")?;
             let delivered = wait_for_direct_message_result_with_pair_refresh(
-                &runtime_a,
-                ticket_a.as_str(),
-                sync_b.local_author_pubkey.as_str(),
-                &runtime_b,
-                ticket_b.as_str(),
-                sync_a.local_author_pubkey.as_str(),
+                DirectMessagePairRefreshContext {
+                    sender_runtime: &runtime_a,
+                    sender_ticket: ticket_a.as_str(),
+                    sender_peer_pubkey: sync_b.local_author_pubkey.as_str(),
+                    receiver_runtime: &runtime_b,
+                    receiver_ticket: ticket_b.as_str(),
+                    receiver_peer_pubkey: sync_a.local_author_pubkey.as_str(),
+                },
                 message_id.as_str(),
                 step_timeout,
             )

--- a/crates/harness/src/scenarios/community_node.rs
+++ b/crates/harness/src/scenarios/community_node.rs
@@ -285,6 +285,27 @@ pub(crate) async fn run_community_node_connectivity(
                 })
                 .await
                 .context("desktop b failed to open direct message in community-node lane")?;
+            let ticket_a = runtime_a
+                .local_peer_ticket()
+                .await
+                .context("failed to load peer ticket for desktop a in community-node lane")?
+                .context("missing peer ticket for desktop a in community-node lane")?;
+            let ticket_b = runtime_b
+                .local_peer_ticket()
+                .await
+                .context("failed to load peer ticket for desktop b in community-node lane")?
+                .context("missing peer ticket for desktop b in community-node lane")?;
+            wait_for_direct_message_pair_ready_with_refresh(
+                &runtime_a,
+                &runtime_b,
+                ticket_a.as_str(),
+                ticket_b.as_str(),
+                sync_a.local_author_pubkey.as_str(),
+                sync_b.local_author_pubkey.as_str(),
+                step_timeout,
+            )
+            .await
+            .context("community-node desktops did not connect direct message peers")?;
             let message_id = runtime_a
                 .send_direct_message(SendDirectMessageRequest {
                     pubkey: sync_b.local_author_pubkey.clone(),

--- a/crates/harness/src/scenarios/direct_message.rs
+++ b/crates/harness/src/scenarios/direct_message.rs
@@ -387,9 +387,20 @@ pub(crate) async fn run_pairwise_direct_message_connectivity(
             poster_payload.bytes_base64,
             BASE64_STANDARD.encode(b"pairwise-dm-video-poster")
         );
-        wait_for_direct_message_outbox_count(&runtime_a, b_pubkey.as_str(), 0, step_timeout)
-            .await
-            .context("desktop a queued video direct message outbox did not drain")?;
+        wait_for_direct_message_outbox_count_with_pair_refresh(
+            DirectMessagePairRefreshContext {
+                sender_runtime: &runtime_a,
+                sender_ticket: ticket_a_after_restart.as_str(),
+                sender_peer_pubkey: b_pubkey.as_str(),
+                receiver_runtime: &runtime_b,
+                receiver_ticket: ticket_b_after_restart.as_str(),
+                receiver_peer_pubkey: a_pubkey.as_str(),
+            },
+            0,
+            step_timeout,
+        )
+        .await
+        .context("desktop a queued video direct message outbox did not drain")?;
         push_named_step(&mut steps, "offline_video_delivery", started_at);
 
         let started_at = Instant::now();

--- a/crates/harness/src/tests/waiters.rs
+++ b/crates/harness/src/tests/waiters.rs
@@ -60,3 +60,40 @@ fn public_replication_retry_flips_to_subscriber_when_both_sides_are_assist_only(
         3,
     ));
 }
+
+#[test]
+fn public_feature_selection_prefers_direct_connected_subscriber_when_available() {
+    let topic = "kukuri:topic:test";
+    let publisher_status = sync_status_with_topic(topic, &[], &["assist-peer"]);
+    let subscriber_status = sync_status_with_topic(topic, &["direct-peer"], &["assist-peer"]);
+
+    let selection =
+        select_public_feature_strategy(&publisher_status, &subscriber_status, topic, 1, 1);
+
+    assert!(selection.select_subscriber);
+    assert!(selection.require_direct_subscriber);
+}
+
+#[test]
+fn public_feature_selection_retry_flips_to_subscriber_without_direct_requirement() {
+    let topic = "kukuri:topic:test";
+    let publisher_status = sync_status_with_topic(topic, &[], &["assist-peer-a"]);
+    let subscriber_status = sync_status_with_topic(topic, &[], &["assist-peer-b"]);
+
+    let selection =
+        select_public_feature_strategy(&publisher_status, &subscriber_status, topic, 1, 2);
+
+    assert!(selection.select_subscriber);
+    assert!(!selection.require_direct_subscriber);
+}
+
+#[test]
+fn direct_topic_readiness_rejects_pending_join_errors() {
+    let topic = "kukuri:topic:test";
+    let mut status = sync_status_with_topic(topic, &["direct-peer"], &["assist-peer"]);
+    status.last_error = Some("topic join pending: timed out waiting for initial topic join".into());
+
+    assert!(!topic_has_direct_peer_without_pending_join(
+        &status, topic, 1
+    ));
+}

--- a/crates/harness/src/waiters.rs
+++ b/crates/harness/src/waiters.rs
@@ -1191,6 +1191,26 @@ pub(crate) async fn select_public_feature_pair<'a>(
     &'static str,
 )> {
     refresh_public_pair(runtime_a, runtime_b, topic, step_timeout).await?;
+    let direct_pair_timeout = ci_timeout_floor(step_timeout, Duration::from_secs(60));
+    let _ =
+        timeout(direct_pair_timeout, async {
+            loop {
+                let publisher_status = runtime_a.get_sync_status().await.context(
+                    "desktop a sync status while waiting for public feature connectivity",
+                )?;
+                let subscriber_status = runtime_b.get_sync_status().await.context(
+                    "desktop b sync status while waiting for public feature connectivity",
+                )?;
+                if topic_has_direct_peer(&publisher_status, topic, 1)
+                    && topic_has_direct_peer(&subscriber_status, topic, 1)
+                {
+                    return Ok::<(), anyhow::Error>(());
+                }
+                refresh_public_pair(runtime_a, runtime_b, topic, direct_pair_timeout).await?;
+                sleep(Duration::from_millis(250)).await;
+            }
+        })
+        .await;
     let publisher_status = runtime_a
         .get_sync_status()
         .await

--- a/crates/harness/src/waiters.rs
+++ b/crates/harness/src/waiters.rs
@@ -220,6 +220,18 @@ pub(crate) fn topic_has_direct_peer(status: &SyncStatus, topic: &str, expected: 
         })
 }
 
+pub(crate) fn topic_has_direct_peer_without_pending_join(
+    status: &SyncStatus,
+    topic: &str,
+    expected: usize,
+) -> bool {
+    topic_has_direct_peer(status, topic, expected)
+        && status
+            .last_error
+            .as_deref()
+            .is_none_or(|error| !error.contains("topic join pending"))
+}
+
 pub(crate) fn should_publish_from_direct_connected_subscriber(
     publisher_status: &SyncStatus,
     subscriber_status: &SyncStatus,
@@ -259,6 +271,33 @@ pub(crate) fn should_retry_public_replication_from_subscriber(
         && !topic_has_direct_peer(subscriber_status, topic, expected)
 }
 
+pub(crate) struct PublicFeatureSelection {
+    pub(crate) select_subscriber: bool,
+    pub(crate) require_direct_subscriber: bool,
+}
+
+pub(crate) fn select_public_feature_strategy(
+    publisher_status: &SyncStatus,
+    subscriber_status: &SyncStatus,
+    topic: &str,
+    expected: usize,
+    attempt: usize,
+) -> PublicFeatureSelection {
+    let select_subscriber = should_retry_public_replication_from_subscriber(
+        publisher_status,
+        subscriber_status,
+        topic,
+        expected,
+        PublicReplicationDirection::PreferDirectConnectedSubscriber,
+        attempt,
+    );
+    PublicFeatureSelection {
+        select_subscriber,
+        require_direct_subscriber: select_subscriber
+            && topic_has_direct_peer(subscriber_status, topic, expected),
+    }
+}
+
 pub(crate) async fn wait_for_direct_topic_peer_count(
     runtime: &DesktopRuntime,
     topic: &str,
@@ -292,6 +331,43 @@ pub(crate) async fn wait_for_direct_topic_peer_count(
                 .map(|status| format_sync_snapshot(&status, topic))
                 .unwrap_or_else(|| "failed to read sync status".to_string());
             anyhow::bail!("direct topic connected-peer assertion timeout; {snapshot}");
+        }
+    }
+}
+
+pub(crate) async fn wait_for_direct_topic_peer_count_without_pending_join(
+    runtime: &DesktopRuntime,
+    topic: &str,
+    expected: usize,
+    step_timeout: Duration,
+) -> Result<()> {
+    match timeout(step_timeout, async {
+        let mut stable_ready_polls = 0usize;
+        loop {
+            let status = runtime.get_sync_status().await?;
+            let ready = topic_has_direct_peer_without_pending_join(&status, topic, expected);
+            if ready {
+                stable_ready_polls += 1;
+                if stable_ready_polls >= 3 {
+                    return Ok::<(), anyhow::Error>(());
+                }
+            } else {
+                stable_ready_polls = 0;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            let snapshot = runtime
+                .get_sync_status()
+                .await
+                .ok()
+                .map(|status| format_sync_snapshot(&status, topic))
+                .unwrap_or_else(|| "failed to read sync status".to_string());
+            anyhow::bail!("direct topic readiness timeout; {snapshot}");
         }
     }
 }
@@ -1248,6 +1324,7 @@ pub(crate) async fn select_public_feature_pair<'a>(
     runtime_b: &'a DesktopRuntime,
     topic: &str,
     step_timeout: Duration,
+    attempt: usize,
 ) -> Result<(
     &'a DesktopRuntime,
     &'a DesktopRuntime,
@@ -1283,19 +1360,21 @@ pub(crate) async fn select_public_feature_pair<'a>(
         .get_sync_status()
         .await
         .context("desktop b sync status for public feature selection")?;
-    let publish_from_b = should_publish_from_direct_connected_subscriber(
-        &publisher_status,
-        &subscriber_status,
-        topic,
-        1,
-        PublicReplicationDirection::PreferDirectConnectedSubscriber,
-    );
-    if publish_from_b {
-        wait_for_direct_topic_peer_count(runtime_b, topic, 1, step_timeout)
-            .await
-            .context("desktop b did not observe direct public topic connectivity")?;
+    let strategy =
+        select_public_feature_strategy(&publisher_status, &subscriber_status, topic, 1, attempt);
+    if strategy.select_subscriber {
+        if strategy.require_direct_subscriber {
+            wait_for_direct_topic_peer_count(runtime_b, topic, 1, step_timeout)
+                .await
+                .context("desktop b did not observe direct public topic connectivity")?;
+        }
         Ok((runtime_b, runtime_a, "desktop b", "desktop a"))
     } else {
+        if topic_has_direct_peer(&publisher_status, topic, 1) {
+            wait_for_direct_topic_peer_count(runtime_a, topic, 1, step_timeout)
+                .await
+                .context("desktop a did not observe direct public topic connectivity")?;
+        }
         Ok((runtime_a, runtime_b, "desktop a", "desktop b"))
     }
 }

--- a/crates/harness/src/waiters.rs
+++ b/crates/harness/src/waiters.rs
@@ -450,6 +450,64 @@ pub(crate) async fn wait_for_direct_message_result_with_sender_refresh(
     }
 }
 
+pub(crate) async fn wait_for_direct_message_result_with_pair_refresh(
+    sender_runtime: &DesktopRuntime,
+    sender_ticket: &str,
+    sender_peer_pubkey: &str,
+    receiver_runtime: &DesktopRuntime,
+    receiver_ticket: &str,
+    receiver_peer_pubkey: &str,
+    message_id: &str,
+    step_timeout: Duration,
+) -> Result<DirectMessageMessageView> {
+    let refresh_interval = Duration::from_secs(5);
+    match timeout(step_timeout, async {
+        let mut next_refresh_at = Instant::now() + refresh_interval;
+        loop {
+            let _ = sender_runtime
+                .get_direct_message_status(DirectMessageRequest {
+                    pubkey: sender_peer_pubkey.to_string(),
+                })
+                .await
+                .context("sender direct message status")?;
+            let timeline = receiver_runtime
+                .list_direct_message_messages(ListDirectMessageMessagesRequest {
+                    pubkey: receiver_peer_pubkey.to_string(),
+                    cursor: None,
+                    limit: Some(20),
+                })
+                .await
+                .context("list direct message timeline")?;
+            if let Some(message) = timeline
+                .items
+                .into_iter()
+                .find(|item| item.message_id == message_id)
+            {
+                return Ok::<DirectMessageMessageView, anyhow::Error>(message);
+            }
+            if Instant::now() >= next_refresh_at {
+                refresh_direct_message_pair(
+                    sender_runtime,
+                    receiver_runtime,
+                    sender_ticket,
+                    receiver_ticket,
+                    sender_peer_pubkey,
+                    receiver_peer_pubkey,
+                )
+                .await
+                .context("refresh direct message pair")?;
+                next_refresh_at = Instant::now() + refresh_interval;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!("direct message delivery timeout for {message_id}"),
+    }
+}
+
 pub(crate) async fn wait_for_direct_message_conversation_result(
     runtime: &DesktopRuntime,
     peer_pubkey: &str,

--- a/crates/harness/src/waiters.rs
+++ b/crates/harness/src/waiters.rs
@@ -680,6 +680,51 @@ pub(crate) async fn wait_for_direct_message_outbox_count(
     }
 }
 
+pub(crate) async fn wait_for_direct_message_outbox_count_with_pair_refresh(
+    pair: DirectMessagePairRefreshContext<'_>,
+    expected: usize,
+    step_timeout: Duration,
+) -> Result<DirectMessageStatusView> {
+    let refresh_interval = Duration::from_secs(5);
+    match timeout(step_timeout, async {
+        let mut next_refresh_at = Instant::now() + refresh_interval;
+        loop {
+            let status = pair
+                .sender_runtime
+                .get_direct_message_status(DirectMessageRequest {
+                    pubkey: pair.sender_peer_pubkey.to_string(),
+                })
+                .await
+                .context("direct message status")?;
+            if status.pending_outbox_count == expected {
+                return Ok::<DirectMessageStatusView, anyhow::Error>(status);
+            }
+            if Instant::now() >= next_refresh_at {
+                refresh_direct_message_pair(
+                    pair.sender_runtime,
+                    pair.receiver_runtime,
+                    pair.sender_ticket,
+                    pair.receiver_ticket,
+                    pair.sender_peer_pubkey,
+                    pair.receiver_peer_pubkey,
+                )
+                .await
+                .context("refresh direct message pair")?;
+                next_refresh_at = Instant::now() + refresh_interval;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!(
+            "direct message outbox count timeout for {}; expected={expected}",
+            pair.sender_peer_pubkey
+        ),
+    }
+}
+
 pub(crate) fn image_attachment_request(
     name: &str,
     mime: &str,

--- a/crates/harness/src/waiters.rs
+++ b/crates/harness/src/waiters.rs
@@ -450,13 +450,17 @@ pub(crate) async fn wait_for_direct_message_result_with_sender_refresh(
     }
 }
 
+pub(crate) struct DirectMessagePairRefreshContext<'a> {
+    pub(crate) sender_runtime: &'a DesktopRuntime,
+    pub(crate) sender_ticket: &'a str,
+    pub(crate) sender_peer_pubkey: &'a str,
+    pub(crate) receiver_runtime: &'a DesktopRuntime,
+    pub(crate) receiver_ticket: &'a str,
+    pub(crate) receiver_peer_pubkey: &'a str,
+}
+
 pub(crate) async fn wait_for_direct_message_result_with_pair_refresh(
-    sender_runtime: &DesktopRuntime,
-    sender_ticket: &str,
-    sender_peer_pubkey: &str,
-    receiver_runtime: &DesktopRuntime,
-    receiver_ticket: &str,
-    receiver_peer_pubkey: &str,
+    pair: DirectMessagePairRefreshContext<'_>,
     message_id: &str,
     step_timeout: Duration,
 ) -> Result<DirectMessageMessageView> {
@@ -464,15 +468,17 @@ pub(crate) async fn wait_for_direct_message_result_with_pair_refresh(
     match timeout(step_timeout, async {
         let mut next_refresh_at = Instant::now() + refresh_interval;
         loop {
-            let _ = sender_runtime
+            let _ = pair
+                .sender_runtime
                 .get_direct_message_status(DirectMessageRequest {
-                    pubkey: sender_peer_pubkey.to_string(),
+                    pubkey: pair.sender_peer_pubkey.to_string(),
                 })
                 .await
                 .context("sender direct message status")?;
-            let timeline = receiver_runtime
+            let timeline = pair
+                .receiver_runtime
                 .list_direct_message_messages(ListDirectMessageMessagesRequest {
-                    pubkey: receiver_peer_pubkey.to_string(),
+                    pubkey: pair.receiver_peer_pubkey.to_string(),
                     cursor: None,
                     limit: Some(20),
                 })
@@ -487,12 +493,12 @@ pub(crate) async fn wait_for_direct_message_result_with_pair_refresh(
             }
             if Instant::now() >= next_refresh_at {
                 refresh_direct_message_pair(
-                    sender_runtime,
-                    receiver_runtime,
-                    sender_ticket,
-                    receiver_ticket,
-                    sender_peer_pubkey,
-                    receiver_peer_pubkey,
+                    pair.sender_runtime,
+                    pair.receiver_runtime,
+                    pair.sender_ticket,
+                    pair.receiver_ticket,
+                    pair.sender_peer_pubkey,
+                    pair.receiver_peer_pubkey,
                 )
                 .await
                 .context("refresh direct message pair")?;

--- a/crates/store/migrations/20260411000000_object_projection_attachments.down.sql
+++ b/crates/store/migrations/20260411000000_object_projection_attachments.down.sql
@@ -1,0 +1,1 @@
+-- SQLite down migration is intentionally a no-op for attachments_json.

--- a/crates/store/migrations/20260411000000_object_projection_attachments.up.sql
+++ b/crates/store/migrations/20260411000000_object_projection_attachments.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE object_index_cache
+    ADD COLUMN attachments_json TEXT NOT NULL DEFAULT '[]';

--- a/crates/store/src/memory.rs
+++ b/crates/store/src/memory.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -180,6 +180,19 @@ impl Store for MemoryStore {
         Ok(self.profiles.read().await.get(pubkey).cloned())
     }
 
+    async fn get_profiles(&self, pubkeys: &[String]) -> Result<HashMap<String, Profile>> {
+        let profiles = self.profiles.read().await;
+        Ok(pubkeys
+            .iter()
+            .filter_map(|pubkey| {
+                profiles
+                    .get(pubkey.as_str())
+                    .cloned()
+                    .map(|profile| (pubkey.clone(), profile))
+            })
+            .collect())
+    }
+
     async fn upsert_follow_edge(&self, edge: FollowEdge) -> Result<()> {
         let key = (
             edge.subject_pubkey.as_str().to_string(),
@@ -235,10 +248,14 @@ impl Store for MemoryStore {
 #[async_trait]
 impl ProjectionStore for MemoryStore {
     async fn put_object_projection(&self, row: ObjectProjectionRow) -> Result<()> {
-        self.object_projection_rows
-            .write()
-            .await
-            .insert(row.object_id.clone(), row);
+        self.put_object_projections(vec![row]).await
+    }
+
+    async fn put_object_projections(&self, rows: Vec<ObjectProjectionRow>) -> Result<()> {
+        let mut projections = self.object_projection_rows.write().await;
+        for row in rows {
+            projections.insert(row.object_id.clone(), row);
+        }
         Ok(())
     }
 
@@ -277,6 +294,32 @@ impl ProjectionStore for MemoryStore {
         Ok(apply_desc_projection_cursor(items, cursor, limit))
     }
 
+    async fn list_topic_timeline_filtered(
+        &self,
+        topic_id: &str,
+        allowed_channels: &BTreeSet<String>,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<Page<ObjectProjectionRow>> {
+        let mut items = self
+            .object_projection_rows
+            .read()
+            .await
+            .values()
+            .filter(|row| {
+                row.topic_id == topic_id && allowed_channels.contains(row.channel_id.as_str())
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        items.sort_by(|left, right| {
+            right
+                .created_at
+                .cmp(&left.created_at)
+                .then_with(|| right.object_id.cmp(&left.object_id))
+        });
+        Ok(apply_desc_projection_cursor(items, cursor, limit))
+    }
+
     async fn list_thread(
         &self,
         topic_id: &str,
@@ -291,6 +334,42 @@ impl ProjectionStore for MemoryStore {
             .values()
             .filter(|row| {
                 row.topic_id == topic_id
+                    && (row.object_id == *thread_root_object_id
+                        || row
+                            .root_object_id
+                            .as_ref()
+                            .is_some_and(|root| root == thread_root_object_id))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        items.sort_by(|left, right| {
+            let left_root = left.object_id == *thread_root_object_id;
+            let right_root = right.object_id == *thread_root_object_id;
+            left_root
+                .cmp(&right_root)
+                .reverse()
+                .then_with(|| left.created_at.cmp(&right.created_at))
+                .then_with(|| left.object_id.cmp(&right.object_id))
+        });
+        Ok(apply_asc_projection_cursor(items, cursor, limit))
+    }
+
+    async fn list_thread_filtered(
+        &self,
+        topic_id: &str,
+        thread_root_object_id: &EnvelopeId,
+        allowed_channel: Option<&str>,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<Page<ObjectProjectionRow>> {
+        let mut items = self
+            .object_projection_rows
+            .read()
+            .await
+            .values()
+            .filter(|row| {
+                row.topic_id == topic_id
+                    && allowed_channel.is_none_or(|channel_id| row.channel_id == channel_id)
                     && (row.object_id == *thread_root_object_id
                         || row
                             .root_object_id
@@ -400,6 +479,23 @@ impl ProjectionStore for MemoryStore {
             .cloned())
     }
 
+    async fn list_author_relationships(
+        &self,
+        local_author_pubkey: &str,
+        author_pubkeys: &[String],
+    ) -> Result<HashMap<String, AuthorRelationshipProjectionRow>> {
+        let relationships = self.author_relationship_rows.read().await;
+        Ok(author_pubkeys
+            .iter()
+            .filter_map(|author_pubkey| {
+                relationships
+                    .get(&(local_author_pubkey.to_string(), author_pubkey.clone()))
+                    .cloned()
+                    .map(|relationship| (author_pubkey.clone(), relationship))
+            })
+            .collect())
+    }
+
     async fn rebuild_author_relationships(
         &self,
         local_author_pubkey: &str,
@@ -499,6 +595,14 @@ impl ProjectionStore for MemoryStore {
         Ok(())
     }
 
+    async fn mark_blob_statuses(&self, rows: Vec<(BlobHash, BlobCacheStatus)>) -> Result<()> {
+        let mut statuses = self.blob_statuses.write().await;
+        for (hash, status) in rows {
+            statuses.insert(hash.as_str().to_string(), status);
+        }
+        Ok(())
+    }
+
     async fn upsert_reaction_cache(&self, row: ReactionProjectionRow) -> Result<()> {
         self.reaction_projection_rows.write().await.insert(
             (
@@ -551,6 +655,36 @@ impl ProjectionStore for MemoryStore {
                 .then_with(|| left.reaction_id.cmp(&right.reaction_id))
         });
         Ok(items)
+    }
+
+    async fn list_reaction_cache_for_targets(
+        &self,
+        source_replica_id: &ReplicaId,
+        target_object_ids: &[EnvelopeId],
+    ) -> Result<HashMap<String, Vec<ReactionProjectionRow>>> {
+        let target_ids = target_object_ids
+            .iter()
+            .map(|target_object_id| target_object_id.as_str().to_string())
+            .collect::<HashSet<_>>();
+        let mut grouped = HashMap::<String, Vec<ReactionProjectionRow>>::new();
+        for row in self.reaction_projection_rows.read().await.values() {
+            if row.source_replica_id == *source_replica_id
+                && target_ids.contains(row.target_object_id.as_str())
+            {
+                grouped
+                    .entry(row.target_object_id.as_str().to_string())
+                    .or_default()
+                    .push(row.clone());
+            }
+        }
+        for rows in grouped.values_mut() {
+            rows.sort_by(|left, right| {
+                left.normalized_reaction_key
+                    .cmp(&right.normalized_reaction_key)
+                    .then_with(|| left.reaction_id.cmp(&right.reaction_id))
+            });
+        }
+        Ok(grouped)
     }
 
     async fn list_recent_reaction_cache_by_author(

--- a/crates/store/src/models.rs
+++ b/crates/store/src/models.rs
@@ -36,6 +36,7 @@ pub struct ObjectProjectionRow {
     pub reply_to_object_id: Option<EnvelopeId>,
     pub payload_ref: PayloadRef,
     pub content: Option<String>,
+    pub attachments: Vec<AssetRef>,
     pub repost_of: Option<RepostSourceSnapshotV1>,
     pub source_replica_id: ReplicaId,
     pub source_key: String,

--- a/crates/store/src/row_mapping.rs
+++ b/crates/store/src/row_mapping.rs
@@ -46,6 +46,13 @@ pub(crate) fn row_to_object_projection(
             .map(EnvelopeId::from),
         payload_ref: serde_json::from_str(row.get::<String, _>("payload_ref_json").as_str())?,
         content: row.try_get("content").ok(),
+        attachments: row
+            .try_get::<String, _>("attachments_json")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| serde_json::from_str(value.as_str()))
+            .transpose()?
+            .unwrap_or_default(),
         repost_of: row
             .try_get::<String, _>("repost_of_json")
             .ok()

--- a/crates/store/src/sqlite.rs
+++ b/crates/store/src/sqlite.rs
@@ -9,7 +9,7 @@ use kukuri_core::{
 };
 use sha2::{Digest, Sha384};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use sqlx::{Pool, Row, Sqlite};
+use sqlx::{Pool, QueryBuilder, Row, Sqlite};
 
 use crate::models::{
     AuthorRelationshipProjectionRow, BlobCacheStatus, BookmarkedCustomReactionRow,
@@ -41,11 +41,17 @@ pub struct SqliteStore {
 
 impl SqliteStore {
     pub async fn connect(database_url: &str) -> Result<Self> {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect(database_url)
-            .await
-            .with_context(|| format!("failed to connect sqlite database: {database_url}"))?;
+        let pool = sqlite_pool_options(
+            if database_url.contains(":memory:") {
+                1
+            } else {
+                4
+            },
+            !database_url.contains(":memory:"),
+        )
+        .connect(database_url)
+        .await
+        .with_context(|| format!("failed to connect sqlite database: {database_url}"))?;
 
         run_store_migrations(&pool).await?;
 
@@ -56,8 +62,7 @@ impl SqliteStore {
         let path = path.as_ref();
         let options = SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))?
             .create_if_missing(true);
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
+        let pool = sqlite_pool_options(4, true)
             .connect_with(options)
             .await
             .with_context(|| format!("failed to connect sqlite database: {}", path.display()))?;
@@ -78,6 +83,28 @@ impl SqliteStore {
     pub async fn close(&self) {
         self.pool.close().await;
     }
+}
+
+fn sqlite_pool_options(max_connections: u32, enable_wal: bool) -> SqlitePoolOptions {
+    SqlitePoolOptions::new()
+        .min_connections(1)
+        .max_connections(max_connections)
+        .after_connect(move |connection, _meta| {
+            Box::pin(async move {
+                sqlx::query("PRAGMA busy_timeout = 5000")
+                    .execute(&mut *connection)
+                    .await?;
+                sqlx::query("PRAGMA synchronous = NORMAL")
+                    .execute(&mut *connection)
+                    .await?;
+                if enable_wal {
+                    sqlx::query("PRAGMA journal_mode = WAL")
+                        .execute(&mut *connection)
+                        .await?;
+                }
+                Ok(())
+            })
+        })
 }
 
 async fn run_store_migrations(pool: &Pool<Sqlite>) -> Result<()> {
@@ -441,6 +468,60 @@ impl Store for SqliteStore {
         }))
     }
 
+    async fn get_profiles(
+        &self,
+        pubkeys: &[String],
+    ) -> Result<std::collections::HashMap<String, Profile>> {
+        if pubkeys.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+
+        let mut builder = QueryBuilder::<Sqlite>::new(
+            r#"
+            SELECT
+              pubkey, name, display_name, about, picture,
+              picture_blob_hash, picture_mime, picture_bytes, updated_at
+            FROM profiles
+            WHERE pubkey IN (
+            "#,
+        );
+        let mut separated = builder.separated(", ");
+        for pubkey in pubkeys {
+            separated.push_bind(pubkey);
+        }
+        separated.push_unseparated(")");
+
+        let rows = builder.build().fetch_all(&self.pool).await?;
+        let mut profiles = std::collections::HashMap::with_capacity(rows.len());
+        for row in rows {
+            let profile = Profile {
+                pubkey: row.get::<String, _>("pubkey").into(),
+                name: row.try_get("name").ok(),
+                display_name: row.try_get("display_name").ok(),
+                about: row.try_get("about").ok(),
+                picture: row.try_get("picture").ok(),
+                picture_asset: row
+                    .try_get::<String, _>("picture_blob_hash")
+                    .ok()
+                    .map(|hash| kukuri_core::AssetRef {
+                        hash: kukuri_core::BlobHash::new(hash),
+                        mime: row
+                            .try_get::<String, _>("picture_mime")
+                            .ok()
+                            .unwrap_or_else(|| "application/octet-stream".into()),
+                        bytes: row
+                            .try_get::<i64, _>("picture_bytes")
+                            .ok()
+                            .unwrap_or_default() as u64,
+                        role: kukuri_core::AssetRole::ProfileAvatar,
+                    }),
+                updated_at: row.get("updated_at"),
+            };
+            profiles.insert(profile.pubkey.as_str().to_string(), profile);
+        }
+        Ok(profiles)
+    }
+
     async fn upsert_follow_edge(&self, edge: FollowEdge) -> Result<()> {
         let existing_updated_at = sqlx::query_scalar::<_, i64>(
             r#"
@@ -519,86 +600,100 @@ impl Store for SqliteStore {
 #[async_trait]
 impl ProjectionStore for SqliteStore {
     async fn put_object_projection(&self, row: ObjectProjectionRow) -> Result<()> {
-        let payload_json = serde_json::to_string(&row.payload_ref)?;
-        let repost_json = row
-            .repost_of
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()?;
-        sqlx::query(
-            r#"
-            INSERT INTO object_index_cache (
-              object_id, topic_id, channel_id, author_pubkey, created_at, object_kind,
-              root_object_id, reply_to_object_id, payload_ref_json, content, repost_of_json,
-              source_replica_id, source_key, source_envelope_id, source_blob_hash, derived_at,
-              projection_version
-            )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
-            ON CONFLICT(object_id) DO UPDATE SET
-              topic_id = excluded.topic_id,
-              channel_id = excluded.channel_id,
-              author_pubkey = excluded.author_pubkey,
-              created_at = excluded.created_at,
-              object_kind = excluded.object_kind,
-              root_object_id = excluded.root_object_id,
-              reply_to_object_id = excluded.reply_to_object_id,
-              payload_ref_json = excluded.payload_ref_json,
-              content = excluded.content,
-              repost_of_json = excluded.repost_of_json,
-              source_replica_id = excluded.source_replica_id,
-              source_key = excluded.source_key,
-              source_envelope_id = excluded.source_envelope_id,
-              source_blob_hash = excluded.source_blob_hash,
-              derived_at = excluded.derived_at,
-              projection_version = excluded.projection_version
-            "#,
-        )
-        .bind(row.object_id.as_str())
-        .bind(row.topic_id.as_str())
-        .bind(row.channel_id.as_str())
-        .bind(row.author_pubkey.as_str())
-        .bind(row.created_at)
-        .bind(row.object_kind.as_str())
-        .bind(row.root_object_id.as_ref().map(EnvelopeId::as_str))
-        .bind(row.reply_to_object_id.as_ref().map(EnvelopeId::as_str))
-        .bind(payload_json)
-        .bind(row.content.as_deref())
-        .bind(repost_json.as_deref())
-        .bind(row.source_replica_id.as_str())
-        .bind(row.source_key.as_str())
-        .bind(row.source_envelope_id.as_str())
-        .bind(row.source_blob_hash.as_ref().map(BlobHash::as_str))
-        .bind(row.derived_at)
-        .bind(row.projection_version)
-        .execute(&self.pool)
-        .await?;
+        self.put_object_projections(vec![row]).await
+    }
 
-        sqlx::query(
-            r#"
-            INSERT INTO object_thread_cache (
-              object_id, topic_id, channel_id, root_object_id, created_at
-            )
-            VALUES (?1, ?2, ?3, ?4, ?5)
-            ON CONFLICT(object_id) DO UPDATE SET
-              topic_id = excluded.topic_id,
-              channel_id = excluded.channel_id,
-              root_object_id = excluded.root_object_id,
-              created_at = excluded.created_at
-            "#,
-        )
-        .bind(row.object_id.as_str())
-        .bind(row.topic_id.as_str())
-        .bind(row.channel_id.as_str())
-        .bind(
-            row.root_object_id
+    async fn put_object_projections(&self, rows: Vec<ObjectProjectionRow>) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx = self.pool.begin().await?;
+        for row in rows {
+            let payload_json = serde_json::to_string(&row.payload_ref)?;
+            let attachments_json = serde_json::to_string(&row.attachments)?;
+            let repost_json = row
+                .repost_of
                 .as_ref()
-                .unwrap_or(&row.object_id)
-                .as_str(),
-        )
-        .bind(row.created_at)
-        .execute(&self.pool)
-        .await?;
+                .map(serde_json::to_string)
+                .transpose()?;
+            sqlx::query(
+                r#"
+                INSERT INTO object_index_cache (
+                  object_id, topic_id, channel_id, author_pubkey, created_at, object_kind,
+                  root_object_id, reply_to_object_id, payload_ref_json, content, attachments_json,
+                  repost_of_json, source_replica_id, source_key, source_envelope_id,
+                  source_blob_hash, derived_at, projection_version
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+                ON CONFLICT(object_id) DO UPDATE SET
+                  topic_id = excluded.topic_id,
+                  channel_id = excluded.channel_id,
+                  author_pubkey = excluded.author_pubkey,
+                  created_at = excluded.created_at,
+                  object_kind = excluded.object_kind,
+                  root_object_id = excluded.root_object_id,
+                  reply_to_object_id = excluded.reply_to_object_id,
+                  payload_ref_json = excluded.payload_ref_json,
+                  content = excluded.content,
+                  attachments_json = excluded.attachments_json,
+                  repost_of_json = excluded.repost_of_json,
+                  source_replica_id = excluded.source_replica_id,
+                  source_key = excluded.source_key,
+                  source_envelope_id = excluded.source_envelope_id,
+                  source_blob_hash = excluded.source_blob_hash,
+                  derived_at = excluded.derived_at,
+                  projection_version = excluded.projection_version
+                "#,
+            )
+            .bind(row.object_id.as_str())
+            .bind(row.topic_id.as_str())
+            .bind(row.channel_id.as_str())
+            .bind(row.author_pubkey.as_str())
+            .bind(row.created_at)
+            .bind(row.object_kind.as_str())
+            .bind(row.root_object_id.as_ref().map(EnvelopeId::as_str))
+            .bind(row.reply_to_object_id.as_ref().map(EnvelopeId::as_str))
+            .bind(payload_json)
+            .bind(row.content.as_deref())
+            .bind(attachments_json)
+            .bind(repost_json.as_deref())
+            .bind(row.source_replica_id.as_str())
+            .bind(row.source_key.as_str())
+            .bind(row.source_envelope_id.as_str())
+            .bind(row.source_blob_hash.as_ref().map(BlobHash::as_str))
+            .bind(row.derived_at)
+            .bind(row.projection_version)
+            .execute(&mut *tx)
+            .await?;
 
+            sqlx::query(
+                r#"
+                INSERT INTO object_thread_cache (
+                  object_id, topic_id, channel_id, root_object_id, created_at
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5)
+                ON CONFLICT(object_id) DO UPDATE SET
+                  topic_id = excluded.topic_id,
+                  channel_id = excluded.channel_id,
+                  root_object_id = excluded.root_object_id,
+                  created_at = excluded.created_at
+                "#,
+            )
+            .bind(row.object_id.as_str())
+            .bind(row.topic_id.as_str())
+            .bind(row.channel_id.as_str())
+            .bind(
+                row.root_object_id
+                    .as_ref()
+                    .unwrap_or(&row.object_id)
+                    .as_str(),
+            )
+            .bind(row.created_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
         Ok(())
     }
 
@@ -609,9 +704,9 @@ impl ProjectionStore for SqliteStore {
         let row = sqlx::query(
             r#"
             SELECT object_id, topic_id, author_pubkey, created_at, object_kind, root_object_id,
-                   reply_to_object_id, channel_id, payload_ref_json, content, repost_of_json,
-                   source_replica_id, source_key, source_envelope_id, source_blob_hash, derived_at,
-                   projection_version
+                   reply_to_object_id, channel_id, payload_ref_json, content, attachments_json,
+                   repost_of_json, source_replica_id, source_key, source_envelope_id,
+                   source_blob_hash, derived_at, projection_version
             FROM object_index_cache
             WHERE object_id = ?1
             "#,
@@ -632,9 +727,9 @@ impl ProjectionStore for SqliteStore {
         let rows = sqlx::query(
             r#"
             SELECT object_id, topic_id, author_pubkey, created_at, object_kind, root_object_id,
-                   reply_to_object_id, channel_id, payload_ref_json, content, repost_of_json,
-                   source_replica_id, source_key, source_envelope_id, source_blob_hash, derived_at,
-                   projection_version
+                   reply_to_object_id, channel_id, payload_ref_json, content, attachments_json,
+                   repost_of_json, source_replica_id, source_key, source_envelope_id,
+                   source_blob_hash, derived_at, projection_version
             FROM object_index_cache
             WHERE topic_id = ?1
               AND (
@@ -656,6 +751,66 @@ impl ProjectionStore for SqliteStore {
         object_projection_page_from_rows(rows, limit)
     }
 
+    async fn list_topic_timeline_filtered(
+        &self,
+        topic_id: &str,
+        allowed_channels: &std::collections::BTreeSet<String>,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<Page<ObjectProjectionRow>> {
+        if limit == 0 || allowed_channels.is_empty() {
+            return Ok(Page {
+                items: Vec::new(),
+                next_cursor: cursor,
+            });
+        }
+
+        let mut builder = QueryBuilder::<Sqlite>::new(
+            r#"
+            SELECT object_id, topic_id, author_pubkey, created_at, object_kind, root_object_id,
+                   reply_to_object_id, channel_id, payload_ref_json, content, attachments_json,
+                   repost_of_json, source_replica_id, source_key, source_envelope_id,
+                   source_blob_hash, derived_at, projection_version
+            FROM object_index_cache
+            WHERE topic_id = "#,
+        );
+        builder.push_bind(topic_id);
+        builder.push(" AND channel_id IN (");
+        let mut separated = builder.separated(", ");
+        for channel_id in allowed_channels {
+            separated.push_bind(channel_id);
+        }
+        separated.push_unseparated(")");
+        builder.push(
+            r#"
+              AND (
+                "#,
+        );
+        builder.push_bind(cursor.as_ref().map(|value| value.created_at));
+        builder.push(
+            r#" IS NULL
+                OR created_at < "#,
+        );
+        builder.push_bind(cursor.as_ref().map(|value| value.created_at));
+        builder.push(
+            r#"
+                OR (created_at = "#,
+        );
+        builder.push_bind(cursor.as_ref().map(|value| value.created_at));
+        builder.push(" AND object_id < ");
+        builder.push_bind(cursor.as_ref().map(|value| value.object_id.as_str()));
+        builder.push(
+            r#")
+              )
+            ORDER BY created_at DESC, object_id DESC
+            LIMIT "#,
+        );
+        builder.push_bind(limit as i64);
+
+        let rows = builder.build().fetch_all(&self.pool).await?;
+        object_projection_page_from_rows(rows, limit)
+    }
+
     async fn list_thread(
         &self,
         topic_id: &str,
@@ -667,9 +822,9 @@ impl ProjectionStore for SqliteStore {
             r#"
             SELECT oic.object_id, oic.topic_id, oic.author_pubkey, oic.created_at, oic.object_kind,
                    oic.root_object_id, oic.reply_to_object_id, oic.channel_id,
-                   oic.payload_ref_json, oic.content, oic.repost_of_json, oic.source_replica_id,
-                   oic.source_key, oic.source_envelope_id, oic.source_blob_hash, oic.derived_at,
-                   oic.projection_version
+                   oic.payload_ref_json, oic.content, oic.attachments_json, oic.repost_of_json,
+                   oic.source_replica_id, oic.source_key, oic.source_envelope_id,
+                   oic.source_blob_hash, oic.derived_at, oic.projection_version
             FROM object_thread_cache tc
             INNER JOIN object_index_cache oic ON oic.object_id = tc.object_id
             WHERE tc.topic_id = ?1
@@ -688,6 +843,61 @@ impl ProjectionStore for SqliteStore {
         )
         .bind(topic_id)
         .bind(thread_root_object_id.as_str())
+        .bind(cursor.as_ref().map(|value| value.created_at))
+        .bind(cursor.as_ref().map(|value| value.object_id.as_str()))
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await?;
+
+        object_projection_page_from_rows(rows, limit)
+    }
+
+    async fn list_thread_filtered(
+        &self,
+        topic_id: &str,
+        thread_root_object_id: &EnvelopeId,
+        allowed_channel: Option<&str>,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<Page<ObjectProjectionRow>> {
+        let Some(channel_id) = allowed_channel else {
+            return ProjectionStore::list_thread(
+                self,
+                topic_id,
+                thread_root_object_id,
+                cursor,
+                limit,
+            )
+            .await;
+        };
+
+        let rows = sqlx::query(
+            r#"
+            SELECT oic.object_id, oic.topic_id, oic.author_pubkey, oic.created_at, oic.object_kind,
+                   oic.root_object_id, oic.reply_to_object_id, oic.channel_id,
+                   oic.payload_ref_json, oic.content, oic.attachments_json, oic.repost_of_json,
+                   oic.source_replica_id, oic.source_key, oic.source_envelope_id,
+                   oic.source_blob_hash, oic.derived_at, oic.projection_version
+            FROM object_thread_cache tc
+            INNER JOIN object_index_cache oic ON oic.object_id = tc.object_id
+            WHERE tc.topic_id = ?1
+              AND tc.root_object_id = ?2
+              AND tc.channel_id = ?3
+              AND (
+                ?4 IS NULL
+                OR oic.created_at > ?4
+                OR (oic.created_at = ?4 AND oic.object_id > ?5)
+              )
+            ORDER BY
+              CASE WHEN oic.object_id = tc.root_object_id THEN 0 ELSE 1 END ASC,
+              oic.created_at ASC,
+              oic.object_id ASC
+            LIMIT ?6
+            "#,
+        )
+        .bind(topic_id)
+        .bind(thread_root_object_id.as_str())
+        .bind(channel_id)
         .bind(cursor.as_ref().map(|value| value.created_at))
         .bind(cursor.as_ref().map(|value| value.object_id.as_str()))
         .bind(limit as i64)
@@ -911,6 +1121,39 @@ impl ProjectionStore for SqliteStore {
         row.map(row_to_author_relationship_projection).transpose()
     }
 
+    async fn list_author_relationships(
+        &self,
+        local_author_pubkey: &str,
+        author_pubkeys: &[String],
+    ) -> Result<std::collections::HashMap<String, AuthorRelationshipProjectionRow>> {
+        if author_pubkeys.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+
+        let mut builder = QueryBuilder::<Sqlite>::new(
+            r#"
+            SELECT local_author_pubkey, author_pubkey, following, followed_by, mutual,
+                   friend_of_friend, friend_of_friend_via_pubkeys_json, derived_at
+            FROM author_relationship_cache
+            WHERE local_author_pubkey = "#,
+        );
+        builder.push_bind(local_author_pubkey);
+        builder.push(" AND author_pubkey IN (");
+        let mut separated = builder.separated(", ");
+        for author_pubkey in author_pubkeys {
+            separated.push_bind(author_pubkey);
+        }
+        separated.push_unseparated(")");
+
+        let rows = builder.build().fetch_all(&self.pool).await?;
+        let mut relationships = std::collections::HashMap::with_capacity(rows.len());
+        for row in rows {
+            let relationship = row_to_author_relationship_projection(row)?;
+            relationships.insert(relationship.author_pubkey.clone(), relationship);
+        }
+        Ok(relationships)
+    }
+
     async fn rebuild_author_relationships(
         &self,
         local_author_pubkey: &str,
@@ -1087,6 +1330,33 @@ impl ProjectionStore for SqliteStore {
         Ok(())
     }
 
+    async fn mark_blob_statuses(&self, rows: Vec<(BlobHash, BlobCacheStatus)>) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx = self.pool.begin().await?;
+        for (hash, status) in rows {
+            sqlx::query(
+                r#"
+                INSERT INTO blob_objects (blob_hash, status)
+                VALUES (?1, ?2)
+                ON CONFLICT(blob_hash) DO UPDATE SET status = excluded.status
+                "#,
+            )
+            .bind(hash.as_str())
+            .bind(match status {
+                BlobCacheStatus::Missing => "missing",
+                BlobCacheStatus::Available => "available",
+                BlobCacheStatus::Pinned => "pinned",
+            })
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
     async fn upsert_reaction_cache(&self, row: ReactionProjectionRow) -> Result<()> {
         let snapshot_json = row
             .custom_asset_snapshot
@@ -1184,6 +1454,46 @@ impl ProjectionStore for SqliteStore {
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter().map(row_to_reaction_projection).collect()
+    }
+
+    async fn list_reaction_cache_for_targets(
+        &self,
+        source_replica_id: &ReplicaId,
+        target_object_ids: &[EnvelopeId],
+    ) -> Result<std::collections::HashMap<String, Vec<ReactionProjectionRow>>> {
+        if target_object_ids.is_empty() {
+            return Ok(std::collections::HashMap::new());
+        }
+
+        let mut builder = QueryBuilder::<Sqlite>::new(
+            r#"
+            SELECT source_replica_id, target_object_id, reaction_id, author_pubkey, created_at,
+                   updated_at, reaction_key_kind, normalized_reaction_key, emoji,
+                   custom_asset_id, custom_asset_snapshot_json, status, source_key,
+                   source_envelope_id, derived_at, projection_version
+            FROM reaction_cache
+            WHERE source_replica_id = "#,
+        );
+        builder.push_bind(source_replica_id.as_str());
+        builder.push(" AND target_object_id IN (");
+        let mut separated = builder.separated(", ");
+        for target_object_id in target_object_ids {
+            separated.push_bind(target_object_id.as_str());
+        }
+        separated.push_unseparated(")");
+        builder
+            .push(" ORDER BY target_object_id ASC, normalized_reaction_key ASC, reaction_id ASC");
+
+        let rows = builder.build().fetch_all(&self.pool).await?;
+        let mut reactions = std::collections::HashMap::<String, Vec<ReactionProjectionRow>>::new();
+        for row in rows {
+            let projection = row_to_reaction_projection(row)?;
+            reactions
+                .entry(projection.target_object_id.as_str().to_string())
+                .or_default()
+                .push(projection);
+        }
+        Ok(reactions)
     }
 
     async fn list_recent_reaction_cache_by_author(
@@ -1894,27 +2204,27 @@ impl ProjectionStore for SqliteStore {
     }
 
     async fn rebuild_object_projections(&self, rows: Vec<ObjectProjectionRow>) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
         sqlx::query("DELETE FROM object_thread_cache")
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
         sqlx::query("DELETE FROM object_index_cache")
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
         sqlx::query("DELETE FROM live_session_cache")
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
         sqlx::query("DELETE FROM game_room_cache")
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
         sqlx::query("DELETE FROM live_presence_cache")
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
         sqlx::query("DELETE FROM reaction_cache")
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
-        for row in rows {
-            self.put_object_projection(row).await?;
-        }
+        tx.commit().await?;
+        self.put_object_projections(rows).await?;
         Ok(())
     }
 }

--- a/crates/store/src/tests/sqlite_projection.rs
+++ b/crates/store/src/tests/sqlite_projection.rs
@@ -1,4 +1,38 @@
 use super::*;
+use std::collections::BTreeSet;
+
+fn projection_row(
+    topic: &str,
+    channel_id: &str,
+    object_id: &str,
+    created_at: i64,
+) -> ObjectProjectionRow {
+    let hash = BlobHash::new(format!("{created_at:064x}"));
+    ObjectProjectionRow {
+        object_id: EnvelopeId::from(object_id),
+        topic_id: topic.to_string(),
+        channel_id: channel_id.to_string(),
+        author_pubkey: format!("{:064x}", created_at + 100),
+        created_at,
+        object_kind: "post".into(),
+        root_object_id: None,
+        reply_to_object_id: None,
+        payload_ref: PayloadRef::BlobText {
+            hash: hash.clone(),
+            mime: "text/plain".into(),
+            bytes: object_id.len() as u64,
+        },
+        content: Some(object_id.to_string()),
+        attachments: Vec::new(),
+        repost_of: None,
+        source_replica_id: ReplicaId::new(format!("topic::{topic}")),
+        source_key: format!("objects/{object_id}/header"),
+        source_envelope_id: EnvelopeId::from(object_id),
+        source_blob_hash: Some(hash),
+        derived_at: created_at,
+        projection_version: 2,
+    }
+}
 
 #[tokio::test]
 async fn recent_reaction_cache_query_returns_latest_rows_for_author() {
@@ -264,13 +298,14 @@ async fn projection_rebuild_from_docs_blobs_only() {
                 bytes: 4,
             },
             content: Some("root".into()),
+            attachments: Vec::new(),
             repost_of: None,
             source_replica_id: ReplicaId::new(format!("topic::{topic}")),
             source_key: "objects/object-root/header".into(),
             source_envelope_id: root_id.clone(),
             source_blob_hash: Some(BlobHash::new("1".repeat(64))),
             derived_at: 10,
-            projection_version: 1,
+            projection_version: 2,
         },
         ObjectProjectionRow {
             object_id: reply_id.clone(),
@@ -287,13 +322,14 @@ async fn projection_rebuild_from_docs_blobs_only() {
                 bytes: 5,
             },
             content: Some("reply".into()),
+            attachments: Vec::new(),
             repost_of: None,
             source_replica_id: ReplicaId::new(format!("topic::{topic}")),
             source_key: "objects/object-reply/header".into(),
             source_envelope_id: reply_id.clone(),
             source_blob_hash: Some(BlobHash::new("2".repeat(64))),
             derived_at: 11,
-            projection_version: 1,
+            projection_version: 2,
         },
     ];
 
@@ -312,4 +348,199 @@ async fn projection_rebuild_from_docs_blobs_only() {
     assert_eq!(timeline.items[0].object_id, reply_id);
     assert_eq!(thread.items.len(), 2);
     assert_eq!(thread.items[0].object_id, root_id);
+}
+
+#[tokio::test]
+async fn filtered_timeline_query_preserves_cursor_across_channel_pages() {
+    let store = SqliteStore::connect_memory().await.expect("sqlite store");
+    let topic = "kukuri:topic:filtered-timeline";
+    let rows = vec![
+        projection_row(topic, "private:friends", "post-4", 40),
+        projection_row(topic, "public", "post-3", 30),
+        projection_row(topic, "private:friends", "post-2", 20),
+        projection_row(topic, "private:friends", "post-1", 10),
+    ];
+    ProjectionStore::put_object_projections(&store, rows)
+        .await
+        .expect("put projections");
+
+    let allowed_channels = BTreeSet::from(["private:friends".to_string()]);
+    let first_page =
+        ProjectionStore::list_topic_timeline_filtered(&store, topic, &allowed_channels, None, 2)
+            .await
+            .expect("first filtered timeline page");
+    assert_eq!(
+        first_page
+            .items
+            .iter()
+            .map(|row| row.object_id.as_str().to_string())
+            .collect::<Vec<_>>(),
+        vec!["post-4".to_string(), "post-2".to_string()]
+    );
+    assert!(first_page.next_cursor.is_some());
+
+    let second_page = ProjectionStore::list_topic_timeline_filtered(
+        &store,
+        topic,
+        &allowed_channels,
+        first_page.next_cursor.clone(),
+        2,
+    )
+    .await
+    .expect("second filtered timeline page");
+    assert_eq!(
+        second_page
+            .items
+            .iter()
+            .map(|row| row.object_id.as_str().to_string())
+            .collect::<Vec<_>>(),
+        vec!["post-1".to_string()]
+    );
+    assert!(second_page.next_cursor.is_none());
+}
+
+#[tokio::test]
+async fn filtered_thread_query_preserves_cursor_across_channel_pages() {
+    let store = SqliteStore::connect_memory().await.expect("sqlite store");
+    let topic = "kukuri:topic:filtered-thread";
+    let root_id = EnvelopeId::from("thread-root");
+    let mut root = projection_row(topic, "private:friends", root_id.as_str(), 10);
+    root.object_id = root_id.clone();
+    root.source_envelope_id = root_id.clone();
+
+    let mut public_reply = projection_row(topic, "public", "reply-public", 20);
+    public_reply.root_object_id = Some(root_id.clone());
+    public_reply.reply_to_object_id = Some(root_id.clone());
+    public_reply.object_kind = "comment".into();
+
+    let mut private_reply_a = projection_row(topic, "private:friends", "reply-a", 30);
+    private_reply_a.root_object_id = Some(root_id.clone());
+    private_reply_a.reply_to_object_id = Some(root_id.clone());
+    private_reply_a.object_kind = "comment".into();
+
+    let mut private_reply_b = projection_row(topic, "private:friends", "reply-b", 40);
+    private_reply_b.root_object_id = Some(root_id.clone());
+    private_reply_b.reply_to_object_id = Some(root_id.clone());
+    private_reply_b.object_kind = "comment".into();
+
+    ProjectionStore::put_object_projections(
+        &store,
+        vec![root, public_reply, private_reply_a, private_reply_b],
+    )
+    .await
+    .expect("put projections");
+
+    let first_page = ProjectionStore::list_thread_filtered(
+        &store,
+        topic,
+        &root_id,
+        Some("private:friends"),
+        None,
+        2,
+    )
+    .await
+    .expect("first filtered thread page");
+    assert_eq!(
+        first_page
+            .items
+            .iter()
+            .map(|row| row.object_id.as_str().to_string())
+            .collect::<Vec<_>>(),
+        vec!["thread-root".to_string(), "reply-a".to_string()]
+    );
+    assert!(first_page.next_cursor.is_some());
+
+    let second_page = ProjectionStore::list_thread_filtered(
+        &store,
+        topic,
+        &root_id,
+        Some("private:friends"),
+        first_page.next_cursor.clone(),
+        2,
+    )
+    .await
+    .expect("second filtered thread page");
+    assert_eq!(
+        second_page
+            .items
+            .iter()
+            .map(|row| row.object_id.as_str().to_string())
+            .collect::<Vec<_>>(),
+        vec!["reply-b".to_string()]
+    );
+    assert!(second_page.next_cursor.is_none());
+}
+
+#[tokio::test]
+async fn batch_projection_insert_matches_single_insert_and_preserves_attachments() {
+    let batch_store = SqliteStore::connect_memory().await.expect("batch store");
+    let single_store = SqliteStore::connect_memory().await.expect("single store");
+    let topic = "kukuri:topic:batch-projection";
+
+    let mut root = projection_row(topic, "public", "batch-root", 10);
+    root.attachments = vec![kukuri_core::AssetRef {
+        hash: BlobHash::new("f".repeat(64)),
+        mime: "image/png".into(),
+        bytes: 42,
+        role: kukuri_core::AssetRole::ImageOriginal,
+    }];
+    let mut reply = projection_row(topic, "public", "batch-reply", 11);
+    reply.object_kind = "comment".into();
+    reply.root_object_id = Some(root.object_id.clone());
+    reply.reply_to_object_id = Some(root.object_id.clone());
+
+    ProjectionStore::put_object_projections(&batch_store, vec![root.clone(), reply.clone()])
+        .await
+        .expect("batch insert");
+    ProjectionStore::put_object_projection(&single_store, root.clone())
+        .await
+        .expect("single insert root");
+    ProjectionStore::put_object_projection(&single_store, reply.clone())
+        .await
+        .expect("single insert reply");
+
+    let batch_timeline = ProjectionStore::list_topic_timeline(&batch_store, topic, None, 10)
+        .await
+        .expect("batch timeline");
+    let single_timeline = ProjectionStore::list_topic_timeline(&single_store, topic, None, 10)
+        .await
+        .expect("single timeline");
+    assert_eq!(
+        batch_timeline
+            .items
+            .iter()
+            .map(|row| row.object_id.as_str().to_string())
+            .collect::<Vec<_>>(),
+        single_timeline
+            .items
+            .iter()
+            .map(|row| row.object_id.as_str().to_string())
+            .collect::<Vec<_>>()
+    );
+
+    let batch_thread = ProjectionStore::list_thread(&batch_store, topic, &root.object_id, None, 10)
+        .await
+        .expect("batch thread");
+    let single_thread =
+        ProjectionStore::list_thread(&single_store, topic, &root.object_id, None, 10)
+            .await
+            .expect("single thread");
+    assert_eq!(
+        batch_thread
+            .items
+            .iter()
+            .map(|row| row.object_id.as_str().to_string())
+            .collect::<Vec<_>>(),
+        single_thread
+            .items
+            .iter()
+            .map(|row| row.object_id.as_str().to_string())
+            .collect::<Vec<_>>()
+    );
+
+    let stored = ProjectionStore::get_object_projection(&batch_store, &root.object_id)
+        .await
+        .expect("get stored projection")
+        .expect("stored projection");
+    assert_eq!(stored.attachments, root.attachments);
 }

--- a/crates/store/src/traits.rs
+++ b/crates/store/src/traits.rs
@@ -1,3 +1,5 @@
+use std::collections::{BTreeSet, HashMap};
+
 use anyhow::Result;
 use async_trait::async_trait;
 use kukuri_core::{BlobHash, EnvelopeId, FollowEdge, KukuriEnvelope, Profile, ReplicaId};
@@ -29,6 +31,15 @@ pub trait Store: Send + Sync {
     ) -> Result<Page<KukuriEnvelope>>;
     async fn upsert_profile(&self, profile: Profile) -> Result<()>;
     async fn get_profile(&self, pubkey: &str) -> Result<Option<Profile>>;
+    async fn get_profiles(&self, pubkeys: &[String]) -> Result<HashMap<String, Profile>> {
+        let mut profiles = HashMap::new();
+        for pubkey in pubkeys {
+            if let Some(profile) = self.get_profile(pubkey.as_str()).await? {
+                profiles.insert(pubkey.clone(), profile);
+            }
+        }
+        Ok(profiles)
+    }
     async fn upsert_follow_edge(&self, edge: FollowEdge) -> Result<()>;
     async fn list_follow_edges_by_subject(&self, subject_pubkey: &str) -> Result<Vec<FollowEdge>>;
     async fn list_follow_edges_by_target(&self, target_pubkey: &str) -> Result<Vec<FollowEdge>>;
@@ -37,6 +48,12 @@ pub trait Store: Send + Sync {
 #[async_trait]
 pub trait ProjectionStore: Send + Sync {
     async fn put_object_projection(&self, row: ObjectProjectionRow) -> Result<()>;
+    async fn put_object_projections(&self, rows: Vec<ObjectProjectionRow>) -> Result<()> {
+        for row in rows {
+            self.put_object_projection(row).await?;
+        }
+        Ok(())
+    }
     async fn get_object_projection(
         &self,
         object_id: &EnvelopeId,
@@ -47,6 +64,42 @@ pub trait ProjectionStore: Send + Sync {
         cursor: Option<TimelineCursor>,
         limit: usize,
     ) -> Result<Page<ObjectProjectionRow>>;
+    async fn list_topic_timeline_filtered(
+        &self,
+        topic_id: &str,
+        allowed_channels: &BTreeSet<String>,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<Page<ObjectProjectionRow>> {
+        if limit == 0 {
+            return Ok(Page {
+                items: Vec::new(),
+                next_cursor: cursor,
+            });
+        }
+
+        let mut current_cursor = cursor;
+        let mut items = Vec::new();
+        let page_size = limit.max(20);
+        loop {
+            let page = self
+                .list_topic_timeline(topic_id, current_cursor.clone(), page_size)
+                .await?;
+            let next_cursor = page.next_cursor.clone();
+            for row in page.items {
+                if allowed_channels.contains(row.channel_id.as_str()) {
+                    items.push(row);
+                    if items.len() >= limit {
+                        return Ok(Page { items, next_cursor });
+                    }
+                }
+            }
+            if next_cursor.is_none() {
+                return Ok(Page { items, next_cursor });
+            }
+            current_cursor = next_cursor;
+        }
+    }
     async fn list_thread(
         &self,
         topic_id: &str,
@@ -54,6 +107,48 @@ pub trait ProjectionStore: Send + Sync {
         cursor: Option<TimelineCursor>,
         limit: usize,
     ) -> Result<Page<ObjectProjectionRow>>;
+    async fn list_thread_filtered(
+        &self,
+        topic_id: &str,
+        thread_root_object_id: &EnvelopeId,
+        allowed_channel: Option<&str>,
+        cursor: Option<TimelineCursor>,
+        limit: usize,
+    ) -> Result<Page<ObjectProjectionRow>> {
+        if limit == 0 {
+            return Ok(Page {
+                items: Vec::new(),
+                next_cursor: cursor,
+            });
+        }
+
+        let mut current_cursor = cursor;
+        let mut items = Vec::new();
+        let page_size = limit.max(20);
+        loop {
+            let page = self
+                .list_thread(
+                    topic_id,
+                    thread_root_object_id,
+                    current_cursor.clone(),
+                    page_size,
+                )
+                .await?;
+            let next_cursor = page.next_cursor.clone();
+            for row in page.items {
+                if allowed_channel.is_none_or(|channel_id| row.channel_id == channel_id) {
+                    items.push(row);
+                    if items.len() >= limit {
+                        return Ok(Page { items, next_cursor });
+                    }
+                }
+            }
+            if next_cursor.is_none() {
+                return Ok(Page { items, next_cursor });
+            }
+            current_cursor = next_cursor;
+        }
+    }
     async fn upsert_profile_cache(&self, profile: Profile) -> Result<()>;
     async fn upsert_live_session_cache(&self, row: LiveSessionProjectionRow) -> Result<()>;
     async fn list_topic_live_sessions(
@@ -67,6 +162,22 @@ pub trait ProjectionStore: Send + Sync {
         local_author_pubkey: &str,
         author_pubkey: &str,
     ) -> Result<Option<AuthorRelationshipProjectionRow>>;
+    async fn list_author_relationships(
+        &self,
+        local_author_pubkey: &str,
+        author_pubkeys: &[String],
+    ) -> Result<HashMap<String, AuthorRelationshipProjectionRow>> {
+        let mut relationships = HashMap::new();
+        for author_pubkey in author_pubkeys {
+            if let Some(relationship) = self
+                .get_author_relationship(local_author_pubkey, author_pubkey.as_str())
+                .await?
+            {
+                relationships.insert(author_pubkey.clone(), relationship);
+            }
+        }
+        Ok(relationships)
+    }
     async fn rebuild_author_relationships(
         &self,
         local_author_pubkey: &str,
@@ -88,6 +199,12 @@ pub trait ProjectionStore: Send + Sync {
     async fn clear_topic_live_presence(&self, topic_id: &str) -> Result<()>;
     async fn clear_expired_live_presence(&self, now_ms: i64) -> Result<()>;
     async fn mark_blob_status(&self, hash: &BlobHash, status: BlobCacheStatus) -> Result<()>;
+    async fn mark_blob_statuses(&self, rows: Vec<(BlobHash, BlobCacheStatus)>) -> Result<()> {
+        for (hash, status) in rows {
+            self.mark_blob_status(&hash, status).await?;
+        }
+        Ok(())
+    }
     async fn upsert_reaction_cache(&self, row: ReactionProjectionRow) -> Result<()>;
     async fn get_reaction_cache(
         &self,
@@ -100,6 +217,21 @@ pub trait ProjectionStore: Send + Sync {
         source_replica_id: &ReplicaId,
         target_object_id: &EnvelopeId,
     ) -> Result<Vec<ReactionProjectionRow>>;
+    async fn list_reaction_cache_for_targets(
+        &self,
+        source_replica_id: &ReplicaId,
+        target_object_ids: &[EnvelopeId],
+    ) -> Result<HashMap<String, Vec<ReactionProjectionRow>>> {
+        let mut reactions = HashMap::new();
+        for target_object_id in target_object_ids {
+            reactions.insert(
+                target_object_id.as_str().to_string(),
+                self.list_reaction_cache_for_target(source_replica_id, target_object_id)
+                    .await?,
+            );
+        }
+        Ok(reactions)
+    }
     async fn list_recent_reaction_cache_by_author(
         &self,
         author_pubkey: &str,


### PR DESCRIPTION
## What changed
- split desktop shell loading into visible-lane refreshes instead of eager all-pane startup fetches
- added per-list pagination state and incremental timeline/thread/DM loading paths
- changed publish/repost UX to optimistic local cards with pending, syncing, retry, and restore-draft flows
- batched projection/profile/relationship/reaction reads in app-api and moved scope filtering into SQL
- added `attachments_json` projection caching plus batched projection/blob-status upserts
- enabled SQLite WAL, `synchronous = NORMAL`, `busy_timeout = 5s`, and a bounded pool configuration
- removed repeated relationship rebuilds and DM subscription restarts from hot read paths
- added store/app-api/desktop regression coverage for filtered pagination, batch projection writes, DM subscription behavior, and the updated shell behavior

## Why this changed
Windows profiling and client logs showed publish and startup latency were dominated by a combination of eager shell-wide loading, overlapping polling, N+1 post view hydration, and SQLite contention around projection cache writes and pool acquisition. On mid-range hardware that translated into multi-second publish waits and very slow first timeline paint.

## Impact
- startup can render the visible timeline without waiting for non-visible panes
- visible timeline/thread/DM refreshes are isolated and lower-frequency when the window is hidden
- publish responds immediately in the UI and converges to authoritative server state on refresh
- projection reads and writes put much less pressure on SQLite on slower Windows machines

## Validation
- `cargo fmt --all`
- `cargo test -p kukuri-store sqlite_projection`
- `cargo test -p kukuri-app-api dm_list_does_not_restart_active_subscription_after_open`
- `cargo test -p kukuri-app-api list_social_connections_followed_is_local_known_only`
- `cd apps/desktop && npx pnpm@10.16.1 exec tsc --noEmit --pretty false`
- `cd apps/desktop && npx pnpm@10.16.1 test -- --runInBand src/shell/DesktopShellPage.test.tsx`

## Not completed in this PR flow
- `cargo xtask check`
- `cargo xtask e2e-smoke`
- Windows 2-client manual re-measurement after the code changes
