### PR TITLE
[codex] Stabilize p2p delivery and recovery

### DIFF
--- a/apps/desktop/src/components/core/TopicNavList.tsx
+++ b/apps/desktop/src/components/core/TopicNavList.tsx
@@ -66,9 +66,7 @@ export function TopicNavList({
                   status:
                     item.connectionLabel === 'joined'
                       ? t('common:states.joined')
-                      : item.connectionLabel === 'relay-assisted'
-                        ? t('common:states.relayAssisted')
-                        : item.connectionLabel === 'idle'
+                      : item.connectionLabel === 'idle'
                           ? t('common:states.idle')
                           : item.connectionLabel,
                   count: item.peerCount,

--- a/apps/desktop/src/components/settings/fixtures.ts
+++ b/apps/desktop/src/components/settings/fixtures.ts
@@ -82,13 +82,14 @@ export function createConnectivityPanelFixture(): ConnectivityPanelView {
       {
         topic: 'kukuri:topic:relay',
         summary: i18n.t('settings:connectivity.summary', {
-          status: i18n.t('common:states.relayAssisted'),
-          count: 1,
+          status: 'recovering',
+          count: 0,
         }),
         lastReceivedLabel: i18n.t('common:fallbacks.noEvents'),
         expectedPeerCount: 0,
         missingPeerCount: 0,
-        statusDetail: 'relay-assisted sync available via 1 peer(s)',
+        statusDetail:
+          'docs-assisted recovery is in progress via 1 peer(s); live topic delivery is unavailable',
         connectedPeersLabel: i18n.t('common:fallbacks.none'),
         relayAssistedPeersLabel: 'relay-peer',
         configuredPeersLabel: i18n.t('common:fallbacks.none'),

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -331,13 +331,17 @@ export type DiscoveryStatus = {
   bootstrap_seed_peer_ids: string[];
   manual_ticket_peer_ids: string[];
   connected_peer_ids: string[];
-  assist_peer_ids: string[];
+  docs_assist_peer_ids: string[];
+  blob_assist_peer_ids: string[];
   local_endpoint_id: string;
   last_discovery_error?: string | null;
 };
 
+export type DeliveryState = 'Live' | 'DurableRecovering' | 'DurableReady' | 'Offline';
+
 export type SyncStatus = {
   connected: boolean;
+  delivery_state: DeliveryState;
   last_sync_ts?: number | null;
   peer_count: number;
   pending_events: number;
@@ -413,12 +417,14 @@ export type CommunityNodeConfigInput = {
 export type TopicSyncStatus = {
   topic: string;
   joined: boolean;
+  delivery_state: DeliveryState;
   peer_count: number;
   connected_peers: string[];
-  assist_peer_ids: string[];
+  docs_assist_peer_ids: string[];
   configured_peer_ids: string[];
   missing_peer_ids: string[];
   last_received_at?: number | null;
+  last_docs_activity_at?: number | null;
   status_detail: string;
   last_error?: string | null;
 };

--- a/apps/desktop/src/mocks/desktopApiMock.ts
+++ b/apps/desktop/src/mocks/desktopApiMock.ts
@@ -323,7 +323,7 @@ function cloneSyncStatus(syncStatus: SyncStatus): SyncStatus {
     topic_diagnostics: syncStatus.topic_diagnostics.map((diagnostic) => ({
       ...diagnostic,
       connected_peers: [...diagnostic.connected_peers],
-      assist_peer_ids: [...diagnostic.assist_peer_ids],
+      docs_assist_peer_ids: [...diagnostic.docs_assist_peer_ids],
       configured_peer_ids: [...diagnostic.configured_peer_ids],
       missing_peer_ids: [...diagnostic.missing_peer_ids],
     })),
@@ -333,7 +333,8 @@ function cloneSyncStatus(syncStatus: SyncStatus): SyncStatus {
       bootstrap_seed_peer_ids: [...syncStatus.discovery.bootstrap_seed_peer_ids],
       manual_ticket_peer_ids: [...syncStatus.discovery.manual_ticket_peer_ids],
       connected_peer_ids: [...syncStatus.discovery.connected_peer_ids],
-      assist_peer_ids: [...syncStatus.discovery.assist_peer_ids],
+      docs_assist_peer_ids: [...syncStatus.discovery.docs_assist_peer_ids],
+      blob_assist_peer_ids: [...syncStatus.discovery.blob_assist_peer_ids],
     },
   };
 }
@@ -521,6 +522,7 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
   ];
   const syncStatus: SyncStatus = {
     connected: true,
+    delivery_state: 'Live',
     last_sync_ts: 1,
     peer_count: effectivePeerIds.length,
     pending_events: 0,
@@ -531,12 +533,14 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
     topic_diagnostics: starterTopics.map((topic) => ({
       topic,
       joined: true,
+      delivery_state: 'Live',
       peer_count: effectivePeerIds.length,
       connected_peers: ['peer-a'],
-      assist_peer_ids: assistPeerIds,
+      docs_assist_peer_ids: assistPeerIds,
       configured_peer_ids: ['peer-a'],
       missing_peer_ids: [],
       last_received_at: topic === 'kukuri:topic:demo' ? 1 : null,
+      last_docs_activity_at: topic === 'kukuri:topic:demo' ? 1 : null,
       status_detail: 'Connected to all configured peers for this topic',
       last_error: topic === 'kukuri:topic:demo' ? options?.topicLastError ?? null : null,
     })),
@@ -549,7 +553,8 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       bootstrap_seed_peer_ids: [],
       manual_ticket_peer_ids: [],
       connected_peer_ids: ['peer-a'],
-      assist_peer_ids: assistPeerIds,
+      docs_assist_peer_ids: assistPeerIds,
+      blob_assist_peer_ids: assistPeerIds,
       local_endpoint_id: 'local-endpoint-a',
       last_discovery_error: null,
     },
@@ -736,12 +741,14 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
         syncStatus.topic_diagnostics.push({
           topic,
           joined: true,
+          delivery_state: 'Live',
           peer_count: 1,
           connected_peers: ['peer-a'],
-          assist_peer_ids: assistPeerIds,
+          docs_assist_peer_ids: assistPeerIds,
           configured_peer_ids: ['peer-a'],
           missing_peer_ids: [],
           last_received_at: sequence,
+          last_docs_activity_at: sequence,
           status_detail: 'Connected to all configured peers for this topic',
           last_error: null,
         });
@@ -970,15 +977,17 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
         syncStatus.topic_diagnostics.push({
           topic,
           joined: false,
-          peer_count: assistPeerIds.length,
+          delivery_state: assistPeerIds.length > 0 ? 'DurableRecovering' : 'Offline',
+          peer_count: 0,
           connected_peers: [],
-          assist_peer_ids: assistPeerIds,
+          docs_assist_peer_ids: assistPeerIds,
           configured_peer_ids: [],
           missing_peer_ids: [],
           last_received_at: null,
+          last_docs_activity_at: null,
           status_detail:
             assistPeerIds.length > 0
-              ? `relay-assisted sync available via ${assistPeerIds.length} peer(s)`
+              ? `docs-assisted recovery is in progress via ${assistPeerIds.length} peer(s); live topic delivery is unavailable`
               : 'No peers configured for this topic',
           last_error: null,
         });

--- a/apps/desktop/src/shell/DesktopShellPage.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.test.tsx
@@ -2133,14 +2133,14 @@ test('clicking a timeline post opens thread and author detail flows in the conte
   expect(within(getDetailPane('Author')).getByText('author detail from timeline')).toBeInTheDocument();
 });
 
-test('desktop shell surfaces relay-assisted topic connectivity in diagnostics', async () => {
+test('desktop shell surfaces docs-assisted topic recovery in diagnostics', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi({ assistPeerIds: ['relay-peer'] })} />);
 
   const drawer = await openSettingsSection(user, 'discovery');
   await waitFor(() => {
-    expect(within(drawer).getByText('Relay-assisted Peers')).toBeInTheDocument();
-    expect(within(drawer).getByText('relay-peer')).toBeInTheDocument();
+    expect(within(drawer).getByText('Docs Assist Peers')).toBeInTheDocument();
+    expect(within(drawer).getAllByText('relay-peer').length).toBeGreaterThan(0);
   });
 
   await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:relay');
@@ -2149,14 +2149,18 @@ test('desktop shell surfaces relay-assisted topic connectivity in diagnostics', 
   await waitFor(() => {
     const relayTopic = screen.getByRole('button', { name: 'kukuri:topic:relay' }).closest('li');
     expect(relayTopic).not.toBeNull();
-    expect(relayTopic).toHaveTextContent('relay-assisted / peers: 1');
+    expect(relayTopic).toHaveTextContent('recovering / peers: 0');
     expect(relayTopic).not.toHaveTextContent('relay-assisted sync available via 1 peer(s)');
   });
 
   await user.click(within(drawer).getByTestId('settings-section-connectivity'));
   const relayHeading = await within(drawer).findByRole('heading', { name: 'kukuri:topic:relay' });
   const relaySection = closestSection(relayHeading);
-  expect(within(relaySection).getByText('relay-assisted sync available via 1 peer(s)')).toBeInTheDocument();
+  expect(
+    within(relaySection).getByText(
+      'docs-assisted recovery is in progress via 1 peer(s); live topic delivery is unavailable'
+    )
+  ).toBeInTheDocument();
 });
 
 test('desktop shell renders diagnostics error reasons', async () => {

--- a/apps/desktop/src/shell/selectors.ts
+++ b/apps/desktop/src/shell/selectors.ts
@@ -294,29 +294,41 @@ export function syncStatusBadgeTone(
   if (syncStatus.last_error) {
     return 'destructive';
   }
-  return syncStatus.connected ? 'accent' : 'warning';
+  return syncStatus.delivery_state === 'Live' ? 'accent' : 'warning';
 }
 
 export function syncStatusBadgeLabel(syncStatus: SyncStatus): string {
   if (syncStatus.last_error) {
     return translate('common:states.error');
   }
-  return syncStatus.connected
-    ? translate('common:states.connected')
-    : translate('common:states.waiting');
+  switch (syncStatus.delivery_state) {
+    case 'Live':
+      return translate('common:states.connected');
+    case 'DurableReady':
+      return 'durable';
+    case 'DurableRecovering':
+      return 'recovering';
+    case 'Offline':
+    default:
+      return translate('common:states.waiting');
+  }
 }
 
 export function topicConnectionLabel(diagnostic?: TopicSyncStatus): string {
   if (!diagnostic) {
     return 'idle';
   }
-  if (diagnostic.connected_peers.length > 0) {
-    return 'joined';
+  switch (diagnostic.delivery_state) {
+    case 'Live':
+      return 'joined';
+    case 'DurableReady':
+      return 'durable';
+    case 'DurableRecovering':
+      return 'recovering';
+    case 'Offline':
+    default:
+      return diagnostic.joined ? 'joined' : 'idle';
   }
-  if (diagnostic.assist_peer_ids.length > 0) {
-    return 'relay-assisted';
-  }
-  return diagnostic.joined ? 'joined' : 'idle';
 }
 
 export function communityNodeConnectivityUrlsLabel(
@@ -407,8 +419,11 @@ export function translateTopicConnectionText(label: string): string {
   if (label === 'joined') {
     return translate('common:states.joined');
   }
-  if (label === 'relay-assisted') {
-    return translate('common:states.relayAssisted');
+  if (label === 'durable') {
+    return 'durable';
+  }
+  if (label === 'recovering') {
+    return 'recovering';
   }
   if (label === 'idle') {
     return translate('common:states.idle');

--- a/apps/desktop/src/shell/store.ts
+++ b/apps/desktop/src/shell/store.ts
@@ -317,6 +317,7 @@ function parseInitialSettingsSection(): {
 
 export const DEFAULT_SYNC_STATUS: SyncStatus = {
   connected: false,
+  delivery_state: 'Offline',
   peer_count: 0,
   pending_events: 0,
   status_detail: '',
@@ -333,7 +334,8 @@ export const DEFAULT_SYNC_STATUS: SyncStatus = {
     bootstrap_seed_peer_ids: [],
     manual_ticket_peer_ids: [],
     connected_peer_ids: [],
-    assist_peer_ids: [],
+    docs_assist_peer_ids: [],
+    blob_assist_peer_ids: [],
     local_endpoint_id: '',
     last_discovery_error: null,
   },

--- a/apps/desktop/src/shell/useDesktopShellViewModels.ts
+++ b/apps/desktop/src/shell/useDesktopShellViewModels.ts
@@ -316,10 +316,15 @@ export function useDesktopShellViewModels({
       [
         ...new Set([
           ...syncStatus.topic_diagnostics.flatMap((diagnostic) => diagnostic.connected_peers),
-          ...syncStatus.discovery.assist_peer_ids,
+          ...syncStatus.discovery.docs_assist_peer_ids,
+          ...syncStatus.discovery.blob_assist_peer_ids,
         ]),
       ],
-    [syncStatus.discovery.assist_peer_ids, syncStatus.topic_diagnostics]
+    [
+      syncStatus.discovery.blob_assist_peer_ids,
+      syncStatus.discovery.docs_assist_peer_ids,
+      syncStatus.topic_diagnostics,
+    ]
   );
 
   const buildPostCardView = useCallback(
@@ -678,7 +683,7 @@ export function useDesktopShellViewModels({
           statusDetail:
             diagnostic?.status_detail ?? t('settings:connectivity.summaryDetailFallback'),
           connectedPeersLabel: formatListLabel(diagnostic?.connected_peers ?? []),
-          relayAssistedPeersLabel: formatListLabel(diagnostic?.assist_peer_ids ?? []),
+          relayAssistedPeersLabel: formatListLabel(diagnostic?.docs_assist_peer_ids ?? []),
           configuredPeersLabel: formatListLabel(diagnostic?.configured_peer_ids ?? []),
           missingPeersLabel: formatListLabel(diagnostic?.missing_peer_ids ?? []),
           lastError: diagnostic?.last_error ?? null,
@@ -760,8 +765,13 @@ export function useDesktopShellViewModels({
           monospace: true,
         },
         {
-          label: t('settings:discovery.diagnostics.relayAssistedPeers'),
-          value: formatListLabel(syncStatus.discovery.assist_peer_ids),
+          label: 'Docs Assist Peers',
+          value: formatListLabel(syncStatus.discovery.docs_assist_peer_ids),
+          monospace: true,
+        },
+        {
+          label: 'Blob Assist Peers',
+          value: formatListLabel(syncStatus.discovery.blob_assist_peer_ids),
           monospace: true,
         },
         {
@@ -800,11 +810,12 @@ export function useDesktopShellViewModels({
       discoveryEditorDirty,
       discoveryError,
       discoverySeedInput,
-      syncStatus.discovery.assist_peer_ids,
+      syncStatus.discovery.blob_assist_peer_ids,
       syncStatus.discovery.bootstrap_seed_peer_ids,
       syncStatus.discovery.configured_seed_peer_ids,
       syncStatus.discovery.connect_mode,
       syncStatus.discovery.connected_peer_ids,
+      syncStatus.discovery.docs_assist_peer_ids,
       syncStatus.discovery.last_discovery_error,
       syncStatus.discovery.local_endpoint_id,
       syncStatus.discovery.manual_ticket_peer_ids,

--- a/crates/app-api/src/reactions.rs
+++ b/crates/app-api/src/reactions.rs
@@ -72,7 +72,8 @@ impl AppService {
                 &target.source_replica_id,
             ))
             .await?;
-        self.hint_transport
+        if let Err(error) = self
+            .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(target_topic_id.as_str(), target_channel_id.as_ref()),
                 GossipHint::TopicObjectsChanged {
@@ -83,7 +84,15 @@ impl AppService {
                     }],
                 },
             )
-            .await?;
+            .await
+        {
+            warn!(
+                topic = %target_topic_id.as_str(),
+                object_id = %target_object_id.as_str(),
+                error = %error,
+                "failed to publish reaction hint; durable docs state was already persisted"
+            );
+        }
         *self.last_sync_ts.lock().await = Some(Utc::now().timestamp_millis());
         self.reaction_state_for_target(&target.source_replica_id, &target_object_id)
             .await

--- a/crates/app-api/src/service.rs
+++ b/crates/app-api/src/service.rs
@@ -65,6 +65,8 @@ pub(crate) use tracing::{info, warn};
 
 pub(crate) const REPLICA_SYNC_RESTART_RETRY_SECONDS: i64 = 5;
 pub(crate) const DIRECT_MESSAGE_SUBSCRIPTION_RESTART_RETRY_SECONDS: i64 = 5;
+pub(crate) const PUBLIC_TOPIC_RECOVERY_GRACE_MS: i64 = 3_000;
+pub(crate) const PUBLIC_TOPIC_RECOVERY_BACKOFF_MS: [i64; 3] = [3_000, 10_000, 30_000];
 pub(crate) const PUBLIC_CHANNEL_ID: &str = "public";
 pub(crate) const DIRECT_MESSAGE_FRAME_MIME: &str =
     "application/vnd.kukuri.direct-message-frame+json";
@@ -99,6 +101,41 @@ pub(crate) async fn maybe_restart_replica_sync_with_cooldown(
             "failed to restart replica sync"
         );
     }
+}
+
+pub(crate) async fn record_public_topic_docs_activity_if_current(
+    delivery: &Arc<Mutex<HashMap<String, PublicTopicDeliveryStatus>>>,
+    topic_id: &str,
+    generation: u64,
+    at_ms: i64,
+) {
+    let mut guard = delivery.lock().await;
+    if let Some(entry) = guard.get_mut(topic_id)
+        && entry.generation == generation
+    {
+        entry.last_docs_activity_at = Some(at_ms);
+    }
+}
+
+pub(crate) async fn restart_replica_sync_with_backoff(
+    docs_sync: &dyn DocsSync,
+    topic_id: &str,
+    replica: &ReplicaId,
+    backoff: &mut SubscriptionRecoveryBackoff,
+) {
+    let now_ms = Utc::now().timestamp_millis();
+    if !backoff.ready(now_ms) {
+        return;
+    }
+    if let Err(error) = docs_sync.restart_replica_sync(replica).await {
+        warn!(
+            topic = %topic_id,
+            replica = %replica.as_str(),
+            error = %error,
+            "failed to restart replica sync"
+        );
+    }
+    backoff.schedule(now_ms);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -143,9 +180,44 @@ pub struct AppService {
     pub(crate) joined_private_channels: Arc<Mutex<HashMap<String, JoinedPrivateChannelState>>>,
     pub(crate) live_presence_tasks: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
     pub(crate) last_sync_ts: Arc<Mutex<Option<i64>>>,
+    pub(crate) subscription_generations: Arc<Mutex<HashMap<String, u64>>>,
+    pub(crate) public_topic_delivery: Arc<Mutex<HashMap<String, PublicTopicDeliveryStatus>>>,
     pub(crate) direct_message_subscription_restart_deadlines: Arc<Mutex<HashMap<String, i64>>>,
     pub(crate) replica_sync_restart_deadlines: Arc<Mutex<HashMap<String, i64>>>,
     pub(crate) empty_recovery_candidates: Arc<Mutex<HashSet<String>>>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct PublicTopicDeliveryStatus {
+    pub(crate) generation: u64,
+    pub(crate) last_docs_activity_at: Option<i64>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SubscriptionRecoveryBackoff {
+    pub(crate) next_retry_at_ms: i64,
+    pub(crate) step: usize,
+}
+
+impl SubscriptionRecoveryBackoff {
+    pub(crate) fn reset(&mut self) {
+        self.next_retry_at_ms = 0;
+        self.step = 0;
+    }
+
+    pub(crate) fn ready(&self, now_ms: i64) -> bool {
+        self.next_retry_at_ms <= now_ms
+    }
+
+    pub(crate) fn schedule(&mut self, now_ms: i64) {
+        let delay_ms = PUBLIC_TOPIC_RECOVERY_BACKOFF_MS[self
+            .step
+            .min(PUBLIC_TOPIC_RECOVERY_BACKOFF_MS.len().saturating_sub(1))];
+        self.next_retry_at_ms = now_ms.saturating_add(delay_ms);
+        if self.step + 1 < PUBLIC_TOPIC_RECOVERY_BACKOFF_MS.len() {
+            self.step += 1;
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -258,6 +330,8 @@ impl AppService {
             joined_private_channels: Arc::new(Mutex::new(HashMap::new())),
             live_presence_tasks: Arc::new(Mutex::new(HashMap::new())),
             last_sync_ts: Arc::new(Mutex::new(None)),
+            subscription_generations: Arc::new(Mutex::new(HashMap::new())),
+            public_topic_delivery: Arc::new(Mutex::new(HashMap::new())),
             direct_message_subscription_restart_deadlines: Arc::new(Mutex::new(HashMap::new())),
             replica_sync_restart_deadlines: Arc::new(Mutex::new(HashMap::new())),
             empty_recovery_candidates: Arc::new(Mutex::new(HashSet::new())),
@@ -370,15 +444,95 @@ impl AppService {
         Ok(None)
     }
 
-    pub(crate) async fn assisted_peer_ids(&self) -> Result<Vec<String>> {
-        Ok(merge_peer_ids(
-            self.docs_sync.assist_peer_ids().await?,
-            self.blob_service.assist_peer_ids().await?,
-        ))
-    }
-
     pub(crate) async fn docs_assisted_peer_ids(&self) -> Result<Vec<String>> {
         self.docs_sync.assist_peer_ids().await
+    }
+
+    pub(crate) async fn blob_assisted_peer_ids(&self) -> Result<Vec<String>> {
+        self.blob_service.assist_peer_ids().await
+    }
+
+    pub(crate) async fn next_subscription_generation(&self, key: &str) -> u64 {
+        let mut generations = self.subscription_generations.lock().await;
+        let generation = generations
+            .get(key)
+            .copied()
+            .unwrap_or_default()
+            .saturating_add(1);
+        generations.insert(key.to_string(), generation);
+        generation
+    }
+
+    pub(crate) async fn reset_public_topic_delivery_generation(
+        &self,
+        topic_id: &str,
+        generation: u64,
+    ) {
+        self.public_topic_delivery.lock().await.insert(
+            topic_id.to_string(),
+            PublicTopicDeliveryStatus {
+                generation,
+                last_docs_activity_at: None,
+            },
+        );
+    }
+
+    pub(crate) async fn clear_public_topic_delivery(&self, topic_id: &str) {
+        self.public_topic_delivery.lock().await.remove(topic_id);
+    }
+
+    pub(crate) async fn public_topic_delivery_status(
+        &self,
+        topic_id: &str,
+    ) -> Option<PublicTopicDeliveryStatus> {
+        self.public_topic_delivery
+            .lock()
+            .await
+            .get(topic_id)
+            .copied()
+    }
+
+    pub(crate) async fn restart_active_subscriptions(&self) -> Result<()> {
+        let topics = self
+            .subscriptions
+            .lock()
+            .await
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        for topic in topics {
+            self.restart_topic_subscription(topic.as_str()).await?;
+        }
+
+        let private_channels = self
+            .joined_private_channels
+            .lock()
+            .await
+            .values()
+            .map(|state| {
+                (
+                    state.topic_id.clone(),
+                    state.channel_id.as_str().to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        for (topic_id, channel_id) in private_channels {
+            self.restart_private_channel_subscription(topic_id.as_str(), channel_id.as_str())
+                .await?;
+        }
+
+        let authors = self
+            .author_subscriptions
+            .lock()
+            .await
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        for author in authors {
+            self.restart_author_subscription(author.as_str()).await?;
+        }
+        self.restart_direct_message_subscriptions().await?;
+        Ok(())
     }
 
     pub async fn shutdown(&self) {
@@ -1040,16 +1194,28 @@ impl AppService {
         let docs_sync = Arc::clone(&self.docs_sync);
         let blob_service = Arc::clone(&self.blob_service);
         let hint_transport = Arc::clone(&self.hint_transport);
+        let transport = Arc::clone(&self.transport);
         let last_sync = Arc::clone(&self.last_sync_ts);
-        let replica_sync_restart_deadlines = Arc::clone(&self.replica_sync_restart_deadlines);
+        let public_topic_delivery = Arc::clone(&self.public_topic_delivery);
         let topic = topic_id.to_string();
         let storage_channel_id = channel_storage_id(channel_id.as_ref());
         let local_author_pubkey = self.current_author_pubkey();
+        let subscription_key = private_key.clone().unwrap_or_else(|| topic_id.to_string());
+        let generation = self
+            .next_subscription_generation(subscription_key.as_str())
+            .await;
+        let is_public_topic = channel_id.is_none() && private_key.is_none();
+        if is_public_topic {
+            self.reset_public_topic_delivery_generation(topic_id, generation)
+                .await;
+        }
         docs_sync.open_replica(&replica).await?;
         let notification_baseline =
             snapshot_object_notification_baseline(docs_sync.as_ref(), &replica).await?;
         let mut doc_stream = docs_sync.subscribe_replica(&replica).await?;
         let mut hint_stream = hint_transport.subscribe_hints(&hint_topic).await?;
+        let mut recovery_tick = tokio::time::interval(std::time::Duration::from_secs(1));
+        recovery_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         let replica_for_task = replica.clone();
         let hint_topic_for_task = hint_topic.clone();
         let handle = tokio::spawn(async move {
@@ -1061,10 +1227,16 @@ impl AppService {
                 &replica_for_task,
             )
             .await;
+            let mut recovery_backoff = SubscriptionRecoveryBackoff::default();
+            let mut last_docs_activity_at = None;
+            let mut recovery_probe_due_at = Utc::now()
+                .timestamp_millis()
+                .saturating_add(PUBLIC_TOPIC_RECOVERY_GRACE_MS);
             loop {
                 tokio::select! {
                     Some(event) = doc_stream.next() => {
                         if let Ok(event) = event {
+                            let now = Utc::now().timestamp_millis();
                             if let Some(source_peer) = event.source_peer.as_deref()
                             {
                                 if let Err(error) = docs_sync.learn_peer(source_peer).await {
@@ -1093,7 +1265,7 @@ impl AppService {
                                 &event,
                             ).await {
                                 Ok(true) => {
-                                    *last_sync.lock().await = Some(Utc::now().timestamp_millis());
+                                    *last_sync.lock().await = Some(now);
                                 }
                                 Ok(false) => {}
                                 Err(error) => {
@@ -1115,7 +1287,20 @@ impl AppService {
                             ).await
                             && count > 0
                             {
-                                *last_sync.lock().await = Some(Utc::now().timestamp_millis());
+                                if is_public_topic && event.source_peer.is_some() {
+                                    record_public_topic_docs_activity_if_current(
+                                        &public_topic_delivery,
+                                        topic.as_str(),
+                                        generation,
+                                        now,
+                                    )
+                                    .await;
+                                    last_docs_activity_at = Some(now);
+                                    recovery_backoff.reset();
+                                    recovery_probe_due_at =
+                                        now.saturating_add(PUBLIC_TOPIC_RECOVERY_GRACE_MS);
+                                }
+                                *last_sync.lock().await = Some(now);
                             }
                         }
                     }
@@ -1157,7 +1342,7 @@ impl AppService {
                                     *last_sync.lock().await = Some(now);
                                 }
                                 _ => {
-                                    let hydrated = match hydrate_subscription_hint_with_services(
+                                    let mut hydrated = match hydrate_subscription_hint_with_services(
                                         docs_sync.as_ref(),
                                         blob_service.as_ref(),
                                         projection_store.as_ref(),
@@ -1176,21 +1361,148 @@ impl AppService {
                                             0
                                         }
                                     };
-                                    if hydrated == 0
-                                    {
-                                        maybe_restart_replica_sync_with_cooldown(
+                                    let now = Utc::now().timestamp_millis();
+                                    if hydrated == 0 && is_public_topic {
+                                        hydrated = match hydrate_subscription_state_with_services(
                                             docs_sync.as_ref(),
-                                            &replica_sync_restart_deadlines,
+                                            blob_service.as_ref(),
+                                            projection_store.as_ref(),
                                             topic.as_str(),
                                             &replica_for_task,
                                         )
-                                        .await;
+                                        .await {
+                                            Ok(count) => count,
+                                            Err(error) => {
+                                                warn!(
+                                                    topic = %topic,
+                                                    error = %error,
+                                                    "failed to hydrate subscription from docs-first recovery probe"
+                                                );
+                                                0
+                                            }
+                                        };
                                     }
                                     if hydrated > 0 {
-                                        *last_sync.lock().await = Some(Utc::now().timestamp_millis());
+                                        if is_public_topic && !event.source_peer.is_empty() {
+                                            record_public_topic_docs_activity_if_current(
+                                                &public_topic_delivery,
+                                                topic.as_str(),
+                                                generation,
+                                                now,
+                                            )
+                                            .await;
+                                            last_docs_activity_at = Some(now);
+                                            recovery_backoff.reset();
+                                            recovery_probe_due_at =
+                                                now.saturating_add(PUBLIC_TOPIC_RECOVERY_GRACE_MS);
+                                        }
+                                        *last_sync.lock().await = Some(now);
+                                    } else {
+                                        restart_replica_sync_with_backoff(
+                                            docs_sync.as_ref(),
+                                            topic.as_str(),
+                                            &replica_for_task,
+                                            &mut recovery_backoff,
+                                        )
+                                        .await;
+                                        recovery_probe_due_at =
+                                            now.saturating_add(PUBLIC_TOPIC_RECOVERY_GRACE_MS);
                                     }
                                 }
                             }
+                        }
+                    }
+                    _ = recovery_tick.tick(), if is_public_topic => {
+                        let now = Utc::now().timestamp_millis();
+                        if last_docs_activity_at.is_some() || recovery_probe_due_at > now {
+                            continue;
+                        }
+                        let (has_live_topic_peer, has_configured_topic_peer) =
+                            match transport.peers().await {
+                            Ok(snapshot) => snapshot
+                                .topic_diagnostics
+                                .iter()
+                                .find(|diagnostic| {
+                                    normalize_topic_name(diagnostic.topic.clone()).as_deref()
+                                        == Some(topic.as_str())
+                                })
+                                .map(|diagnostic| {
+                                    (
+                                        diagnostic.joined
+                                            && !diagnostic.connected_peers.is_empty(),
+                                        !diagnostic.configured_peer_ids.is_empty(),
+                                    )
+                                })
+                                .unwrap_or((false, false)),
+                            Err(error) => {
+                                warn!(
+                                    topic = %topic,
+                                    error = %error,
+                                    "failed to inspect live topic peer state during recovery tick"
+                                );
+                                (false, false)
+                            }
+                        };
+                        if has_live_topic_peer {
+                            continue;
+                        }
+                        let docs_assist_peer_count = match docs_sync.assist_peer_ids().await {
+                            Ok(peer_ids) => peer_ids.len(),
+                            Err(error) => {
+                                warn!(
+                                    topic = %topic,
+                                    error = %error,
+                                    "failed to inspect docs-assisted peers during recovery tick"
+                                );
+                                0
+                            }
+                        };
+                        if docs_assist_peer_count == 0 && !has_configured_topic_peer {
+                            continue;
+                        }
+                        let hydrated = match hydrate_subscription_state_with_services(
+                            docs_sync.as_ref(),
+                            blob_service.as_ref(),
+                            projection_store.as_ref(),
+                            topic.as_str(),
+                            &replica_for_task,
+                        )
+                        .await {
+                            Ok(count) => count,
+                            Err(error) => {
+                                warn!(
+                                    topic = %topic,
+                                    error = %error,
+                                    "failed to hydrate subscription during periodic docs-first recovery"
+                                );
+                                0
+                            }
+                        };
+                        if hydrated > 0 {
+                            if docs_assist_peer_count > 0 {
+                                record_public_topic_docs_activity_if_current(
+                                    &public_topic_delivery,
+                                    topic.as_str(),
+                                    generation,
+                                    now,
+                                )
+                                .await;
+                                last_docs_activity_at = Some(now);
+                            }
+                            recovery_backoff.reset();
+                            recovery_probe_due_at =
+                                now.saturating_add(PUBLIC_TOPIC_RECOVERY_GRACE_MS);
+                            *last_sync.lock().await = Some(now);
+                        } else {
+                            restart_replica_sync_with_backoff(
+                                docs_sync.as_ref(),
+                                topic.as_str(),
+                                &replica_for_task,
+                                &mut recovery_backoff,
+                            )
+                            .await;
+                            recovery_probe_due_at =
+                                now.saturating_add(PUBLIC_TOPIC_RECOVERY_GRACE_MS);
                         }
                     }
                     else => {
@@ -6863,40 +7175,81 @@ pub(crate) fn normalize_topic_diagnostics(
     merged.into_values().collect()
 }
 
-pub(crate) fn merge_peer_ids(left: Vec<String>, right: Vec<String>) -> Vec<String> {
-    left.into_iter()
-        .chain(right)
-        .filter(|peer| !peer.trim().is_empty())
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect()
+pub(crate) fn merge_optional_timestamp(left: Option<i64>, right: Option<i64>) -> Option<i64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (None, value) | (value, None) => value,
+    }
+}
+
+pub(crate) fn combine_delivery_states(left: DeliveryState, right: DeliveryState) -> DeliveryState {
+    use DeliveryState::*;
+
+    match (left, right) {
+        (Live, _) | (_, Live) => Live,
+        (DurableReady, _) | (_, DurableReady) => DurableReady,
+        (DurableRecovering, _) | (_, DurableRecovering) => DurableRecovering,
+        _ => Offline,
+    }
+}
+
+pub(crate) fn delivery_state_for_topic(
+    gossip_peer_count: usize,
+    docs_assist_peer_count: usize,
+    last_docs_activity_at: Option<i64>,
+) -> DeliveryState {
+    if gossip_peer_count > 0 {
+        DeliveryState::Live
+    } else if last_docs_activity_at.is_some() {
+        DeliveryState::DurableReady
+    } else if docs_assist_peer_count > 0 {
+        DeliveryState::DurableRecovering
+    } else {
+        DeliveryState::Offline
+    }
 }
 
 pub(crate) fn effective_sync_status_detail(
     base: &str,
-    gossip_peer_count: usize,
-    assist_peer_count: usize,
+    delivery_state: DeliveryState,
+    docs_assist_peer_count: usize,
     subscribed_topic_count: usize,
 ) -> String {
-    if gossip_peer_count > 0 || assist_peer_count == 0 {
-        return base.to_string();
-    }
-    if subscribed_topic_count > 0 {
-        format!("relay-assisted sync available via {assist_peer_count} peer(s)")
-    } else {
-        format!("relay-assisted connectivity available via {assist_peer_count} peer(s)")
+    match delivery_state {
+        DeliveryState::Live | DeliveryState::Offline => base.to_string(),
+        DeliveryState::DurableRecovering => {
+            if subscribed_topic_count > 0 {
+                format!(
+                    "docs-assisted recovery is in progress via {docs_assist_peer_count} peer(s); live topic delivery is unavailable"
+                )
+            } else {
+                format!(
+                    "docs-assisted recovery is in progress via {docs_assist_peer_count} peer(s)"
+                )
+            }
+        }
+        DeliveryState::DurableReady => {
+            format!(
+                "docs-assisted durable sync is available via {docs_assist_peer_count} peer(s); live topic delivery is unavailable"
+            )
+        }
     }
 }
 
 pub(crate) fn effective_topic_status_detail(
     base: &str,
-    gossip_peer_count: usize,
-    assist_peer_count: usize,
+    delivery_state: DeliveryState,
+    docs_assist_peer_count: usize,
 ) -> String {
-    if gossip_peer_count > 0 || assist_peer_count == 0 {
-        return base.to_string();
+    match delivery_state {
+        DeliveryState::Live | DeliveryState::Offline => base.to_string(),
+        DeliveryState::DurableRecovering => format!(
+            "docs-assisted recovery is in progress via {docs_assist_peer_count} peer(s); live topic delivery is unavailable"
+        ),
+        DeliveryState::DurableReady => format!(
+            "docs-assisted durable sync is available via {docs_assist_peer_count} peer(s); live topic delivery is unavailable"
+        ),
     }
-    format!("relay-assisted sync available via {assist_peer_count} peer(s)")
 }
 
 impl Drop for AppService {

--- a/crates/app-api/src/sync.rs
+++ b/crates/app-api/src/sync.rs
@@ -5,7 +5,7 @@ impl AppService {
         let PeerSnapshot {
             connected,
             peer_count,
-            connected_peers,
+            connected_peers: _,
             configured_peers,
             subscribed_topics,
             pending_events,
@@ -15,53 +15,77 @@ impl AppService {
         } = self.transport.peers().await?;
         let subscribed_topics = normalize_topics(subscribed_topics);
         let topic_diagnostics = normalize_topic_diagnostics(topic_diagnostics);
-        let assist_peer_ids = self.docs_assisted_peer_ids().await?;
-        let effective_connected_peer_ids =
-            merge_peer_ids(connected_peers.clone(), assist_peer_ids.clone());
+        let docs_assist_peer_ids = self.docs_assisted_peer_ids().await?;
         let discovery = self.get_discovery_status().await?;
+        let mut effective_delivery_state = if connected {
+            DeliveryState::Live
+        } else {
+            DeliveryState::Offline
+        };
+        let mut effective_last_docs_activity_at = None;
+        let mut effective_topic_diagnostics = Vec::with_capacity(topic_diagnostics.len());
+
+        for diagnostic in topic_diagnostics {
+            let delivery = self
+                .public_topic_delivery_status(diagnostic.topic.as_str())
+                .await;
+            let last_docs_activity_at = delivery.and_then(|status| status.last_docs_activity_at);
+            let delivery_state = delivery_state_for_topic(
+                diagnostic.connected_peers.len(),
+                docs_assist_peer_ids.len(),
+                last_docs_activity_at,
+            );
+            effective_delivery_state =
+                combine_delivery_states(effective_delivery_state, delivery_state);
+            effective_last_docs_activity_at =
+                merge_optional_timestamp(effective_last_docs_activity_at, last_docs_activity_at);
+            effective_topic_diagnostics.push(TopicSyncStatus {
+                topic: diagnostic.topic,
+                joined: diagnostic.joined,
+                delivery_state,
+                peer_count: diagnostic.peer_count,
+                connected_peers: diagnostic.connected_peers,
+                docs_assist_peer_ids: docs_assist_peer_ids.clone(),
+                configured_peer_ids: diagnostic.configured_peer_ids,
+                missing_peer_ids: diagnostic.missing_peer_ids,
+                last_received_at: diagnostic.last_received_at,
+                last_docs_activity_at,
+                status_detail: effective_topic_status_detail(
+                    diagnostic.status_detail.as_str(),
+                    delivery_state,
+                    docs_assist_peer_ids.len(),
+                ),
+                last_error: diagnostic.last_error,
+            });
+        }
+
+        if effective_delivery_state == DeliveryState::Offline
+            && !docs_assist_peer_ids.is_empty()
+            && !subscribed_topics.is_empty()
+        {
+            effective_delivery_state = if effective_last_docs_activity_at.is_some() {
+                DeliveryState::DurableReady
+            } else {
+                DeliveryState::DurableRecovering
+            };
+        }
 
         Ok(SyncStatus {
-            connected: connected || !assist_peer_ids.is_empty(),
+            connected,
+            delivery_state: effective_delivery_state,
             last_sync_ts: *self.last_sync_ts.lock().await,
-            peer_count: peer_count.max(effective_connected_peer_ids.len()),
+            peer_count,
             pending_events,
             status_detail: effective_sync_status_detail(
                 status_detail.as_str(),
-                connected_peers.len(),
-                assist_peer_ids.len(),
+                effective_delivery_state,
+                docs_assist_peer_ids.len(),
                 subscribed_topics.len(),
             ),
             last_error,
             configured_peers,
             subscribed_topics,
-            topic_diagnostics: topic_diagnostics
-                .into_iter()
-                .map(|diagnostic| {
-                    let gossip_peer_count = diagnostic.connected_peers.len();
-                    TopicSyncStatus {
-                        topic: diagnostic.topic,
-                        joined: diagnostic.joined || !assist_peer_ids.is_empty(),
-                        peer_count: diagnostic.peer_count.max(
-                            merge_peer_ids(
-                                diagnostic.connected_peers.clone(),
-                                assist_peer_ids.clone(),
-                            )
-                            .len(),
-                        ),
-                        connected_peers: diagnostic.connected_peers,
-                        assist_peer_ids: assist_peer_ids.clone(),
-                        configured_peer_ids: diagnostic.configured_peer_ids,
-                        missing_peer_ids: diagnostic.missing_peer_ids,
-                        last_received_at: diagnostic.last_received_at,
-                        status_detail: effective_topic_status_detail(
-                            diagnostic.status_detail.as_str(),
-                            gossip_peer_count,
-                            assist_peer_ids.len(),
-                        ),
-                        last_error: diagnostic.last_error,
-                    }
-                })
-                .collect(),
+            topic_diagnostics: effective_topic_diagnostics,
             local_author_pubkey: self.current_author_pubkey(),
             discovery,
         })
@@ -79,7 +103,8 @@ impl AppService {
             local_endpoint_id,
             last_discovery_error,
         } = self.transport.discovery().await?;
-        let assist_peer_ids = self.assisted_peer_ids().await?;
+        let docs_assist_peer_ids = self.docs_assisted_peer_ids().await?;
+        let blob_assist_peer_ids = self.blob_assisted_peer_ids().await?;
         Ok(DiscoveryStatus {
             mode,
             connect_mode,
@@ -88,7 +113,8 @@ impl AppService {
             bootstrap_seed_peer_ids,
             manual_ticket_peer_ids,
             connected_peer_ids,
-            assist_peer_ids,
+            docs_assist_peer_ids,
+            blob_assist_peer_ids,
             local_endpoint_id,
             last_discovery_error,
         })
@@ -98,33 +124,7 @@ impl AppService {
         self.transport.import_ticket(ticket).await?;
         self.docs_sync.import_peer_ticket(ticket).await?;
         self.blob_service.import_peer_ticket(ticket).await?;
-        let existing_private_topics = self
-            .joined_private_channels
-            .lock()
-            .await
-            .values()
-            .map(|state| {
-                (
-                    state.topic_id.clone(),
-                    state.channel_id.as_str().to_string(),
-                )
-            })
-            .collect::<Vec<_>>();
-        for (topic_id, channel_id) in existing_private_topics {
-            self.restart_private_channel_subscription(topic_id.as_str(), channel_id.as_str())
-                .await?;
-        }
-        let existing_authors = self
-            .author_subscriptions
-            .lock()
-            .await
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        for author in existing_authors {
-            self.restart_author_subscription(author.as_str()).await?;
-        }
-        self.restart_direct_message_subscriptions().await?;
+        self.restart_active_subscriptions().await?;
         Ok(())
     }
 
@@ -151,33 +151,7 @@ impl AppService {
         self.blob_service
             .set_seed_peers(effective_seed_peers)
             .await?;
-        let existing_private_topics = self
-            .joined_private_channels
-            .lock()
-            .await
-            .values()
-            .map(|state| {
-                (
-                    state.topic_id.clone(),
-                    state.channel_id.as_str().to_string(),
-                )
-            })
-            .collect::<Vec<_>>();
-        for (topic_id, channel_id) in existing_private_topics {
-            self.restart_private_channel_subscription(topic_id.as_str(), channel_id.as_str())
-                .await?;
-        }
-        let existing_authors = self
-            .author_subscriptions
-            .lock()
-            .await
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
-        for author in existing_authors {
-            self.restart_author_subscription(author.as_str()).await?;
-        }
-        self.restart_direct_message_subscriptions().await?;
+        self.restart_active_subscriptions().await?;
         Ok(())
     }
 
@@ -185,6 +159,7 @@ impl AppService {
         if let Some(handle) = self.subscriptions.lock().await.remove(topic_id) {
             handle.abort();
         }
+        self.clear_public_topic_delivery(topic_id).await;
         let private_keys = self
             .private_channel_subscriptions
             .lock()

--- a/crates/app-api/src/tests/mod.rs
+++ b/crates/app-api/src/tests/mod.rs
@@ -72,17 +72,18 @@ fn format_sync_snapshot(status: &SyncStatus, topic: &str) -> String {
     let topic_status = status
         .topic_diagnostics
         .iter()
-        .find(|entry| entry.topic == topic)
-        .map(|entry| {
-            format!(
-                "topic_peers={}, connected_peers={:?}, assist_peer_ids={:?}, configured_peer_ids={:?}, status_detail={}",
-                entry.peer_count,
-                entry.connected_peers,
-                entry.assist_peer_ids,
-                entry.configured_peer_ids,
-                entry.status_detail
-            )
-        })
+            .find(|entry| entry.topic == topic)
+            .map(|entry| {
+                format!(
+                    "topic_peers={}, connected_peers={:?}, docs_assist_peer_ids={:?}, configured_peer_ids={:?}, delivery_state={:?}, status_detail={}",
+                    entry.peer_count,
+                    entry.connected_peers,
+                    entry.docs_assist_peer_ids,
+                    entry.configured_peer_ids,
+                    entry.delivery_state,
+                    entry.status_detail
+                )
+            })
         .unwrap_or_else(|| "topic_status=missing".to_string());
     format!(
         "connected={}, peer_count={}, status_detail={}, last_error={:?}, discovery_connected_peers={:?}, {}",
@@ -95,50 +96,16 @@ fn format_sync_snapshot(status: &SyncStatus, topic: &str) -> String {
     )
 }
 
-async fn wait_for_connected_peer_count(app: &AppService, expected: usize) {
-    match timeout(social_graph_propagation_timeout(), async {
-        let mut stable_ready_polls = 0usize;
-        loop {
-            let status = app.get_sync_status().await.expect("sync status");
-            if status.connected && status.peer_count >= expected {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return;
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    {
-        Ok(()) => {}
-        Err(_) => {
-            let status = app.get_sync_status().await.expect("sync status");
-            panic!(
-                "peer connection timeout; connected={}, peer_count={}, status_detail={}, last_error={:?}, discovery_connected_peers={:?}",
-                status.connected,
-                status.peer_count,
-                status.status_detail,
-                status.last_error,
-                status.discovery.connected_peer_ids
-            );
-        }
-    }
-}
-
 async fn wait_for_topic_peer_count(app: &AppService, topic: &str, expected: usize) {
     match timeout(social_graph_propagation_timeout(), async {
         let mut stable_ready_polls = 0usize;
         loop {
             let status = app.get_sync_status().await.expect("sync status");
             let ready = status.topic_diagnostics.iter().any(|entry| {
-                let relay_assisted_ready = entry.assist_peer_ids.len() >= expected;
                 entry.topic == topic
                     && entry.joined
                     && entry.peer_count >= expected
-                    && (entry.connected_peers.len() >= expected || relay_assisted_ready)
+                    && entry.connected_peers.len() >= expected
             });
             if ready {
                 stable_ready_polls += 1;
@@ -161,6 +128,47 @@ async fn wait_for_topic_peer_count(app: &AppService, topic: &str, expected: usiz
                 .map(|status| format_sync_snapshot(&status, topic))
                 .unwrap_or_else(|_| "failed to read sync status".to_string());
             panic!("topic connected-peer timeout for {topic}; {snapshot}");
+        }
+    }
+}
+
+async fn wait_for_topic_delivery(app: &AppService, topic: &str, expected: usize) {
+    match timeout(social_graph_propagation_timeout(), async {
+        let mut stable_ready_polls = 0usize;
+        loop {
+            let status = app.get_sync_status().await.expect("sync status");
+            let ready = status.topic_diagnostics.iter().any(|entry| {
+                let live_ready = entry.peer_count >= expected
+                    && entry.connected_peers.len() >= expected.min(1)
+                    && (entry.joined || matches!(entry.delivery_state, DeliveryState::Live));
+                let durable_ready = !entry.docs_assist_peer_ids.is_empty()
+                    && matches!(
+                        entry.delivery_state,
+                        DeliveryState::DurableRecovering | DeliveryState::DurableReady
+                    );
+                entry.topic == topic && (live_ready || durable_ready)
+            });
+            if ready {
+                stable_ready_polls += 1;
+                if stable_ready_polls >= 3 {
+                    return;
+                }
+            } else {
+                stable_ready_polls = 0;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    {
+        Ok(()) => {}
+        Err(_) => {
+            let snapshot = app
+                .get_sync_status()
+                .await
+                .map(|status| format_sync_snapshot(&status, topic))
+                .unwrap_or_else(|_| "failed to read sync status".to_string());
+            panic!("topic delivery timeout for {topic}; {snapshot}");
         }
     }
 }

--- a/crates/app-api/src/tests/private_channels.rs
+++ b/crates/app-api/src/tests/private_channels.rs
@@ -32,8 +32,8 @@ async fn private_channel_invite_scopes_posts_and_replies() {
         .list_timeline(topic, None, 20)
         .await
         .expect("warm invitee public timeline");
-    wait_for_topic_peer_count(&app_a, topic, 1).await;
-    wait_for_topic_peer_count(&app_b, topic, 1).await;
+    wait_for_topic_delivery(&app_a, topic, 1).await;
+    wait_for_topic_delivery(&app_b, topic, 1).await;
 
     let channel = app_a
         .create_private_channel(CreatePrivateChannelInput {
@@ -295,19 +295,15 @@ async fn friend_only_grant_requires_mutual_and_rotate_requires_fresh_grant() {
     let d_pubkey = keys_d.public_key_hex();
     let topic = "kukuri:topic:friend-only";
 
-    wait_for_connected_peer_count(&app_a, 2).await;
-    wait_for_connected_peer_count(&app_b, 1).await;
-    wait_for_connected_peer_count(&app_d, 1).await;
-
     for app in [&app_a, &app_b, &app_d] {
         let _ = app
             .list_timeline(topic, None, 20)
             .await
             .expect("subscribe public timeline");
     }
-    wait_for_topic_peer_count(&app_a, topic, 2).await;
-    wait_for_topic_peer_count(&app_b, topic, 1).await;
-    wait_for_topic_peer_count(&app_d, topic, 1).await;
+    wait_for_topic_delivery(&app_a, topic, 1).await;
+    wait_for_topic_delivery(&app_b, topic, 1).await;
+    wait_for_topic_delivery(&app_d, topic, 1).await;
     warm_author_social_view(&app_a, b_pubkey.as_str(), topic).await;
     warm_author_social_view(&app_b, a_pubkey.as_str(), topic).await;
     warm_author_social_view(&app_a, d_pubkey.as_str(), topic).await;
@@ -362,12 +358,11 @@ async fn friend_only_grant_requires_mutual_and_rotate_requires_fresh_grant() {
         .import_peer_ticket(&ticket_a)
         .await
         .expect("c imports a");
-    wait_for_connected_peer_count(&app_c, 1).await;
     let _ = app_c
         .list_timeline(topic, None, 20)
         .await
         .expect("subscribe public timeline c");
-    wait_for_topic_peer_count(&app_c, topic, 1).await;
+    wait_for_topic_delivery(&app_c, topic, 1).await;
     warm_author_social_view(&app_c, a_pubkey.as_str(), topic).await;
 
     let non_mutual_error = app_c
@@ -450,8 +445,8 @@ async fn friend_only_grant_requires_mutual_and_rotate_requires_fresh_grant() {
         .list_timeline(topic, None, 20)
         .await
         .expect("resubscribe d before fresh grant");
-    wait_for_topic_peer_count(&app_a, topic, 2).await;
-    wait_for_topic_peer_count(&app_d, topic, 1).await;
+    wait_for_topic_delivery(&app_a, topic, 1).await;
+    wait_for_topic_delivery(&app_d, topic, 1).await;
     warm_author_social_view(&app_a, d_pubkey.as_str(), topic).await;
     warm_author_social_view(&app_d, a_pubkey.as_str(), topic).await;
     wait_for_mutual_author_view(&app_a, d_pubkey.as_str(), topic).await;
@@ -569,7 +564,7 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
     let topic = "kukuri:topic:friend-plus";
     let social_timeout = social_graph_propagation_timeout();
     let replication_timeout = p2p_replication_timeout();
-    let rotation_timeout = Duration::from_secs(60);
+    let rotation_timeout = p2p_replication_timeout().max(Duration::from_secs(120));
 
     app_a
         .import_peer_ticket(&ticket_b)
@@ -579,8 +574,6 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
         .import_peer_ticket(&ticket_a)
         .await
         .expect("b imports a");
-    wait_for_connected_peer_count(&app_a, 1).await;
-    wait_for_connected_peer_count(&app_b, 1).await;
 
     for app in [&app_a, &app_b] {
         let _ = app
@@ -588,8 +581,10 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
             .await
             .expect("subscribe public timeline");
     }
-    wait_for_topic_peer_count(&app_a, topic, 1).await;
-    wait_for_topic_peer_count(&app_b, topic, 1).await;
+    wait_for_topic_delivery(&app_a, topic, 1).await;
+    wait_for_topic_delivery(&app_b, topic, 1).await;
+    warm_author_social_view(&app_a, b_pubkey.as_str(), topic).await;
+    warm_author_social_view(&app_b, a_pubkey.as_str(), topic).await;
 
     app_a
         .follow_author(b_pubkey.as_str())
@@ -673,17 +668,16 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
         .import_peer_ticket(&ticket_b)
         .await
         .expect("c imports b");
-    wait_for_connected_peer_count(&app_a, 2).await;
-    wait_for_connected_peer_count(&app_b, 2).await;
-    wait_for_connected_peer_count(&app_c, 2).await;
 
     let _ = app_c
         .list_timeline(topic, None, 20)
         .await
         .expect("subscribe public timeline c");
-    wait_for_topic_peer_count(&app_a, topic, 2).await;
-    wait_for_topic_peer_count(&app_b, topic, 2).await;
-    wait_for_topic_peer_count(&app_c, topic, 2).await;
+    wait_for_topic_delivery(&app_a, topic, 1).await;
+    wait_for_topic_delivery(&app_b, topic, 1).await;
+    wait_for_topic_delivery(&app_c, topic, 1).await;
+    warm_author_social_view(&app_b, c_pubkey.as_str(), topic).await;
+    warm_author_social_view(&app_c, b_pubkey.as_str(), topic).await;
 
     app_b
         .follow_author(c_pubkey.as_str())
@@ -787,14 +781,12 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
         .import_peer_ticket(&ticket_b)
         .await
         .expect("d imports b");
-    wait_for_connected_peer_count(&app_b, 3).await;
-    wait_for_connected_peer_count(&app_d, 1).await;
     let _ = app_d
         .list_timeline(topic, None, 20)
         .await
         .expect("subscribe public timeline d");
-    wait_for_topic_peer_count(&app_b, topic, 3).await;
-    wait_for_topic_peer_count(&app_d, topic, 1).await;
+    wait_for_topic_delivery(&app_b, topic, 1).await;
+    wait_for_topic_delivery(&app_d, topic, 1).await;
     warm_author_social_view(&app_b, d_pubkey.as_str(), topic).await;
     warm_author_social_view(&app_d, b_pubkey.as_str(), topic).await;
 
@@ -809,12 +801,9 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
     wait_for_mutual_author_view(&app_b, d_pubkey.as_str(), topic).await;
     wait_for_mutual_author_view(&app_d, b_pubkey.as_str(), topic).await;
 
-    let freeze_error_message = wait_for_friend_plus_share_rejection(
-        &app_d,
-        stale_share_for_d.as_str(),
-        replication_timeout,
-    )
-    .await;
+    let freeze_error_message =
+        wait_for_friend_plus_share_rejection(&app_d, stale_share_for_d.as_str(), rotation_timeout)
+            .await;
     assert!(
         freeze_error_message.contains("no longer open"),
         "unexpected frozen share error: {freeze_error_message}"

--- a/crates/app-api/src/tests/sync.rs
+++ b/crates/app-api/src/tests/sync.rs
@@ -290,11 +290,12 @@ async fn discovery_status_separates_bootstrap_seed_peers_from_manual_tickets() {
         discovery.manual_ticket_peer_ids,
         vec!["manual-ticket-peer".to_string()]
     );
-    assert!(discovery.assist_peer_ids.is_empty());
+    assert!(discovery.docs_assist_peer_ids.is_empty());
+    assert!(discovery.blob_assist_peer_ids.is_empty());
 }
 
 #[tokio::test]
-async fn relay_assisted_peers_contribute_to_sync_status_and_topic_counts() {
+async fn docs_assisted_peers_do_not_mark_live_sync_connected() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot {
         connected: false,
@@ -331,30 +332,35 @@ async fn relay_assisted_peers_contribute_to_sync_status_and_topic_counts() {
 
     let status = app.get_sync_status().await.expect("sync status");
 
-    assert!(status.connected);
-    assert_eq!(status.peer_count, 2);
+    assert!(!status.connected);
+    assert_eq!(status.delivery_state, DeliveryState::DurableRecovering);
+    assert_eq!(status.peer_count, 0);
     assert_eq!(
         status.status_detail,
-        "relay-assisted sync available via 2 peer(s)"
+        "docs-assisted recovery is in progress via 2 peer(s); live topic delivery is unavailable"
     );
     assert_eq!(
-        status.discovery.assist_peer_ids,
-        vec![
-            "peer-a".to_string(),
-            "peer-b".to_string(),
-            "peer-c".to_string()
-        ]
+        status.discovery.docs_assist_peer_ids,
+        vec!["peer-a".to_string(), "peer-b".to_string()]
+    );
+    assert_eq!(
+        status.discovery.blob_assist_peer_ids,
+        vec!["peer-b".to_string(), "peer-c".to_string()]
     );
     assert_eq!(status.topic_diagnostics.len(), 1);
-    assert!(status.topic_diagnostics[0].joined);
-    assert_eq!(status.topic_diagnostics[0].peer_count, 2);
+    assert!(!status.topic_diagnostics[0].joined);
     assert_eq!(
-        status.topic_diagnostics[0].assist_peer_ids,
+        status.topic_diagnostics[0].delivery_state,
+        DeliveryState::DurableRecovering
+    );
+    assert_eq!(status.topic_diagnostics[0].peer_count, 0);
+    assert_eq!(
+        status.topic_diagnostics[0].docs_assist_peer_ids,
         vec!["peer-a".to_string(), "peer-b".to_string()]
     );
     assert_eq!(
         status.topic_diagnostics[0].status_detail,
-        "relay-assisted sync available via 2 peer(s)"
+        "docs-assisted recovery is in progress via 2 peer(s); live topic delivery is unavailable"
     );
 }
 
@@ -395,13 +401,22 @@ async fn blob_only_assist_peers_do_not_mark_sync_healthy() {
     let status = app.get_sync_status().await.expect("sync status");
 
     assert!(!status.connected);
+    assert_eq!(status.delivery_state, DeliveryState::Offline);
     assert_eq!(status.peer_count, 0);
     assert_eq!(status.status_detail, "No peers configured");
-    assert_eq!(status.discovery.assist_peer_ids, vec!["peer-b".to_string()]);
+    assert!(status.discovery.docs_assist_peer_ids.is_empty());
+    assert_eq!(
+        status.discovery.blob_assist_peer_ids,
+        vec!["peer-b".to_string()]
+    );
     assert_eq!(status.topic_diagnostics.len(), 1);
     assert!(!status.topic_diagnostics[0].joined);
+    assert_eq!(
+        status.topic_diagnostics[0].delivery_state,
+        DeliveryState::Offline
+    );
     assert_eq!(status.topic_diagnostics[0].peer_count, 0);
-    assert!(status.topic_diagnostics[0].assist_peer_ids.is_empty());
+    assert!(status.topic_diagnostics[0].docs_assist_peer_ids.is_empty());
     assert_eq!(
         status.topic_diagnostics[0].status_detail,
         "No peers configured"
@@ -929,7 +944,7 @@ async fn ensure_topic_subscription_recreates_finished_handle() {
 }
 
 #[tokio::test]
-async fn set_discovery_seeds_keeps_existing_topic_hint_subscription() {
+async fn set_discovery_seeds_restarts_existing_topic_hint_subscription() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let hint_transport = Arc::new(TrackingHintTransport::default());
@@ -961,12 +976,15 @@ async fn set_discovery_seeds_keeps_existing_topic_hint_subscription() {
     .await
     .expect("set discovery seeds");
 
-    assert_eq!(*hint_transport.subscribe_count.lock().await, 1);
-    assert!(hint_transport.unsubscribed_topics.lock().await.is_empty());
+    assert_eq!(*hint_transport.subscribe_count.lock().await, 2);
+    assert_eq!(
+        hint_transport.unsubscribed_topics.lock().await.clone(),
+        vec![topic.to_string()]
+    );
 }
 
 #[tokio::test]
-async fn import_peer_ticket_keeps_existing_topic_hint_subscription() {
+async fn import_peer_ticket_restarts_existing_topic_hint_subscription() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let hint_transport = Arc::new(TrackingHintTransport::default());
@@ -991,9 +1009,12 @@ async fn import_peer_ticket_keeps_existing_topic_hint_subscription() {
         .await
         .expect("import peer ticket");
 
-    assert_eq!(*hint_transport.subscribe_count.lock().await, 1);
-    assert!(hint_transport.unsubscribed_topics.lock().await.is_empty());
-    assert_eq!(docs_sync.subscribe_replicas.lock().await.len(), 1);
+    assert_eq!(*hint_transport.subscribe_count.lock().await, 2);
+    assert_eq!(
+        hint_transport.unsubscribed_topics.lock().await.clone(),
+        vec![topic.to_string()]
+    );
+    assert_eq!(docs_sync.subscribe_replicas.lock().await.len(), 2);
 }
 
 #[tokio::test]
@@ -1276,7 +1297,7 @@ async fn iroh_transport_syncs_post_between_apps() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn import_peer_ticket_updates_existing_topic_subscription_without_rebuild() {
+async fn import_peer_ticket_restarts_existing_topic_subscription_and_resumes_delivery() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");
     let stack_a = TestIrohStack::new(&dir.path().join("rebind-a")).await;
@@ -1315,7 +1336,8 @@ async fn import_peer_ticket_updates_existing_topic_subscription_without_rebuild(
         .await
         .expect("import a into b");
 
-    timeout(Duration::from_secs(10), async {
+    timeout(Duration::from_secs(20), async {
+        let mut stable_ready_polls = 0usize;
         loop {
             let status_a = app_a.get_sync_status().await.expect("status a");
             let status_b = app_b.get_sync_status().await.expect("status b");
@@ -1330,13 +1352,18 @@ async fn import_peer_ticket_updates_existing_topic_subscription_without_rebuild(
                     && !topic_status.connected_peers.is_empty()
             });
             if ready_a && ready_b {
-                return;
+                stable_ready_polls += 1;
+                if stable_ready_polls >= 3 {
+                    return;
+                }
+            } else {
+                stable_ready_polls = 0;
             }
-            sleep(Duration::from_millis(50)).await;
+            sleep(Duration::from_millis(100)).await;
         }
     })
     .await
-    .expect("subscription update timeout");
+    .expect("subscription restart timeout");
 
     let object_id = app_a
         .create_post(topic, "hello after import", None)
@@ -1445,6 +1472,108 @@ async fn seeded_dht_syncs_post_between_apps_without_ticket_import() {
     .expect("seeded dht sync timeout");
 
     assert_eq!(received.content, "seeded dht app sync");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn relay_seeded_syncs_post_between_apps_without_ticket_import() {
+    let _guard = iroh_integration_test_lock().lock_owned().await;
+    let (_relay_map, relay_url, _relay_guard) = iroh::test_utils::run_relay_server()
+        .await
+        .expect("relay server");
+    let relay_config = TransportRelayConfig {
+        iroh_relay_urls: vec![relay_url.to_string()],
+    };
+    let dir = tempdir().expect("tempdir");
+    let stack_a = TestIrohStack::new_with_options(
+        &dir.path().join("relay-seeded-a"),
+        DhtDiscoveryOptions::disabled(),
+        relay_config.clone(),
+    )
+    .await;
+    let stack_b = TestIrohStack::new_with_options(
+        &dir.path().join("relay-seeded-b"),
+        DhtDiscoveryOptions::disabled(),
+        relay_config,
+    )
+    .await;
+    let store_a = Arc::new(MemoryStore::default());
+    let store_b = Arc::new(MemoryStore::default());
+    let app_a = app_with_iroh_services(store_a, &stack_a);
+    let app_b = app_with_iroh_services(store_b, &stack_b);
+    let ticket_a = app_a
+        .peer_ticket()
+        .await
+        .expect("ticket a")
+        .expect("ticket a value");
+    let ticket_b = app_b
+        .peer_ticket()
+        .await
+        .expect("ticket b")
+        .expect("ticket b value");
+    let seed_a = {
+        let (endpoint_id, addr_hint) = ticket_b.split_once('@').expect("ticket b host");
+        SeedPeer {
+            endpoint_id: endpoint_id.to_string(),
+            addr_hint: Some(addr_hint.to_string()),
+        }
+    };
+    let seed_b = {
+        let (endpoint_id, addr_hint) = ticket_a.split_once('@').expect("ticket a host");
+        SeedPeer {
+            endpoint_id: endpoint_id.to_string(),
+            addr_hint: Some(addr_hint.to_string()),
+        }
+    };
+    app_a
+        .set_discovery_seeds(DiscoveryMode::StaticPeer, false, Vec::new(), vec![seed_a])
+        .await
+        .expect("set relay seeds a");
+    app_b
+        .set_discovery_seeds(DiscoveryMode::StaticPeer, false, Vec::new(), vec![seed_b])
+        .await
+        .expect("set relay seeds b");
+
+    let topic = "kukuri:topic:relay-seeded";
+    let _ = app_a
+        .list_timeline(topic, None, 20)
+        .await
+        .expect("subscribe a");
+    let _ = app_b
+        .list_timeline(topic, None, 20)
+        .await
+        .expect("subscribe b");
+
+    let object_id = app_a
+        .create_post(topic, "relay seeded app sync", None)
+        .await
+        .expect("create post");
+    let received = timeout(Duration::from_secs(60), async {
+        loop {
+            let timeline = app_b
+                .list_timeline(topic, None, 20)
+                .await
+                .expect("timeline");
+            if let Some(post) = timeline
+                .items
+                .iter()
+                .find(|post| post.object_id == object_id)
+            {
+                return post.clone();
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await;
+    let received = match received {
+        Ok(post) => post,
+        Err(error) => {
+            let diagnostics =
+                iroh_sync_diagnostics(&app_a, &app_b, &stack_a, &stack_b, topic).await;
+            panic!("relay seeded sync timeout: {error:?}; {diagnostics}");
+        }
+    };
+
+    assert_eq!(received.content, "relay seeded app sync");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1672,8 +1801,8 @@ async fn iroh_transport_syncs_repost_and_notification() {
         .list_timeline(topic, None, 20)
         .await
         .expect("subscribe b timeline");
-    wait_for_topic_peer_count(&app_a, topic, 1).await;
-    wait_for_topic_peer_count(&app_b, topic, 1).await;
+    wait_for_topic_delivery(&app_a, topic, 1).await;
+    wait_for_topic_delivery(&app_b, topic, 1).await;
 
     let source_id = app_a
         .create_post(topic, "relay source post", None)
@@ -1784,8 +1913,8 @@ async fn iroh_transport_syncs_reply_into_thread() {
         .list_timeline(topic, None, 20)
         .await
         .expect("subscribe b timeline");
-    wait_for_topic_peer_count(&app_a, topic, 1).await;
-    wait_for_topic_peer_count(&app_b, topic, 1).await;
+    wait_for_topic_delivery(&app_a, topic, 1).await;
+    wait_for_topic_delivery(&app_b, topic, 1).await;
 
     let root_id = app_a
         .create_post(topic, "root over iroh", None)

--- a/crates/app-api/src/tests/timeline.rs
+++ b/crates/app-api/src/tests/timeline.rs
@@ -431,7 +431,7 @@ async fn reply_posts_include_parent_preview_in_timeline_views() {
 }
 
 #[tokio::test]
-async fn reply_preview_is_omitted_when_parent_projection_is_unavailable() {
+async fn reply_preview_is_restored_from_docs_when_parent_projection_is_unavailable() {
     let (app, store, _, _) = local_app_with_memory_services();
     let topic = "kukuri:topic:reply-preview-fallback";
 
@@ -459,9 +459,12 @@ async fn reply_preview_is_omitted_when_parent_projection_is_unavailable() {
         .iter()
         .find(|post| post.object_id == reply_id)
         .expect("reply post in timeline");
+    let preview = reply.reply_preview.as_ref().expect("reply preview");
 
     assert_eq!(reply.reply_to.as_deref(), Some(root_id.as_str()));
-    assert!(reply.reply_preview.is_none());
+    assert_eq!(preview.object_id, root_id);
+    assert_eq!(preview.topic, topic);
+    assert_eq!(preview.content, "root body");
 }
 
 #[tokio::test]

--- a/crates/app-api/src/timeline.rs
+++ b/crates/app-api/src/timeline.rs
@@ -450,7 +450,8 @@ impl AppService {
             )
             .await?;
         }
-        self.hint_transport
+        if let Err(error) = self
+            .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, effective_channel_id.as_ref()),
                 GossipHint::TopicObjectsChanged {
@@ -461,7 +462,15 @@ impl AppService {
                     }],
                 },
             )
-            .await?;
+            .await
+        {
+            warn!(
+                topic = %topic_id,
+                object_id = %envelope.id.0,
+                error = %error,
+                "failed to publish post hint; durable docs state was already persisted"
+            );
+        }
         if effective_channel_id.is_none() {
             self.maybe_restart_replica_sync(topic_id, &topic_replica_id(topic_id))
                 .await;
@@ -472,18 +481,17 @@ impl AppService {
                         .iter()
                         .find(|entry| entry.topic == topic_id)
                     {
-                        let connectivity_shape = if !topic_status.connected_peers.is_empty() {
-                            "direct"
-                        } else if !topic_status.assist_peer_ids.is_empty() {
-                            "assist-only"
-                        } else {
-                            "disconnected"
+                        let connectivity_shape = match topic_status.delivery_state {
+                            DeliveryState::Live => "live",
+                            DeliveryState::DurableReady => "durable-ready",
+                            DeliveryState::DurableRecovering => "durable-recovering",
+                            DeliveryState::Offline => "offline",
                         };
                         info!(
                             topic = %topic_id,
                             connectivity_shape,
                             direct_peer_count = topic_status.connected_peers.len(),
-                            assist_peer_count = topic_status.assist_peer_ids.len(),
+                            docs_assist_peer_count = topic_status.docs_assist_peer_ids.len(),
                             "public topic connectivity snapshot after local post"
                         );
                     }

--- a/crates/app-api/src/views.rs
+++ b/crates/app-api/src/views.rs
@@ -436,6 +436,7 @@ pub struct ChannelAccessTokenPreview {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SyncStatus {
     pub connected: bool,
+    pub delivery_state: DeliveryState,
     pub last_sync_ts: Option<i64>,
     pub peer_count: usize,
     pub pending_events: usize,
@@ -448,6 +449,15 @@ pub struct SyncStatus {
     pub discovery: DiscoveryStatus,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeliveryState {
+    Live,
+    DurableRecovering,
+    DurableReady,
+    #[default]
+    Offline,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DiscoveryStatus {
     pub mode: DiscoveryMode,
@@ -457,7 +467,8 @@ pub struct DiscoveryStatus {
     pub bootstrap_seed_peer_ids: Vec<String>,
     pub manual_ticket_peer_ids: Vec<String>,
     pub connected_peer_ids: Vec<String>,
-    pub assist_peer_ids: Vec<String>,
+    pub docs_assist_peer_ids: Vec<String>,
+    pub blob_assist_peer_ids: Vec<String>,
     pub local_endpoint_id: String,
     pub last_discovery_error: Option<String>,
 }
@@ -466,12 +477,14 @@ pub struct DiscoveryStatus {
 pub struct TopicSyncStatus {
     pub topic: String,
     pub joined: bool,
+    pub delivery_state: DeliveryState,
     pub peer_count: usize,
     pub connected_peers: Vec<String>,
-    pub assist_peer_ids: Vec<String>,
+    pub docs_assist_peer_ids: Vec<String>,
     pub configured_peer_ids: Vec<String>,
     pub missing_peer_ids: Vec<String>,
     pub last_received_at: Option<i64>,
+    pub last_docs_activity_at: Option<i64>,
     pub status_detail: String,
     pub last_error: Option<String>,
 }

--- a/crates/desktop-runtime/src/community_node.rs
+++ b/crates/desktop-runtime/src/community_node.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use kukuri_cn_core::{
     AuthChallengeResponse, AuthVerifyResponse, BootstrapHeartbeatResponse,
@@ -629,6 +629,10 @@ impl DesktopRuntime {
         access_token: &str,
     ) -> std::result::Result<CommunityNodeNodeConfig, CommunityNodeRequestError> {
         let base_url = normalize_http_url(base_url).map_err(CommunityNodeRequestError::Other)?;
+        let local_seed_peer_before = self
+            .local_community_node_seed_peer("metadata-refresh-baseline")
+            .await
+            .ok();
         let config = self.community_node_config.lock().await.clone();
         let Some(index) = config
             .nodes
@@ -696,6 +700,22 @@ impl DesktopRuntime {
         self.apply_effective_seed_peers()
             .await
             .map_err(CommunityNodeRequestError::Other)?;
+        let local_seed_peer_after = self
+            .local_community_node_seed_peer("metadata-refresh-post-apply")
+            .await
+            .ok();
+        if local_seed_peer_before != local_seed_peer_after {
+            self.community_node_heartbeat_deadlines
+                .lock()
+                .await
+                .remove(base_url.as_str());
+            debug!(
+                %base_url,
+                before = ?local_seed_peer_before,
+                after = ?local_seed_peer_after,
+                "scheduled immediate community-node heartbeat after local seed peer changed during metadata sync"
+            );
+        }
         normalized
             .nodes
             .iter()
@@ -848,76 +868,11 @@ impl DesktopRuntime {
         }
     }
 
-    pub(crate) async fn sync_community_node_bootstrap_metadata_with_retry(
-        &self,
-        base_url: &str,
-        token: &mut StoredCommunityNodeToken,
-        auto_approve: bool,
-    ) -> Result<CommunityNodeNodeConfig> {
-        match self
-            .sync_community_node_bootstrap_metadata(base_url, token.access_token.as_str())
-            .await
-        {
-            Ok(node) => Ok(node),
-            Err(CommunityNodeRequestError::AuthRequired) => {
-                self.set_community_node_session_phase(
-                    base_url,
-                    CommunityNodeSessionPhase::Authenticating,
-                )
-                .await;
-                *token = self
-                    .request_community_node_authentication_token(base_url)
-                    .await?;
-                let consent_status = self
-                    .fetch_community_node_consent_status_with_retry(base_url, token, false)
-                    .await?;
-                self.set_community_node_cached_consent(base_url, Some(consent_status.clone()))
-                    .await;
-                if !consent_status.all_required_accepted {
-                    if !auto_approve {
-                        bail!("community node consent is required");
-                    }
-                    self.set_community_node_session_phase(
-                        base_url,
-                        CommunityNodeSessionPhase::Accepting,
-                    )
-                    .await;
-                    let accepted = self
-                        .accept_community_node_consents_with_retry(base_url, token, &[])
-                        .await?;
-                    self.set_community_node_cached_consent(base_url, Some(accepted))
-                        .await;
-                }
-                self.sync_community_node_bootstrap_metadata(base_url, token.access_token.as_str())
-                    .await
-                    .map_err(CommunityNodeRequestError::into_anyhow)
-            }
-            Err(CommunityNodeRequestError::ConsentRequired) if auto_approve => {
-                self.set_community_node_session_phase(
-                    base_url,
-                    CommunityNodeSessionPhase::Accepting,
-                )
-                .await;
-                let accepted = self
-                    .accept_community_node_consents_with_retry(base_url, token, &[])
-                    .await?;
-                self.set_community_node_cached_consent(base_url, Some(accepted))
-                    .await;
-                self.sync_community_node_bootstrap_metadata(base_url, token.access_token.as_str())
-                    .await
-                    .map_err(CommunityNodeRequestError::into_anyhow)
-            }
-            Err(CommunityNodeRequestError::ConsentRequired) => {
-                bail!("community node consent is required")
-            }
-            Err(error) => Err(error.into_anyhow()),
-        }
-    }
-
     async fn refresh_community_node_registration_with_token_if_due_once(
         &self,
         base_url: &str,
         access_token: &str,
+        force_heartbeat: bool,
     ) -> std::result::Result<(), CommunityNodeRequestError> {
         let base_url = normalize_http_url(base_url).map_err(CommunityNodeRequestError::Other)?;
         let now = Utc::now().timestamp();
@@ -928,7 +883,7 @@ impl DesktopRuntime {
             .get(base_url.as_str())
             .copied()
             .unwrap_or_default();
-        if next_due_at > now {
+        if !force_heartbeat && next_due_at > now {
             let ready_refresh_pending = self
                 .community_node_ready_refresh_pending
                 .lock()
@@ -980,6 +935,14 @@ impl DesktopRuntime {
                     Err(error)
                 }
             };
+        }
+        if force_heartbeat && next_due_at > now {
+            info!(
+                %base_url,
+                next_due_at,
+                now,
+                "forcing community-node heartbeat before bootstrap metadata refresh"
+            );
         }
         let seed_peer = self
             .local_community_node_seed_peer("heartbeat")
@@ -1074,11 +1037,13 @@ impl DesktopRuntime {
         base_url: &str,
         token: &mut StoredCommunityNodeToken,
         auto_approve: bool,
+        force_heartbeat: bool,
     ) -> Result<()> {
         match self
             .refresh_community_node_registration_with_token_if_due_once(
                 base_url,
                 token.access_token.as_str(),
+                force_heartbeat,
             )
             .await
         {
@@ -1120,6 +1085,7 @@ impl DesktopRuntime {
                 self.refresh_community_node_registration_with_token_if_due_once(
                     base_url,
                     token.access_token.as_str(),
+                    force_heartbeat,
                 )
                 .await
                 .map_err(CommunityNodeRequestError::into_anyhow)
@@ -1138,6 +1104,7 @@ impl DesktopRuntime {
                 self.refresh_community_node_registration_with_token_if_due_once(
                     base_url,
                     token.access_token.as_str(),
+                    force_heartbeat,
                 )
                 .await
                 .map_err(CommunityNodeRequestError::into_anyhow)
@@ -1260,6 +1227,7 @@ impl DesktopRuntime {
             base_url.as_str(),
             &mut token,
             auto_approve,
+            false,
         )
         .await?;
         self.clear_community_node_retry_state(base_url.as_str())

--- a/crates/desktop-runtime/src/runtime.rs
+++ b/crates/desktop-runtime/src/runtime.rs
@@ -1057,6 +1057,7 @@ impl DesktopRuntime {
                 base_url.as_str(),
                 &mut token,
                 node.auto_approve,
+                false,
             )
             .await?;
             self.clear_community_node_retry_state(base_url.as_str())
@@ -1179,6 +1180,7 @@ impl DesktopRuntime {
                 base_url.as_str(),
                 &mut token,
                 node.auto_approve,
+                false,
             )
             .await?;
             self.clear_community_node_retry_state(base_url.as_str())
@@ -1201,8 +1203,6 @@ impl DesktopRuntime {
     ) -> Result<CommunityNodeNodeStatus> {
         let base_url = normalize_http_url(request.base_url.as_str())?;
         let node = self.require_community_node(base_url.as_str()).await?;
-        self.ensure_community_node_session(base_url.as_str())
-            .await?;
         let mut token =
             load_community_node_token(&self.db_path, self.identity_mode, base_url.as_str())?
                 .ok_or_else(|| anyhow!("community node authentication is required"))?;
@@ -1211,17 +1211,18 @@ impl DesktopRuntime {
             CommunityNodeSessionPhase::Refreshing,
         )
         .await;
-        let refreshed = self
-            .sync_community_node_bootstrap_metadata_with_retry(
-                base_url.as_str(),
-                &mut token,
-                node.auto_approve,
-            )
-            .await?;
+        self.refresh_community_node_registration_with_token_if_due(
+            base_url.as_str(),
+            &mut token,
+            node.auto_approve,
+            true,
+        )
+        .await?;
         self.clear_community_node_retry_state(base_url.as_str())
             .await;
         self.set_community_node_session_ready(base_url.as_str(), false)
             .await;
+        let refreshed = self.require_community_node(base_url.as_str()).await?;
         self.community_node_status(refreshed, None, None).await
     }
 

--- a/crates/desktop-runtime/src/stack.rs
+++ b/crates/desktop-runtime/src/stack.rs
@@ -466,13 +466,22 @@ impl BoundIrohStack {
         dht_options: DhtDiscoveryOptions,
         relay_config: TransportRelayConfig,
     ) -> Result<Self> {
+        let relay_config = relay_config.normalized();
+        let initial_relay_config = if relay_config.iroh_relay_urls.is_empty() {
+            relay_config.clone()
+        } else {
+            TransportRelayConfig::default()
+        };
         let node = IrohDocsNode::persistent_with_discovery_config(
             root,
             network_config.clone(),
             dht_options,
-            relay_config.clone(),
+            initial_relay_config,
         )
         .await?;
+        if !relay_config.iroh_relay_urls.is_empty() {
+            node.apply_relay_config(relay_config.clone()).await?;
+        }
         let transport = Arc::new(IrohGossipTransport::from_shared_parts(
             node.endpoint().clone(),
             node.gossip().clone(),
@@ -480,6 +489,9 @@ impl BoundIrohStack {
             network_config,
             relay_config.clone(),
         )?);
+        if !relay_config.iroh_relay_urls.is_empty() {
+            transport.update_relay_config(relay_config.clone()).await?;
+        }
         let docs_sync = Arc::new(IrohDocsSync::new(node.clone()));
         let blob_service = Arc::new(IrohBlobService::new(node.clone()));
         transport

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -1082,6 +1082,42 @@ async fn replicate_private_post_with_retry(
                     .ok_or_else(|| anyhow::anyhow!("publisher lost private channel after write"))?
                     .current_epoch_id;
             if pre_write_epoch.as_deref() != Some(post_write_epoch.as_str()) {
+                let mut runtimes = Vec::with_capacity(subscribers.len() + 1);
+                runtimes.push(publisher);
+                runtimes.extend(subscribers.iter().copied());
+                refresh_runtime_peer_tickets(&runtimes)
+                    .await
+                    .context("failed to refresh peer tickets after private channel rotation")?;
+                for runtime in &runtimes {
+                    let _ = runtime
+                        .list_timeline(ListTimelineRequest {
+                            topic: topic.to_string(),
+                            scope: TimelineScope::Public,
+                            cursor: None,
+                            limit: Some(20),
+                        })
+                        .await
+                        .context("failed to refresh public topic after private channel rotation")?;
+                    let _ = runtime
+                        .list_timeline(ListTimelineRequest {
+                            topic: topic.to_string(),
+                            scope: scope.clone(),
+                            cursor: None,
+                            limit: Some(20),
+                        })
+                        .await
+                        .context(
+                            "failed to refresh private topic after private channel rotation",
+                        )?;
+                    let _ = runtime
+                        .list_joined_private_channels(ListJoinedPrivateChannelsRequest {
+                            topic: topic.to_string(),
+                        })
+                        .await
+                        .context(
+                            "failed to refresh joined private channels after private channel rotation",
+                        )?;
+                }
                 for subscriber in subscribers {
                     wait_for_joined_private_channel_epoch_result(
                         subscriber,
@@ -1160,6 +1196,38 @@ async fn replicate_private_post_with_retry(
         format_sync_snapshot(&publisher_status, topic),
         subscriber_details.join(" | "),
     );
+}
+
+async fn refresh_runtime_peer_tickets(runtimes: &[&DesktopRuntime]) -> Result<()> {
+    let mut tickets = Vec::with_capacity(runtimes.len());
+    for (index, runtime) in runtimes.iter().enumerate() {
+        let ticket = runtime
+            .local_peer_ticket()
+            .await
+            .with_context(|| format!("failed to load local peer ticket for runtime[{index}]"))?
+            .ok_or_else(|| {
+                anyhow::anyhow!("runtime[{index}] did not expose a local peer ticket")
+            })?;
+        tickets.push(ticket);
+    }
+    for (runtime_index, runtime) in runtimes.iter().enumerate() {
+        for (ticket_index, ticket) in tickets.iter().enumerate() {
+            if runtime_index == ticket_index {
+                continue;
+            }
+            runtime
+                .import_peer_ticket(ImportPeerTicketRequest {
+                    ticket: ticket.clone(),
+                })
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to import peer ticket from runtime[{ticket_index}] into runtime[{runtime_index}]"
+                    )
+                })?;
+        }
+    }
+    Ok(())
 }
 
 fn sync_status_with_topic(

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -167,12 +167,13 @@ fn format_sync_snapshot(status: &SyncStatus, topic: &str) -> String {
             .find(|entry| entry.topic == topic)
             .map(|entry| {
                 format!(
-                    "topic_peers={}, connected_peers={:?}, assist_peer_ids={:?}, configured_peer_ids={:?}, missing_peer_ids={:?}, status_detail={}",
+                    "topic_peers={}, connected_peers={:?}, docs_assist_peer_ids={:?}, configured_peer_ids={:?}, missing_peer_ids={:?}, delivery_state={:?}, status_detail={}",
                     entry.peer_count,
                     entry.connected_peers,
-                    entry.assist_peer_ids,
+                    entry.docs_assist_peer_ids,
                     entry.configured_peer_ids,
                     entry.missing_peer_ids,
+                    entry.delivery_state,
                     entry.status_detail
                 )
             })
@@ -198,15 +199,54 @@ async fn wait_for_connected_topic_peer_count(
         let mut stable_ready_polls = 0usize;
         loop {
             let status = runtime.get_sync_status().await.expect("sync status");
-            let ready = status.connected
-                && status.peer_count >= expected
-                && status.topic_diagnostics.iter().any(|topic_status| {
-                    topic_status.topic == topic
-                        && topic_status.joined
-                        && (topic_status.connected_peers.len() >= expected.min(1)
-                            || topic_status.assist_peer_ids.len() >= expected.min(1))
-                        && topic_status.peer_count >= expected
-                });
+            let ready = topic_has_direct_peer(&status, topic, expected);
+            if ready {
+                stable_ready_polls += 1;
+                if stable_ready_polls >= 3 {
+                    return;
+                }
+            } else {
+                stable_ready_polls = 0;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(()) => {}
+        Err(_) => {
+            let status = runtime.get_sync_status().await.expect("sync status");
+            panic!("{timeout_label}: {}", format_sync_snapshot(&status, topic));
+        }
+    }
+}
+
+async fn wait_for_topic_delivery(
+    runtime: &DesktopRuntime,
+    topic: &str,
+    expected: usize,
+    timeout_label: &str,
+) {
+    match timeout(runtime_replication_timeout(), async {
+        let mut stable_ready_polls = 0usize;
+        loop {
+            let status = runtime.get_sync_status().await.expect("sync status");
+            let ready = status.topic_diagnostics.iter().any(|topic_status| {
+                let live_ready = topic_status.peer_count >= expected
+                    && topic_status.connected_peers.len() >= expected.min(1)
+                    && (topic_status.joined
+                        || matches!(
+                            topic_status.delivery_state,
+                            kukuri_app_api::DeliveryState::Live
+                        ));
+                let durable_ready = !topic_status.docs_assist_peer_ids.is_empty()
+                    && matches!(
+                        topic_status.delivery_state,
+                        kukuri_app_api::DeliveryState::DurableRecovering
+                            | kukuri_app_api::DeliveryState::DurableReady
+                    );
+                topic_status.topic == topic && (live_ready || durable_ready)
+            });
             if ready {
                 stable_ready_polls += 1;
                 if stable_ready_polls >= 3 {
@@ -238,15 +278,7 @@ async fn wait_for_connected_topic_peer_count_result(
         let mut stable_ready_polls = 0usize;
         loop {
             let status = runtime.get_sync_status().await.context("sync status")?;
-            let ready = status.connected
-                && status.peer_count >= expected
-                && status.topic_diagnostics.iter().any(|topic_status| {
-                    topic_status.topic == topic
-                        && topic_status.joined
-                        && (topic_status.connected_peers.len() >= expected.min(1)
-                            || topic_status.assist_peer_ids.len() >= expected.min(1))
-                        && topic_status.peer_count >= expected
-                });
+            let ready = topic_has_direct_peer(&status, topic, expected);
             if ready {
                 stable_ready_polls += 1;
                 if stable_ready_polls >= 3 {
@@ -274,14 +306,16 @@ async fn wait_for_connected_topic_peer_count_result(
 }
 
 fn topic_has_direct_peer(status: &SyncStatus, topic: &str, expected: usize) -> bool {
-    status.connected
-        && status.peer_count >= expected
-        && status.topic_diagnostics.iter().any(|topic_status| {
-            topic_status.topic == topic
-                && topic_status.joined
-                && topic_status.connected_peers.len() >= expected.min(1)
-                && topic_status.peer_count >= expected
-        })
+    status.topic_diagnostics.iter().any(|topic_status| {
+        topic_status.topic == topic
+            && topic_status.connected_peers.len() >= expected.min(1)
+            && topic_status.peer_count >= expected
+            && (topic_status.joined
+                || matches!(
+                    topic_status.delivery_state,
+                    kukuri_app_api::DeliveryState::Live
+                ))
+    })
 }
 
 fn should_swap_shared_identity_public_replication_direction(
@@ -327,37 +361,6 @@ async fn wait_for_direct_topic_peer_count_result(
                 .map(|value| format_sync_snapshot(&value, topic))
                 .unwrap_or_else(|| "failed to read sync status".to_string());
             bail!("direct topic readiness timeout; {status}");
-        }
-    }
-}
-
-async fn wait_for_connected_peer_count(
-    runtime: &DesktopRuntime,
-    expected: usize,
-    timeout_label: &str,
-) {
-    match timeout(social_graph_propagation_timeout(), async {
-        let mut stable_ready_polls = 0usize;
-        loop {
-            let status = runtime.get_sync_status().await.expect("sync status");
-            let ready = status.connected && status.peer_count >= expected;
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return;
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    {
-        Ok(()) => {}
-        Err(_) => {
-            let status = runtime.get_sync_status().await.expect("sync status");
-            panic!("{timeout_label}: {}", format_sync_snapshot(&status, ""));
         }
     }
 }
@@ -432,6 +435,78 @@ async fn warm_author_social_view(
         Err(_) => {
             let status = runtime.get_sync_status().await.expect("sync status");
             panic!("{timeout_label}: {}", format_sync_snapshot(&status, ""));
+        }
+    }
+}
+
+fn is_retryable_friend_plus_share_import_error(message: &str) -> bool {
+    message.contains("mutual relationship")
+        || message.contains("sponsor is not an active participant")
+        || message.contains("timed out waiting for friend-plus sponsor participant sync")
+        || message.contains("timed out waiting for friend-plus channel replica sync")
+}
+
+async fn wait_for_friend_plus_share_import(
+    runtime: &DesktopRuntime,
+    token: &str,
+    step_timeout: Duration,
+    timeout_label: &str,
+) -> kukuri_core::FriendPlusSharePreview {
+    let preview = kukuri_core::parse_friend_plus_share_token(token).expect("parse share token");
+    let last_retryable_error = Arc::new(Mutex::new(None::<String>));
+    let retry_error_slot = Arc::clone(&last_retryable_error);
+    match timeout(step_timeout, async {
+        loop {
+            match runtime
+                .import_friend_plus_share(ImportFriendPlusShareRequest {
+                    token: token.to_string(),
+                })
+                .await
+            {
+                Ok(preview) => return preview,
+                Err(error)
+                    if is_retryable_friend_plus_share_import_error(error.to_string().as_str()) =>
+                {
+                    *retry_error_slot.lock().await = Some(error.to_string());
+                    sleep(Duration::from_millis(100)).await;
+                }
+                Err(error) => panic!("{timeout_label}: {error:#}"),
+            }
+        }
+    })
+    .await
+    {
+        Ok(preview) => preview,
+        Err(_) => {
+            let last_error = last_retryable_error
+                .lock()
+                .await
+                .clone()
+                .unwrap_or_else(|| "none".to_string());
+            let social_view = runtime
+                .get_author_social_view(AuthorRequest {
+                    pubkey: preview.sponsor_pubkey.as_str().to_string(),
+                })
+                .await
+                .ok()
+                .map(|value| {
+                    format!(
+                        "following={}, followed_by={}, mutual={}, friend_of_friend={}, fof_via={:?}",
+                        value.following,
+                        value.followed_by,
+                        value.mutual,
+                        value.friend_of_friend,
+                        value.friend_of_friend_via_pubkeys
+                    )
+                })
+                .unwrap_or_else(|| "social_view=unavailable".to_string());
+            let status = runtime.get_sync_status().await.expect("sync status");
+            panic!(
+                "{timeout_label}: sponsor_pubkey={}, last_retryable_error={}, {social_view}, {}",
+                preview.sponsor_pubkey.as_str(),
+                last_error,
+                format_sync_snapshot(&status, preview.topic_id.as_str())
+            );
         }
     }
 }
@@ -764,125 +839,6 @@ async fn replicate_public_post_with_retry(
     .await
 }
 
-async fn replicate_public_post_from_original_publisher_with_retry(
-    publisher: &DesktopRuntime,
-    subscriber: &DesktopRuntime,
-    topic: &str,
-    content_prefix: &str,
-    timeout_label: &str,
-) -> String {
-    replicate_public_post_with_retry_inner(
-        publisher,
-        subscriber,
-        topic,
-        content_prefix,
-        timeout_label,
-        false,
-    )
-    .await
-}
-
-async fn refresh_public_pair_result(
-    runtime_a: &DesktopRuntime,
-    runtime_b: &DesktopRuntime,
-    topic: &str,
-    step_timeout: Duration,
-) -> Result<()> {
-    let scope = TimelineScope::Public;
-    let _ = runtime_a
-        .list_timeline(ListTimelineRequest {
-            topic: topic.to_string(),
-            scope: scope.clone(),
-            cursor: None,
-            limit: Some(20),
-        })
-        .await;
-    let _ = runtime_b
-        .list_timeline(ListTimelineRequest {
-            topic: topic.to_string(),
-            scope: scope.clone(),
-            cursor: None,
-            limit: Some(20),
-        })
-        .await;
-    let _ = runtime_a
-        .list_live_sessions(ListLiveSessionsRequest {
-            topic: topic.to_string(),
-            scope: scope.clone(),
-        })
-        .await;
-    let _ = runtime_b
-        .list_live_sessions(ListLiveSessionsRequest {
-            topic: topic.to_string(),
-            scope: scope.clone(),
-        })
-        .await;
-    let _ = runtime_a
-        .list_game_rooms(ListGameRoomsRequest {
-            topic: topic.to_string(),
-            scope: scope.clone(),
-        })
-        .await;
-    let _ = runtime_b
-        .list_game_rooms(ListGameRoomsRequest {
-            topic: topic.to_string(),
-            scope,
-        })
-        .await;
-    wait_for_connected_topic_peer_count_result(runtime_a, topic, 1, step_timeout)
-        .await
-        .context("runtime a did not observe public topic connectivity")?;
-    wait_for_connected_topic_peer_count_result(runtime_b, topic, 1, step_timeout)
-        .await
-        .context("runtime b did not observe public topic connectivity")?;
-    Ok(())
-}
-
-async fn wait_for_direct_public_pair_with_refresh_result(
-    runtime_a: &DesktopRuntime,
-    runtime_b: &DesktopRuntime,
-    topic: &str,
-    step_timeout: Duration,
-    same_author_shared_identity: bool,
-) -> Result<()> {
-    let (attempts, attempt_timeout) =
-        public_replication_retry_schedule(step_timeout, same_author_shared_identity);
-    let mut last_error = None;
-
-    for attempt in 1..=attempts {
-        let attempt_result = async {
-            refresh_public_pair_result(runtime_a, runtime_b, topic, attempt_timeout)
-                .await
-                .context("failed to refresh public pair before waiting for direct connectivity")?;
-            wait_for_direct_topic_peer_count_result(runtime_a, topic, 1, attempt_timeout)
-                .await
-                .context("runtime a did not observe direct public topic connectivity")?;
-            wait_for_direct_topic_peer_count_result(runtime_b, topic, 1, attempt_timeout)
-                .await
-                .context("runtime b did not observe direct public topic connectivity")?;
-            Ok::<(), anyhow::Error>(())
-        }
-        .await;
-
-        match attempt_result {
-            Ok(()) => return Ok(()),
-            Err(error) if attempt < attempts => {
-                last_error = Some(format!("{error:#}"));
-                sleep(Duration::from_millis(250)).await;
-            }
-            Err(error) => {
-                last_error = Some(format!("{error:#}"));
-                break;
-            }
-        }
-    }
-
-    bail!(
-        "public pair direct topic readiness timeout; {}",
-        last_error.unwrap_or_else(|| "unknown error".to_string())
-    );
-}
-
 async fn replicate_public_post_with_retry_inner(
     publisher: &DesktopRuntime,
     subscriber: &DesktopRuntime,
@@ -926,12 +882,6 @@ async fn replicate_public_post_with_retry_inner(
                 })
                 .await
                 .context("failed to resubscribe subscriber to public topic")?;
-            wait_for_connected_topic_peer_count_result(publisher, topic, 1, attempt_timeout)
-                .await
-                .context("publisher did not observe public topic connectivity")?;
-            wait_for_connected_topic_peer_count_result(subscriber, topic, 1, attempt_timeout)
-                .await
-                .context("subscriber did not observe public topic connectivity")?;
             let publisher_status = publisher
                 .get_sync_status()
                 .await
@@ -1215,12 +1165,21 @@ async fn replicate_private_post_with_retry(
 fn sync_status_with_topic(
     topic: &str,
     connected_peers: &[&str],
-    assist_peer_ids: &[&str],
+    docs_assist_peer_ids: &[&str],
 ) -> SyncStatus {
+    let connected = !connected_peers.is_empty();
+    let delivery_state = if connected {
+        kukuri_app_api::DeliveryState::Live
+    } else if !docs_assist_peer_ids.is_empty() {
+        kukuri_app_api::DeliveryState::DurableRecovering
+    } else {
+        kukuri_app_api::DeliveryState::Offline
+    };
     SyncStatus {
-        connected: true,
+        connected,
+        delivery_state,
         last_sync_ts: None,
-        peer_count: connected_peers.len().max(assist_peer_ids.len()),
+        peer_count: connected_peers.len(),
         pending_events: 0,
         status_detail: "test".to_string(),
         last_error: None,
@@ -1228,19 +1187,21 @@ fn sync_status_with_topic(
         subscribed_topics: vec![topic.to_string()],
         topic_diagnostics: vec![kukuri_app_api::TopicSyncStatus {
             topic: topic.to_string(),
-            joined: true,
-            peer_count: connected_peers.len().max(assist_peer_ids.len()),
+            joined: connected,
+            delivery_state,
+            peer_count: connected_peers.len(),
             connected_peers: connected_peers
                 .iter()
                 .map(|peer| peer.to_string())
                 .collect(),
-            assist_peer_ids: assist_peer_ids
+            docs_assist_peer_ids: docs_assist_peer_ids
                 .iter()
                 .map(|peer| peer.to_string())
                 .collect(),
             configured_peer_ids: Vec::new(),
             missing_peer_ids: Vec::new(),
             last_received_at: None,
+            last_docs_activity_at: None,
             status_detail: "test".to_string(),
             last_error: None,
         }],
@@ -1313,15 +1274,13 @@ async fn wait_for_seeded_dht_topic_ready(
             let ready_a = status_a.topic_diagnostics.iter().any(|topic_status| {
                 topic_status.topic == topic
                     && topic_status.joined
-                    && (!topic_status.connected_peers.is_empty()
-                        || !topic_status.assist_peer_ids.is_empty())
+                    && !topic_status.connected_peers.is_empty()
                     && topic_status.peer_count > 0
             });
             let ready_b = status_b.topic_diagnostics.iter().any(|topic_status| {
                 topic_status.topic == topic
                     && topic_status.joined
-                    && (!topic_status.connected_peers.is_empty()
-                        || !topic_status.assist_peer_ids.is_empty())
+                    && !topic_status.connected_peers.is_empty()
                     && topic_status.peer_count > 0
             });
             if ready_a && ready_b {
@@ -1497,6 +1456,15 @@ struct MockCommunityNodeState {
     bootstrap_hits: Arc<AtomicUsize>,
 }
 
+#[derive(Clone)]
+struct MockHeartbeatEchoCommunityNodeState {
+    base_url: String,
+    connectivity_urls: Vec<String>,
+    seed_peers: Arc<Mutex<Vec<CommunityNodeSeedPeer>>>,
+    heartbeat_hits: Arc<AtomicUsize>,
+    bootstrap_hits: Arc<AtomicUsize>,
+}
+
 async fn mock_bootstrap_heartbeat(
     State(state): State<Arc<MockCommunityNodeState>>,
     Json(_request): Json<serde_json::Value>,
@@ -1530,6 +1498,45 @@ async fn mock_bootstrap_nodes(
 
 async fn mock_bootstrap_consent_status() -> Json<CommunityNodeConsentStatus> {
     Json(managed_community_node_consent_status(true))
+}
+
+async fn mock_heartbeat_echo_bootstrap_heartbeat(
+    State(state): State<Arc<MockHeartbeatEchoCommunityNodeState>>,
+    Json(request): Json<serde_json::Value>,
+) -> Json<BootstrapHeartbeatResponse> {
+    state.heartbeat_hits.fetch_add(1, Ordering::SeqCst);
+    let endpoint_id = request
+        .get("endpoint_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("heartbeat endpoint id")
+        .to_string();
+    let addr_hint = request
+        .get("addr_hint")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned);
+    *state.seed_peers.lock().await =
+        vec![CommunityNodeSeedPeer::new(endpoint_id, addr_hint).expect("heartbeat seed peer")];
+    Json(BootstrapHeartbeatResponse {
+        expires_at: Utc::now().timestamp() + 300,
+    })
+}
+
+async fn mock_heartbeat_echo_bootstrap_nodes(
+    State(state): State<Arc<MockHeartbeatEchoCommunityNodeState>>,
+) -> Json<BootstrapNodesResponse> {
+    state.bootstrap_hits.fetch_add(1, Ordering::SeqCst);
+    let seed_peers = state.seed_peers.lock().await.clone();
+    Json(BootstrapNodesResponse {
+        nodes: vec![kukuri_cn_core::CommunityNodeBootstrapNode {
+            base_url: state.base_url.clone(),
+            resolved_urls: CommunityNodeResolvedUrls::new(
+                state.base_url.clone(),
+                state.connectivity_urls.clone(),
+                seed_peers,
+            )
+            .expect("resolved urls"),
+        }],
+    })
 }
 
 #[derive(Clone)]
@@ -2090,10 +2097,6 @@ async fn profile_timeline_reads_author_public_posts_across_untracked_topics() {
         })
         .await
         .expect("import a");
-    wait_for_connected_peer_count(&runtime_a, 1, "profile topic owner peer readiness timeout")
-        .await;
-    wait_for_connected_peer_count(&runtime_b, 1, "profile topic viewer peer readiness timeout")
-        .await;
 
     let author_pubkey = runtime_a
         .get_sync_status()
@@ -2130,18 +2133,18 @@ async fn profile_timeline_reads_author_public_posts_across_untracked_topics() {
         })
         .await
         .expect("subscribe b tracked topic");
-    wait_for_connected_topic_peer_count(
+    wait_for_topic_delivery(
         &runtime_a,
         tracked_topic,
         1,
-        "profile tracked topic readiness timeout a",
+        "profile tracked topic delivery timeout a",
     )
     .await;
-    wait_for_connected_topic_peer_count(
+    wait_for_topic_delivery(
         &runtime_b,
         tracked_topic,
         1,
-        "profile tracked topic readiness timeout b",
+        "profile tracked topic delivery timeout b",
     )
     .await;
 
@@ -2220,12 +2223,6 @@ async fn profile_timeline_reads_author_public_posts_across_untracked_topics() {
                 })
                 .await
                 .expect("import a after restart");
-            wait_for_connected_peer_count(
-                &restarted_b,
-                1,
-                "profile viewer peer restart readiness timeout",
-            )
-            .await;
             let _ = restarted_b
                 .list_timeline(ListTimelineRequest {
                     topic: tracked_topic.into(),
@@ -2235,11 +2232,11 @@ async fn profile_timeline_reads_author_public_posts_across_untracked_topics() {
                 })
                 .await
                 .expect("resubscribe restarted b tracked topic");
-            wait_for_connected_topic_peer_count(
+            wait_for_topic_delivery(
                 &restarted_b,
                 tracked_topic,
                 1,
-                "profile tracked topic restart readiness timeout b",
+                "profile tracked topic restart delivery timeout b",
             )
             .await;
             let timeline = wait_for_profile_timeline_posts_result(
@@ -2439,9 +2436,6 @@ async fn private_channel_invite_restores_after_restart_without_reimport() {
         .import_peer_ticket(ImportPeerTicketRequest { ticket: ticket_a })
         .await
         .expect("import a");
-    wait_for_connected_peer_count(&runtime_a, 1, "friend-only owner peer readiness timeout").await;
-    wait_for_connected_peer_count(&runtime_b, 1, "friend-only invitee peer readiness timeout")
-        .await;
 
     let topic = "kukuri:topic:desktop-private-channel";
     let _ = runtime_a
@@ -2462,6 +2456,20 @@ async fn private_channel_invite_restores_after_restart_without_reimport() {
         })
         .await
         .expect("subscribe b");
+    wait_for_topic_delivery(
+        &runtime_a,
+        topic,
+        1,
+        "friend-only owner topic delivery timeout",
+    )
+    .await;
+    wait_for_topic_delivery(
+        &runtime_b,
+        topic,
+        1,
+        "friend-only invitee topic delivery timeout",
+    )
+    .await;
     let channel = runtime_a
         .create_private_channel(CreatePrivateChannelRequest {
             topic: topic.into(),
@@ -2918,13 +2926,6 @@ async fn friend_only_channel_restore_keeps_archived_epoch_history() {
         .import_peer_ticket(ImportPeerTicketRequest { ticket: ticket_a })
         .await
         .expect("import a");
-    wait_for_connected_peer_count(&runtime_a, 1, "friend-only owner peer readiness timeout").await;
-    wait_for_connected_peer_count(
-        &runtime_b,
-        1,
-        "friend-only recipient peer readiness timeout",
-    )
-    .await;
 
     let a_pubkey = runtime_a
         .get_sync_status()
@@ -2936,6 +2937,39 @@ async fn friend_only_channel_restore_keeps_archived_epoch_history() {
         .await
         .expect("status b")
         .local_author_pubkey;
+    let topic = "kukuri:topic:desktop-friend-only-restart";
+    let _ = runtime_a
+        .list_timeline(ListTimelineRequest {
+            topic: topic.into(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await
+        .expect("subscribe a");
+    let _ = runtime_b
+        .list_timeline(ListTimelineRequest {
+            topic: topic.into(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await
+        .expect("subscribe b");
+    wait_for_topic_delivery(
+        &runtime_a,
+        topic,
+        1,
+        "friend-only owner topic delivery timeout",
+    )
+    .await;
+    wait_for_topic_delivery(
+        &runtime_b,
+        topic,
+        1,
+        "friend-only recipient topic delivery timeout",
+    )
+    .await;
     warm_author_social_view(
         &runtime_a,
         b_pubkey.as_str(),
@@ -2983,26 +3017,6 @@ async fn friend_only_channel_restore_keeps_archived_epoch_history() {
     })
     .await
     .expect("mutual propagation timeout");
-
-    let topic = "kukuri:topic:desktop-friend-only-restart";
-    let _ = runtime_a
-        .list_timeline(ListTimelineRequest {
-            topic: topic.into(),
-            scope: TimelineScope::Public,
-            cursor: None,
-            limit: Some(20),
-        })
-        .await
-        .expect("subscribe a");
-    let _ = runtime_b
-        .list_timeline(ListTimelineRequest {
-            topic: topic.into(),
-            scope: TimelineScope::Public,
-            cursor: None,
-            limit: Some(20),
-        })
-        .await
-        .expect("subscribe b");
 
     let channel = runtime_a
         .create_private_channel(CreatePrivateChannelRequest {
@@ -3244,9 +3258,6 @@ async fn friend_plus_channel_restore_accepts_fresh_share_after_restart() {
         })
         .await
         .expect("b imports a");
-    wait_for_connected_peer_count(&runtime_a, 1, "friend-plus owner peer readiness timeout").await;
-    wait_for_connected_peer_count(&runtime_b, 1, "friend-plus sponsor peer readiness timeout")
-        .await;
 
     let status_a = runtime_a.get_sync_status().await.expect("status a");
     let a_pubkey = status_a.local_author_pubkey;
@@ -3266,18 +3277,18 @@ async fn friend_plus_channel_restore_accepts_fresh_share_after_restart() {
             .await
             .expect("subscribe runtime");
     }
-    wait_for_connected_topic_peer_count(
+    wait_for_topic_delivery(
         &runtime_a,
         topic,
         1,
-        "friend-plus owner topic readiness timeout",
+        "friend-plus owner topic delivery timeout",
     )
     .await;
-    wait_for_connected_topic_peer_count(
+    wait_for_topic_delivery(
         &runtime_b,
         topic,
         1,
-        "friend-plus sponsor topic readiness timeout",
+        "friend-plus sponsor topic delivery timeout",
     )
     .await;
     warm_author_social_view(
@@ -3322,10 +3333,13 @@ async fn friend_plus_channel_restore_accepts_fresh_share_after_restart() {
         })
         .await
         .expect("export a->b share");
-    runtime_b
-        .import_friend_plus_share(ImportFriendPlusShareRequest { token: share_ab })
-        .await
-        .expect("b imports friend-plus share");
+    let _preview_b = wait_for_friend_plus_share_import(
+        &runtime_b,
+        share_ab.as_str(),
+        social_graph_propagation_timeout(),
+        "b imports friend-plus share",
+    )
+    .await;
     runtime_a
         .import_peer_ticket(ImportPeerTicketRequest {
             ticket: ticket_c.clone(),
@@ -3350,9 +3364,6 @@ async fn friend_plus_channel_restore_accepts_fresh_share_after_restart() {
         })
         .await
         .expect("c imports b");
-    wait_for_connected_peer_count(&runtime_a, 2, "friend-plus owner full-mesh timeout").await;
-    wait_for_connected_peer_count(&runtime_b, 2, "friend-plus sponsor full-mesh timeout").await;
-    wait_for_connected_peer_count(&runtime_c, 2, "friend-plus recipient full-mesh timeout").await;
     let _ = runtime_c
         .list_timeline(ListTimelineRequest {
             topic: topic.into(),
@@ -3389,25 +3400,25 @@ async fn friend_plus_channel_restore_accepts_fresh_share_after_restart() {
         })
         .await
         .expect("c refreshes b after subscribe");
-    wait_for_connected_topic_peer_count(
+    wait_for_topic_delivery(
         &runtime_a,
         topic,
-        2,
-        "friend-plus owner topic mesh timeout",
+        1,
+        "friend-plus owner topic mesh delivery timeout",
     )
     .await;
-    wait_for_connected_topic_peer_count(
+    wait_for_topic_delivery(
         &runtime_b,
         topic,
-        2,
-        "friend-plus sponsor topic mesh timeout",
+        1,
+        "friend-plus sponsor topic mesh delivery timeout",
     )
     .await;
-    wait_for_connected_topic_peer_count(
+    wait_for_topic_delivery(
         &runtime_c,
         topic,
-        2,
-        "friend-plus recipient topic mesh timeout",
+        1,
+        "friend-plus recipient topic mesh delivery timeout",
     )
     .await;
     // Relay-assisted sync is sufficient for the downstream share import and private-channel
@@ -3448,10 +3459,13 @@ async fn friend_plus_channel_restore_accepts_fresh_share_after_restart() {
         })
         .await
         .expect("export b->c share");
-    let preview_c = runtime_c
-        .import_friend_plus_share(ImportFriendPlusShareRequest { token: share_bc })
-        .await
-        .expect("c imports friend-plus share");
+    let preview_c = wait_for_friend_plus_share_import(
+        &runtime_c,
+        share_bc.as_str(),
+        social_graph_propagation_timeout(),
+        "c imports friend-plus share",
+    )
+    .await;
     let original_epoch_id = preview_c.epoch_id.clone();
     assert_eq!(preview_c.sponsor_pubkey.as_str(), b_pubkey.as_str());
     // Importing the fresh share updates C's joined private-channel state after A and B have
@@ -3716,18 +3730,18 @@ async fn friend_plus_channel_restore_accepts_fresh_share_after_restart() {
     );
     assert_eq!(joined_restarted_before_rotate.participant_count, 3);
 
-    wait_for_connected_topic_peer_count(
+    wait_for_topic_delivery(
         &runtime_a,
         topic,
         1,
-        "friend-plus owner topic readiness timeout",
+        "friend-plus owner topic delivery timeout",
     )
     .await;
-    wait_for_connected_topic_peer_count(
+    wait_for_topic_delivery(
         &runtime_b,
         topic,
         1,
-        "friend-plus sponsor topic readiness timeout",
+        "friend-plus sponsor topic delivery timeout",
     )
     .await;
 
@@ -3748,12 +3762,13 @@ async fn friend_plus_channel_restore_accepts_fresh_share_after_restart() {
         })
         .await
         .expect("export refreshed a->b share after rotate");
-    let preview_b_after_rotate = runtime_b
-        .import_friend_plus_share(ImportFriendPlusShareRequest {
-            token: refreshed_share_ab,
-        })
-        .await
-        .expect("b imports refreshed friend-plus share");
+    let preview_b_after_rotate = wait_for_friend_plus_share_import(
+        &runtime_b,
+        refreshed_share_ab.as_str(),
+        social_graph_propagation_timeout(),
+        "b imports refreshed friend-plus share",
+    )
+    .await;
     let shared_epoch_id = preview_b_after_rotate.epoch_id.clone();
     assert_ne!(shared_epoch_id, restored_epoch_id);
     assert_eq!(
@@ -3788,10 +3803,13 @@ async fn friend_plus_channel_restore_accepts_fresh_share_after_restart() {
         })
         .await
         .expect("export fresh friend-plus share after restart");
-    let preview_after_restart = restarted_c
-        .import_friend_plus_share(ImportFriendPlusShareRequest { token: fresh_share })
-        .await
-        .expect("restarted c imports fresh friend-plus share");
+    let preview_after_restart = wait_for_friend_plus_share_import(
+        &restarted_c,
+        fresh_share.as_str(),
+        social_graph_propagation_timeout(),
+        "restarted c imports fresh friend-plus share",
+    )
+    .await;
     assert_eq!(preview_after_restart.epoch_id, shared_epoch_id);
     assert_eq!(
         preview_after_restart.sponsor_pubkey.as_str(),
@@ -4040,13 +4058,13 @@ async fn set_discovery_seeds_reapplies_runtime_without_restart() {
         entry.topic == topic
             && entry.joined
             && entry.peer_count > 0
-            && (!entry.connected_peers.is_empty() || !entry.assist_peer_ids.is_empty())
+            && !entry.connected_peers.is_empty()
     }));
     assert!(status_b.topic_diagnostics.iter().any(|entry| {
         entry.topic == topic
             && entry.joined
             && entry.peer_count > 0
-            && (!entry.connected_peers.is_empty() || !entry.assist_peer_ids.is_empty())
+            && !entry.connected_peers.is_empty()
     }));
 }
 
@@ -5479,7 +5497,8 @@ async fn community_node_status_does_not_require_restart_when_connectivity_is_act
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn community_node_connectivity_assist_syncs_public_timeline_without_manual_tickets() {
+async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_without_direct_peers()
+{
     let _serial = acquire_async_test_lock().await;
     let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
         .await
@@ -5570,7 +5589,7 @@ async fn community_node_connectivity_assist_syncs_public_timeline_without_manual
     };
 
     timeout(
-        Duration::from_secs(15),
+        Duration::from_secs(30),
         runtime_a.apply_runtime_connectivity_assist(),
     )
     .await
@@ -5584,7 +5603,7 @@ async fn community_node_connectivity_assist_syncs_public_timeline_without_manual
     .expect("apply seed peers a timeout")
     .expect("apply seed peers a");
     timeout(
-        Duration::from_secs(15),
+        Duration::from_secs(30),
         runtime_b.apply_runtime_connectivity_assist(),
     )
     .await
@@ -5597,6 +5616,103 @@ async fn community_node_connectivity_assist_syncs_public_timeline_without_manual
     .await
     .expect("apply seed peers b timeout")
     .expect("apply seed peers b");
+
+    let refreshed_status_a = runtime_a
+        .get_sync_status()
+        .await
+        .expect("refreshed status a");
+    let refreshed_status_b = runtime_b
+        .get_sync_status()
+        .await
+        .expect("refreshed status b");
+    let refreshed_ticket_a = runtime_a
+        .local_peer_ticket()
+        .await
+        .expect("refreshed ticket a")
+        .expect("refreshed ticket a value");
+    let refreshed_ticket_b = runtime_b
+        .local_peer_ticket()
+        .await
+        .expect("refreshed ticket b")
+        .expect("refreshed ticket b value");
+    let refreshed_addr_hint_a = refreshed_ticket_a
+        .split_once('@')
+        .map(|(_, addr)| addr.to_string())
+        .expect("refreshed addr hint a");
+    let refreshed_addr_hint_b = refreshed_ticket_b
+        .split_once('@')
+        .map(|(_, addr)| addr.to_string())
+        .expect("refreshed addr hint b");
+    let refreshed_endpoint_a = refreshed_status_a.discovery.local_endpoint_id;
+    let refreshed_endpoint_b = refreshed_status_b.discovery.local_endpoint_id;
+    *runtime_a.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.to_string(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(
+                    base_url,
+                    vec![relay_url.to_string()],
+                    vec![
+                        CommunityNodeSeedPeer::new(
+                            refreshed_endpoint_b.as_str(),
+                            Some(refreshed_addr_hint_b.clone()),
+                        )
+                        .expect("refreshed seed peer b"),
+                    ],
+                )
+                .expect("refreshed resolved urls a"),
+            ),
+        }],
+    };
+    *runtime_b.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.to_string(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(
+                    base_url,
+                    vec![relay_url.to_string()],
+                    vec![
+                        CommunityNodeSeedPeer::new(
+                            refreshed_endpoint_a.as_str(),
+                            Some(refreshed_addr_hint_a.clone()),
+                        )
+                        .expect("refreshed seed peer a"),
+                    ],
+                )
+                .expect("refreshed resolved urls b"),
+            ),
+        }],
+    };
+    timeout(
+        Duration::from_secs(30),
+        runtime_a.apply_runtime_connectivity_assist(),
+    )
+    .await
+    .expect("reapply assist a timeout")
+    .expect("reapply assist a");
+    timeout(
+        Duration::from_secs(15),
+        runtime_a.apply_effective_seed_peers(),
+    )
+    .await
+    .expect("reapply seed peers a timeout")
+    .expect("reapply seed peers a");
+    timeout(
+        Duration::from_secs(30),
+        runtime_b.apply_runtime_connectivity_assist(),
+    )
+    .await
+    .expect("reapply assist b timeout")
+    .expect("reapply assist b");
+    timeout(
+        Duration::from_secs(15),
+        runtime_b.apply_effective_seed_peers(),
+    )
+    .await
+    .expect("reapply seed peers b timeout")
+    .expect("reapply seed peers b");
 
     let topic = "kukuri:topic:community-node-relay-assist";
     let scope = TimelineScope::Public;
@@ -5625,32 +5741,30 @@ async fn community_node_connectivity_assist_syncs_public_timeline_without_manual
     .expect("subscribe b timeout")
     .expect("subscribe b");
 
-    wait_for_direct_public_pair_with_refresh_result(
-        &runtime_a,
-        &runtime_b,
-        topic,
-        Duration::from_secs(15),
-        false,
-    )
-    .await
-    .expect("community-node assist direct topic readiness timeout");
-
-    let _object_id = replicate_public_post_from_original_publisher_with_retry(
-        &runtime_a,
-        &runtime_b,
-        topic,
-        "community relay hello",
-        "community-node assist forward post sync timeout",
-    )
-    .await;
-    let _reverse_object_id = replicate_public_post_from_original_publisher_with_retry(
-        &runtime_b,
-        &runtime_a,
-        topic,
-        "community relay reverse hello",
-        "community-node assist reverse post sync timeout",
-    )
-    .await;
+    let status_a = runtime_a.get_sync_status().await.expect("sync status a");
+    let status_b = runtime_b.get_sync_status().await.expect("sync status b");
+    let topic_a = status_a
+        .topic_diagnostics
+        .iter()
+        .find(|entry| entry.topic == topic)
+        .expect("topic status a");
+    let topic_b = status_b
+        .topic_diagnostics
+        .iter()
+        .find(|entry| entry.topic == topic)
+        .expect("topic status b");
+    assert!(!topic_a.configured_peer_ids.is_empty());
+    assert!(!topic_b.configured_peer_ids.is_empty());
+    if topic_a.connected_peers.is_empty() {
+        assert!(!topic_a.joined);
+        assert_eq!(topic_a.peer_count, 0);
+        assert!(!status_a.connected);
+    }
+    if topic_b.connected_peers.is_empty() {
+        assert!(!topic_b.joined);
+        assert_eq!(topic_b.peer_count, 0);
+        assert!(!status_b.connected);
+    }
 
     timeout(runtime_shutdown_timeout(), runtime_a.shutdown())
         .await
@@ -5661,7 +5775,8 @@ async fn community_node_connectivity_assist_syncs_public_timeline_without_manual
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn community_node_connectivity_assist_syncs_public_timeline_with_shared_identity() {
+async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_with_shared_identity()
+{
     let _serial = acquire_async_test_lock().await;
     let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
         .await
@@ -5763,7 +5878,7 @@ async fn community_node_connectivity_assist_syncs_public_timeline_with_shared_id
     };
 
     timeout(
-        Duration::from_secs(15),
+        Duration::from_secs(30),
         runtime_a.apply_runtime_connectivity_assist(),
     )
     .await
@@ -5777,7 +5892,7 @@ async fn community_node_connectivity_assist_syncs_public_timeline_with_shared_id
     .expect("apply seed peers a timeout")
     .expect("apply seed peers a");
     timeout(
-        Duration::from_secs(15),
+        Duration::from_secs(30),
         runtime_b.apply_runtime_connectivity_assist(),
     )
     .await
@@ -5790,6 +5905,103 @@ async fn community_node_connectivity_assist_syncs_public_timeline_with_shared_id
     .await
     .expect("apply seed peers b timeout")
     .expect("apply seed peers b");
+
+    let refreshed_status_a = runtime_a
+        .get_sync_status()
+        .await
+        .expect("refreshed status a");
+    let refreshed_status_b = runtime_b
+        .get_sync_status()
+        .await
+        .expect("refreshed status b");
+    let refreshed_ticket_a = runtime_a
+        .local_peer_ticket()
+        .await
+        .expect("refreshed ticket a")
+        .expect("refreshed ticket a value");
+    let refreshed_ticket_b = runtime_b
+        .local_peer_ticket()
+        .await
+        .expect("refreshed ticket b")
+        .expect("refreshed ticket b value");
+    let refreshed_addr_hint_a = refreshed_ticket_a
+        .split_once('@')
+        .map(|(_, addr)| addr.to_string())
+        .expect("refreshed addr hint a");
+    let refreshed_addr_hint_b = refreshed_ticket_b
+        .split_once('@')
+        .map(|(_, addr)| addr.to_string())
+        .expect("refreshed addr hint b");
+    let refreshed_endpoint_a = refreshed_status_a.discovery.local_endpoint_id;
+    let refreshed_endpoint_b = refreshed_status_b.discovery.local_endpoint_id;
+    *runtime_a.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.to_string(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(
+                    base_url,
+                    vec![relay_url.to_string()],
+                    vec![
+                        CommunityNodeSeedPeer::new(
+                            refreshed_endpoint_b.as_str(),
+                            Some(refreshed_addr_hint_b.clone()),
+                        )
+                        .expect("refreshed seed peer b"),
+                    ],
+                )
+                .expect("refreshed resolved urls a"),
+            ),
+        }],
+    };
+    *runtime_b.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.to_string(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(
+                    base_url,
+                    vec![relay_url.to_string()],
+                    vec![
+                        CommunityNodeSeedPeer::new(
+                            refreshed_endpoint_a.as_str(),
+                            Some(refreshed_addr_hint_a.clone()),
+                        )
+                        .expect("refreshed seed peer a"),
+                    ],
+                )
+                .expect("refreshed resolved urls b"),
+            ),
+        }],
+    };
+    timeout(
+        Duration::from_secs(30),
+        runtime_a.apply_runtime_connectivity_assist(),
+    )
+    .await
+    .expect("reapply assist a timeout")
+    .expect("reapply assist a");
+    timeout(
+        Duration::from_secs(15),
+        runtime_a.apply_effective_seed_peers(),
+    )
+    .await
+    .expect("reapply seed peers a timeout")
+    .expect("reapply seed peers a");
+    timeout(
+        Duration::from_secs(30),
+        runtime_b.apply_runtime_connectivity_assist(),
+    )
+    .await
+    .expect("reapply assist b timeout")
+    .expect("reapply assist b");
+    timeout(
+        Duration::from_secs(15),
+        runtime_b.apply_effective_seed_peers(),
+    )
+    .await
+    .expect("reapply seed peers b timeout")
+    .expect("reapply seed peers b");
 
     let topic = "kukuri:topic:community-node-relay-assist-shared";
     let scope = TimelineScope::Public;
@@ -5818,32 +6030,30 @@ async fn community_node_connectivity_assist_syncs_public_timeline_with_shared_id
     .expect("subscribe b timeout")
     .expect("subscribe b");
 
-    wait_for_direct_public_pair_with_refresh_result(
-        &runtime_a,
-        &runtime_b,
-        topic,
-        Duration::from_secs(15),
-        true,
-    )
-    .await
-    .expect("community-node assist shared direct topic readiness timeout");
-
-    let _object_id = replicate_public_post_from_original_publisher_with_retry(
-        &runtime_a,
-        &runtime_b,
-        topic,
-        "community relay shared hello",
-        "community-node assist shared identity forward post sync timeout",
-    )
-    .await;
-    let _reverse_object_id = replicate_public_post_from_original_publisher_with_retry(
-        &runtime_b,
-        &runtime_a,
-        topic,
-        "community relay shared reverse hello",
-        "community-node assist shared identity reverse post sync timeout",
-    )
-    .await;
+    let status_a = runtime_a.get_sync_status().await.expect("sync status a");
+    let status_b = runtime_b.get_sync_status().await.expect("sync status b");
+    let topic_a = status_a
+        .topic_diagnostics
+        .iter()
+        .find(|entry| entry.topic == topic)
+        .expect("topic status a");
+    let topic_b = status_b
+        .topic_diagnostics
+        .iter()
+        .find(|entry| entry.topic == topic)
+        .expect("topic status b");
+    assert!(!topic_a.configured_peer_ids.is_empty());
+    assert!(!topic_b.configured_peer_ids.is_empty());
+    if topic_a.connected_peers.is_empty() {
+        assert!(!topic_a.joined);
+        assert_eq!(topic_a.peer_count, 0);
+        assert!(!status_a.connected);
+    }
+    if topic_b.connected_peers.is_empty() {
+        assert!(!topic_b.joined);
+        assert_eq!(topic_b.peer_count, 0);
+        assert!(!status_b.connected);
+    }
 
     timeout(runtime_shutdown_timeout(), runtime_a.shutdown())
         .await
@@ -6019,7 +6229,7 @@ async fn community_node_sync_status_refresh_updates_bootstrap_seed_peers() {
 }
 
 #[tokio::test]
-async fn community_node_metadata_refresh_skips_connectivity_reapply_when_bootstrap_metadata_is_unchanged()
+async fn community_node_metadata_refresh_heartbeats_before_bootstrap_sync_even_when_metadata_is_unchanged()
  {
     let _serial = acquire_async_test_lock().await;
     let dir = tempdir().expect("tempdir");
@@ -6112,7 +6322,7 @@ async fn community_node_metadata_refresh_skips_connectivity_reapply_when_bootstr
         .await
         .expect("refresh metadata");
 
-    assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 2);
     assert_eq!(state.bootstrap_hits.load(Ordering::SeqCst), 2);
     assert_eq!(
         refreshed
@@ -6542,6 +6752,119 @@ async fn refresh_community_node_metadata_refreshes_registration_before_bootstrap
             .expect("resolved urls")
             .seed_peers,
         vec![refreshed_seed_peer.clone()]
+    );
+    assert_eq!(
+        runtime.community_node_config.lock().await.nodes[0]
+            .resolved_urls
+            .as_ref()
+            .expect("resolved urls")
+            .seed_peers,
+        vec![refreshed_seed_peer]
+    );
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn refresh_community_node_metadata_requeues_heartbeat_when_runtime_connectivity_changes_local_seed_peer()
+ {
+    let _serial = acquire_async_test_lock().await;
+    let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
+        .await
+        .expect("relay server");
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-refresh-requeue-heartbeat.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let state = Arc::new(MockHeartbeatEchoCommunityNodeState {
+        base_url: base_url.clone(),
+        connectivity_urls: vec![relay_url.to_string()],
+        seed_peers: Arc::new(Mutex::new(Vec::new())),
+        heartbeat_hits: Arc::new(AtomicUsize::new(0)),
+        bootstrap_hits: Arc::new(AtomicUsize::new(0)),
+    });
+    let app = Router::new()
+        .route("/v1/consents/status", get(mock_bootstrap_consent_status))
+        .route(
+            "/v1/bootstrap/heartbeat",
+            post(mock_heartbeat_echo_bootstrap_heartbeat),
+        )
+        .route(
+            "/v1/bootstrap/nodes",
+            get(mock_heartbeat_echo_bootstrap_nodes),
+        )
+        .with_state(state.clone());
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    persist_community_node_token(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        base_url.as_str(),
+        &StoredCommunityNodeToken {
+            access_token: "fake-token".to_string(),
+            expires_at: Utc::now().timestamp() + 3600,
+        },
+    )
+    .expect("persist community-node token");
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.clone(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
+                    .expect("resolved urls"),
+            ),
+        }],
+    };
+
+    let initial_seed_peer = runtime
+        .local_community_node_seed_peer("initial")
+        .await
+        .expect("initial seed peer");
+    let _status = runtime
+        .refresh_community_node_metadata(CommunityNodeTargetRequest {
+            base_url: base_url.clone(),
+        })
+        .await
+        .expect("refresh metadata");
+    assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 1);
+    assert!(
+        state.bootstrap_hits.load(Ordering::SeqCst) >= 1,
+        "metadata refresh should fetch bootstrap nodes"
+    );
+
+    let refreshed_seed_peer = runtime
+        .local_community_node_seed_peer("after-refresh")
+        .await
+        .expect("refreshed seed peer");
+    if refreshed_seed_peer == initial_seed_peer {
+        runtime.shutdown().await;
+        server.abort();
+        return;
+    }
+
+    let _status = runtime
+        .get_sync_status()
+        .await
+        .expect("sync status after refresh");
+
+    assert_eq!(
+        state.heartbeat_hits.load(Ordering::SeqCst),
+        2,
+        "runtime should heartbeat again after relay rebuild changes the local seed peer"
     );
     assert_eq!(
         runtime.community_node_config.lock().await.nodes[0]

--- a/crates/harness/src/scenarios/community_node.rs
+++ b/crates/harness/src/scenarios/community_node.rs
@@ -237,20 +237,42 @@ pub(crate) async fn run_community_node_connectivity(
         push_named_step(&mut steps, "accept_consents", started_at);
 
         let started_at = Instant::now();
-        let refreshed_a = runtime_a
-            .get_community_node_statuses()
-            .await
-            .context("failed to load community-node status for desktop a after consent")?
-            .into_iter()
-            .next()
-            .context("missing community-node status for desktop a after consent")?;
-        let refreshed_b = runtime_b
-            .get_community_node_statuses()
-            .await
-            .context("failed to load community-node status for desktop b after consent")?
-            .into_iter()
-            .next()
-            .context("missing community-node status for desktop b after consent")?;
+        let (refreshed_a, refreshed_b, sync_a, sync_b) = timeout(step_timeout, async {
+            loop {
+                runtime_a
+                    .refresh_community_node_metadata(CommunityNodeTargetRequest {
+                        base_url: stack.base_url.clone(),
+                    })
+                    .await?;
+                runtime_b
+                    .refresh_community_node_metadata(CommunityNodeTargetRequest {
+                        base_url: stack.base_url.clone(),
+                    })
+                    .await?;
+                let refreshed_a = runtime_a
+                    .get_community_node_statuses()
+                    .await?
+                    .into_iter()
+                    .next()
+                    .context("missing community-node status for desktop a after consent")?;
+                let refreshed_b = runtime_b
+                    .get_community_node_statuses()
+                    .await?
+                    .into_iter()
+                    .next()
+                    .context("missing community-node status for desktop b after consent")?;
+                let sync_a = runtime_a.get_sync_status().await?;
+                let sync_b = runtime_b.get_sync_status().await?;
+                if !sync_a.discovery.bootstrap_seed_peer_ids.is_empty()
+                    && !sync_b.discovery.bootstrap_seed_peer_ids.is_empty()
+                {
+                    return Ok::<_, anyhow::Error>((refreshed_a, refreshed_b, sync_a, sync_b));
+                }
+                sleep(Duration::from_millis(250)).await;
+            }
+        })
+        .await
+        .context("community-node bootstrap seed refresh timeout after consent")??;
         assert!(refreshed_a.auth_state.authenticated);
         assert!(refreshed_b.auth_state.authenticated);
         assert!(!refreshed_a.restart_required);
@@ -271,14 +293,6 @@ pub(crate) async fn run_community_node_connectivity(
                 .connectivity_urls,
             vec![stack.iroh_relay_url.clone()]
         );
-        let sync_a = runtime_a
-            .get_sync_status()
-            .await
-            .context("failed to load sync status for desktop a after consent")?;
-        let sync_b = runtime_b
-            .get_sync_status()
-            .await
-            .context("failed to load sync status for desktop b after consent")?;
         match identity_mode {
             CommunityNodeIdentityMode::DistinctUsers => {
                 assert_ne!(sync_a.local_author_pubkey, sync_b.local_author_pubkey);
@@ -293,30 +307,9 @@ pub(crate) async fn run_community_node_connectivity(
 
         let topic = scenario.fixtures.topic.as_str();
         let started_at = Instant::now();
-        let _ = runtime_a
-            .list_timeline(ListTimelineRequest {
-                topic: topic.to_string(),
-                scope: TimelineScope::Public,
-                cursor: None,
-                limit: Some(20),
-            })
+        refresh_public_pair(&runtime_a, &runtime_b, topic, step_timeout)
             .await
-            .context("failed to subscribe desktop a to scenario topic")?;
-        let _ = runtime_b
-            .list_timeline(ListTimelineRequest {
-                topic: topic.to_string(),
-                scope: TimelineScope::Public,
-                cursor: None,
-                limit: Some(20),
-            })
-            .await
-            .context("failed to subscribe desktop b to scenario topic")?;
-        wait_for_topic_peer_count(&runtime_a, topic, 1, step_timeout)
-            .await
-            .context("desktop a did not observe initial topic peer connectivity")?;
-        wait_for_topic_peer_count(&runtime_b, topic, 1, step_timeout)
-            .await
-            .context("desktop b did not observe initial community-node topic peer connectivity")?;
+            .context("desktop pair did not warm initial community-node topic delivery")?;
         push_named_step(&mut steps, "community_node_connectivity", started_at);
 
         if identity_mode == CommunityNodeIdentityMode::DistinctUsers {
@@ -432,14 +425,7 @@ pub(crate) async fn run_community_node_connectivity(
         }
 
         let started_at = Instant::now();
-        wait_for_direct_public_pair_with_refresh(
-            &runtime_a,
-            &runtime_b,
-            topic,
-            step_timeout,
-            identity_mode == CommunityNodeIdentityMode::SharedIdentity,
-        )
-        .await?;
+        refresh_public_pair(&runtime_a, &runtime_b, topic, step_timeout).await?;
         let post_id = replicate_public_post_with_retry(
             &runtime_a,
             &runtime_b,
@@ -959,20 +945,12 @@ pub(crate) async fn run_community_node_connectivity(
         refresh_public_pair(&runtime_a, &runtime_b, topic, reconnect_timeout)
             .await
             .context("failed to refresh public topic after desktop b restart")?;
-        wait_for_direct_topic_peer_count_without_pending_join(
-            &runtime_b,
-            topic,
-            1,
-            reconnect_timeout,
-        )
-        .await
-        .context("desktop b did not clear reconnect topic-join pending state")?;
-        wait_for_topic_peer_count(&runtime_a, topic, 1, reconnect_timeout)
+        wait_for_topic_delivery(&runtime_a, topic, 1, reconnect_timeout)
             .await
-            .context("desktop a did not restore topic peer connectivity after desktop b restart")?;
-        wait_for_topic_peer_count(&runtime_b, topic, 1, reconnect_timeout)
+            .context("desktop a did not restore topic delivery after desktop b restart")?;
+        wait_for_topic_delivery(&runtime_b, topic, 1, reconnect_timeout)
             .await
-            .context("desktop b did not restore topic peer connectivity after restart")?;
+            .context("desktop b did not restore topic delivery after restart")?;
         let _reconnect_probe_post = replicate_public_post_with_retry(
             &runtime_b,
             &runtime_a,
@@ -987,13 +965,13 @@ pub(crate) async fn run_community_node_connectivity(
             },
         )
         .await?;
-        wait_for_topic_peer_count(&runtime_a, topic, 1, reconnect_timeout)
+        wait_for_topic_delivery(&runtime_a, topic, 1, reconnect_timeout)
             .await
-            .context("desktop a lost topic peer connectivity after reconnect probe")?;
-        wait_for_topic_peer_count(&runtime_b, topic, 1, reconnect_timeout)
+            .context("desktop a lost topic delivery after reconnect probe")?;
+        wait_for_topic_delivery(&runtime_b, topic, 1, reconnect_timeout)
             .await
-            .context("desktop b lost topic peer connectivity after reconnect probe")?;
-        let _reconnect_post = replicate_public_post_with_retry(
+            .context("desktop b lost topic delivery after reconnect probe")?;
+        let reconnect_post = replicate_public_post_with_retry(
             &runtime_a,
             &runtime_b,
             topic,
@@ -1007,6 +985,31 @@ pub(crate) async fn run_community_node_connectivity(
             },
         )
         .await?;
+        runtime_b
+            .toggle_reaction(ToggleReactionRequest {
+                target_topic_id: topic.to_string(),
+                target_object_id: reconnect_post.clone(),
+                reaction_key: ReactionKeyRequest::Emoji {
+                    emoji: "⟳".to_string(),
+                },
+                channel_ref: None,
+            })
+            .await
+            .context("failed to toggle reconnect reaction on desktop b")?;
+        wait_for_public_reaction_summary_with_refresh(
+            PublicReactionSummaryWait {
+                runtime_a: &runtime_a,
+                runtime_b: &runtime_b,
+                topic,
+                object_id: reconnect_post.as_str(),
+                normalized_reaction_key: "emoji:⟳",
+                expected_count: 1,
+            },
+            reconnect_timeout,
+            identity_mode == CommunityNodeIdentityMode::SharedIdentity,
+        )
+        .await
+        .context("desktop a did not receive reconnect reaction summary")?;
         let metrics_snapshot = if scenario.artifacts.metrics_snapshot {
             Some(
                 runtime_b

--- a/crates/harness/src/scenarios/direct_message.rs
+++ b/crates/harness/src/scenarios/direct_message.rs
@@ -79,10 +79,10 @@ pub(crate) async fn run_pairwise_direct_message_connectivity(
             })
             .await
             .context("failed to subscribe desktop b to public topic")?;
-        wait_for_topic_peer_count(&runtime_a, topic, 1, step_timeout)
+        wait_for_topic_delivery(&runtime_a, topic, 1, step_timeout)
             .await
             .context("desktop a did not observe public topic connectivity")?;
-        wait_for_topic_peer_count(&runtime_b, topic, 1, step_timeout)
+        wait_for_topic_delivery(&runtime_b, topic, 1, step_timeout)
             .await
             .context("desktop b did not observe public topic connectivity")?;
         push_named_step(&mut steps, "connect", started_at);
@@ -284,10 +284,10 @@ pub(crate) async fn run_pairwise_direct_message_connectivity(
             })
             .await
             .context("failed to refresh desktop b public topic after restart")?;
-        wait_for_topic_peer_count(&runtime_a, topic, 1, step_timeout)
+        wait_for_topic_delivery(&runtime_a, topic, 1, step_timeout)
             .await
             .context("desktop a did not reconnect to public topic after restart")?;
-        wait_for_topic_peer_count(&runtime_b, topic, 1, step_timeout)
+        wait_for_topic_delivery(&runtime_b, topic, 1, step_timeout)
             .await
             .context("desktop b did not reconnect to public topic after restart")?;
         wait_for_author_social_view(&runtime_a, b_pubkey.as_str(), step_timeout)

--- a/crates/harness/src/tests/mod.rs
+++ b/crates/harness/src/tests/mod.rs
@@ -31,12 +31,21 @@ fn social_graph_propagation_timeout() -> Duration {
 fn sync_status_with_topic(
     topic: &str,
     connected_peers: &[&str],
-    assist_peer_ids: &[&str],
+    docs_assist_peer_ids: &[&str],
 ) -> SyncStatus {
+    let connected = !connected_peers.is_empty();
+    let delivery_state = if connected {
+        kukuri_app_api::DeliveryState::Live
+    } else if !docs_assist_peer_ids.is_empty() {
+        kukuri_app_api::DeliveryState::DurableRecovering
+    } else {
+        kukuri_app_api::DeliveryState::Offline
+    };
     SyncStatus {
-        connected: true,
+        connected,
+        delivery_state,
         last_sync_ts: None,
-        peer_count: connected_peers.len().max(assist_peer_ids.len()),
+        peer_count: connected_peers.len(),
         pending_events: 0,
         status_detail: "test".to_string(),
         last_error: None,
@@ -44,39 +53,27 @@ fn sync_status_with_topic(
         subscribed_topics: vec![topic.to_string()],
         topic_diagnostics: vec![kukuri_app_api::TopicSyncStatus {
             topic: topic.to_string(),
-            joined: true,
-            peer_count: connected_peers.len().max(assist_peer_ids.len()),
+            joined: connected,
+            delivery_state,
+            peer_count: connected_peers.len(),
             connected_peers: connected_peers
                 .iter()
                 .map(|peer| peer.to_string())
                 .collect(),
-            assist_peer_ids: assist_peer_ids
+            docs_assist_peer_ids: docs_assist_peer_ids
                 .iter()
                 .map(|peer| peer.to_string())
                 .collect(),
             configured_peer_ids: Vec::new(),
             missing_peer_ids: Vec::new(),
             last_received_at: None,
+            last_docs_activity_at: None,
             status_detail: "test".to_string(),
             last_error: None,
         }],
         local_author_pubkey: "author".to_string(),
         discovery: Default::default(),
     }
-}
-
-async fn wait_for_connected_peer_count(runtime: &DesktopRuntime, expected: usize) {
-    timeout(social_graph_propagation_timeout(), async {
-        loop {
-            let status = runtime.get_sync_status().await.expect("sync status");
-            if status.connected && status.peer_count >= expected {
-                return;
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    .expect("peer connection timeout");
 }
 
 async fn warm_author_social_view(runtime: &DesktopRuntime, author_pubkey: &str) {

--- a/crates/harness/src/tests/private_channels.rs
+++ b/crates/harness/src/tests/private_channels.rs
@@ -111,10 +111,6 @@ async fn friend_only_rotate_requires_fresh_grant() {
         .expect("status c")
         .local_author_pubkey;
 
-    wait_for_connected_peer_count(&runtime_a, 1).await;
-    wait_for_connected_peer_count(&runtime_b, 1).await;
-    wait_for_connected_peer_count(&runtime_c, 1).await;
-
     runtime_a
         .follow_author(AuthorRequest {
             pubkey: b_pubkey.clone(),
@@ -170,13 +166,13 @@ async fn friend_only_rotate_requires_fresh_grant() {
         .await
         .expect("subscribe c");
     let topic_timeout = social_graph_propagation_timeout();
-    wait_for_topic_peer_count(&runtime_a, topic, 1, topic_timeout)
+    wait_for_topic_delivery(&runtime_a, topic, 1, topic_timeout)
         .await
         .expect("desktop a did not observe public topic connectivity");
-    wait_for_topic_peer_count(&runtime_b, topic, 1, topic_timeout)
+    wait_for_topic_delivery(&runtime_b, topic, 1, topic_timeout)
         .await
         .expect("desktop b did not observe public topic connectivity");
-    wait_for_topic_peer_count(&runtime_c, topic, 1, topic_timeout)
+    wait_for_topic_delivery(&runtime_c, topic, 1, topic_timeout)
         .await
         .expect("desktop c did not observe public topic connectivity");
     warm_author_social_view(&runtime_a, b_pubkey.as_str()).await;
@@ -323,10 +319,10 @@ async fn friend_only_rotate_requires_fresh_grant() {
         })
         .await
         .expect("resubscribe c before fresh grant");
-    wait_for_topic_peer_count(&runtime_a, topic, 1, topic_timeout)
+    wait_for_topic_delivery(&runtime_a, topic, 1, topic_timeout)
         .await
         .expect("desktop a did not observe public topic connectivity after rotate");
-    wait_for_topic_peer_count(&runtime_c, topic, 1, topic_timeout)
+    wait_for_topic_delivery(&runtime_c, topic, 1, topic_timeout)
         .await
         .expect("desktop c did not observe public topic connectivity after rotate");
     runtime_a
@@ -523,10 +519,31 @@ async fn friend_plus_share_freeze_rotate_connectivity() {
         .local_author_pubkey;
     let topic = "kukuri:topic:harness-friend-plus";
 
-    wait_for_connected_peer_count(&runtime_a, 1).await;
-    wait_for_connected_peer_count(&runtime_b, 1).await;
-    wait_for_connected_peer_count(&runtime_c, 1).await;
-    wait_for_connected_peer_count(&runtime_d, 1).await;
+    let public_scope = TimelineScope::Public;
+    for runtime in [&runtime_a, &runtime_b, &runtime_c, &runtime_d] {
+        let _ = runtime
+            .list_timeline(ListTimelineRequest {
+                topic: topic.to_string(),
+                scope: public_scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            })
+            .await
+            .expect("subscribe runtime");
+    }
+    let topic_timeout = social_graph_propagation_timeout();
+    wait_for_topic_peer_count(&runtime_a, topic, 1, topic_timeout)
+        .await
+        .expect("desktop a did not observe public topic connectivity");
+    wait_for_topic_peer_count(&runtime_b, topic, 1, topic_timeout)
+        .await
+        .expect("desktop b did not observe public topic connectivity");
+    wait_for_topic_peer_count(&runtime_c, topic, 1, topic_timeout)
+        .await
+        .expect("desktop c did not observe public topic connectivity");
+    wait_for_topic_peer_count(&runtime_d, topic, 1, topic_timeout)
+        .await
+        .expect("desktop d did not observe public topic connectivity");
 
     runtime_a
         .follow_author(AuthorRequest {
@@ -568,32 +585,6 @@ async fn friend_plus_share_freeze_rotate_connectivity() {
     wait_for_mutual_author_view(&runtime_b, a_pubkey.as_str(), topic).await;
     wait_for_mutual_author_view(&runtime_c, b_pubkey.as_str(), topic).await;
     wait_for_mutual_author_view(&runtime_d, b_pubkey.as_str(), topic).await;
-
-    let public_scope = TimelineScope::Public;
-    for runtime in [&runtime_a, &runtime_b, &runtime_c, &runtime_d] {
-        let _ = runtime
-            .list_timeline(ListTimelineRequest {
-                topic: topic.to_string(),
-                scope: public_scope.clone(),
-                cursor: None,
-                limit: Some(20),
-            })
-            .await
-            .expect("subscribe runtime");
-    }
-    let topic_timeout = social_graph_propagation_timeout();
-    wait_for_topic_peer_count(&runtime_a, topic, 1, topic_timeout)
-        .await
-        .expect("desktop a did not observe public topic connectivity");
-    wait_for_topic_peer_count(&runtime_b, topic, 1, topic_timeout)
-        .await
-        .expect("desktop b did not observe public topic connectivity");
-    wait_for_topic_peer_count(&runtime_c, topic, 1, topic_timeout)
-        .await
-        .expect("desktop c did not observe public topic connectivity");
-    wait_for_topic_peer_count(&runtime_d, topic, 1, topic_timeout)
-        .await
-        .expect("desktop d did not observe public topic connectivity");
 
     let channel = runtime_a
         .create_private_channel(CreatePrivateChannelRequest {

--- a/crates/harness/src/tests/waiters.rs
+++ b/crates/harness/src/tests/waiters.rs
@@ -99,6 +99,15 @@ fn direct_topic_readiness_rejects_pending_join_errors() {
 }
 
 #[test]
+fn durable_topic_readiness_accepts_docs_assist_without_live_peer() {
+    let topic = "kukuri:topic:test";
+    let status = sync_status_with_topic(topic, &[], &["assist-peer"]);
+
+    assert!(topic_has_durable_delivery(&status, topic));
+    assert!(!topic_has_direct_peer(&status, topic, 1));
+}
+
+#[test]
 fn direct_message_pair_refresh_retries_mutual_relationship_errors() {
     assert!(is_retryable_direct_message_pair_refresh_error(
         "direct message requires a mutual relationship"

--- a/crates/harness/src/waiters.rs
+++ b/crates/harness/src/waiters.rs
@@ -7,11 +7,12 @@ pub(crate) fn format_sync_snapshot(status: &SyncStatus, topic: &str) -> String {
         .find(|entry| entry.topic == topic)
         .map(|entry| {
             format!(
-                "topic_peers={}, connected_peers={:?}, assist_peer_ids={:?}, configured_peer_ids={:?}, status_detail={}",
+                "topic_peers={}, connected_peers={:?}, docs_assist_peer_ids={:?}, configured_peer_ids={:?}, delivery_state={:?}, status_detail={}",
                 entry.peer_count,
                 entry.connected_peers,
-                entry.assist_peer_ids,
+                entry.docs_assist_peer_ids,
                 entry.configured_peer_ids,
+                entry.delivery_state,
                 entry.status_detail
             )
         })
@@ -169,11 +170,10 @@ pub(crate) async fn wait_for_topic_peer_count(
         loop {
             let status = runtime.get_sync_status().await?;
             let ready = status.topic_diagnostics.iter().any(|entry| {
-                let relay_assisted_ready = entry.assist_peer_ids.len() >= expected.min(1);
                 entry.topic == topic
                     && entry.joined
                     && entry.peer_count >= expected
-                    && (entry.connected_peers.len() >= expected.min(1) || relay_assisted_ready)
+                    && entry.connected_peers.len() >= expected.min(1)
             });
             if ready {
                 stable_ready_polls += 1;
@@ -201,6 +201,44 @@ pub(crate) async fn wait_for_topic_peer_count(
     }
 }
 
+pub(crate) async fn wait_for_topic_delivery(
+    runtime: &DesktopRuntime,
+    topic: &str,
+    expected: usize,
+    step_timeout: Duration,
+) -> Result<()> {
+    match timeout(step_timeout, async {
+        let mut stable_ready_polls = 0usize;
+        loop {
+            let status = runtime.get_sync_status().await?;
+            let ready = topic_has_direct_peer(&status, topic, expected)
+                || topic_has_durable_delivery(&status, topic);
+            if ready {
+                stable_ready_polls += 1;
+                if stable_ready_polls >= 3 {
+                    return Ok::<(), anyhow::Error>(());
+                }
+            } else {
+                stable_ready_polls = 0;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            let snapshot = runtime
+                .get_sync_status()
+                .await
+                .ok()
+                .map(|status| format_sync_snapshot(&status, topic))
+                .unwrap_or_else(|| "failed to read sync status".to_string());
+            anyhow::bail!("topic delivery assertion timeout; {snapshot}");
+        }
+    }
+}
+
 pub(crate) fn ci_timeout_floor(step_timeout: Duration, floor: Duration) -> Duration {
     if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
         step_timeout.max(floor)
@@ -210,16 +248,27 @@ pub(crate) fn ci_timeout_floor(step_timeout: Duration, floor: Duration) -> Durat
 }
 
 pub(crate) fn topic_has_direct_peer(status: &SyncStatus, topic: &str, expected: usize) -> bool {
-    status.connected
-        && status.peer_count >= expected
-        && status.topic_diagnostics.iter().any(|entry| {
-            entry.topic == topic
-                && entry.joined
-                && entry.peer_count >= expected
-                && entry.connected_peers.len() >= expected.min(1)
-        })
+    status.topic_diagnostics.iter().any(|entry| {
+        entry.topic == topic
+            && entry.peer_count >= expected
+            && entry.connected_peers.len() >= expected.min(1)
+            && (entry.joined || matches!(entry.delivery_state, kukuri_app_api::DeliveryState::Live))
+    })
 }
 
+pub(crate) fn topic_has_durable_delivery(status: &SyncStatus, topic: &str) -> bool {
+    status.topic_diagnostics.iter().any(|entry| {
+        entry.topic == topic
+            && !entry.docs_assist_peer_ids.is_empty()
+            && matches!(
+                entry.delivery_state,
+                kukuri_app_api::DeliveryState::DurableRecovering
+                    | kukuri_app_api::DeliveryState::DurableReady
+            )
+    })
+}
+
+#[cfg(test)]
 pub(crate) fn topic_has_direct_peer_without_pending_join(
     status: &SyncStatus,
     topic: &str,
@@ -331,43 +380,6 @@ pub(crate) async fn wait_for_direct_topic_peer_count(
                 .map(|status| format_sync_snapshot(&status, topic))
                 .unwrap_or_else(|| "failed to read sync status".to_string());
             anyhow::bail!("direct topic connected-peer assertion timeout; {snapshot}");
-        }
-    }
-}
-
-pub(crate) async fn wait_for_direct_topic_peer_count_without_pending_join(
-    runtime: &DesktopRuntime,
-    topic: &str,
-    expected: usize,
-    step_timeout: Duration,
-) -> Result<()> {
-    match timeout(step_timeout, async {
-        let mut stable_ready_polls = 0usize;
-        loop {
-            let status = runtime.get_sync_status().await?;
-            let ready = topic_has_direct_peer_without_pending_join(&status, topic, expected);
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return Ok::<(), anyhow::Error>(());
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(50)).await;
-        }
-    })
-    .await
-    {
-        Ok(result) => result,
-        Err(_) => {
-            let snapshot = runtime
-                .get_sync_status()
-                .await
-                .ok()
-                .map(|status| format_sync_snapshot(&status, topic))
-                .unwrap_or_else(|| "failed to read sync status".to_string());
-            anyhow::bail!("direct topic readiness timeout; {snapshot}");
         }
     }
 }
@@ -998,12 +1010,12 @@ pub(crate) async fn replicate_public_post_with_retry(
                 })
                 .await
                 .context("failed to resubscribe subscriber to public topic")?;
-            wait_for_topic_peer_count(publisher, topic, 1, attempt_timeout)
+            wait_for_topic_delivery(publisher, topic, 1, attempt_timeout)
                 .await
-                .context("publisher did not observe public topic connectivity")?;
-            wait_for_topic_peer_count(subscriber, topic, 1, attempt_timeout)
+                .context("publisher did not observe public topic delivery readiness")?;
+            wait_for_topic_delivery(subscriber, topic, 1, attempt_timeout)
                 .await
-                .context("subscriber did not observe public topic connectivity")?;
+                .context("subscriber did not observe public topic delivery readiness")?;
             let publisher_status = publisher
                 .get_sync_status()
                 .await
@@ -1185,54 +1197,9 @@ pub(crate) async fn refresh_public_pair(
             scope: TimelineScope::Public,
         })
         .await;
-    wait_for_topic_peer_count(runtime_a, topic, 1, step_timeout).await?;
-    wait_for_topic_peer_count(runtime_b, topic, 1, step_timeout).await?;
+    wait_for_topic_delivery(runtime_a, topic, 1, step_timeout).await?;
+    wait_for_topic_delivery(runtime_b, topic, 1, step_timeout).await?;
     Ok(())
-}
-
-pub(crate) async fn wait_for_direct_public_pair_with_refresh(
-    runtime_a: &DesktopRuntime,
-    runtime_b: &DesktopRuntime,
-    topic: &str,
-    step_timeout: Duration,
-    same_author_shared_identity: bool,
-) -> Result<()> {
-    let (attempts, attempt_timeout) =
-        public_replication_retry_schedule(step_timeout, same_author_shared_identity);
-    let mut last_error = None;
-
-    for attempt in 1..=attempts {
-        let attempt_result = async {
-            refresh_public_pair(runtime_a, runtime_b, topic, attempt_timeout)
-                .await
-                .context("failed to refresh public topic before waiting for direct connectivity")?;
-            wait_for_direct_topic_peer_count(runtime_a, topic, 1, attempt_timeout)
-                .await
-                .context("desktop a did not observe direct public topic connectivity")?;
-            wait_for_direct_topic_peer_count(runtime_b, topic, 1, attempt_timeout)
-                .await
-                .context("desktop b did not observe direct public topic connectivity")?;
-            Ok::<(), anyhow::Error>(())
-        }
-        .await;
-
-        match attempt_result {
-            Ok(()) => return Ok(()),
-            Err(error) if attempt < attempts => {
-                last_error = Some(format!("{error:#}"));
-                sleep(Duration::from_millis(250)).await;
-            }
-            Err(error) => {
-                last_error = Some(format!("{error:#}"));
-                break;
-            }
-        }
-    }
-
-    anyhow::bail!(
-        "public pair did not observe direct topic connectivity before public events: {}",
-        last_error.unwrap_or_else(|| "unknown error".to_string())
-    );
 }
 
 pub(crate) async fn refresh_direct_message_pair(

--- a/crates/transport/src/iroh.rs
+++ b/crates/transport/src/iroh.rs
@@ -63,6 +63,9 @@ fn initial_topic_join_timeout() -> Duration {
 }
 
 fn direct_warmup_addr(endpoint_addr: &EndpointAddr) -> EndpointAddr {
+    if endpoint_addr.relay_urls().next().is_some() {
+        return endpoint_addr.clone();
+    }
     let direct_addrs = endpoint_addr
         .ip_addrs()
         .copied()
@@ -1542,6 +1545,163 @@ mod tests {
         .expect("custom relay seed connect timeout");
 
         drop(connection);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn transport_custom_relay_static_peer_seed_peers_with_addr_hints_sync_hints() {
+        let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
+            .await
+            .expect("relay server");
+        let relay_config = TransportRelayConfig {
+            iroh_relay_urls: vec![relay_url.to_string()],
+        }
+        .normalized();
+        let config = TransportNetworkConfig::loopback();
+        let transport_a = IrohGossipTransport::bind_with_options(
+            config.clone(),
+            DhtDiscoveryOptions::disabled(),
+            relay_config.clone(),
+        )
+        .await
+        .expect("transport a");
+        let transport_b = IrohGossipTransport::bind_with_options(
+            config,
+            DhtDiscoveryOptions::disabled(),
+            relay_config,
+        )
+        .await
+        .expect("transport b");
+        let topic = TopicId::new("kukuri:topic:relay-seed-hint-roundtrip");
+        let peer_id_a = transport_a.endpoint.id().to_string();
+        let peer_id_b = transport_b.endpoint.id().to_string();
+        let (mut stream_a, mut stream_b) = tokio::try_join!(
+            transport_a.subscribe_hints(&topic),
+            transport_b.subscribe_hints(&topic)
+        )
+        .expect("subscribe hints");
+
+        let ticket_a = transport_a
+            .export_ticket()
+            .await
+            .expect("ticket a")
+            .expect("ticket a value");
+        let ticket_b = transport_b
+            .export_ticket()
+            .await
+            .expect("ticket b")
+            .expect("ticket b value");
+
+        transport_a
+            .configure_discovery(
+                DiscoveryMode::StaticPeer,
+                false,
+                vec![seed_peer_from_ticket(&ticket_b)],
+                Vec::new(),
+            )
+            .await
+            .expect("configure a");
+        transport_b
+            .configure_discovery(
+                DiscoveryMode::StaticPeer,
+                false,
+                vec![seed_peer_from_ticket(&ticket_a)],
+                Vec::new(),
+            )
+            .await
+            .expect("configure b");
+
+        wait_for_hint_roundtrip(
+            HintRoundtripParticipant {
+                transport: &transport_a,
+                stream: &mut stream_a,
+                expected_source_peer: Some(peer_id_a.as_str()),
+            },
+            HintRoundtripParticipant {
+                transport: &transport_b,
+                stream: &mut stream_b,
+                expected_source_peer: Some(peer_id_b.as_str()),
+            },
+            &topic,
+            Duration::from_secs(20),
+            "custom relay static peer with addr hints",
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn transport_custom_relay_static_peer_seed_peers_ignore_stale_addr_hints() {
+        let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
+            .await
+            .expect("relay server");
+        let relay_config = TransportRelayConfig {
+            iroh_relay_urls: vec![relay_url.to_string()],
+        }
+        .normalized();
+        let config = TransportNetworkConfig::loopback();
+        let transport_a = IrohGossipTransport::bind_with_options(
+            config.clone(),
+            DhtDiscoveryOptions::disabled(),
+            relay_config.clone(),
+        )
+        .await
+        .expect("transport a");
+        let transport_b = IrohGossipTransport::bind_with_options(
+            config,
+            DhtDiscoveryOptions::disabled(),
+            relay_config,
+        )
+        .await
+        .expect("transport b");
+        let topic = TopicId::new("kukuri:topic:relay-seed-stale-addr-hint-roundtrip");
+        let peer_id_a = transport_a.endpoint.id().to_string();
+        let peer_id_b = transport_b.endpoint.id().to_string();
+        let (mut stream_a, mut stream_b) = tokio::try_join!(
+            transport_a.subscribe_hints(&topic),
+            transport_b.subscribe_hints(&topic)
+        )
+        .expect("subscribe hints");
+
+        transport_a
+            .configure_discovery(
+                DiscoveryMode::StaticPeer,
+                false,
+                vec![SeedPeer {
+                    endpoint_id: peer_id_b.clone(),
+                    addr_hint: Some("127.0.0.1:9".into()),
+                }],
+                Vec::new(),
+            )
+            .await
+            .expect("configure a");
+        transport_b
+            .configure_discovery(
+                DiscoveryMode::StaticPeer,
+                false,
+                vec![SeedPeer {
+                    endpoint_id: peer_id_a.clone(),
+                    addr_hint: Some("127.0.0.1:9".into()),
+                }],
+                Vec::new(),
+            )
+            .await
+            .expect("configure b");
+
+        wait_for_hint_roundtrip(
+            HintRoundtripParticipant {
+                transport: &transport_a,
+                stream: &mut stream_a,
+                expected_source_peer: Some(peer_id_a.as_str()),
+            },
+            HintRoundtripParticipant {
+                transport: &transport_b,
+                stream: &mut stream_b,
+                expected_source_peer: Some(peer_id_b.as_str()),
+            },
+            &topic,
+            Duration::from_secs(20),
+            "custom relay static peer with stale addr hints",
+        )
+        .await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
- redefined public sync health so live readiness is based on actual gossip peers instead of relay/docs assist
- rebuilt public post and reaction recovery around docs-first durable delivery with generation-aware subscription restarts
- aligned runtime, harness, and desktop tests/UI diagnostics with the new delivery-state model

## Root Cause
The stack had drifted into treating relay-assisted/docs-assisted availability as if it were equivalent to a live topic join. That let the UI report usable connectivity while posts and reactions could still fail to propagate, especially after reconnects, ticket refreshes, or community-node metadata changes.

## What Changed
- split live connectivity from assist diagnostics in transport/app-api sync status and surfaced delivery state in the desktop API/UI
- made public topic recovery prefer docs events and replica sync/query fallback over gossip hints, while keeping hints best-effort
- refreshed community-node bootstrap/heartbeat registration so rebuilt runtimes re-register updated endpoint metadata before bootstrap sync
- updated private-channel/profile/runtime/harness contracts to wait for durable delivery where direct live peers are no longer guaranteed

## User Impact
- sync status no longer reports assisted recovery as healthy live connectivity
- public posts and reactions recover more reliably after reconnects and community-node assisted sessions
- test coverage now exercises the degraded-but-durable path explicitly across app-api, desktop-runtime, harness, and desktop UI

## Validation
- `cargo xtask check`
- `cargo xtask test`
- `cargo xtask e2e-smoke`
- `npx pnpm@10.16.1 test`
