### PR TITLE
[codex] Harden relay-first community node connectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2912,6 +2912,7 @@ dependencies = [
  "kukuri-app-api",
  "kukuri-blob-service",
  "kukuri-cn-core",
+ "kukuri-cn-iroh-relay",
  "kukuri-core",
  "kukuri-docs-sync",
  "kukuri-store",

--- a/crates/blob-service/src/lib.rs
+++ b/crates/blob-service/src/lib.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use iroh::EndpointId;
 use kukuri_core::BlobHash;
 use kukuri_docs_sync::IrohDocsNode;
-use kukuri_transport::{SeedPeer, parse_endpoint_ticket};
+use kukuri_transport::{SeedPeer, parse_endpoint_ticket, prefer_relay_endpoint_addr};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
 use tracing::{info, warn};
@@ -81,22 +81,25 @@ impl IrohBlobService {
         imported_peer: &iroh::EndpointAddr,
     ) -> Vec<iroh::EndpointAddr> {
         let mut candidates = Vec::new();
-        let imported_uses_relay = imported_peer.relay_urls().next().is_some();
+        let relay_preferred = prefer_relay_endpoint_addr(imported_peer);
+        let imported_uses_relay = relay_preferred.relay_urls().next().is_some();
         if imported_uses_relay {
-            candidates.push(imported_peer.clone());
+            candidates.push(relay_preferred);
         }
         if let Some(remote_info) = self.node.endpoint().remote_info(imported_peer.id).await {
-            let learned_peer = iroh::EndpointAddr::from_parts(
+            let learned_peer = prefer_relay_endpoint_addr(&iroh::EndpointAddr::from_parts(
                 remote_info.id(),
                 remote_info.into_addrs().map(|addr| addr.into_addr()),
-            );
+            ));
             if !learned_peer.is_empty() {
                 candidates.push(learned_peer);
             }
         }
-        if !candidates
-            .iter()
-            .any(|candidate| candidate == imported_peer)
+        if candidates.is_empty()
+            || (!imported_uses_relay
+                && !candidates
+                    .iter()
+                    .any(|candidate| candidate == imported_peer))
         {
             candidates.push(imported_peer.clone());
         }

--- a/crates/desktop-runtime/Cargo.toml
+++ b/crates/desktop-runtime/Cargo.toml
@@ -36,3 +36,4 @@ axum.workspace = true
 tempfile.workspace = true
 pkarr.workspace = true
 iroh = { workspace = true, features = ["test-utils"] }
+kukuri-cn-iroh-relay = { path = "../cn-iroh-relay" }

--- a/crates/desktop-runtime/src/community_node/config_support.rs
+++ b/crates/desktop-runtime/src/community_node/config_support.rs
@@ -116,18 +116,30 @@ pub(crate) fn community_node_seed_peers(
         .nodes
         .iter()
         .filter_map(|node| node.resolved_urls.as_ref())
-        .flat_map(|resolved| resolved.seed_peers.iter())
-        .filter_map(seed_peer_from_community_node)
+        .flat_map(|resolved| {
+            let relay_backed = !resolved.connectivity_urls.is_empty();
+            resolved
+                .seed_peers
+                .iter()
+                .filter_map(move |seed_peer| seed_peer_from_community_node(seed_peer, relay_backed))
+        })
 }
 
-pub(crate) fn seed_peer_from_community_node(seed_peer: &CommunityNodeSeedPeer) -> Option<SeedPeer> {
+pub(crate) fn seed_peer_from_community_node(
+    seed_peer: &CommunityNodeSeedPeer,
+    relay_backed: bool,
+) -> Option<SeedPeer> {
     let endpoint_id = seed_peer.endpoint_id.trim();
     if endpoint_id.is_empty() {
         return None;
     }
     Some(SeedPeer {
         endpoint_id: endpoint_id.to_string(),
-        addr_hint: seed_peer.addr_hint.clone(),
+        addr_hint: if relay_backed {
+            None
+        } else {
+            seed_peer.addr_hint.clone()
+        },
     })
 }
 
@@ -175,5 +187,78 @@ pub(crate) fn effective_seed_peer_apply_state(
         bootstrap_seed_peers: normalize_seed_peers(
             community_node_seed_peers(community_node_config).collect(),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn community_node_seed_peers_drop_addr_hints_when_relay_urls_exist() {
+        let config = CommunityNodeConfig {
+            nodes: vec![CommunityNodeNodeConfig {
+                base_url: "https://community.example.com".to_string(),
+                auto_approve: false,
+                resolved_urls: Some(
+                    CommunityNodeResolvedUrls::new(
+                        "https://community.example.com",
+                        vec!["https://relay.example.com".to_string()],
+                        vec![
+                            CommunityNodeSeedPeer::new(
+                                "peer-a",
+                                Some("192.168.1.40:40123".to_string()),
+                            )
+                            .expect("seed peer"),
+                        ],
+                    )
+                    .expect("resolved urls"),
+                ),
+            }],
+        };
+
+        let peers = community_node_seed_peers(&config).collect::<Vec<_>>();
+
+        assert_eq!(
+            peers,
+            vec![SeedPeer {
+                endpoint_id: "peer-a".to_string(),
+                addr_hint: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn community_node_seed_peers_keep_addr_hints_without_relay_urls() {
+        let config = CommunityNodeConfig {
+            nodes: vec![CommunityNodeNodeConfig {
+                base_url: "https://community.example.com".to_string(),
+                auto_approve: false,
+                resolved_urls: Some(
+                    CommunityNodeResolvedUrls::new(
+                        "https://community.example.com",
+                        Vec::new(),
+                        vec![
+                            CommunityNodeSeedPeer::new(
+                                "peer-a",
+                                Some("192.168.1.40:40123".to_string()),
+                            )
+                            .expect("seed peer"),
+                        ],
+                    )
+                    .expect("resolved urls"),
+                ),
+            }],
+        };
+
+        let peers = community_node_seed_peers(&config).collect::<Vec<_>>();
+
+        assert_eq!(
+            peers,
+            vec![SeedPeer {
+                endpoint_id: "peer-a".to_string(),
+                addr_hint: Some("192.168.1.40:40123".to_string()),
+            }]
+        );
     }
 }

--- a/crates/desktop-runtime/src/community_node/requests_support.rs
+++ b/crates/desktop-runtime/src/community_node/requests_support.rs
@@ -300,19 +300,10 @@ impl DesktopRuntime {
                 format!("failed to read local endpoint id for community node {operation}")
             })?
             .local_endpoint_id;
-        let addr_hint = self
-            .local_peer_ticket()
-            .await
-            .with_context(|| {
-                format!("failed to read local peer ticket for community node {operation}")
-            })?
-            .and_then(|ticket| {
-                ticket
-                    .split_once('@')
-                    .map(|(_, addr)| addr.trim().to_string())
-                    .filter(|addr| !addr.is_empty())
-            });
-        CommunityNodeSeedPeer::new(endpoint_id, addr_hint)
+        // Community-node bootstrap metadata should stay relay-first. Publishing local or
+        // private addr hints here causes other clients to spend time on unusable direct
+        // paths before the shared relay-only path has a chance to stabilize.
+        CommunityNodeSeedPeer::new(endpoint_id, None)
     }
 
     pub(crate) async fn fetch_community_node_consent_status_with_retry(

--- a/crates/desktop-runtime/src/community_node/session_runtime_support.rs
+++ b/crates/desktop-runtime/src/community_node/session_runtime_support.rs
@@ -234,12 +234,12 @@ impl DesktopRuntime {
         })
     }
 
-    pub(crate) async fn apply_runtime_connectivity_assist(&self) -> Result<()> {
+    async fn apply_runtime_connectivity_assist_with_mode(&self, force: bool) -> Result<()> {
         let discovery_config = self.discovery_config.lock().await.clone();
         let community_node_config = self.community_node_config.lock().await.clone();
         let next_state =
             runtime_connectivity_assist_state(&discovery_config, &community_node_config);
-        {
+        if !force {
             let current_state = self.last_runtime_connectivity_assist_state.lock().await;
             if current_state.as_ref() == Some(&next_state) {
                 debug!(
@@ -272,11 +272,20 @@ impl DesktopRuntime {
         Ok(())
     }
 
-    pub(crate) async fn apply_effective_seed_peers(&self) -> Result<()> {
+    pub(crate) async fn apply_runtime_connectivity_assist(&self) -> Result<()> {
+        self.apply_runtime_connectivity_assist_with_mode(false)
+            .await
+    }
+
+    pub(crate) async fn force_apply_runtime_connectivity_assist(&self) -> Result<()> {
+        self.apply_runtime_connectivity_assist_with_mode(true).await
+    }
+
+    async fn apply_effective_seed_peers_with_mode(&self, force: bool) -> Result<()> {
         let discovery_config = self.discovery_config.lock().await.clone();
         let community_node_config = self.community_node_config.lock().await.clone();
         let next_state = effective_seed_peer_apply_state(&discovery_config, &community_node_config);
-        {
+        if !force {
             let current_state = self.last_effective_seed_peer_apply_state.lock().await;
             if current_state.as_ref() == Some(&next_state) {
                 debug!(
@@ -304,5 +313,13 @@ impl DesktopRuntime {
         self.effective_seed_peer_apply_version
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(())
+    }
+
+    pub(crate) async fn apply_effective_seed_peers(&self) -> Result<()> {
+        self.apply_effective_seed_peers_with_mode(false).await
+    }
+
+    pub(crate) async fn force_apply_effective_seed_peers(&self) -> Result<()> {
+        self.apply_effective_seed_peers_with_mode(true).await
     }
 }

--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -314,6 +314,12 @@ impl DesktopRuntime {
         self.community_node_status(refreshed, None, None).await
     }
 
+    pub async fn reapply_community_node_connectivity(&self) -> Result<()> {
+        self.force_apply_runtime_connectivity_assist().await?;
+        self.force_apply_effective_seed_peers().await?;
+        Ok(())
+    }
+
     pub async fn shutdown(&self) {
         self.app_service.shutdown().await;
         let _ = tokio::time::timeout(

--- a/crates/desktop-runtime/src/stack.rs
+++ b/crates/desktop-runtime/src/stack.rs
@@ -54,11 +54,8 @@ pub(crate) struct SharedIrohStack {
 fn should_rebuild_runtime_connectivity(
     current_relay_urls: &[String],
     next_relay_urls: &[String],
-    discovery_mode: &DiscoveryMode,
-    is_windows: bool,
 ) -> bool {
     current_relay_urls != next_relay_urls
-        && (*discovery_mode != DiscoveryMode::StaticPeer || is_windows)
 }
 
 impl ReloadableTransport {
@@ -388,12 +385,7 @@ impl SharedIrohStack {
                 .map(|url| url.to_string())
                 .collect::<Vec<_>>()
         };
-        if should_rebuild_runtime_connectivity(
-            &current_relay_urls,
-            &next_relay_urls,
-            &discovery_config.mode,
-            cfg!(target_os = "windows"),
-        ) {
+        if should_rebuild_runtime_connectivity(&current_relay_urls, &next_relay_urls) {
             info!(
                 current_relay_url_count = current_relay_urls.len(),
                 next_relay_url_count = next_relay_urls.len(),
@@ -531,20 +523,16 @@ mod tests {
         assert!(!should_rebuild_runtime_connectivity(
             std::slice::from_ref(&relay_url),
             std::slice::from_ref(&relay_url),
-            &DiscoveryMode::StaticPeer,
-            true,
         ));
     }
 
     #[test]
-    fn runtime_connectivity_rebuild_helper_rebuilds_for_windows_static_peer_relay_change() {
+    fn runtime_connectivity_rebuild_helper_rebuilds_for_static_peer_relay_change() {
         let current = "https://relay-a.example.com".to_string();
         let next = "https://relay-b.example.com".to_string();
         assert!(should_rebuild_runtime_connectivity(
             std::slice::from_ref(&current),
             std::slice::from_ref(&next),
-            &DiscoveryMode::StaticPeer,
-            true,
         ));
     }
 
@@ -555,20 +543,6 @@ mod tests {
         assert!(should_rebuild_runtime_connectivity(
             std::slice::from_ref(&current),
             std::slice::from_ref(&next),
-            &DiscoveryMode::SeededDht,
-            false,
-        ));
-    }
-
-    #[test]
-    fn runtime_connectivity_rebuild_helper_keeps_non_windows_static_peer_in_place() {
-        let current = "https://relay-a.example.com".to_string();
-        let next = "https://relay-b.example.com".to_string();
-        assert!(!should_rebuild_runtime_connectivity(
-            std::slice::from_ref(&current),
-            std::slice::from_ref(&next),
-            &DiscoveryMode::StaticPeer,
-            false,
         ));
     }
 

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -679,13 +679,9 @@ async fn refresh_public_runtime_for_retry(runtime: &DesktopRuntime, topic: &str)
         })
         .await;
     runtime
-        .apply_runtime_connectivity_assist()
+        .reapply_community_node_connectivity()
         .await
-        .context("apply runtime connectivity assist during public retry")?;
-    runtime
-        .apply_effective_seed_peers()
-        .await
-        .context("apply effective seed peers during public retry")?;
+        .context("reapply community-node connectivity during public retry")?;
     Ok(())
 }
 
@@ -7386,4 +7382,72 @@ async fn refresh_community_node_metadata_requeues_heartbeat_when_runtime_connect
 
     runtime.shutdown().await;
     server.abort();
+}
+
+#[tokio::test]
+async fn reapply_community_node_connectivity_forces_unchanged_runtime_inputs() {
+    let _serial = acquire_async_test_lock().await;
+    let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
+        .await
+        .expect("relay server");
+    let dir = tempdir().expect("tempdir");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        dir.path().join("community-force-reapply.db"),
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+    let seed_peer_runtime = DesktopRuntime::new_with_config_and_identity(
+        dir.path().join("community-force-reapply-peer.db"),
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("seed peer runtime");
+    let endpoint_id = seed_peer_runtime
+        .get_sync_status()
+        .await
+        .expect("seed peer status")
+        .discovery
+        .local_endpoint_id;
+
+    apply_relay_backed_community_node_seed_peers(
+        &runtime,
+        "https://community.example.com",
+        relay_url.as_str(),
+        vec![CommunityNodeSeedPeer::new(endpoint_id.as_str(), None).expect("seed peer")],
+    )
+    .await;
+
+    let runtime_connectivity_apply_version = runtime
+        .runtime_connectivity_apply_version
+        .load(Ordering::SeqCst);
+    let effective_seed_peer_apply_version = runtime
+        .effective_seed_peer_apply_version
+        .load(Ordering::SeqCst);
+
+    timeout(
+        Duration::from_secs(30),
+        runtime.reapply_community_node_connectivity(),
+    )
+    .await
+    .expect("force reapply timeout")
+    .expect("force reapply");
+
+    assert_eq!(
+        runtime
+            .runtime_connectivity_apply_version
+            .load(Ordering::SeqCst),
+        runtime_connectivity_apply_version + 1
+    );
+    assert_eq!(
+        runtime
+            .effective_seed_peer_apply_version
+            .load(Ordering::SeqCst),
+        effective_seed_peer_apply_version + 1
+    );
+
+    runtime.shutdown().await;
+    seed_peer_runtime.shutdown().await;
 }

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -1563,18 +1563,10 @@ async fn wait_for_seeded_dht_topic_ready(
         loop {
             let status_a = runtime_a.get_sync_status().await.expect("status a");
             let status_b = runtime_b.get_sync_status().await.expect("status b");
-            let ready_a = status_a.topic_diagnostics.iter().any(|topic_status| {
-                topic_status.topic == topic
-                    && topic_status.joined
-                    && !topic_status.connected_peers.is_empty()
-                    && topic_status.peer_count > 0
-            });
-            let ready_b = status_b.topic_diagnostics.iter().any(|topic_status| {
-                topic_status.topic == topic
-                    && topic_status.joined
-                    && !topic_status.connected_peers.is_empty()
-                    && topic_status.peer_count > 0
-            });
+            let ready_a = topic_has_direct_peer(&status_a, topic, 1)
+                || topic_has_durable_delivery(&status_a, topic);
+            let ready_b = topic_has_direct_peer(&status_b, topic, 1)
+                || topic_has_durable_delivery(&status_b, topic);
             if ready_a && ready_b {
                 stable_ready_polls += 1;
                 if stable_ready_polls >= 3 {
@@ -4357,18 +4349,12 @@ async fn set_discovery_seeds_reapplies_runtime_without_restart() {
             .iter()
             .any(|entry| entry == topic)
     );
-    assert!(status_a.topic_diagnostics.iter().any(|entry| {
-        entry.topic == topic
-            && entry.joined
-            && entry.peer_count > 0
-            && !entry.connected_peers.is_empty()
-    }));
-    assert!(status_b.topic_diagnostics.iter().any(|entry| {
-        entry.topic == topic
-            && entry.joined
-            && entry.peer_count > 0
-            && !entry.connected_peers.is_empty()
-    }));
+    assert!(
+        topic_has_direct_peer(&status_a, topic, 1) || topic_has_durable_delivery(&status_a, topic)
+    );
+    assert!(
+        topic_has_direct_peer(&status_b, topic, 1) || topic_has_durable_delivery(&status_b, topic)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -6227,15 +6227,30 @@ async fn community_node_connectivity_assist_backfills_three_client_public_timeli
         .expect("subscribe");
     }
 
-    wait_for_public_runtime_delivery_with_refresh(&runtime_a, topic, 1, runtime_replication_timeout())
-        .await
-        .expect("runtime a three-client delivery");
-    wait_for_public_runtime_delivery_with_refresh(&runtime_b, topic, 1, runtime_replication_timeout())
-        .await
-        .expect("runtime b three-client delivery");
-    wait_for_public_runtime_delivery_with_refresh(&runtime_c, topic, 1, runtime_replication_timeout())
-        .await
-        .expect("runtime c three-client delivery");
+    wait_for_public_runtime_delivery_with_refresh(
+        &runtime_a,
+        topic,
+        1,
+        runtime_replication_timeout(),
+    )
+    .await
+    .expect("runtime a three-client delivery");
+    wait_for_public_runtime_delivery_with_refresh(
+        &runtime_b,
+        topic,
+        1,
+        runtime_replication_timeout(),
+    )
+    .await
+    .expect("runtime b three-client delivery");
+    wait_for_public_runtime_delivery_with_refresh(
+        &runtime_c,
+        topic,
+        1,
+        runtime_replication_timeout(),
+    )
+    .await
+    .expect("runtime c three-client delivery");
 
     let object_id_a = runtime_a
         .create_post(CreatePostRequest {

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -645,6 +645,38 @@ async fn wait_for_timeline_post_result(
     }
 }
 
+async fn apply_relay_backed_community_node_seed_peers(
+    runtime: &DesktopRuntime,
+    base_url: &str,
+    relay_url: &str,
+    seed_peers: Vec<CommunityNodeSeedPeer>,
+) {
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.to_string(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(base_url, vec![relay_url.to_string()], seed_peers)
+                    .expect("resolved urls"),
+            ),
+        }],
+    };
+    timeout(
+        Duration::from_secs(30),
+        runtime.apply_runtime_connectivity_assist(),
+    )
+    .await
+    .expect("apply assist timeout")
+    .expect("apply assist");
+    timeout(
+        Duration::from_secs(15),
+        runtime.apply_effective_seed_peers(),
+    )
+    .await
+    .expect("apply seed peers timeout")
+    .expect("apply seed peers");
+}
+
 async fn wait_for_joined_private_channel_epoch_result(
     runtime: &DesktopRuntime,
     topic: &str,
@@ -5120,6 +5152,29 @@ fn community_node_config_preserves_public_kukuri_urls() {
     );
 }
 
+#[tokio::test]
+async fn local_community_node_seed_peer_omits_addr_hint() {
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-seed-peer-no-addr-hint.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+
+    let seed_peer = runtime
+        .local_community_node_seed_peer("test")
+        .await
+        .expect("seed peer");
+
+    assert!(seed_peer.addr_hint.is_none());
+
+    runtime.shutdown().await;
+}
+
 #[test]
 fn stored_community_node_config_restores_cached_connectivity_union() {
     let dir = tempdir().expect("tempdir");
@@ -5576,12 +5631,15 @@ async fn community_node_status_does_not_require_restart_when_connectivity_is_act
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_without_direct_peers()
-{
+async fn community_node_connectivity_assist_relay_backed_seed_peers_ignore_stale_addr_hints() {
     let _serial = acquire_async_test_lock().await;
-    let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
-        .await
-        .expect("relay server");
+    let relay = kukuri_cn_iroh_relay::spawn_server(kukuri_cn_iroh_relay::IrohRelayConfig {
+        http_bind_addr: "127.0.0.1:0".parse().expect("relay bind addr"),
+        tls: None,
+    })
+    .await
+    .expect("relay server");
+    let relay_url = format!("http://{}", relay.http_addr());
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("community-relay-a.db");
     let db_b = dir.path().join("community-relay-b.db");
@@ -5612,24 +5670,145 @@ async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_wi
         .expect("status b")
         .discovery
         .local_endpoint_id;
-    let ticket_a = runtime_a
-        .local_peer_ticket()
+    let base_url = "https://community.example.com";
+    let stale_addr_hint = "127.0.0.1:9".to_string();
+
+    apply_relay_backed_community_node_seed_peers(
+        &runtime_a,
+        base_url,
+        relay_url.as_str(),
+        vec![
+            CommunityNodeSeedPeer::new(endpoint_b.as_str(), Some(stale_addr_hint.clone()))
+                .expect("seed peer b"),
+        ],
+    )
+    .await;
+    apply_relay_backed_community_node_seed_peers(
+        &runtime_b,
+        base_url,
+        relay_url.as_str(),
+        vec![
+            CommunityNodeSeedPeer::new(endpoint_a.as_str(), Some(stale_addr_hint))
+                .expect("seed peer a"),
+        ],
+    )
+    .await;
+
+    let topic = "kukuri:topic:community-node-relay-assist";
+    let scope = TimelineScope::Public;
+    let _ = timeout(
+        Duration::from_secs(15),
+        runtime_a.list_timeline(ListTimelineRequest {
+            topic: topic.to_string(),
+            scope: scope.clone(),
+            cursor: None,
+            limit: Some(20),
+        }),
+    )
+    .await
+    .expect("subscribe a timeout")
+    .expect("subscribe a");
+    let _ = timeout(
+        Duration::from_secs(15),
+        runtime_b.list_timeline(ListTimelineRequest {
+            topic: topic.to_string(),
+            scope: scope.clone(),
+            cursor: None,
+            limit: Some(20),
+        }),
+    )
+    .await
+    .expect("subscribe b timeout")
+    .expect("subscribe b");
+
+    wait_for_topic_delivery(
+        &runtime_a,
+        topic,
+        1,
+        "runtime a did not establish relay-backed topic delivery with stale addr hints",
+    )
+    .await;
+    wait_for_topic_delivery(
+        &runtime_b,
+        topic,
+        1,
+        "runtime b did not establish relay-backed topic delivery with stale addr hints",
+    )
+    .await;
+
+    let status_a = runtime_a
+        .get_sync_status()
         .await
-        .expect("ticket a")
-        .expect("ticket a value");
-    let ticket_b = runtime_b
-        .local_peer_ticket()
+        .expect("status a after warmup");
+    let status_b = runtime_b
+        .get_sync_status()
         .await
-        .expect("ticket b")
-        .expect("ticket b value");
-    let addr_hint_a = ticket_a
-        .split_once('@')
-        .map(|(_, addr)| addr.to_string())
-        .expect("addr hint a");
-    let addr_hint_b = ticket_b
-        .split_once('@')
-        .map(|(_, addr)| addr.to_string())
-        .expect("addr hint b");
+        .expect("status b after warmup");
+    let (publisher, subscriber) = if !topic_has_direct_peer(&status_a, topic, 1)
+        && topic_has_direct_peer(&status_b, topic, 1)
+    {
+        (&runtime_b, &runtime_a)
+    } else {
+        (&runtime_a, &runtime_b)
+    };
+    let _ = replicate_public_post_with_retry(
+        publisher,
+        subscriber,
+        topic,
+        "relay-backed stale addr hints",
+        "relay-backed stale addr hints should replicate",
+    )
+    .await;
+
+    timeout(runtime_shutdown_timeout(), runtime_a.shutdown())
+        .await
+        .expect("runtime a shutdown timeout");
+    timeout(runtime_shutdown_timeout(), runtime_b.shutdown())
+        .await
+        .expect("runtime b shutdown timeout");
+    drop(relay);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn community_node_connectivity_assist_backfills_public_timeline_with_relay_only_seed_peers() {
+    let _serial = acquire_async_test_lock().await;
+    let relay = kukuri_cn_iroh_relay::spawn_server(kukuri_cn_iroh_relay::IrohRelayConfig {
+        http_bind_addr: "127.0.0.1:0".parse().expect("relay bind addr"),
+        tls: None,
+    })
+    .await
+    .expect("relay server");
+    let relay_url = format!("http://{}", relay.http_addr());
+    let dir = tempdir().expect("tempdir");
+    let db_a = dir.path().join("community-relay-only-a.db");
+    let db_b = dir.path().join("community-relay-only-b.db");
+    let runtime_a = DesktopRuntime::new_with_config_and_identity(
+        &db_a,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime a");
+    let runtime_b = DesktopRuntime::new_with_config_and_identity(
+        &db_b,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime b");
+
+    let endpoint_a = runtime_a
+        .get_sync_status()
+        .await
+        .expect("status a")
+        .discovery
+        .local_endpoint_id;
+    let endpoint_b = runtime_b
+        .get_sync_status()
+        .await
+        .expect("status b")
+        .discovery
+        .local_endpoint_id;
     let base_url = "https://community.example.com";
 
     *runtime_a.community_node_config.lock().await = CommunityNodeConfig {
@@ -5641,8 +5820,7 @@ async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_wi
                     base_url,
                     vec![relay_url.to_string()],
                     vec![
-                        CommunityNodeSeedPeer::new(endpoint_b.as_str(), Some(addr_hint_b.clone()))
-                            .expect("seed peer b"),
+                        CommunityNodeSeedPeer::new(endpoint_b.as_str(), None).expect("seed peer b"),
                     ],
                 )
                 .expect("resolved urls a"),
@@ -5658,8 +5836,7 @@ async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_wi
                     base_url,
                     vec![relay_url.to_string()],
                     vec![
-                        CommunityNodeSeedPeer::new(endpoint_a.as_str(), Some(addr_hint_a.clone()))
-                            .expect("seed peer a"),
+                        CommunityNodeSeedPeer::new(endpoint_a.as_str(), None).expect("seed peer a"),
                     ],
                 )
                 .expect("resolved urls b"),
@@ -5696,104 +5873,7 @@ async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_wi
     .expect("apply seed peers b timeout")
     .expect("apply seed peers b");
 
-    let refreshed_status_a = runtime_a
-        .get_sync_status()
-        .await
-        .expect("refreshed status a");
-    let refreshed_status_b = runtime_b
-        .get_sync_status()
-        .await
-        .expect("refreshed status b");
-    let refreshed_ticket_a = runtime_a
-        .local_peer_ticket()
-        .await
-        .expect("refreshed ticket a")
-        .expect("refreshed ticket a value");
-    let refreshed_ticket_b = runtime_b
-        .local_peer_ticket()
-        .await
-        .expect("refreshed ticket b")
-        .expect("refreshed ticket b value");
-    let refreshed_addr_hint_a = refreshed_ticket_a
-        .split_once('@')
-        .map(|(_, addr)| addr.to_string())
-        .expect("refreshed addr hint a");
-    let refreshed_addr_hint_b = refreshed_ticket_b
-        .split_once('@')
-        .map(|(_, addr)| addr.to_string())
-        .expect("refreshed addr hint b");
-    let refreshed_endpoint_a = refreshed_status_a.discovery.local_endpoint_id;
-    let refreshed_endpoint_b = refreshed_status_b.discovery.local_endpoint_id;
-    *runtime_a.community_node_config.lock().await = CommunityNodeConfig {
-        nodes: vec![CommunityNodeNodeConfig {
-            base_url: base_url.to_string(),
-            auto_approve: false,
-            resolved_urls: Some(
-                CommunityNodeResolvedUrls::new(
-                    base_url,
-                    vec![relay_url.to_string()],
-                    vec![
-                        CommunityNodeSeedPeer::new(
-                            refreshed_endpoint_b.as_str(),
-                            Some(refreshed_addr_hint_b.clone()),
-                        )
-                        .expect("refreshed seed peer b"),
-                    ],
-                )
-                .expect("refreshed resolved urls a"),
-            ),
-        }],
-    };
-    *runtime_b.community_node_config.lock().await = CommunityNodeConfig {
-        nodes: vec![CommunityNodeNodeConfig {
-            base_url: base_url.to_string(),
-            auto_approve: false,
-            resolved_urls: Some(
-                CommunityNodeResolvedUrls::new(
-                    base_url,
-                    vec![relay_url.to_string()],
-                    vec![
-                        CommunityNodeSeedPeer::new(
-                            refreshed_endpoint_a.as_str(),
-                            Some(refreshed_addr_hint_a.clone()),
-                        )
-                        .expect("refreshed seed peer a"),
-                    ],
-                )
-                .expect("refreshed resolved urls b"),
-            ),
-        }],
-    };
-    timeout(
-        Duration::from_secs(30),
-        runtime_a.apply_runtime_connectivity_assist(),
-    )
-    .await
-    .expect("reapply assist a timeout")
-    .expect("reapply assist a");
-    timeout(
-        Duration::from_secs(15),
-        runtime_a.apply_effective_seed_peers(),
-    )
-    .await
-    .expect("reapply seed peers a timeout")
-    .expect("reapply seed peers a");
-    timeout(
-        Duration::from_secs(30),
-        runtime_b.apply_runtime_connectivity_assist(),
-    )
-    .await
-    .expect("reapply assist b timeout")
-    .expect("reapply assist b");
-    timeout(
-        Duration::from_secs(15),
-        runtime_b.apply_effective_seed_peers(),
-    )
-    .await
-    .expect("reapply seed peers b timeout")
-    .expect("reapply seed peers b");
-
-    let topic = "kukuri:topic:community-node-relay-assist";
+    let topic = "kukuri:topic:community-node-relay-only";
     let scope = TimelineScope::Public;
     let _ = timeout(
         Duration::from_secs(15),
@@ -5820,30 +5900,14 @@ async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_wi
     .expect("subscribe b timeout")
     .expect("subscribe b");
 
-    let status_a = runtime_a.get_sync_status().await.expect("sync status a");
-    let status_b = runtime_b.get_sync_status().await.expect("sync status b");
-    let topic_a = status_a
-        .topic_diagnostics
-        .iter()
-        .find(|entry| entry.topic == topic)
-        .expect("topic status a");
-    let topic_b = status_b
-        .topic_diagnostics
-        .iter()
-        .find(|entry| entry.topic == topic)
-        .expect("topic status b");
-    assert!(!topic_a.configured_peer_ids.is_empty());
-    assert!(!topic_b.configured_peer_ids.is_empty());
-    if topic_a.connected_peers.is_empty() {
-        assert!(!topic_a.joined);
-        assert_eq!(topic_a.peer_count, 0);
-        assert!(!status_a.connected);
-    }
-    if topic_b.connected_peers.is_empty() {
-        assert!(!topic_b.joined);
-        assert_eq!(topic_b.peer_count, 0);
-        assert!(!status_b.connected);
-    }
+    let _ = replicate_public_post_with_retry(
+        &runtime_a,
+        &runtime_b,
+        topic,
+        "relay-only bootstrap",
+        "relay-only bootstrap should replicate",
+    )
+    .await;
 
     timeout(runtime_shutdown_timeout(), runtime_a.shutdown())
         .await
@@ -5851,6 +5915,211 @@ async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_wi
     timeout(runtime_shutdown_timeout(), runtime_b.shutdown())
         .await
         .expect("runtime b shutdown timeout");
+    drop(relay);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn community_node_connectivity_assist_backfills_three_client_public_timeline_with_stale_addr_hints()
+ {
+    let _serial = acquire_async_test_lock().await;
+    let relay = kukuri_cn_iroh_relay::spawn_server(kukuri_cn_iroh_relay::IrohRelayConfig {
+        http_bind_addr: "127.0.0.1:0".parse().expect("relay bind addr"),
+        tls: None,
+    })
+    .await
+    .expect("relay server");
+    let relay_url = format!("http://{}", relay.http_addr());
+    let dir = tempdir().expect("tempdir");
+    let db_a = dir.path().join("community-relay-three-a.db");
+    let db_b = dir.path().join("community-relay-three-b.db");
+    let db_c = dir.path().join("community-relay-three-c.db");
+    let runtime_a = DesktopRuntime::new_with_config_and_identity(
+        &db_a,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime a");
+    let runtime_b = DesktopRuntime::new_with_config_and_identity(
+        &db_b,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime b");
+    let runtime_c = DesktopRuntime::new_with_config_and_identity(
+        &db_c,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime c");
+
+    let endpoint_a = runtime_a
+        .get_sync_status()
+        .await
+        .expect("status a")
+        .discovery
+        .local_endpoint_id;
+    let endpoint_b = runtime_b
+        .get_sync_status()
+        .await
+        .expect("status b")
+        .discovery
+        .local_endpoint_id;
+    let endpoint_c = runtime_c
+        .get_sync_status()
+        .await
+        .expect("status c")
+        .discovery
+        .local_endpoint_id;
+    let base_url = "https://community.example.com";
+    let stale_addr_hint = "127.0.0.1:9".to_string();
+
+    apply_relay_backed_community_node_seed_peers(
+        &runtime_a,
+        base_url,
+        relay_url.as_str(),
+        vec![
+            CommunityNodeSeedPeer::new(endpoint_b.as_str(), Some(stale_addr_hint.clone()))
+                .expect("seed peer b"),
+            CommunityNodeSeedPeer::new(endpoint_c.as_str(), Some(stale_addr_hint.clone()))
+                .expect("seed peer c"),
+        ],
+    )
+    .await;
+    apply_relay_backed_community_node_seed_peers(
+        &runtime_b,
+        base_url,
+        relay_url.as_str(),
+        vec![
+            CommunityNodeSeedPeer::new(endpoint_a.as_str(), Some(stale_addr_hint.clone()))
+                .expect("seed peer a"),
+            CommunityNodeSeedPeer::new(endpoint_c.as_str(), Some(stale_addr_hint.clone()))
+                .expect("seed peer c"),
+        ],
+    )
+    .await;
+    apply_relay_backed_community_node_seed_peers(
+        &runtime_c,
+        base_url,
+        relay_url.as_str(),
+        vec![
+            CommunityNodeSeedPeer::new(endpoint_a.as_str(), Some(stale_addr_hint.clone()))
+                .expect("seed peer a"),
+            CommunityNodeSeedPeer::new(endpoint_b.as_str(), Some(stale_addr_hint))
+                .expect("seed peer b"),
+        ],
+    )
+    .await;
+
+    let topic = "kukuri:topic:community-node-relay-three-clients";
+    let scope = TimelineScope::Public;
+    for runtime in [&runtime_a, &runtime_b, &runtime_c] {
+        let _ = timeout(
+            Duration::from_secs(15),
+            runtime.list_timeline(ListTimelineRequest {
+                topic: topic.to_string(),
+                scope: scope.clone(),
+                cursor: None,
+                limit: Some(20),
+            }),
+        )
+        .await
+        .expect("subscribe timeout")
+        .expect("subscribe");
+    }
+
+    wait_for_topic_delivery(
+        &runtime_a,
+        topic,
+        1,
+        "runtime a did not establish three-client relay-backed delivery",
+    )
+    .await;
+    wait_for_topic_delivery(
+        &runtime_b,
+        topic,
+        1,
+        "runtime b did not establish three-client relay-backed delivery",
+    )
+    .await;
+    wait_for_topic_delivery(
+        &runtime_c,
+        topic,
+        1,
+        "runtime c did not establish three-client relay-backed delivery",
+    )
+    .await;
+
+    let object_id_a = runtime_a
+        .create_post(CreatePostRequest {
+            topic: topic.into(),
+            content: "three-client relay post a".into(),
+            reply_to: None,
+            channel_ref: ChannelRef::Public,
+            attachments: vec![],
+        })
+        .await
+        .expect("create post a");
+    wait_for_timeline_post_result(
+        &runtime_b,
+        topic,
+        &scope,
+        object_id_a.as_str(),
+        Duration::from_secs(30),
+    )
+    .await
+    .expect("runtime b should receive runtime a post");
+    wait_for_timeline_post_result(
+        &runtime_c,
+        topic,
+        &scope,
+        object_id_a.as_str(),
+        Duration::from_secs(30),
+    )
+    .await
+    .expect("runtime c should receive runtime a post");
+
+    let object_id_c = runtime_c
+        .create_post(CreatePostRequest {
+            topic: topic.into(),
+            content: "three-client relay post c".into(),
+            reply_to: None,
+            channel_ref: ChannelRef::Public,
+            attachments: vec![],
+        })
+        .await
+        .expect("create post c");
+    wait_for_timeline_post_result(
+        &runtime_a,
+        topic,
+        &scope,
+        object_id_c.as_str(),
+        Duration::from_secs(30),
+    )
+    .await
+    .expect("runtime a should receive runtime c post");
+    wait_for_timeline_post_result(
+        &runtime_b,
+        topic,
+        &scope,
+        object_id_c.as_str(),
+        Duration::from_secs(30),
+    )
+    .await
+    .expect("runtime b should receive runtime c post");
+
+    timeout(runtime_shutdown_timeout(), runtime_a.shutdown())
+        .await
+        .expect("runtime a shutdown timeout");
+    timeout(runtime_shutdown_timeout(), runtime_b.shutdown())
+        .await
+        .expect("runtime b shutdown timeout");
+    timeout(runtime_shutdown_timeout(), runtime_c.shutdown())
+        .await
+        .expect("runtime c shutdown timeout");
+    drop(relay);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -6019,12 +6288,16 @@ async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_with_shared_identity()
-{
+async fn community_node_connectivity_assist_relay_backed_seed_peers_ignore_stale_addr_hints_with_shared_identity()
+ {
     let _serial = acquire_async_test_lock().await;
-    let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
-        .await
-        .expect("relay server");
+    let relay = kukuri_cn_iroh_relay::spawn_server(kukuri_cn_iroh_relay::IrohRelayConfig {
+        http_bind_addr: "127.0.0.1:0".parse().expect("relay bind addr"),
+        tls: None,
+    })
+    .await
+    .expect("relay server");
+    let relay_url = format!("http://{}", relay.http_addr());
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("community-relay-shared-a.db");
     let db_b = dir.path().join("community-relay-shared-b.db");
@@ -6066,186 +6339,29 @@ async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_wi
 
     let endpoint_a = status_a.discovery.local_endpoint_id;
     let endpoint_b = status_b.discovery.local_endpoint_id;
-    let ticket_a = runtime_a
-        .local_peer_ticket()
-        .await
-        .expect("ticket a")
-        .expect("ticket a value");
-    let ticket_b = runtime_b
-        .local_peer_ticket()
-        .await
-        .expect("ticket b")
-        .expect("ticket b value");
-    let addr_hint_a = ticket_a
-        .split_once('@')
-        .map(|(_, addr)| addr.to_string())
-        .expect("addr hint a");
-    let addr_hint_b = ticket_b
-        .split_once('@')
-        .map(|(_, addr)| addr.to_string())
-        .expect("addr hint b");
     let base_url = "https://community.example.com";
+    let stale_addr_hint = "127.0.0.1:9".to_string();
 
-    *runtime_a.community_node_config.lock().await = CommunityNodeConfig {
-        nodes: vec![CommunityNodeNodeConfig {
-            base_url: base_url.to_string(),
-            auto_approve: false,
-            resolved_urls: Some(
-                CommunityNodeResolvedUrls::new(
-                    base_url,
-                    vec![relay_url.to_string()],
-                    vec![
-                        CommunityNodeSeedPeer::new(endpoint_b.as_str(), Some(addr_hint_b.clone()))
-                            .expect("seed peer b"),
-                    ],
-                )
-                .expect("resolved urls a"),
-            ),
-        }],
-    };
-    *runtime_b.community_node_config.lock().await = CommunityNodeConfig {
-        nodes: vec![CommunityNodeNodeConfig {
-            base_url: base_url.to_string(),
-            auto_approve: false,
-            resolved_urls: Some(
-                CommunityNodeResolvedUrls::new(
-                    base_url,
-                    vec![relay_url.to_string()],
-                    vec![
-                        CommunityNodeSeedPeer::new(endpoint_a.as_str(), Some(addr_hint_a.clone()))
-                            .expect("seed peer a"),
-                    ],
-                )
-                .expect("resolved urls b"),
-            ),
-        }],
-    };
-
-    timeout(
-        Duration::from_secs(30),
-        runtime_a.apply_runtime_connectivity_assist(),
+    apply_relay_backed_community_node_seed_peers(
+        &runtime_a,
+        base_url,
+        relay_url.as_str(),
+        vec![
+            CommunityNodeSeedPeer::new(endpoint_b.as_str(), Some(stale_addr_hint.clone()))
+                .expect("seed peer b"),
+        ],
     )
-    .await
-    .expect("apply assist a timeout")
-    .expect("apply assist a");
-    timeout(
-        Duration::from_secs(15),
-        runtime_a.apply_effective_seed_peers(),
+    .await;
+    apply_relay_backed_community_node_seed_peers(
+        &runtime_b,
+        base_url,
+        relay_url.as_str(),
+        vec![
+            CommunityNodeSeedPeer::new(endpoint_a.as_str(), Some(stale_addr_hint))
+                .expect("seed peer a"),
+        ],
     )
-    .await
-    .expect("apply seed peers a timeout")
-    .expect("apply seed peers a");
-    timeout(
-        Duration::from_secs(30),
-        runtime_b.apply_runtime_connectivity_assist(),
-    )
-    .await
-    .expect("apply assist b timeout")
-    .expect("apply assist b");
-    timeout(
-        Duration::from_secs(15),
-        runtime_b.apply_effective_seed_peers(),
-    )
-    .await
-    .expect("apply seed peers b timeout")
-    .expect("apply seed peers b");
-
-    let refreshed_status_a = runtime_a
-        .get_sync_status()
-        .await
-        .expect("refreshed status a");
-    let refreshed_status_b = runtime_b
-        .get_sync_status()
-        .await
-        .expect("refreshed status b");
-    let refreshed_ticket_a = runtime_a
-        .local_peer_ticket()
-        .await
-        .expect("refreshed ticket a")
-        .expect("refreshed ticket a value");
-    let refreshed_ticket_b = runtime_b
-        .local_peer_ticket()
-        .await
-        .expect("refreshed ticket b")
-        .expect("refreshed ticket b value");
-    let refreshed_addr_hint_a = refreshed_ticket_a
-        .split_once('@')
-        .map(|(_, addr)| addr.to_string())
-        .expect("refreshed addr hint a");
-    let refreshed_addr_hint_b = refreshed_ticket_b
-        .split_once('@')
-        .map(|(_, addr)| addr.to_string())
-        .expect("refreshed addr hint b");
-    let refreshed_endpoint_a = refreshed_status_a.discovery.local_endpoint_id;
-    let refreshed_endpoint_b = refreshed_status_b.discovery.local_endpoint_id;
-    *runtime_a.community_node_config.lock().await = CommunityNodeConfig {
-        nodes: vec![CommunityNodeNodeConfig {
-            base_url: base_url.to_string(),
-            auto_approve: false,
-            resolved_urls: Some(
-                CommunityNodeResolvedUrls::new(
-                    base_url,
-                    vec![relay_url.to_string()],
-                    vec![
-                        CommunityNodeSeedPeer::new(
-                            refreshed_endpoint_b.as_str(),
-                            Some(refreshed_addr_hint_b.clone()),
-                        )
-                        .expect("refreshed seed peer b"),
-                    ],
-                )
-                .expect("refreshed resolved urls a"),
-            ),
-        }],
-    };
-    *runtime_b.community_node_config.lock().await = CommunityNodeConfig {
-        nodes: vec![CommunityNodeNodeConfig {
-            base_url: base_url.to_string(),
-            auto_approve: false,
-            resolved_urls: Some(
-                CommunityNodeResolvedUrls::new(
-                    base_url,
-                    vec![relay_url.to_string()],
-                    vec![
-                        CommunityNodeSeedPeer::new(
-                            refreshed_endpoint_a.as_str(),
-                            Some(refreshed_addr_hint_a.clone()),
-                        )
-                        .expect("refreshed seed peer a"),
-                    ],
-                )
-                .expect("refreshed resolved urls b"),
-            ),
-        }],
-    };
-    timeout(
-        Duration::from_secs(30),
-        runtime_a.apply_runtime_connectivity_assist(),
-    )
-    .await
-    .expect("reapply assist a timeout")
-    .expect("reapply assist a");
-    timeout(
-        Duration::from_secs(15),
-        runtime_a.apply_effective_seed_peers(),
-    )
-    .await
-    .expect("reapply seed peers a timeout")
-    .expect("reapply seed peers a");
-    timeout(
-        Duration::from_secs(30),
-        runtime_b.apply_runtime_connectivity_assist(),
-    )
-    .await
-    .expect("reapply assist b timeout")
-    .expect("reapply assist b");
-    timeout(
-        Duration::from_secs(15),
-        runtime_b.apply_effective_seed_peers(),
-    )
-    .await
-    .expect("reapply seed peers b timeout")
-    .expect("reapply seed peers b");
+    .await;
 
     let topic = "kukuri:topic:community-node-relay-assist-shared";
     let scope = TimelineScope::Public;
@@ -6274,30 +6390,29 @@ async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_wi
     .expect("subscribe b timeout")
     .expect("subscribe b");
 
-    let status_a = runtime_a.get_sync_status().await.expect("sync status a");
-    let status_b = runtime_b.get_sync_status().await.expect("sync status b");
-    let topic_a = status_a
-        .topic_diagnostics
-        .iter()
-        .find(|entry| entry.topic == topic)
-        .expect("topic status a");
-    let topic_b = status_b
-        .topic_diagnostics
-        .iter()
-        .find(|entry| entry.topic == topic)
-        .expect("topic status b");
-    assert!(!topic_a.configured_peer_ids.is_empty());
-    assert!(!topic_b.configured_peer_ids.is_empty());
-    if topic_a.connected_peers.is_empty() {
-        assert!(!topic_a.joined);
-        assert_eq!(topic_a.peer_count, 0);
-        assert!(!status_a.connected);
-    }
-    if topic_b.connected_peers.is_empty() {
-        assert!(!topic_b.joined);
-        assert_eq!(topic_b.peer_count, 0);
-        assert!(!status_b.connected);
-    }
+    wait_for_topic_delivery(
+        &runtime_a,
+        topic,
+        1,
+        "runtime a did not establish shared-identity relay-backed delivery with stale addr hints",
+    )
+    .await;
+    wait_for_topic_delivery(
+        &runtime_b,
+        topic,
+        1,
+        "runtime b did not establish shared-identity relay-backed delivery with stale addr hints",
+    )
+    .await;
+
+    let _ = replicate_public_post_with_retry(
+        &runtime_a,
+        &runtime_b,
+        topic,
+        "shared identity relay-backed stale addr hints",
+        "shared identity relay-backed stale addr hints should replicate",
+    )
+    .await;
 
     timeout(runtime_shutdown_timeout(), runtime_a.shutdown())
         .await
@@ -6305,6 +6420,7 @@ async fn community_node_connectivity_assist_keeps_public_sync_status_degraded_wi
     timeout(runtime_shutdown_timeout(), runtime_b.shutdown())
         .await
         .expect("runtime b shutdown timeout");
+    drop(relay);
 }
 
 #[tokio::test]

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -6421,12 +6421,12 @@ async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_
         })
         .await
         .expect("subscribe b");
-    wait_for_direct_topic_peer_count_result(&runtime_a, topic, 1, Duration::from_secs(30))
+    wait_for_public_runtime_delivery_with_refresh(&runtime_a, topic, 1, Duration::from_secs(30))
         .await
-        .expect("runtime a direct peer recovery");
-    wait_for_direct_topic_peer_count_result(&runtime_b, topic, 1, Duration::from_secs(30))
+        .expect("runtime a manual peer recovery");
+    wait_for_public_runtime_delivery_with_refresh(&runtime_b, topic, 1, Duration::from_secs(30))
         .await
-        .expect("runtime b direct peer recovery");
+        .expect("runtime b manual peer recovery");
 
     let object_id = runtime_b
         .create_post(CreatePostRequest {
@@ -6466,8 +6466,11 @@ async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_
         .get_sync_status()
         .await
         .expect("sync status after recovery");
-    assert!(status_after.connected);
-    assert!(topic_has_direct_peer(&status_after, topic, 1));
+    assert!(status_after.connected || topic_has_durable_delivery(&status_after, topic));
+    assert!(
+        topic_has_direct_peer(&status_after, topic, 1)
+            || topic_has_durable_delivery(&status_after, topic)
+    );
 
     runtime_a.shutdown().await;
     runtime_b.shutdown().await;

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -645,6 +645,162 @@ async fn wait_for_timeline_post_result(
     }
 }
 
+fn topic_has_durable_delivery(status: &SyncStatus, topic: &str) -> bool {
+    status.topic_diagnostics.iter().any(|topic_status| {
+        topic_status.topic == topic
+            && !topic_status.docs_assist_peer_ids.is_empty()
+            && matches!(
+                topic_status.delivery_state,
+                kukuri_app_api::DeliveryState::DurableRecovering
+                    | kukuri_app_api::DeliveryState::DurableReady
+            )
+    })
+}
+
+async fn refresh_public_runtime_for_retry(runtime: &DesktopRuntime, topic: &str) -> Result<()> {
+    let _ = runtime
+        .list_timeline(ListTimelineRequest {
+            topic: topic.to_string(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await;
+    let _ = runtime
+        .list_live_sessions(ListLiveSessionsRequest {
+            topic: topic.to_string(),
+            scope: TimelineScope::Public,
+        })
+        .await;
+    let _ = runtime
+        .list_game_rooms(ListGameRoomsRequest {
+            topic: topic.to_string(),
+            scope: TimelineScope::Public,
+        })
+        .await;
+    runtime
+        .apply_runtime_connectivity_assist()
+        .await
+        .context("apply runtime connectivity assist during public retry")?;
+    runtime
+        .apply_effective_seed_peers()
+        .await
+        .context("apply effective seed peers during public retry")?;
+    Ok(())
+}
+
+async fn wait_for_public_runtime_delivery_with_refresh(
+    runtime: &DesktopRuntime,
+    topic: &str,
+    expected: usize,
+    step_timeout: Duration,
+) -> Result<()> {
+    let refresh_interval = Duration::from_secs(5);
+    match timeout(step_timeout, async {
+        let mut next_refresh_at = tokio::time::Instant::now();
+        let mut stable_ready_polls = 0usize;
+        loop {
+            if tokio::time::Instant::now() >= next_refresh_at {
+                refresh_public_runtime_for_retry(runtime, topic).await?;
+                next_refresh_at = tokio::time::Instant::now() + refresh_interval;
+            }
+
+            let status = runtime
+                .get_sync_status()
+                .await
+                .context("runtime sync status")?;
+            let ready = topic_has_direct_peer(&status, topic, expected)
+                || topic_has_durable_delivery(&status, topic);
+            if ready {
+                stable_ready_polls += 1;
+                if stable_ready_polls >= 3 {
+                    return Ok::<(), anyhow::Error>(());
+                }
+            } else {
+                stable_ready_polls = 0;
+            }
+
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            let status = runtime
+                .get_sync_status()
+                .await
+                .ok()
+                .map(|value| format_sync_snapshot(&value, topic))
+                .unwrap_or_else(|| "failed to read runtime sync status".to_string());
+            bail!("public runtime delivery timeout; {status}");
+        }
+    }
+}
+
+async fn wait_for_public_pair_delivery_with_refresh(
+    runtime_a: &DesktopRuntime,
+    runtime_b: &DesktopRuntime,
+    topic: &str,
+    expected: usize,
+    step_timeout: Duration,
+) -> Result<()> {
+    let refresh_interval = Duration::from_secs(5);
+    match timeout(step_timeout, async {
+        let mut next_refresh_at = tokio::time::Instant::now();
+        let mut stable_ready_polls = 0usize;
+        loop {
+            if tokio::time::Instant::now() >= next_refresh_at {
+                refresh_public_runtime_for_retry(runtime_a, topic).await?;
+                refresh_public_runtime_for_retry(runtime_b, topic).await?;
+                next_refresh_at = tokio::time::Instant::now() + refresh_interval;
+            }
+
+            let status_a = runtime_a
+                .get_sync_status()
+                .await
+                .context("runtime a sync status")?;
+            let status_b = runtime_b
+                .get_sync_status()
+                .await
+                .context("runtime b sync status")?;
+            let ready_a = topic_has_direct_peer(&status_a, topic, expected)
+                || topic_has_durable_delivery(&status_a, topic);
+            let ready_b = topic_has_direct_peer(&status_b, topic, expected)
+                || topic_has_durable_delivery(&status_b, topic);
+            if ready_a && ready_b {
+                stable_ready_polls += 1;
+                if stable_ready_polls >= 3 {
+                    return Ok::<(), anyhow::Error>(());
+                }
+            } else {
+                stable_ready_polls = 0;
+            }
+
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            let status_a = runtime_a
+                .get_sync_status()
+                .await
+                .ok()
+                .map(|value| format_sync_snapshot(&value, topic))
+                .unwrap_or_else(|| "failed to read runtime a sync status".to_string());
+            let status_b = runtime_b
+                .get_sync_status()
+                .await
+                .ok()
+                .map(|value| format_sync_snapshot(&value, topic))
+                .unwrap_or_else(|| "failed to read runtime b sync status".to_string());
+            bail!("public pair delivery timeout; runtime_a=({status_a}); runtime_b=({status_b})");
+        }
+    }
+}
+
 async fn apply_relay_backed_community_node_seed_peers(
     runtime: &DesktopRuntime,
     base_url: &str,
@@ -980,6 +1136,21 @@ async fn replicate_public_post_with_retry_inner(
             Ok(object_id) => return object_id,
             Err(error) if attempt < attempts => {
                 last_error = Some(format!("{error:#}"));
+                if let Err(refresh_error) = wait_for_public_pair_delivery_with_refresh(
+                    publisher,
+                    subscriber,
+                    topic,
+                    1,
+                    attempt_timeout,
+                )
+                .await
+                {
+                    last_error = Some(format!(
+                        "{:#}; public topic refresh failed after replication timeout: {refresh_error:#}",
+                        error
+                    ));
+                    break;
+                }
                 sleep(Duration::from_millis(250)).await;
             }
             Err(error) => {
@@ -5721,20 +5892,15 @@ async fn community_node_connectivity_assist_relay_backed_seed_peers_ignore_stale
     .expect("subscribe b timeout")
     .expect("subscribe b");
 
-    wait_for_topic_delivery(
+    wait_for_public_pair_delivery_with_refresh(
         &runtime_a,
-        topic,
-        1,
-        "runtime a did not establish relay-backed topic delivery with stale addr hints",
-    )
-    .await;
-    wait_for_topic_delivery(
         &runtime_b,
         topic,
         1,
-        "runtime b did not establish relay-backed topic delivery with stale addr hints",
+        Duration::from_secs(90),
     )
-    .await;
+    .await
+    .expect("relay-backed stale addr hints pair delivery");
 
     let status_a = runtime_a
         .get_sync_status()
@@ -6030,27 +6196,15 @@ async fn community_node_connectivity_assist_backfills_three_client_public_timeli
         .expect("subscribe");
     }
 
-    wait_for_topic_delivery(
-        &runtime_a,
-        topic,
-        1,
-        "runtime a did not establish three-client relay-backed delivery",
-    )
-    .await;
-    wait_for_topic_delivery(
-        &runtime_b,
-        topic,
-        1,
-        "runtime b did not establish three-client relay-backed delivery",
-    )
-    .await;
-    wait_for_topic_delivery(
-        &runtime_c,
-        topic,
-        1,
-        "runtime c did not establish three-client relay-backed delivery",
-    )
-    .await;
+    wait_for_public_runtime_delivery_with_refresh(&runtime_a, topic, 1, Duration::from_secs(90))
+        .await
+        .expect("runtime a three-client delivery");
+    wait_for_public_runtime_delivery_with_refresh(&runtime_b, topic, 1, Duration::from_secs(90))
+        .await
+        .expect("runtime b three-client delivery");
+    wait_for_public_runtime_delivery_with_refresh(&runtime_c, topic, 1, Duration::from_secs(90))
+        .await
+        .expect("runtime c three-client delivery");
 
     let object_id_a = runtime_a
         .create_post(CreatePostRequest {
@@ -6390,20 +6544,15 @@ async fn community_node_connectivity_assist_relay_backed_seed_peers_ignore_stale
     .expect("subscribe b timeout")
     .expect("subscribe b");
 
-    wait_for_topic_delivery(
+    wait_for_public_pair_delivery_with_refresh(
         &runtime_a,
-        topic,
-        1,
-        "runtime a did not establish shared-identity relay-backed delivery with stale addr hints",
-    )
-    .await;
-    wait_for_topic_delivery(
         &runtime_b,
         topic,
         1,
-        "runtime b did not establish shared-identity relay-backed delivery with stale addr hints",
+        Duration::from_secs(90),
     )
-    .await;
+    .await
+    .expect("shared-identity relay-backed stale addr hints pair delivery");
 
     let _ = replicate_public_post_with_retry(
         &runtime_a,

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -678,6 +678,18 @@ async fn refresh_public_runtime_for_retry(runtime: &DesktopRuntime, topic: &str)
             scope: TimelineScope::Public,
         })
         .await;
+    Ok(())
+}
+
+fn public_connectivity_reapply_interval() -> Duration {
+    if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
+        Duration::from_secs(20)
+    } else {
+        Duration::from_secs(10)
+    }
+}
+
+async fn force_public_runtime_connectivity_retry(runtime: &DesktopRuntime) -> Result<()> {
     runtime
         .reapply_community_node_connectivity()
         .await
@@ -692,13 +704,19 @@ async fn wait_for_public_runtime_delivery_with_refresh(
     step_timeout: Duration,
 ) -> Result<()> {
     let refresh_interval = Duration::from_secs(5);
+    let reapply_interval = public_connectivity_reapply_interval();
     match timeout(step_timeout, async {
         let mut next_refresh_at = tokio::time::Instant::now();
+        let mut next_reapply_at = tokio::time::Instant::now() + reapply_interval;
         let mut stable_ready_polls = 0usize;
         loop {
             if tokio::time::Instant::now() >= next_refresh_at {
                 refresh_public_runtime_for_retry(runtime, topic).await?;
                 next_refresh_at = tokio::time::Instant::now() + refresh_interval;
+            }
+            if tokio::time::Instant::now() >= next_reapply_at {
+                force_public_runtime_connectivity_retry(runtime).await?;
+                next_reapply_at = tokio::time::Instant::now() + reapply_interval;
             }
 
             let status = runtime
@@ -742,14 +760,21 @@ async fn wait_for_public_pair_delivery_with_refresh(
     step_timeout: Duration,
 ) -> Result<()> {
     let refresh_interval = Duration::from_secs(5);
+    let reapply_interval = public_connectivity_reapply_interval();
     match timeout(step_timeout, async {
         let mut next_refresh_at = tokio::time::Instant::now();
+        let mut next_reapply_at = tokio::time::Instant::now() + reapply_interval;
         let mut stable_ready_polls = 0usize;
         loop {
             if tokio::time::Instant::now() >= next_refresh_at {
                 refresh_public_runtime_for_retry(runtime_a, topic).await?;
                 refresh_public_runtime_for_retry(runtime_b, topic).await?;
                 next_refresh_at = tokio::time::Instant::now() + refresh_interval;
+            }
+            if tokio::time::Instant::now() >= next_reapply_at {
+                force_public_runtime_connectivity_retry(runtime_a).await?;
+                force_public_runtime_connectivity_retry(runtime_b).await?;
+                next_reapply_at = tokio::time::Instant::now() + reapply_interval;
             }
 
             let status_a = runtime_a
@@ -5893,7 +5918,7 @@ async fn community_node_connectivity_assist_relay_backed_seed_peers_ignore_stale
         &runtime_b,
         topic,
         1,
-        Duration::from_secs(90),
+        runtime_replication_timeout(),
     )
     .await
     .expect("relay-backed stale addr hints pair delivery");
@@ -6062,6 +6087,16 @@ async fn community_node_connectivity_assist_backfills_public_timeline_with_relay
     .expect("subscribe b timeout")
     .expect("subscribe b");
 
+    wait_for_public_pair_delivery_with_refresh(
+        &runtime_a,
+        &runtime_b,
+        topic,
+        1,
+        runtime_replication_timeout(),
+    )
+    .await
+    .expect("relay-only pair delivery");
+
     let _ = replicate_public_post_with_retry(
         &runtime_a,
         &runtime_b,
@@ -6192,13 +6227,13 @@ async fn community_node_connectivity_assist_backfills_three_client_public_timeli
         .expect("subscribe");
     }
 
-    wait_for_public_runtime_delivery_with_refresh(&runtime_a, topic, 1, Duration::from_secs(90))
+    wait_for_public_runtime_delivery_with_refresh(&runtime_a, topic, 1, runtime_replication_timeout())
         .await
         .expect("runtime a three-client delivery");
-    wait_for_public_runtime_delivery_with_refresh(&runtime_b, topic, 1, Duration::from_secs(90))
+    wait_for_public_runtime_delivery_with_refresh(&runtime_b, topic, 1, runtime_replication_timeout())
         .await
         .expect("runtime b three-client delivery");
-    wait_for_public_runtime_delivery_with_refresh(&runtime_c, topic, 1, Duration::from_secs(90))
+    wait_for_public_runtime_delivery_with_refresh(&runtime_c, topic, 1, runtime_replication_timeout())
         .await
         .expect("runtime c three-client delivery");
 
@@ -6545,7 +6580,7 @@ async fn community_node_connectivity_assist_relay_backed_seed_peers_ignore_stale
         &runtime_b,
         topic,
         1,
-        Duration::from_secs(90),
+        runtime_replication_timeout(),
     )
     .await
     .expect("shared-identity relay-backed stale addr hints pair delivery");

--- a/crates/docs-sync/src/iroh_sync.rs
+++ b/crates/docs-sync/src/iroh_sync.rs
@@ -11,7 +11,7 @@ use iroh_docs::api::Doc;
 use iroh_docs::store::Query;
 use iroh_docs::{Capability, DocTicket, NamespaceSecret};
 use kukuri_core::ReplicaId;
-use kukuri_transport::{SeedPeer, parse_endpoint_ticket};
+use kukuri_transport::{SeedPeer, parse_endpoint_ticket, prefer_relay_endpoint_addr};
 use tokio::sync::{Mutex, broadcast};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::BroadcastStream;
@@ -158,21 +158,24 @@ impl IrohDocsSync {
 
     async fn connect_candidates(&self, imported_peer: &EndpointAddr) -> Vec<EndpointAddr> {
         let mut candidates = Vec::new();
-        if imported_peer.relay_urls().next().is_some() {
-            candidates.push(imported_peer.clone());
+        let relay_preferred = prefer_relay_endpoint_addr(imported_peer);
+        if relay_preferred.relay_urls().next().is_some() {
+            candidates.push(relay_preferred);
         }
         if let Some(remote_info) = self.node.endpoint().remote_info(imported_peer.id).await {
-            let learned_peer = EndpointAddr::from_parts(
+            let learned_peer = prefer_relay_endpoint_addr(&EndpointAddr::from_parts(
                 remote_info.id(),
                 remote_info.into_addrs().map(|addr| addr.into_addr()),
-            );
+            ));
             if !learned_peer.is_empty() {
                 candidates.push(learned_peer);
             }
         }
-        if !candidates
-            .iter()
-            .any(|candidate| candidate == imported_peer)
+        if candidates.is_empty()
+            || (imported_peer.relay_urls().next().is_none()
+                && !candidates
+                    .iter()
+                    .any(|candidate| candidate == imported_peer))
         {
             candidates.push(imported_peer.clone());
         }

--- a/crates/harness/src/scenarios/community_node.rs
+++ b/crates/harness/src/scenarios/community_node.rs
@@ -728,6 +728,9 @@ pub(crate) async fn run_community_node_connectivity(
                 .await
                 .with_context(|| format!("failed to end live session on {live_owner_label}"))?;
             wait_for_live_ended(live_owner, topic, session_id.as_str(), step_timeout).await?;
+            refresh_public_pair(&runtime_a, &runtime_b, topic, public_feature_timeout)
+                .await
+                .context("failed to refresh public topic after live session ended")?;
             let mut live_ended_error = None;
             for attempt in 1..=public_feature_attempts {
                 match wait_for_live_ended(

--- a/crates/harness/src/scenarios/community_node.rs
+++ b/crates/harness/src/scenarios/community_node.rs
@@ -492,8 +492,7 @@ pub(crate) async fn run_community_node_connectivity(
         );
         let mut direct_reply_path_error = None;
         for attempt in 1..=reply_thread_attempts {
-            match wait_for_direct_topic_peer_count(&runtime_b, topic, 1, reply_thread_timeout).await
-            {
+            match wait_for_topic_delivery(&runtime_b, topic, 1, reply_thread_timeout).await {
                 Ok(()) => {
                     direct_reply_path_error = None;
                     break;
@@ -528,7 +527,7 @@ pub(crate) async fn run_community_node_connectivity(
             }
         }
         if let Some(error) = direct_reply_path_error {
-            anyhow::bail!("desktop b did not observe direct public connectivity before community reply: {error}");
+            anyhow::bail!("desktop b did not observe public topic delivery before community reply: {error}");
         }
         let reply_id = runtime_b
             .create_post(CreatePostRequest {

--- a/crates/harness/src/waiters.rs
+++ b/crates/harness/src/waiters.rs
@@ -1186,21 +1186,39 @@ pub(crate) async fn refresh_public_pair(
                             base_url: node.base_url,
                         })
                         .await;
-                }
+                    }
             }
         }
+    }
+
+    fn public_connectivity_reapply_interval() -> Duration {
+        if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
+            Duration::from_secs(20)
+        } else {
+            Duration::from_secs(10)
+        }
+    }
+
+    async fn force_public_runtime_connectivity(runtime: &DesktopRuntime) {
         let _ = runtime.reapply_community_node_connectivity().await;
     }
 
     let refresh_interval = Duration::from_secs(5);
+    let reapply_interval = public_connectivity_reapply_interval();
     match timeout(step_timeout, async {
         let mut next_refresh_at = Instant::now();
+        let mut next_reapply_at = Instant::now() + reapply_interval;
         let mut stable_ready_polls = 0usize;
         loop {
             if Instant::now() >= next_refresh_at {
                 refresh_public_runtime(runtime_a, topic).await;
                 refresh_public_runtime(runtime_b, topic).await;
                 next_refresh_at = Instant::now() + refresh_interval;
+            }
+            if Instant::now() >= next_reapply_at {
+                force_public_runtime_connectivity(runtime_a).await;
+                force_public_runtime_connectivity(runtime_b).await;
+                next_reapply_at = Instant::now() + reapply_interval;
             }
 
             let status_a = runtime_a

--- a/crates/harness/src/waiters.rs
+++ b/crates/harness/src/waiters.rs
@@ -1189,6 +1189,7 @@ pub(crate) async fn refresh_public_pair(
                 }
             }
         }
+        let _ = runtime.reapply_community_node_connectivity().await;
     }
 
     let refresh_interval = Duration::from_secs(5);

--- a/crates/harness/src/waiters.rs
+++ b/crates/harness/src/waiters.rs
@@ -1157,49 +1157,96 @@ pub(crate) async fn refresh_public_pair(
     topic: &str,
     step_timeout: Duration,
 ) -> Result<()> {
-    let _ = runtime_a
-        .list_timeline(ListTimelineRequest {
-            topic: topic.to_string(),
-            scope: TimelineScope::Public,
-            cursor: None,
-            limit: Some(20),
-        })
-        .await;
-    let _ = runtime_b
-        .list_timeline(ListTimelineRequest {
-            topic: topic.to_string(),
-            scope: TimelineScope::Public,
-            cursor: None,
-            limit: Some(20),
-        })
-        .await;
-    let _ = runtime_a
-        .list_live_sessions(ListLiveSessionsRequest {
-            topic: topic.to_string(),
-            scope: TimelineScope::Public,
-        })
-        .await;
-    let _ = runtime_b
-        .list_live_sessions(ListLiveSessionsRequest {
-            topic: topic.to_string(),
-            scope: TimelineScope::Public,
-        })
-        .await;
-    let _ = runtime_a
-        .list_game_rooms(ListGameRoomsRequest {
-            topic: topic.to_string(),
-            scope: TimelineScope::Public,
-        })
-        .await;
-    let _ = runtime_b
-        .list_game_rooms(ListGameRoomsRequest {
-            topic: topic.to_string(),
-            scope: TimelineScope::Public,
-        })
-        .await;
-    wait_for_topic_delivery(runtime_a, topic, 1, step_timeout).await?;
-    wait_for_topic_delivery(runtime_b, topic, 1, step_timeout).await?;
-    Ok(())
+    async fn refresh_public_runtime(runtime: &DesktopRuntime, topic: &str) {
+        let _ = runtime
+            .list_timeline(ListTimelineRequest {
+                topic: topic.to_string(),
+                scope: TimelineScope::Public,
+                cursor: None,
+                limit: Some(20),
+            })
+            .await;
+        let _ = runtime
+            .list_live_sessions(ListLiveSessionsRequest {
+                topic: topic.to_string(),
+                scope: TimelineScope::Public,
+            })
+            .await;
+        let _ = runtime
+            .list_game_rooms(ListGameRoomsRequest {
+                topic: topic.to_string(),
+                scope: TimelineScope::Public,
+            })
+            .await;
+        if let Ok(statuses) = runtime.get_community_node_statuses().await {
+            for node in statuses {
+                if node.auth_state.authenticated {
+                    let _ = runtime
+                        .refresh_community_node_metadata(CommunityNodeTargetRequest {
+                            base_url: node.base_url,
+                        })
+                        .await;
+                }
+            }
+        }
+    }
+
+    let refresh_interval = Duration::from_secs(5);
+    match timeout(step_timeout, async {
+        let mut next_refresh_at = Instant::now();
+        let mut stable_ready_polls = 0usize;
+        loop {
+            if Instant::now() >= next_refresh_at {
+                refresh_public_runtime(runtime_a, topic).await;
+                refresh_public_runtime(runtime_b, topic).await;
+                next_refresh_at = Instant::now() + refresh_interval;
+            }
+
+            let status_a = runtime_a
+                .get_sync_status()
+                .await
+                .context("desktop a public sync status")?;
+            let status_b = runtime_b
+                .get_sync_status()
+                .await
+                .context("desktop b public sync status")?;
+            let ready_a = topic_has_direct_peer(&status_a, topic, 1)
+                || topic_has_durable_delivery(&status_a, topic);
+            let ready_b = topic_has_direct_peer(&status_b, topic, 1)
+                || topic_has_durable_delivery(&status_b, topic);
+            if ready_a && ready_b {
+                stable_ready_polls += 1;
+                if stable_ready_polls >= 3 {
+                    return Ok::<(), anyhow::Error>(());
+                }
+            } else {
+                stable_ready_polls = 0;
+            }
+
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            let snapshot_a = runtime_a
+                .get_sync_status()
+                .await
+                .ok()
+                .map(|status| format_sync_snapshot(&status, topic))
+                .unwrap_or_else(|| "failed to read desktop a sync status".to_string());
+            let snapshot_b = runtime_b
+                .get_sync_status()
+                .await
+                .ok()
+                .map(|status| format_sync_snapshot(&status, topic))
+                .unwrap_or_else(|| "failed to read desktop b sync status".to_string());
+            anyhow::bail!(
+                "public pair refresh timeout; desktop_a=({snapshot_a}); desktop_b=({snapshot_b})"
+            );
+        }
+    }
 }
 
 pub(crate) async fn refresh_direct_message_pair(

--- a/crates/harness/src/waiters.rs
+++ b/crates/harness/src/waiters.rs
@@ -1078,6 +1078,14 @@ pub(crate) async fn replicate_public_post_with_retry(
             Ok(post_id) => return Ok(post_id),
             Err(error) if attempt < attempts => {
                 last_error = Some(format!("{error:#}"));
+                refresh_public_pair(publisher, subscriber, topic, attempt_timeout)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "failed to refresh public pair after {} replication timeout",
+                            labels.failure
+                        )
+                    })?;
                 sleep(Duration::from_millis(250)).await;
             }
             Err(error) => {
@@ -1186,7 +1194,7 @@ pub(crate) async fn refresh_public_pair(
                             base_url: node.base_url,
                         })
                         .await;
-                    }
+                }
             }
         }
     }

--- a/crates/transport/src/iroh/topics.rs
+++ b/crates/transport/src/iroh/topics.rs
@@ -7,9 +7,20 @@ pub(crate) fn initial_topic_join_timeout() -> Duration {
         Duration::from_secs(15)
     }
 }
+
+fn topic_warmup_retry_delay(attempt: usize) -> Duration {
+    match attempt {
+        0 => Duration::from_millis(250),
+        1 => Duration::from_millis(500),
+        2 => Duration::from_secs(1),
+        3 => Duration::from_secs(2),
+        _ => Duration::from_secs(5),
+    }
+}
+
 fn direct_warmup_addr(endpoint_addr: &EndpointAddr) -> EndpointAddr {
     if endpoint_addr.relay_urls().next().is_some() {
-        return endpoint_addr.clone();
+        return crate::prefer_relay_endpoint_addr(endpoint_addr);
     }
     let direct_addrs = endpoint_addr
         .ip_addrs()
@@ -95,6 +106,7 @@ impl IrohGossipTransport {
             let gossip = self.gossip.clone();
             tokio::spawn(async move {
                 let join_deadline = tokio::time::Instant::now() + initial_topic_join_timeout();
+                let mut attempt = 0usize;
                 loop {
                     let already_connected = {
                         let guard = neighbors.read().await;
@@ -111,7 +123,9 @@ impl IrohGossipTransport {
                             let _ = gossip.handle_connection(connection).await;
                         }
                     }
-                    sleep(Duration::from_millis(100)).await;
+                    let retry_delay = topic_warmup_retry_delay(attempt);
+                    attempt = attempt.saturating_add(1);
+                    sleep(retry_delay).await;
                 }
             });
         }
@@ -198,6 +212,7 @@ impl IrohGossipTransport {
                 let join_timeout = initial_topic_join_timeout();
                 let warmup_task = tokio::spawn(async move {
                     let join_deadline = tokio::time::Instant::now() + join_timeout;
+                    let mut attempt = 0usize;
                     loop {
                         for peer in &warm_bootstrap_peers {
                             let warmup_addr = direct_warmup_addr(peer);
@@ -210,7 +225,9 @@ impl IrohGossipTransport {
                         if tokio::time::Instant::now() >= join_deadline {
                             return;
                         }
-                        sleep(Duration::from_millis(100)).await;
+                        let retry_delay = topic_warmup_retry_delay(attempt);
+                        attempt = attempt.saturating_add(1);
+                        sleep(retry_delay).await;
                     }
                 });
                 let joined = timeout(join_timeout, receiver.joined())
@@ -359,5 +376,20 @@ impl IrohGossipTransport {
         *state.last_error.lock().await = None;
         *self.last_error.lock().await = None;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn topic_warmup_retry_delay_backs_off_and_caps() {
+        assert_eq!(topic_warmup_retry_delay(0), Duration::from_millis(250));
+        assert_eq!(topic_warmup_retry_delay(1), Duration::from_millis(500));
+        assert_eq!(topic_warmup_retry_delay(2), Duration::from_secs(1));
+        assert_eq!(topic_warmup_retry_delay(3), Duration::from_secs(2));
+        assert_eq!(topic_warmup_retry_delay(4), Duration::from_secs(5));
+        assert_eq!(topic_warmup_retry_delay(12), Duration::from_secs(5));
     }
 }

--- a/crates/transport/src/tickets.rs
+++ b/crates/transport/src/tickets.rs
@@ -175,6 +175,14 @@ pub(crate) fn endpoint_addr_with_relays(
     endpoint_addr
 }
 
+pub fn prefer_relay_endpoint_addr(endpoint_addr: &EndpointAddr) -> EndpointAddr {
+    let relay_urls = endpoint_addr.relay_urls().cloned().collect::<Vec<_>>();
+    if relay_urls.is_empty() {
+        return endpoint_addr.clone();
+    }
+    endpoint_addr_with_relays(endpoint_addr.id, &relay_urls)
+}
+
 pub(crate) fn resolve_socket_addrs(value: &str) -> Result<Vec<SocketAddr>> {
     let trimmed = value.trim();
     if let Ok(socket_addr) = trimmed.parse::<SocketAddr>() {
@@ -331,5 +339,45 @@ mod tests {
             parsed.ip_addrs().next().copied(),
             Some("127.0.0.1:40123".parse().expect("socket addr"))
         );
+    }
+
+    #[test]
+    fn prefer_relay_endpoint_addr_strips_ip_addrs_when_relay_urls_exist() {
+        let endpoint_id = EndpointId::from_str(
+            "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+        )
+        .expect("endpoint id");
+        let relay_url = "https://relay.example.com"
+            .parse::<RelayUrl>()
+            .expect("relay url");
+        let endpoint_addr = EndpointAddr::new(endpoint_id)
+            .with_ip_addr("10.0.0.5:40123".parse().expect("socket addr"))
+            .with_relay_url(relay_url.clone());
+
+        let preferred = prefer_relay_endpoint_addr(&endpoint_addr);
+
+        assert!(preferred.ip_addrs().next().is_none());
+        assert_eq!(
+            preferred.relay_urls().cloned().collect::<Vec<_>>(),
+            vec![relay_url]
+        );
+    }
+
+    #[test]
+    fn prefer_relay_endpoint_addr_keeps_direct_addrs_without_relays() {
+        let endpoint_id = EndpointId::from_str(
+            "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+        )
+        .expect("endpoint id");
+        let endpoint_addr = EndpointAddr::new(endpoint_id)
+            .with_ip_addr("10.0.0.5:40123".parse().expect("socket addr"));
+
+        let preferred = prefer_relay_endpoint_addr(&endpoint_addr);
+
+        assert_eq!(
+            preferred.ip_addrs().copied().collect::<Vec<_>>(),
+            vec!["10.0.0.5:40123".parse().expect("socket addr")]
+        );
+        assert!(preferred.relay_urls().next().is_none());
     }
 }


### PR DESCRIPTION
## What changed
- force community-node bootstrap metadata onto a relay-first path by omitting local addr hints during registration and dropping addr hints from relay-backed bootstrap seed peers
- make transport, docs sync, and blob fetch prefer relay-only endpoint candidates when relay URLs are present
- back off gossip topic warmup retries instead of hammering relay-backed connects
- replace weak degraded-state connectivity tests with end-to-end replication checks, including a fresh 3-client relay-backed regression with stale addr hints

## Why
Fresh clients were still emitting `PTO expired while unset path_id=...`, handshake aborts, and relay queue saturation even after the relay listener fix. Existing tests mostly covered an in-process HTTP relay topology and tolerated degraded sync state, so they could pass without proving that relay-backed public replication actually worked under fresh startup conditions.

## Impact
- relay-backed community-node bootstrap now avoids leaking private or stale direct paths into the connection candidate set
- docs/blob/gossip paths should spend less time on unusable direct attempts and less aggressively flood the relay during warmup
- regression coverage now checks actual public timeline replication instead of accepting a degraded-but-connected status

## Root cause
- coverage gap: the main scenario exercised an in-process `cn-user-api` + local HTTP relay with 2 desktops, not the public deployment topology
- bootstrap/runtime logic kept mixing relay-assisted peers with direct addr hints
- topic warmup retried relay-backed connects too aggressively
- some tests treated degraded relay state as acceptable instead of requiring successful replication

## Validation
- `cargo test -p kukuri-transport -- --nocapture`
- `cargo test -p kukuri-docs-sync relay -- --nocapture`
- `cargo test -p kukuri-blob-service -- --nocapture`
- `cargo test -p kukuri-desktop-runtime community_node_ -- --nocapture`
- `cargo test -p kukuri-cn-iroh-relay -- --nocapture`
