### PR TITLE
[codex] Throttle remote fetch retries

### DIFF
--- a/crates/blob-service/src/lib.rs
+++ b/crates/blob-service/src/lib.rs
@@ -10,6 +10,7 @@ use kukuri_docs_sync::IrohDocsNode;
 use kukuri_transport::{SeedPeer, parse_endpoint_ticket, prefer_relay_endpoint_addr};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
+use tokio::time::{Duration, Instant, timeout};
 use tracing::{info, warn};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -24,6 +25,50 @@ pub enum BlobStatus {
     Missing,
     Available,
     Pinned,
+}
+
+const REMOTE_FETCH_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const REMOTE_FETCH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15);
+const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(15);
+
+#[derive(Debug, PartialEq, Eq)]
+enum RemoteFetchStart {
+    Ready,
+    InFlight,
+    CoolingDown,
+}
+
+#[derive(Debug, Default)]
+struct RemoteFetchRetryState {
+    in_flight: std::collections::BTreeSet<String>,
+    retry_after: BTreeMap<String, Instant>,
+}
+
+impl RemoteFetchRetryState {
+    fn try_begin(&mut self, key: &str, now: Instant) -> RemoteFetchStart {
+        if self
+            .retry_after
+            .get(key)
+            .is_some_and(|retry_after| *retry_after > now)
+        {
+            return RemoteFetchStart::CoolingDown;
+        }
+        self.retry_after.remove(key);
+        if !self.in_flight.insert(key.to_string()) {
+            return RemoteFetchStart::InFlight;
+        }
+        RemoteFetchStart::Ready
+    }
+
+    fn finish(&mut self, key: &str, success: bool, now: Instant) {
+        self.in_flight.remove(key);
+        if success {
+            self.retry_after.remove(key);
+        } else {
+            self.retry_after
+                .insert(key.to_string(), now + REMOTE_FETCH_RETRY_COOLDOWN);
+        }
+    }
 }
 
 #[async_trait]
@@ -51,6 +96,7 @@ pub struct IrohBlobService {
     learned_peers: Arc<Mutex<BTreeMap<String, iroh::EndpointAddr>>>,
     seed_peers: Arc<Mutex<BTreeMap<String, iroh::EndpointAddr>>>,
     imported_peers: Arc<Mutex<BTreeMap<String, iroh::EndpointAddr>>>,
+    remote_fetch_retries: Arc<Mutex<RemoteFetchRetryState>>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -73,6 +119,7 @@ impl IrohBlobService {
             learned_peers: Arc::new(Mutex::new(BTreeMap::new())),
             seed_peers: Arc::new(Mutex::new(BTreeMap::new())),
             imported_peers: Arc::new(Mutex::new(BTreeMap::new())),
+            remote_fetch_retries: Arc::new(Mutex::new(RemoteFetchRetryState::default())),
         }
     }
 
@@ -208,6 +255,113 @@ impl IrohBlobService {
         self.insert_learned_peer_addr(endpoint_addr).await;
         Ok(())
     }
+
+    async fn fetch_blob_from_remote(
+        &self,
+        hash_text: &str,
+        hash: iroh_blobs::Hash,
+        local_error: impl std::fmt::Display,
+    ) -> Result<Option<Vec<u8>>> {
+        let peers = self.fetch_peers().await;
+        info!(
+            hash = %hash_text,
+            error = %local_error,
+            configured_peer_count = peers.len(),
+            "blob fetch local miss, trying remote peers"
+        );
+        for imported_peer in peers {
+            let candidates = self.connect_candidates(&imported_peer).await;
+            info!(
+                hash = %hash_text,
+                peer_id = %imported_peer.id,
+                imported_addrs = ?imported_peer.addrs,
+                candidate_count = candidates.len(),
+                "blob fetch prepared remote peer candidates"
+            );
+            for peer in candidates {
+                match timeout(
+                    REMOTE_FETCH_CONNECT_TIMEOUT,
+                    self.node.endpoint().connect(peer.clone(), iroh_blobs::ALPN),
+                )
+                .await
+                {
+                    Ok(Ok(conn)) => {
+                        info!(
+                            hash = %hash_text,
+                            peer_id = %peer.id,
+                            addrs = ?peer.addrs,
+                            "blob fetch connected to remote peer"
+                        );
+                        match timeout(
+                            REMOTE_FETCH_TRANSFER_TIMEOUT,
+                            self.node.blobs().remote().fetch(conn, hash),
+                        )
+                        .await
+                        {
+                            Ok(Ok(_)) => {
+                                info!(
+                                    hash = %hash_text,
+                                    peer_id = %peer.id,
+                                    "blob fetch remote transfer completed"
+                                );
+                            }
+                            Ok(Err(error)) => {
+                                warn!(
+                                    hash = %hash_text,
+                                    peer_id = %peer.id,
+                                    addrs = ?peer.addrs,
+                                    error = %error,
+                                    "blob fetch remote transfer failed"
+                                );
+                                continue;
+                            }
+                            Err(_) => {
+                                warn!(
+                                    hash = %hash_text,
+                                    peer_id = %peer.id,
+                                    addrs = ?peer.addrs,
+                                    timeout_ms = REMOTE_FETCH_TRANSFER_TIMEOUT.as_millis(),
+                                    "blob fetch remote transfer timed out"
+                                );
+                                continue;
+                            }
+                        }
+                        match self.node.blobs().blobs().get_bytes(hash).await {
+                            Ok(bytes) => return Ok(Some(bytes.to_vec())),
+                            Err(error) => {
+                                warn!(
+                                    hash = %hash_text,
+                                    peer_id = %peer.id,
+                                    error = %error,
+                                    "blob fetch transfer completed but blob still missing locally"
+                                );
+                            }
+                        }
+                    }
+                    Ok(Err(error)) => {
+                        warn!(
+                            hash = %hash_text,
+                            peer_id = %peer.id,
+                            addrs = ?peer.addrs,
+                            error = %error,
+                            "blob fetch connect failed"
+                        );
+                    }
+                    Err(_) => {
+                        warn!(
+                            hash = %hash_text,
+                            peer_id = %peer.id,
+                            addrs = ?peer.addrs,
+                            timeout_ms = REMOTE_FETCH_CONNECT_TIMEOUT.as_millis(),
+                            "blob fetch connect timed out"
+                        );
+                    }
+                }
+            }
+        }
+        warn!(hash = %hash_text, "blob fetch exhausted remote peers without success");
+        Ok(None)
+    }
 }
 
 #[async_trait]
@@ -267,81 +421,39 @@ impl BlobService for IrohBlobService {
         match self.node.blobs().blobs().get_bytes(hash).await {
             Ok(bytes) => Ok(Some(bytes.to_vec())),
             Err(error) => {
-                let peers = self.fetch_peers().await;
-                info!(
-                    hash = %hash_text,
-                    error = %error,
-                    configured_peer_count = peers.len(),
-                    "blob fetch local miss, trying remote peers"
-                );
-                for imported_peer in peers {
-                    let candidates = self.connect_candidates(&imported_peer).await;
-                    info!(
-                        hash = %hash_text,
-                        peer_id = %imported_peer.id,
-                        imported_addrs = ?imported_peer.addrs,
-                        candidate_count = candidates.len(),
-                        "blob fetch prepared remote peer candidates"
-                    );
-                    for peer in candidates {
-                        match self
-                            .node
-                            .endpoint()
-                            .connect(peer.clone(), iroh_blobs::ALPN)
-                            .await
-                        {
-                            Ok(conn) => {
-                                info!(
-                                    hash = %hash_text,
-                                    peer_id = %peer.id,
-                                    addrs = ?peer.addrs,
-                                    "blob fetch connected to remote peer"
-                                );
-                                match self.node.blobs().remote().fetch(conn, hash).await {
-                                    Ok(_) => {
-                                        info!(
-                                            hash = %hash_text,
-                                            peer_id = %peer.id,
-                                            "blob fetch remote transfer completed"
-                                        );
-                                    }
-                                    Err(error) => {
-                                        warn!(
-                                            hash = %hash_text,
-                                            peer_id = %peer.id,
-                                            addrs = ?peer.addrs,
-                                            error = %error,
-                                            "blob fetch remote transfer failed"
-                                        );
-                                        continue;
-                                    }
-                                }
-                                match self.node.blobs().blobs().get_bytes(hash).await {
-                                    Ok(bytes) => return Ok(Some(bytes.to_vec())),
-                                    Err(error) => {
-                                        warn!(
-                                            hash = %hash_text,
-                                            peer_id = %peer.id,
-                                            error = %error,
-                                            "blob fetch transfer completed but blob still missing locally"
-                                        );
-                                    }
-                                }
-                            }
-                            Err(error) => {
-                                warn!(
-                                    hash = %hash_text,
-                                    peer_id = %peer.id,
-                                    addrs = ?peer.addrs,
-                                    error = %error,
-                                    "blob fetch connect failed"
-                                );
-                            }
-                        }
+                match self
+                    .remote_fetch_retries
+                    .lock()
+                    .await
+                    .try_begin(hash_text.as_str(), Instant::now())
+                {
+                    RemoteFetchStart::Ready => {}
+                    RemoteFetchStart::InFlight => {
+                        info!(
+                            hash = %hash_text,
+                            error = %error,
+                            "blob remote fetch skipped because another fetch is already running"
+                        );
+                        return Ok(None);
+                    }
+                    RemoteFetchStart::CoolingDown => {
+                        info!(
+                            hash = %hash_text,
+                            error = %error,
+                            "blob remote fetch skipped during retry cooldown"
+                        );
+                        return Ok(None);
                     }
                 }
-                warn!(hash = %hash_text, "blob fetch exhausted remote peers without success");
-                Ok(None)
+                let result = self
+                    .fetch_blob_from_remote(hash_text.as_str(), hash, error)
+                    .await;
+                self.remote_fetch_retries.lock().await.finish(
+                    hash_text.as_str(),
+                    matches!(&result, Ok(Some(_))),
+                    Instant::now(),
+                );
+                result
             }
         }
     }
@@ -398,7 +510,7 @@ mod tests {
     use iroh::Endpoint;
     use kukuri_transport::{TransportNetworkConfig, encode_endpoint_ticket};
     use tempfile::tempdir;
-    use tokio::time::{Duration, sleep, timeout};
+    use tokio::time::{sleep, timeout};
 
     fn loopback_ticket(endpoint: &Endpoint, config: &TransportNetworkConfig) -> String {
         let endpoint_addr = endpoint.addr();
@@ -428,6 +540,31 @@ mod tests {
 
     fn is_ticket_host_candidate(addr: SocketAddr) -> bool {
         !addr.ip().is_unspecified()
+    }
+
+    #[test]
+    fn remote_fetch_retry_state_blocks_duplicate_and_cools_down_failures() {
+        let now = Instant::now();
+        let mut state = RemoteFetchRetryState::default();
+
+        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
+        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::InFlight);
+
+        state.finish("hash-a", false, now);
+        assert_eq!(
+            state.try_begin("hash-a", now + Duration::from_secs(1)),
+            RemoteFetchStart::CoolingDown
+        );
+        assert_eq!(
+            state.try_begin("hash-a", now + REMOTE_FETCH_RETRY_COOLDOWN),
+            RemoteFetchStart::Ready
+        );
+
+        state.finish("hash-a", true, now + REMOTE_FETCH_RETRY_COOLDOWN);
+        assert_eq!(
+            state.try_begin("hash-a", now + REMOTE_FETCH_RETRY_COOLDOWN),
+            RemoteFetchStart::Ready
+        );
     }
 
     #[tokio::test]

--- a/crates/blob-service/src/lib.rs
+++ b/crates/blob-service/src/lib.rs
@@ -29,7 +29,7 @@ pub enum BlobStatus {
 
 const REMOTE_FETCH_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const REMOTE_FETCH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15);
-const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(15);
+const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(3);
 
 #[derive(Debug, PartialEq, Eq)]
 enum RemoteFetchStart {

--- a/crates/blob-service/src/lib.rs
+++ b/crates/blob-service/src/lib.rs
@@ -34,13 +34,11 @@ const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(15);
 #[derive(Debug, PartialEq, Eq)]
 enum RemoteFetchStart {
     Ready,
-    InFlight,
     CoolingDown,
 }
 
 #[derive(Debug, Default)]
 struct RemoteFetchRetryState {
-    in_flight: std::collections::BTreeSet<String>,
     retry_after: BTreeMap<String, Instant>,
 }
 
@@ -54,14 +52,10 @@ impl RemoteFetchRetryState {
             return RemoteFetchStart::CoolingDown;
         }
         self.retry_after.remove(key);
-        if !self.in_flight.insert(key.to_string()) {
-            return RemoteFetchStart::InFlight;
-        }
         RemoteFetchStart::Ready
     }
 
     fn finish(&mut self, key: &str, success: bool, now: Instant) {
-        self.in_flight.remove(key);
         if success {
             self.retry_after.remove(key);
         } else {
@@ -428,14 +422,6 @@ impl BlobService for IrohBlobService {
                     .try_begin(hash_text.as_str(), Instant::now())
                 {
                     RemoteFetchStart::Ready => {}
-                    RemoteFetchStart::InFlight => {
-                        info!(
-                            hash = %hash_text,
-                            error = %error,
-                            "blob remote fetch skipped because another fetch is already running"
-                        );
-                        return Ok(None);
-                    }
                     RemoteFetchStart::CoolingDown => {
                         info!(
                             hash = %hash_text,
@@ -543,12 +529,12 @@ mod tests {
     }
 
     #[test]
-    fn remote_fetch_retry_state_blocks_duplicate_and_cools_down_failures() {
+    fn remote_fetch_retry_state_cools_down_failures_without_blocking_active_fetches() {
         let now = Instant::now();
         let mut state = RemoteFetchRetryState::default();
 
         assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
-        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::InFlight);
+        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
 
         state.finish("hash-a", false, now);
         assert_eq!(

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -6237,12 +6237,20 @@ async fn community_node_connectivity_assist_backfills_three_client_public_timeli
         })
         .await
         .expect("create post a");
+    wait_for_topic_doc_index_entry_result(
+        &runtime_a,
+        topic,
+        object_id_a.as_str(),
+        runtime_replication_timeout(),
+    )
+    .await
+    .expect("runtime a should persist post a into docs index");
     wait_for_timeline_post_result(
         &runtime_b,
         topic,
         &scope,
         object_id_a.as_str(),
-        Duration::from_secs(30),
+        runtime_replication_timeout(),
     )
     .await
     .expect("runtime b should receive runtime a post");
@@ -6251,7 +6259,7 @@ async fn community_node_connectivity_assist_backfills_three_client_public_timeli
         topic,
         &scope,
         object_id_a.as_str(),
-        Duration::from_secs(30),
+        runtime_replication_timeout(),
     )
     .await
     .expect("runtime c should receive runtime a post");
@@ -6266,12 +6274,20 @@ async fn community_node_connectivity_assist_backfills_three_client_public_timeli
         })
         .await
         .expect("create post c");
+    wait_for_topic_doc_index_entry_result(
+        &runtime_c,
+        topic,
+        object_id_c.as_str(),
+        runtime_replication_timeout(),
+    )
+    .await
+    .expect("runtime c should persist post c into docs index");
     wait_for_timeline_post_result(
         &runtime_a,
         topic,
         &scope,
         object_id_c.as_str(),
-        Duration::from_secs(30),
+        runtime_replication_timeout(),
     )
     .await
     .expect("runtime a should receive runtime c post");
@@ -6280,7 +6296,7 @@ async fn community_node_connectivity_assist_backfills_three_client_public_timeli
         topic,
         &scope,
         object_id_c.as_str(),
-        Duration::from_secs(30),
+        runtime_replication_timeout(),
     )
     .await
     .expect("runtime b should receive runtime c post");

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -231,22 +231,7 @@ async fn wait_for_topic_delivery(
         let mut stable_ready_polls = 0usize;
         loop {
             let status = runtime.get_sync_status().await.expect("sync status");
-            let ready = status.topic_diagnostics.iter().any(|topic_status| {
-                let live_ready = topic_status.peer_count >= expected
-                    && topic_status.connected_peers.len() >= expected.min(1)
-                    && (topic_status.joined
-                        || matches!(
-                            topic_status.delivery_state,
-                            kukuri_app_api::DeliveryState::Live
-                        ));
-                let durable_ready = !topic_status.docs_assist_peer_ids.is_empty()
-                    && matches!(
-                        topic_status.delivery_state,
-                        kukuri_app_api::DeliveryState::DurableRecovering
-                            | kukuri_app_api::DeliveryState::DurableReady
-                    );
-                topic_status.topic == topic && (live_ready || durable_ready)
-            });
+            let ready = topic_has_delivery(&status, topic, expected);
             if ready {
                 stable_ready_polls += 1;
                 if stable_ready_polls >= 3 {
@@ -268,7 +253,7 @@ async fn wait_for_topic_delivery(
     }
 }
 
-async fn wait_for_connected_topic_peer_count_result(
+async fn wait_for_topic_delivery_result(
     runtime: &DesktopRuntime,
     topic: &str,
     expected: usize,
@@ -278,7 +263,7 @@ async fn wait_for_connected_topic_peer_count_result(
         let mut stable_ready_polls = 0usize;
         loop {
             let status = runtime.get_sync_status().await.context("sync status")?;
-            let ready = topic_has_direct_peer(&status, topic, expected);
+            let ready = topic_has_delivery(&status, topic, expected);
             if ready {
                 stable_ready_polls += 1;
                 if stable_ready_polls >= 3 {
@@ -300,7 +285,7 @@ async fn wait_for_connected_topic_peer_count_result(
                 .ok()
                 .map(|value| format_sync_snapshot(&value, topic))
                 .unwrap_or_else(|| "failed to read sync status".to_string());
-            bail!("topic readiness timeout; {status}");
+            bail!("topic delivery timeout; {status}");
         }
     }
 }
@@ -316,6 +301,10 @@ fn topic_has_direct_peer(status: &SyncStatus, topic: &str, expected: usize) -> b
                     kukuri_app_api::DeliveryState::Live
                 ))
     })
+}
+
+fn topic_has_delivery(status: &SyncStatus, topic: &str, expected: usize) -> bool {
+    topic_has_direct_peer(status, topic, expected) || topic_has_durable_delivery(status, topic)
 }
 
 fn should_swap_shared_identity_public_replication_direction(
@@ -1243,9 +1232,9 @@ async fn replicate_private_post_with_retry(
                 })
                 .await
                 .context("failed to refresh publisher joined private channels")?;
-            wait_for_connected_topic_peer_count_result(publisher, topic, 1, attempt_timeout)
+            wait_for_topic_delivery_result(publisher, topic, 1, attempt_timeout)
                 .await
-                .context("publisher did not observe private topic connectivity")?;
+                .context("publisher did not observe private topic delivery readiness")?;
             for subscriber in subscribers {
                 let _ = subscriber
                     .list_timeline(ListTimelineRequest {
@@ -1271,9 +1260,9 @@ async fn replicate_private_post_with_retry(
                     })
                     .await
                     .context("failed to refresh subscriber joined private channels")?;
-                wait_for_connected_topic_peer_count_result(subscriber, topic, 1, attempt_timeout)
+                wait_for_topic_delivery_result(subscriber, topic, 1, attempt_timeout)
                     .await
-                    .context("subscriber did not observe private topic connectivity")?;
+                    .context("subscriber did not observe private topic delivery readiness")?;
             }
             let pre_write_epoch =
                 joined_private_channel_epoch_result(publisher, topic, channel_id.as_str())

--- a/crates/docs-sync/src/iroh_sync.rs
+++ b/crates/docs-sync/src/iroh_sync.rs
@@ -34,7 +34,7 @@ struct ReplicaHandle {
 
 const REMOTE_FETCH_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const REMOTE_FETCH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15);
-const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(15);
+const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(3);
 
 #[derive(Debug, PartialEq, Eq)]
 enum RemoteFetchStart {

--- a/crates/docs-sync/src/iroh_sync.rs
+++ b/crates/docs-sync/src/iroh_sync.rs
@@ -14,6 +14,7 @@ use kukuri_core::ReplicaId;
 use kukuri_transport::{SeedPeer, parse_endpoint_ticket, prefer_relay_endpoint_addr};
 use tokio::sync::{Mutex, broadcast};
 use tokio::task::JoinHandle;
+use tokio::time::{Duration, Instant, timeout};
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::{info, warn};
 
@@ -31,6 +32,50 @@ struct ReplicaHandle {
     live_task: JoinHandle<()>,
 }
 
+const REMOTE_FETCH_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const REMOTE_FETCH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15);
+const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(15);
+
+#[derive(Debug, PartialEq, Eq)]
+enum RemoteFetchStart {
+    Ready,
+    InFlight,
+    CoolingDown,
+}
+
+#[derive(Debug, Default)]
+struct RemoteFetchRetryState {
+    in_flight: BTreeSet<String>,
+    retry_after: BTreeMap<String, Instant>,
+}
+
+impl RemoteFetchRetryState {
+    fn try_begin(&mut self, key: &str, now: Instant) -> RemoteFetchStart {
+        if self
+            .retry_after
+            .get(key)
+            .is_some_and(|retry_after| *retry_after > now)
+        {
+            return RemoteFetchStart::CoolingDown;
+        }
+        self.retry_after.remove(key);
+        if !self.in_flight.insert(key.to_string()) {
+            return RemoteFetchStart::InFlight;
+        }
+        RemoteFetchStart::Ready
+    }
+
+    fn finish(&mut self, key: &str, success: bool, now: Instant) {
+        self.in_flight.remove(key);
+        if success {
+            self.retry_after.remove(key);
+        } else {
+            self.retry_after
+                .insert(key.to_string(), now + REMOTE_FETCH_RETRY_COOLDOWN);
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct DocsPeerState {
     pub learned_peers: Vec<EndpointAddr>,
@@ -45,6 +90,7 @@ pub struct IrohDocsSync {
     seed_peers: Arc<Mutex<BTreeMap<String, EndpointAddr>>>,
     imported_peers: Arc<Mutex<BTreeMap<String, EndpointAddr>>>,
     private_replica_secrets: Arc<Mutex<HashMap<String, NamespaceSecret>>>,
+    remote_fetch_retries: Arc<Mutex<RemoteFetchRetryState>>,
 }
 
 impl IrohDocsSync {
@@ -56,6 +102,7 @@ impl IrohDocsSync {
             seed_peers: Arc::new(Mutex::new(BTreeMap::new())),
             imported_peers: Arc::new(Mutex::new(BTreeMap::new())),
             private_replica_secrets: Arc::new(Mutex::new(HashMap::new())),
+            remote_fetch_retries: Arc::new(Mutex::new(RemoteFetchRetryState::default())),
         }
     }
 
@@ -324,69 +371,135 @@ impl IrohDocsSync {
             Err(error) => {
                 if policy == DocFetchPolicy::LocalOnly {
                     info!(
-                        hash = %content_hash,
-                        error = %error,
-                        "docs entry fetch local miss under local-only policy"
+                            hash = %content_hash,
+                            error = %error,
+                            "docs entry fetch local miss under local-only policy"
                     );
                     return Ok(None);
                 }
-                let peers = self.sync_peers().await;
-                info!(
-                    hash = %content_hash,
-                    error = %error,
-                    configured_peer_count = peers.len(),
-                    "docs entry fetch local miss, trying remote peers"
+                match self
+                    .remote_fetch_retries
+                    .lock()
+                    .await
+                    .try_begin(content_hash, Instant::now())
+                {
+                    RemoteFetchStart::Ready => {}
+                    RemoteFetchStart::InFlight => {
+                        info!(
+                            hash = %content_hash,
+                            error = %error,
+                            "docs entry remote fetch skipped because another fetch is already running"
+                        );
+                        return Ok(None);
+                    }
+                    RemoteFetchStart::CoolingDown => {
+                        info!(
+                            hash = %content_hash,
+                            error = %error,
+                            "docs entry remote fetch skipped during retry cooldown"
+                        );
+                        return Ok(None);
+                    }
+                }
+                let result = self
+                    .fetch_entry_bytes_from_remote(content_hash, hash, error)
+                    .await;
+                self.remote_fetch_retries.lock().await.finish(
+                    content_hash,
+                    matches!(&result, Ok(Some(_))),
+                    Instant::now(),
                 );
-                for imported_peer in peers {
-                    let candidates = self.connect_candidates(&imported_peer).await;
-                    for peer in candidates {
-                        match self
-                            .node
-                            .endpoint()
-                            .connect(peer.clone(), iroh_blobs::ALPN)
-                            .await
+                result
+            }
+        }
+    }
+
+    async fn fetch_entry_bytes_from_remote(
+        &self,
+        content_hash: &str,
+        hash: iroh_blobs::Hash,
+        local_error: impl std::fmt::Display,
+    ) -> Result<Option<Vec<u8>>> {
+        let peers = self.sync_peers().await;
+        info!(
+            hash = %content_hash,
+            error = %local_error,
+            configured_peer_count = peers.len(),
+            "docs entry fetch local miss, trying remote peers"
+        );
+        for imported_peer in peers {
+            let candidates = self.connect_candidates(&imported_peer).await;
+            for peer in candidates {
+                match timeout(
+                    REMOTE_FETCH_CONNECT_TIMEOUT,
+                    self.node.endpoint().connect(peer.clone(), iroh_blobs::ALPN),
+                )
+                .await
+                {
+                    Ok(Ok(conn)) => {
+                        match timeout(
+                            REMOTE_FETCH_TRANSFER_TIMEOUT,
+                            self.node.blobs().remote().fetch(conn, hash),
+                        )
+                        .await
                         {
-                            Ok(conn) => match self.node.blobs().remote().fetch(conn, hash).await {
-                                Ok(_) => match self.node.blobs().blobs().get_bytes(hash).await {
-                                    Ok(bytes) => return Ok(Some(bytes.to_vec())),
-                                    Err(error) => {
-                                        warn!(
-                                            hash = %content_hash,
-                                            peer_id = %peer.id,
-                                            error = %error,
-                                            "docs entry transfer completed but content is still missing locally"
-                                        );
-                                    }
-                                },
+                            Ok(Ok(_)) => match self.node.blobs().blobs().get_bytes(hash).await {
+                                Ok(bytes) => return Ok(Some(bytes.to_vec())),
                                 Err(error) => {
                                     warn!(
                                         hash = %content_hash,
                                         peer_id = %peer.id,
-                                        addrs = ?peer.addrs,
                                         error = %error,
-                                        "docs entry remote transfer failed"
+                                        "docs entry transfer completed but content is still missing locally"
                                     );
                                 }
                             },
-                            Err(error) => {
+                            Ok(Err(error)) => {
                                 warn!(
                                     hash = %content_hash,
                                     peer_id = %peer.id,
                                     addrs = ?peer.addrs,
                                     error = %error,
-                                    "docs entry fetch connect failed"
+                                    "docs entry remote transfer failed"
+                                );
+                            }
+                            Err(_) => {
+                                warn!(
+                                    hash = %content_hash,
+                                    peer_id = %peer.id,
+                                    addrs = ?peer.addrs,
+                                    timeout_ms = REMOTE_FETCH_TRANSFER_TIMEOUT.as_millis(),
+                                    "docs entry remote transfer timed out"
                                 );
                             }
                         }
                     }
+                    Ok(Err(error)) => {
+                        warn!(
+                            hash = %content_hash,
+                            peer_id = %peer.id,
+                            addrs = ?peer.addrs,
+                            error = %error,
+                            "docs entry fetch connect failed"
+                        );
+                    }
+                    Err(_) => {
+                        warn!(
+                            hash = %content_hash,
+                            peer_id = %peer.id,
+                            addrs = ?peer.addrs,
+                            timeout_ms = REMOTE_FETCH_CONNECT_TIMEOUT.as_millis(),
+                            "docs entry fetch connect timed out"
+                        );
+                    }
                 }
-                warn!(
-                    hash = %content_hash,
-                    "docs entry fetch exhausted remote peers without success"
-                );
-                Ok(None)
             }
         }
+        warn!(
+            hash = %content_hash,
+            "docs entry fetch exhausted remote peers without success"
+        );
+        Ok(None)
     }
 }
 
@@ -563,4 +676,34 @@ impl DocsSync for IrohDocsSync {
 
 async fn doc_start_sync(doc: &Doc, peers: Vec<EndpointAddr>) -> Result<()> {
     doc.start_sync(peers).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_fetch_retry_state_blocks_duplicate_and_cools_down_failures() {
+        let now = Instant::now();
+        let mut state = RemoteFetchRetryState::default();
+
+        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
+        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::InFlight);
+
+        state.finish("hash-a", false, now);
+        assert_eq!(
+            state.try_begin("hash-a", now + Duration::from_secs(1)),
+            RemoteFetchStart::CoolingDown
+        );
+        assert_eq!(
+            state.try_begin("hash-a", now + REMOTE_FETCH_RETRY_COOLDOWN),
+            RemoteFetchStart::Ready
+        );
+
+        state.finish("hash-a", true, now + REMOTE_FETCH_RETRY_COOLDOWN);
+        assert_eq!(
+            state.try_begin("hash-a", now + REMOTE_FETCH_RETRY_COOLDOWN),
+            RemoteFetchStart::Ready
+        );
+    }
 }

--- a/crates/docs-sync/src/iroh_sync.rs
+++ b/crates/docs-sync/src/iroh_sync.rs
@@ -39,13 +39,11 @@ const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(15);
 #[derive(Debug, PartialEq, Eq)]
 enum RemoteFetchStart {
     Ready,
-    InFlight,
     CoolingDown,
 }
 
 #[derive(Debug, Default)]
 struct RemoteFetchRetryState {
-    in_flight: BTreeSet<String>,
     retry_after: BTreeMap<String, Instant>,
 }
 
@@ -59,14 +57,10 @@ impl RemoteFetchRetryState {
             return RemoteFetchStart::CoolingDown;
         }
         self.retry_after.remove(key);
-        if !self.in_flight.insert(key.to_string()) {
-            return RemoteFetchStart::InFlight;
-        }
         RemoteFetchStart::Ready
     }
 
     fn finish(&mut self, key: &str, success: bool, now: Instant) {
-        self.in_flight.remove(key);
         if success {
             self.retry_after.remove(key);
         } else {
@@ -384,14 +378,6 @@ impl IrohDocsSync {
                     .try_begin(content_hash, Instant::now())
                 {
                     RemoteFetchStart::Ready => {}
-                    RemoteFetchStart::InFlight => {
-                        info!(
-                            hash = %content_hash,
-                            error = %error,
-                            "docs entry remote fetch skipped because another fetch is already running"
-                        );
-                        return Ok(None);
-                    }
                     RemoteFetchStart::CoolingDown => {
                         info!(
                             hash = %content_hash,
@@ -683,12 +669,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn remote_fetch_retry_state_blocks_duplicate_and_cools_down_failures() {
+    fn remote_fetch_retry_state_cools_down_failures_without_blocking_active_fetches() {
         let now = Instant::now();
         let mut state = RemoteFetchRetryState::default();
 
         assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
-        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::InFlight);
+        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
 
         state.finish("hash-a", false, now);
         assert_eq!(


### PR DESCRIPTION
﻿## Summary
- Add single-flight remote fetch gating for docs entries and blobs.
- Add retry cooldowns after failed remote fetches.
- Wrap remote connect and transfer attempts in bounded timeouts.

## Why
After PR269, real clients can keep retrying failed docs/blob fetches while relay connectivity is degraded. Those repeated retries can contribute to relay/client backpressure such as `failed to forward packet: Full` and `Dropping received relay packet: no available capacity`, eventually preventing event propagation.

## Validation
- cargo test -p kukuri-docs-sync -- --nocapture
- cargo test -p kukuri-blob-service -- --nocapture
- GITHUB_ACTIONS=1 cargo test -p kukuri-desktop-runtime community_node_connectivity_assist_backfills_three_client_public_timeline_with_stale_addr_hints -- --nocapture
- cargo xtask check
