### PR TITLE
[codex] Fix external community node relay sync

### DIFF
--- a/crates/app-api/src/service/private_channels_support.rs
+++ b/crates/app-api/src/service/private_channels_support.rs
@@ -838,9 +838,6 @@ impl AppService {
                                 (false, false)
                             }
                         };
-                        if has_live_topic_peer {
-                            continue;
-                        }
                         let docs_assist_peer_count = match docs_sync.assist_peer_ids().await {
                             Ok(peer_ids) => peer_ids.len(),
                             Err(error) => {
@@ -852,6 +849,9 @@ impl AppService {
                                 0
                             }
                         };
+                        if has_live_topic_peer && docs_assist_peer_count == 0 {
+                            continue;
+                        }
                         if docs_assist_peer_count == 0 && !has_configured_topic_peer {
                             continue;
                         }

--- a/crates/app-api/src/service/timeline_runtime_support.rs
+++ b/crates/app-api/src/service/timeline_runtime_support.rs
@@ -95,6 +95,13 @@ impl AppService {
             envelope.clone(),
         )
         .await?;
+        if let Err(error) = self.docs_sync.restart_replica_sync(replica).await {
+            warn!(
+                replica_id = %replica.as_str(),
+                error = %error,
+                "failed to restart replica sync after local timeline write"
+            );
+        }
         ProjectionStore::put_object_projection(
             self.projection_store.as_ref(),
             projection_row_from_header(&object, content, replica),

--- a/crates/app-api/src/tests/mod.rs
+++ b/crates/app-api/src/tests/mod.rs
@@ -670,10 +670,25 @@ impl TestIrohStack {
         dht_options: DhtDiscoveryOptions,
         relay_config: TransportRelayConfig,
     ) -> Self {
+        Self::new_with_network_options(
+            root,
+            kukuri_transport::TransportNetworkConfig::loopback(),
+            dht_options,
+            relay_config,
+        )
+        .await
+    }
+
+    async fn new_with_network_options(
+        root: &std::path::Path,
+        network_config: kukuri_transport::TransportNetworkConfig,
+        dht_options: DhtDiscoveryOptions,
+        relay_config: TransportRelayConfig,
+    ) -> Self {
         let relay_config = relay_config.normalized();
         let node = IrohDocsNode::persistent_with_discovery_config(
             root,
-            kukuri_transport::TransportNetworkConfig::loopback(),
+            network_config.clone(),
             dht_options,
             relay_config.clone(),
         )
@@ -684,7 +699,7 @@ impl TestIrohStack {
                 node.endpoint().clone(),
                 node.gossip().clone(),
                 node.discovery(),
-                kukuri_transport::TransportNetworkConfig::loopback(),
+                network_config,
                 relay_config.clone(),
             )
             .expect("transport"),

--- a/crates/app-api/src/tests/sync.rs
+++ b/crates/app-api/src/tests/sync.rs
@@ -1340,7 +1340,7 @@ async fn import_peer_ticket_restarts_existing_topic_hint_subscription() {
 }
 
 #[tokio::test]
-async fn local_public_post_coalesces_replica_sync_restarts() {
+async fn local_public_post_restarts_replica_sync_after_each_write() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let docs_sync = Arc::new(TrackingDocsSync::default());
@@ -1364,9 +1364,17 @@ async fn local_public_post_coalesces_replica_sync_restarts() {
         .await
         .expect("second post");
 
-    assert_eq!(
-        docs_sync.restarted_replicas.lock().await.clone(),
-        vec![topic_replica_id(topic).as_str().to_string()]
+    let restarted = docs_sync.restarted_replicas.lock().await.clone();
+    let expected_replica = topic_replica_id(topic).as_str().to_string();
+    assert!(
+        restarted.len() >= 2,
+        "expected at least one sync restart per local post, got {restarted:?}"
+    );
+    assert!(
+        restarted
+            .iter()
+            .all(|replica| replica.as_str() == expected_replica),
+        "local post restarts should target only the topic replica, got {restarted:?}"
     );
 }
 

--- a/crates/app-api/src/tests/sync.rs
+++ b/crates/app-api/src/tests/sync.rs
@@ -6,9 +6,17 @@ use std::collections::HashMap;
 struct CountingDocsSync {
     inner: kukuri_docs_sync::MemoryDocsSync,
     queries: Arc<TokioMutex<Vec<(String, DocQuery)>>>,
+    assist_peer_ids: Vec<String>,
 }
 
 impl CountingDocsSync {
+    fn with_assist_peer_ids(peer_ids: Vec<&str>) -> Self {
+        Self {
+            assist_peer_ids: peer_ids.into_iter().map(str::to_string).collect(),
+            ..Self::default()
+        }
+    }
+
     async fn clear_queries(&self) {
         self.queries.lock().await.clear();
     }
@@ -64,6 +72,10 @@ impl DocsSync for CountingDocsSync {
 
     async fn import_peer_ticket(&self, ticket: &str) -> Result<()> {
         self.inner.import_peer_ticket(ticket).await
+    }
+
+    async fn assist_peer_ids(&self) -> Result<Vec<String>> {
+        Ok(self.assist_peer_ids.clone())
     }
 }
 
@@ -972,6 +984,98 @@ async fn topic_reaction_hints_rehydrate_only_target_reactions() {
 }
 
 #[tokio::test]
+async fn public_topic_recovery_keeps_docs_probe_when_live_peer_has_not_delivered_content() {
+    let store = Arc::new(MemoryStore::default());
+    let topic = TopicId::new("kukuri:topic:live-peer-docs-probe");
+    let transport = Arc::new(StaticTransport::new(PeerSnapshot {
+        connected: true,
+        peer_count: 1,
+        connected_peers: vec!["peer-a".into()],
+        configured_peers: vec!["peer-a".into()],
+        subscribed_topics: vec![topic.as_str().to_string()],
+        pending_events: 0,
+        status_detail: "live peer connected".into(),
+        last_error: None,
+        topic_diagnostics: vec![TopicPeerSnapshot {
+            topic: topic.as_str().to_string(),
+            joined: true,
+            peer_count: 1,
+            connected_peers: vec!["peer-a".into()],
+            configured_peer_ids: vec!["peer-a".into()],
+            missing_peer_ids: Vec::new(),
+            last_received_at: None,
+            status_detail: "live peer connected".into(),
+            last_error: None,
+        }],
+    }));
+    let docs_sync = Arc::new(CountingDocsSync::with_assist_peer_ids(vec!["peer-a"]));
+    let app = AppService::new_with_services(
+        store.clone(),
+        store,
+        transport.clone(),
+        transport.clone(),
+        docs_sync.clone(),
+        Arc::new(MemoryBlobService::default()),
+        generate_keys(),
+    );
+
+    let _ = app
+        .list_timeline(topic.as_str(), None, 20)
+        .await
+        .expect("initial timeline");
+    sleep(Duration::from_millis(100)).await;
+    docs_sync.clear_queries().await;
+
+    transport
+        .publish_hint(
+            &channel_hint_topic_for(topic.as_str(), None),
+            GossipHint::TopicObjectsChanged {
+                topic_id: topic.clone(),
+                objects: vec![HintObjectRef {
+                    object_id: "missing-post".into(),
+                    object_kind: "post".into(),
+                }],
+            },
+        )
+        .await
+        .expect("publish hint miss");
+
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let queries = docs_sync.queries().await;
+            if queries
+                .iter()
+                .any(|(_, query)| *query == DocQuery::Prefix("objects/".into()))
+            {
+                break;
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("initial recovery probe timeout");
+    docs_sync.clear_queries().await;
+
+    timeout(
+        Duration::from_millis(PUBLIC_TOPIC_RECOVERY_GRACE_MS as u64 + 2_000),
+        async {
+            loop {
+                let queries = docs_sync.queries().await;
+                if queries
+                    .iter()
+                    .any(|(_, query)| *query == DocQuery::Prefix("objects/".into()))
+                {
+                    break;
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        },
+    )
+    .await
+    .expect("periodic docs-assisted recovery probe timeout");
+}
+
+#[tokio::test]
 async fn topic_session_hints_retry_until_manifest_blob_is_available() {
     let docs_sync = Arc::new(kukuri_docs_sync::MemoryDocsSync::default());
     let blob_service = Arc::new(DelayedBlobService::default());
@@ -1766,6 +1870,120 @@ async fn relay_seeded_syncs_post_between_apps_without_ticket_import() {
     };
 
     assert_eq!(received.content, "relay seeded app sync");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn external_relay_endpoint_only_seeds_sync_post_between_apps() {
+    let Some(relay_url) = std::env::var("KUKURI_TEST_EXTERNAL_IROH_RELAY_URL")
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+
+    let _guard = iroh_integration_test_lock().lock_owned().await;
+    let relay_config = TransportRelayConfig {
+        iroh_relay_urls: vec![relay_url],
+    };
+    let dir = tempdir().expect("tempdir");
+    let stack_a = TestIrohStack::new_with_network_options(
+        &dir.path().join("external-relay-a"),
+        kukuri_transport::TransportNetworkConfig::default(),
+        DhtDiscoveryOptions::disabled(),
+        relay_config.clone(),
+    )
+    .await;
+    let stack_b = TestIrohStack::new_with_network_options(
+        &dir.path().join("external-relay-b"),
+        kukuri_transport::TransportNetworkConfig::default(),
+        DhtDiscoveryOptions::disabled(),
+        relay_config,
+    )
+    .await;
+    let app_a = app_with_iroh_services(Arc::new(MemoryStore::default()), &stack_a);
+    let app_b = app_with_iroh_services(Arc::new(MemoryStore::default()), &stack_b);
+    let endpoint_a = app_a
+        .get_sync_status()
+        .await
+        .expect("status a")
+        .discovery
+        .local_endpoint_id;
+    let endpoint_b = app_b
+        .get_sync_status()
+        .await
+        .expect("status b")
+        .discovery
+        .local_endpoint_id;
+
+    app_a
+        .set_discovery_seeds(
+            DiscoveryMode::StaticPeer,
+            false,
+            Vec::new(),
+            vec![SeedPeer {
+                endpoint_id: endpoint_b,
+                addr_hint: None,
+            }],
+        )
+        .await
+        .expect("set seed a");
+    app_b
+        .set_discovery_seeds(
+            DiscoveryMode::StaticPeer,
+            false,
+            Vec::new(),
+            vec![SeedPeer {
+                endpoint_id: endpoint_a,
+                addr_hint: None,
+            }],
+        )
+        .await
+        .expect("set seed b");
+
+    let topic = "kukuri:topic:external-relay-endpoint-only";
+    let _ = app_a
+        .list_timeline(topic, None, 20)
+        .await
+        .expect("subscribe a");
+    let _ = app_b
+        .list_timeline(topic, None, 20)
+        .await
+        .expect("subscribe b");
+    wait_for_topic_delivery(&app_a, topic, 1).await;
+    wait_for_topic_delivery(&app_b, topic, 1).await;
+
+    let object_id = app_a
+        .create_post(topic, "external relay endpoint-only app sync", None)
+        .await
+        .expect("create post");
+    let received = timeout(Duration::from_secs(120), async {
+        loop {
+            let timeline = app_b
+                .list_timeline(topic, None, 20)
+                .await
+                .expect("timeline");
+            if let Some(post) = timeline
+                .items
+                .iter()
+                .find(|post| post.object_id == object_id)
+            {
+                return post.clone();
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await;
+    let received = match received {
+        Ok(post) => post,
+        Err(error) => {
+            let diagnostics =
+                iroh_sync_diagnostics(&app_a, &app_b, &stack_a, &stack_b, topic).await;
+            panic!("external relay endpoint-only sync timeout: {error:?}; {diagnostics}");
+        }
+    };
+
+    assert_eq!(received.content, "external relay endpoint-only app sync");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/app-api/src/timeline.rs
+++ b/crates/app-api/src/timeline.rs
@@ -452,20 +452,29 @@ impl AppService {
             )
             .await?;
         }
-        if let Err(error) = self
-            .hint_transport
-            .publish_hint(
-                &channel_hint_topic_for(topic_id, effective_channel_id.as_ref()),
-                GossipHint::TopicObjectsChanged {
-                    topic_id: topic.clone(),
-                    objects: vec![HintObjectRef {
-                        object_id: envelope.id.0.clone(),
-                        object_kind: envelope.kind.clone(),
-                    }],
-                },
-            )
-            .await
-        {
+        let hint_topic = channel_hint_topic_for(topic_id, effective_channel_id.as_ref());
+        let hint = GossipHint::TopicObjectsChanged {
+            topic_id: topic.clone(),
+            objects: vec![HintObjectRef {
+                object_id: envelope.id.0.clone(),
+                object_kind: envelope.kind.clone(),
+            }],
+        };
+        let mut hint_error = None;
+        for attempt in 0..3 {
+            if attempt > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(250 * attempt)).await;
+            }
+            match self
+                .hint_transport
+                .publish_hint(&hint_topic, hint.clone())
+                .await
+            {
+                Ok(()) => hint_error = None,
+                Err(error) => hint_error = Some(error),
+            }
+        }
+        if let Some(error) = hint_error {
             warn!(
                 topic = %topic_id,
                 object_id = %envelope.id.0,

--- a/crates/desktop-runtime/src/community_node/config_support.rs
+++ b/crates/desktop-runtime/src/community_node/config_support.rs
@@ -112,6 +112,20 @@ pub(crate) fn merge_community_node_resolved_urls(
     }
 }
 
+pub(crate) fn refresh_community_node_resolved_urls(
+    current: Option<CommunityNodeResolvedUrls>,
+    incoming: CommunityNodeResolvedUrls,
+) -> Result<CommunityNodeResolvedUrls> {
+    let public_base_url = incoming.public_base_url;
+    let connectivity_urls = current
+        .map(|current| current.connectivity_urls)
+        .unwrap_or_default()
+        .into_iter()
+        .chain(incoming.connectivity_urls)
+        .collect();
+    CommunityNodeResolvedUrls::new(public_base_url, connectivity_urls, incoming.seed_peers)
+}
+
 pub(crate) fn community_node_seed_peers(
     config: &CommunityNodeConfig,
 ) -> impl Iterator<Item = SeedPeer> + '_ {
@@ -282,5 +296,36 @@ mod tests {
         assert_eq!(merged.seed_peers.len(), 1);
         assert_eq!(merged.seed_peers[0].endpoint_id, "peer-a");
         assert!(merged.seed_peers[0].addr_hint.is_none());
+    }
+
+    #[test]
+    fn refresh_resolved_urls_replaces_seed_peer_snapshot() {
+        let current = CommunityNodeResolvedUrls::new(
+            "https://api.example.com",
+            vec!["https://relay-a.example.com".to_string()],
+            vec![CommunityNodeSeedPeer::new("peer-a", None).expect("seed peer")],
+        )
+        .expect("current urls");
+        let incoming = CommunityNodeResolvedUrls::new(
+            "https://api.example.com",
+            vec!["https://relay-b.example.com".to_string()],
+            vec![CommunityNodeSeedPeer::new("peer-b", None).expect("seed peer")],
+        )
+        .expect("incoming urls");
+
+        let refreshed =
+            refresh_community_node_resolved_urls(Some(current), incoming).expect("refreshed urls");
+
+        assert_eq!(
+            refreshed.connectivity_urls,
+            vec![
+                "https://relay-a.example.com".to_string(),
+                "https://relay-b.example.com".to_string()
+            ]
+        );
+        assert_eq!(
+            refreshed.seed_peers,
+            vec![CommunityNodeSeedPeer::new("peer-b", None).expect("seed peer")]
+        );
     }
 }

--- a/crates/desktop-runtime/src/community_node/config_support.rs
+++ b/crates/desktop-runtime/src/community_node/config_support.rs
@@ -95,11 +95,14 @@ pub(crate) fn merge_community_node_resolved_urls(
                 .into_iter()
                 .chain(incoming.connectivity_urls)
                 .collect();
-            let seed_peers = current
-                .seed_peers
-                .into_iter()
-                .chain(incoming.seed_peers)
-                .collect();
+            let mut seed_peers_by_endpoint = std::collections::BTreeMap::new();
+            for seed_peer in current.seed_peers {
+                seed_peers_by_endpoint.insert(seed_peer.endpoint_id.clone(), seed_peer);
+            }
+            for seed_peer in incoming.seed_peers {
+                seed_peers_by_endpoint.insert(seed_peer.endpoint_id.clone(), seed_peer);
+            }
+            let seed_peers = seed_peers_by_endpoint.into_values().collect();
             Ok(Some(CommunityNodeResolvedUrls::new(
                 public_base_url,
                 connectivity_urls,
@@ -252,5 +255,32 @@ mod tests {
                 addr_hint: Some("192.168.1.40:40123".to_string()),
             }]
         );
+    }
+
+    #[test]
+    fn merge_resolved_urls_replaces_cached_addr_hint_with_incoming_endpoint() {
+        let current = CommunityNodeResolvedUrls::new(
+            "https://api.example.com",
+            vec!["https://relay.example.com".to_string()],
+            vec![
+                CommunityNodeSeedPeer::new("peer-a", Some("172.20.80.1:40123".to_string()))
+                    .expect("seed peer"),
+            ],
+        )
+        .expect("current urls");
+        let incoming = CommunityNodeResolvedUrls::new(
+            "https://api.example.com",
+            vec!["https://relay.example.com".to_string()],
+            vec![CommunityNodeSeedPeer::new("peer-a", None).expect("seed peer")],
+        )
+        .expect("incoming urls");
+
+        let merged = merge_community_node_resolved_urls(Some(current), Some(incoming))
+            .expect("merged urls")
+            .expect("resolved urls");
+
+        assert_eq!(merged.seed_peers.len(), 1);
+        assert_eq!(merged.seed_peers[0].endpoint_id, "peer-a");
+        assert!(merged.seed_peers[0].addr_hint.is_none());
     }
 }

--- a/crates/desktop-runtime/src/community_node/requests_support.rs
+++ b/crates/desktop-runtime/src/community_node/requests_support.rs
@@ -199,11 +199,13 @@ impl DesktopRuntime {
             "community-node metadata sync resolved bootstrap metadata"
         );
         let mut next_config = config;
-        next_config.nodes[index].resolved_urls = merge_community_node_resolved_urls(
-            next_config.nodes[index].resolved_urls.clone(),
-            Some(resolved_urls),
-        )
-        .map_err(CommunityNodeRequestError::Other)?;
+        next_config.nodes[index].resolved_urls = Some(
+            refresh_community_node_resolved_urls(
+                next_config.nodes[index].resolved_urls.clone(),
+                resolved_urls,
+            )
+            .map_err(CommunityNodeRequestError::Other)?,
+        );
         let normalized = normalize_community_node_config(next_config)
             .map_err(CommunityNodeRequestError::Other)?;
         save_community_node_config(&self.db_path, &normalized)

--- a/crates/desktop-runtime/src/community_node/requests_support.rs
+++ b/crates/desktop-runtime/src/community_node/requests_support.rs
@@ -199,7 +199,11 @@ impl DesktopRuntime {
             "community-node metadata sync resolved bootstrap metadata"
         );
         let mut next_config = config;
-        next_config.nodes[index].resolved_urls = Some(resolved_urls);
+        next_config.nodes[index].resolved_urls = merge_community_node_resolved_urls(
+            next_config.nodes[index].resolved_urls.clone(),
+            Some(resolved_urls),
+        )
+        .map_err(CommunityNodeRequestError::Other)?;
         let normalized = normalize_community_node_config(next_config)
             .map_err(CommunityNodeRequestError::Other)?;
         save_community_node_config(&self.db_path, &normalized)
@@ -291,13 +295,27 @@ impl DesktopRuntime {
         &self,
         operation: &str,
     ) -> Result<CommunityNodeSeedPeer> {
-        if let Some(ticket) = self.local_peer_ticket().await? {
-            let seed_peer = parse_seed_peer(ticket.as_str()).with_context(|| {
-                format!(
-                    "failed to derive local seed peer from ticket for community node {operation}"
-                )
-            })?;
-            return CommunityNodeSeedPeer::new(seed_peer.endpoint_id, seed_peer.addr_hint);
+        let publish_addr_hint = self.should_publish_community_node_addr_hint().await;
+        match self.local_peer_ticket().await {
+            Ok(Some(ticket)) => {
+                let mut seed_peer = parse_seed_peer(ticket.as_str()).with_context(|| {
+                    format!(
+                        "failed to derive local seed peer from ticket for community node {operation}"
+                    )
+                })?;
+                if !publish_addr_hint {
+                    seed_peer.addr_hint = None;
+                }
+                return CommunityNodeSeedPeer::new(seed_peer.endpoint_id, seed_peer.addr_hint);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                debug!(
+                    operation,
+                    error = %error,
+                    "local peer ticket unavailable; registering community-node endpoint without addr_hint"
+                );
+            }
         }
 
         let endpoint_id = self
@@ -310,6 +328,21 @@ impl DesktopRuntime {
             })?
             .local_endpoint_id;
         CommunityNodeSeedPeer::new(endpoint_id, None)
+    }
+
+    async fn should_publish_community_node_addr_hint(&self) -> bool {
+        let community_node_config = self.community_node_config.lock().await.clone();
+        let relay_config = relay_config_from_community_node_config(&community_node_config);
+        if relay_config.iroh_relay_urls.is_empty() {
+            return true;
+        }
+        self.iroh_stack.network_config.advertised_host.is_some()
+            || !self
+                .iroh_stack
+                .network_config
+                .bind_addr
+                .ip()
+                .is_unspecified()
     }
 
     pub(crate) async fn fetch_community_node_consent_status_with_retry(

--- a/crates/desktop-runtime/src/stack.rs
+++ b/crates/desktop-runtime/src/stack.rs
@@ -194,6 +194,10 @@ impl DocsSync for ReloadableDocsSync {
         self.current().await.learn_peer(endpoint_id).await
     }
 
+    async fn restart_replica_sync(&self, replica_id: &ReplicaId) -> Result<()> {
+        self.current().await.restart_replica_sync(replica_id).await
+    }
+
     async fn set_seed_peers(&self, peers: Vec<SeedPeer>) -> Result<()> {
         self.current().await.set_seed_peers(peers).await
     }

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -5342,6 +5342,43 @@ async fn local_community_node_seed_peer_includes_addr_hint() {
     runtime.shutdown().await;
 }
 
+#[tokio::test]
+async fn local_community_node_seed_peer_omits_auto_addr_hint_when_relay_assisted() {
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-seed-peer-relay-auto-hint.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::default(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: "https://api.example.com".to_string(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(
+                    "https://api.example.com",
+                    vec!["https://relay.example.com".to_string()],
+                    Vec::new(),
+                )
+                .expect("resolved urls"),
+            ),
+        }],
+    };
+
+    let seed_peer = runtime
+        .local_community_node_seed_peer("test")
+        .await
+        .expect("seed peer");
+
+    assert!(seed_peer.addr_hint.is_none());
+
+    runtime.shutdown().await;
+}
+
 #[test]
 fn stored_community_node_config_restores_cached_connectivity_union() {
     let dir = tempdir().expect("tempdir");
@@ -6088,6 +6125,159 @@ async fn community_node_connectivity_assist_backfills_public_timeline_with_relay
         .await
         .expect("runtime b shutdown timeout");
     drop(relay);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn external_relay_endpoint_only_seed_peers_backfill_desktop_public_timeline() {
+    let Some(relay_url) = std::env::var("KUKURI_TEST_EXTERNAL_IROH_RELAY_URL")
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db_a = dir.path().join("external-relay-only-a.db");
+    let db_b = dir.path().join("external-relay-only-b.db");
+    let runtime_a = DesktopRuntime::new_with_config_and_identity(
+        &db_a,
+        TransportNetworkConfig::default(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime a");
+    let runtime_b = DesktopRuntime::new_with_config_and_identity(
+        &db_b,
+        TransportNetworkConfig::default(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime b");
+
+    let endpoint_a = runtime_a
+        .get_sync_status()
+        .await
+        .expect("status a")
+        .discovery
+        .local_endpoint_id;
+    let endpoint_b = runtime_b
+        .get_sync_status()
+        .await
+        .expect("status b")
+        .discovery
+        .local_endpoint_id;
+    let base_url = "https://community.example.com";
+
+    *runtime_a.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.to_string(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(
+                    base_url,
+                    vec![relay_url.clone()],
+                    vec![
+                        CommunityNodeSeedPeer::new(endpoint_b.as_str(), None).expect("seed peer b"),
+                    ],
+                )
+                .expect("resolved urls a"),
+            ),
+        }],
+    };
+    *runtime_b.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.to_string(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(
+                    base_url,
+                    vec![relay_url],
+                    vec![
+                        CommunityNodeSeedPeer::new(endpoint_a.as_str(), None).expect("seed peer a"),
+                    ],
+                )
+                .expect("resolved urls b"),
+            ),
+        }],
+    };
+
+    timeout(
+        Duration::from_secs(30),
+        runtime_a.apply_runtime_connectivity_assist(),
+    )
+    .await
+    .expect("apply assist a timeout")
+    .expect("apply assist a");
+    timeout(
+        Duration::from_secs(15),
+        runtime_a.apply_effective_seed_peers(),
+    )
+    .await
+    .expect("apply seed peers a timeout")
+    .expect("apply seed peers a");
+    timeout(
+        Duration::from_secs(30),
+        runtime_b.apply_runtime_connectivity_assist(),
+    )
+    .await
+    .expect("apply assist b timeout")
+    .expect("apply assist b");
+    timeout(
+        Duration::from_secs(15),
+        runtime_b.apply_effective_seed_peers(),
+    )
+    .await
+    .expect("apply seed peers b timeout")
+    .expect("apply seed peers b");
+
+    let topic = "kukuri:topic:external-relay-desktop";
+    let scope = TimelineScope::Public;
+    let _ = runtime_a
+        .list_timeline(ListTimelineRequest {
+            topic: topic.to_string(),
+            scope: scope.clone(),
+            cursor: None,
+            limit: Some(20),
+        })
+        .await
+        .expect("subscribe a");
+    let _ = runtime_b
+        .list_timeline(ListTimelineRequest {
+            topic: topic.to_string(),
+            scope,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await
+        .expect("subscribe b");
+
+    wait_for_public_pair_delivery_with_refresh(
+        &runtime_a,
+        &runtime_b,
+        topic,
+        1,
+        runtime_replication_timeout(),
+    )
+    .await
+    .expect("external relay endpoint-only pair delivery");
+
+    let _ = replicate_public_post_with_retry(
+        &runtime_a,
+        &runtime_b,
+        topic,
+        "external relay desktop",
+        "external relay desktop should replicate",
+    )
+    .await;
+
+    timeout(runtime_shutdown_timeout(), runtime_a.shutdown())
+        .await
+        .expect("runtime a shutdown timeout");
+    timeout(runtime_shutdown_timeout(), runtime_b.shutdown())
+        .await
+        .expect("runtime b shutdown timeout");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/docs-sync/src/tests/relay.rs
+++ b/crates/docs-sync/src/tests/relay.rs
@@ -19,6 +19,13 @@ fn relay_seeded_public_replication_timeout() -> Duration {
     }
 }
 
+fn external_relay_url() -> Option<String> {
+    std::env::var("KUKURI_TEST_EXTERNAL_IROH_RELAY_URL")
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+}
+
 async fn wait_for_relay_seeded_replica_row(
     docs: &IrohDocsSync,
     replica: &str,
@@ -44,6 +51,72 @@ async fn wait_for_relay_seeded_replica_row(
     if let Err(error) = sync_result {
         anyhow::bail!("relay-seeded public replica sync timeout: {error:?}");
     }
+    Ok(())
+}
+
+async fn assert_public_replica_syncs_over_relay(relay_url: &str, topic: &str) -> Result<()> {
+    let relay_config = TransportRelayConfig {
+        iroh_relay_urls: vec![relay_url.to_string()],
+    }
+    .normalized();
+    let dir = tempdir()?;
+    let node_a = IrohDocsNode::persistent_with_discovery_config(
+        dir.path().join("docs-a"),
+        TransportNetworkConfig::default(),
+        DhtDiscoveryOptions::disabled(),
+        relay_config.clone(),
+    )
+    .await?;
+    let node_b = IrohDocsNode::persistent_with_discovery_config(
+        dir.path().join("docs-b"),
+        TransportNetworkConfig::default(),
+        DhtDiscoveryOptions::disabled(),
+        relay_config,
+    )
+    .await?;
+    let docs_a = IrohDocsSync::new(node_a.clone());
+    let docs_b = IrohDocsSync::new(node_b.clone());
+    let replica = topic_replica_id(topic);
+    let key = stable_key("timeline", "0001-external-relay-event");
+
+    docs_a
+        .set_seed_peers(vec![SeedPeer {
+            endpoint_id: node_b.endpoint().id().to_string(),
+            addr_hint: None,
+        }])
+        .await?;
+    docs_b
+        .set_seed_peers(vec![SeedPeer {
+            endpoint_id: node_a.endpoint().id().to_string(),
+            addr_hint: None,
+        }])
+        .await?;
+    docs_a.open_replica(&replica).await?;
+    docs_b.open_replica(&replica).await?;
+    docs_a
+        .apply_doc_op(
+            &replica,
+            DocOp::SetBytes {
+                key: key.clone(),
+                value: b"external-relay-doc-entry".repeat(64),
+            },
+        )
+        .await?;
+
+    if let Err(error) = wait_for_relay_seeded_replica_row(&docs_b, topic, key.as_str()).await {
+        let diagnostics =
+            relay_seeded_timeout_diagnostics(&docs_a, &docs_b, &node_a, &node_b, topic).await;
+        docs_a.shutdown().await;
+        docs_b.shutdown().await;
+        node_a.shutdown().await?;
+        node_b.shutdown().await?;
+        anyhow::bail!("{error:#}; {diagnostics}");
+    }
+
+    docs_a.shutdown().await;
+    docs_b.shutdown().await;
+    node_a.shutdown().await?;
+    node_b.shutdown().await?;
     Ok(())
 }
 
@@ -212,6 +285,16 @@ async fn public_replica_syncs_over_custom_relay_seed_peers() -> Result<()> {
     node_a.shutdown().await?;
     node_b.shutdown().await?;
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn public_replica_syncs_over_external_relay_when_configured() -> Result<()> {
+    let Some(relay_url) = external_relay_url() else {
+        return Ok(());
+    };
+
+    assert_public_replica_syncs_over_relay(relay_url.as_str(), "kukuri:topic:external-relay-docs")
+        .await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/harness/src/runtime.rs
+++ b/crates/harness/src/runtime.rs
@@ -1,6 +1,8 @@
 use crate::*;
 
 const DEFAULT_CN_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:55432/cn";
+const EXTERNAL_CN_BASE_URL_ENV: &str = "KUKURI_HARNESS_COMMUNITY_NODE_BASE_URL";
+const EXTERNAL_CN_CONNECTIVITY_URLS_ENV: &str = "KUKURI_HARNESS_COMMUNITY_NODE_CONNECTIVITY_URLS";
 
 pub(crate) struct ScenarioRuntime {
     pub(crate) db_path: PathBuf,
@@ -48,15 +50,28 @@ impl ScenarioRuntime {
 }
 
 pub(crate) struct CommunityNodeStack {
-    pub(crate) database: TestDatabase,
-    pub(crate) user_api_task: tokio::task::JoinHandle<()>,
-    pub(crate) _iroh_relay: SpawnedIrohRelay,
+    pub(crate) external: bool,
+    pub(crate) database: Option<TestDatabase>,
+    pub(crate) user_api_task: Option<tokio::task::JoinHandle<()>>,
+    pub(crate) _iroh_relay: Option<SpawnedIrohRelay>,
     pub(crate) base_url: String,
-    pub(crate) iroh_relay_url: String,
+    pub(crate) expected_connectivity_urls: Option<Vec<String>>,
 }
 
 impl CommunityNodeStack {
     pub(crate) async fn spawn(prefix: &str) -> Result<Self> {
+        if let Some(base_url) = external_community_node_base_url() {
+            let expected_connectivity_urls = external_community_node_connectivity_urls();
+            return Ok(Self {
+                external: true,
+                database: None,
+                user_api_task: None,
+                _iroh_relay: None,
+                base_url,
+                expected_connectivity_urls,
+            });
+        }
+
         let admin_database_url = community_node_admin_database_url();
         let database = TestDatabase::create(admin_database_url.as_str(), prefix).await?;
         let iroh_relay = kukuri_cn_iroh_relay::spawn_server(IrohRelayConfig {
@@ -95,17 +110,23 @@ impl CommunityNodeStack {
         });
 
         Ok(Self {
-            database,
-            user_api_task,
-            _iroh_relay: iroh_relay,
+            external: false,
+            database: Some(database),
+            user_api_task: Some(user_api_task),
+            _iroh_relay: Some(iroh_relay),
             base_url,
-            iroh_relay_url,
+            expected_connectivity_urls: Some(vec![iroh_relay_url]),
         })
     }
 
     pub(crate) async fn shutdown(self) -> Result<()> {
-        self.user_api_task.abort();
-        self.database.cleanup().await
+        if let Some(user_api_task) = self.user_api_task {
+            user_api_task.abort();
+        }
+        if let Some(database) = self.database {
+            database.cleanup().await?;
+        }
+        Ok(())
     }
 }
 
@@ -121,6 +142,33 @@ pub(crate) fn community_node_admin_database_url() -> String {
         .ok()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_CN_ADMIN_DATABASE_URL.to_string())
+}
+
+fn external_community_node_base_url() -> Option<String> {
+    std::env::var(EXTERNAL_CN_BASE_URL_ENV)
+        .ok()
+        .map(|value| normalize_url(value.as_str()))
+        .filter(|value| !value.is_empty())
+}
+
+fn external_community_node_connectivity_urls() -> Option<Vec<String>> {
+    let urls = std::env::var(EXTERNAL_CN_CONNECTIVITY_URLS_ENV)
+        .ok()
+        .map(|value| parse_connectivity_urls(value.as_str()))
+        .unwrap_or_default();
+    (!urls.is_empty()).then_some(urls)
+}
+
+fn parse_connectivity_urls(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(normalize_url)
+        .filter(|url| !url.is_empty())
+        .collect()
+}
+
+fn normalize_url(value: &str) -> String {
+    value.trim().trim_end_matches('/').to_string()
 }
 
 pub(crate) fn persist_runtime_identity(db_path: &Path, keys: &KukuriKeys) -> Result<()> {
@@ -197,4 +245,28 @@ pub(crate) fn remove_sqlite_runtime_db(db_path: &Path) -> Result<()> {
             .with_context(|| format!("failed to remove sqlite artifact {}", path.display()))?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_connectivity_urls_normalizes_comma_separated_values() {
+        assert_eq!(
+            parse_connectivity_urls(" https://iroh-relay.kukuri.app/ , http://127.0.0.1:3340 "),
+            vec![
+                "https://iroh-relay.kukuri.app".to_string(),
+                "http://127.0.0.1:3340".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_connectivity_urls_ignores_empty_values() {
+        assert_eq!(
+            parse_connectivity_urls(" , https://iroh-relay.kukuri.app///, "),
+            vec!["https://iroh-relay.kukuri.app".to_string()]
+        );
+    }
 }

--- a/crates/harness/src/scenarios/community_node.rs
+++ b/crates/harness/src/scenarios/community_node.rs
@@ -6,6 +6,25 @@ pub(crate) enum CommunityNodeIdentityMode {
     SharedIdentity,
 }
 
+fn expect_connectivity_urls(
+    actual: &[String],
+    expected: Option<&[String]>,
+    label: &str,
+) -> Result<()> {
+    if let Some(expected) = expected {
+        anyhow::ensure!(
+            actual == expected,
+            "{label} connectivity urls mismatch: expected {expected:?}, got {actual:?}"
+        );
+    } else {
+        anyhow::ensure!(
+            !actual.is_empty(),
+            "{label} did not resolve any community-node connectivity urls"
+        );
+    }
+    Ok(())
+}
+
 struct PublicReactionSummaryWait<'a> {
     runtime_a: &'a DesktopRuntime,
     runtime_b: &'a DesktopRuntime,
@@ -125,10 +144,15 @@ pub(crate) async fn run_community_node_connectivity(
         let mut steps = Vec::new();
 
         let started_at = Instant::now();
-        let runtime_a = DesktopRuntime::new_with_config(&db_a, TransportNetworkConfig::loopback())
+        let network_config = if stack.external {
+            TransportNetworkConfig::default()
+        } else {
+            TransportNetworkConfig::loopback()
+        };
+        let runtime_a = DesktopRuntime::new_with_config(&db_a, network_config.clone())
             .await
             .context("failed to launch community-node desktop a")?;
-        let runtime_b = DesktopRuntime::new_with_config(&db_b, TransportNetworkConfig::loopback())
+        let runtime_b = DesktopRuntime::new_with_config(&db_b, network_config.clone())
             .await
             .context("failed to launch community-node desktop b")?;
         push_named_step(&mut steps, "launch_desktops", started_at);
@@ -216,22 +240,24 @@ pub(crate) async fn run_community_node_connectivity(
                 .expect("accepted consent state b")
                 .all_required_accepted
         );
-        assert_eq!(
-            accepted_a
+        expect_connectivity_urls(
+            &accepted_a
                 .resolved_urls
                 .as_ref()
                 .expect("resolved urls a")
                 .connectivity_urls,
-            vec![stack.iroh_relay_url.clone()]
-        );
-        assert_eq!(
-            accepted_b
+            stack.expected_connectivity_urls.as_deref(),
+            "desktop a accepted",
+        )?;
+        expect_connectivity_urls(
+            &accepted_b
                 .resolved_urls
                 .as_ref()
                 .expect("resolved urls b")
                 .connectivity_urls,
-            vec![stack.iroh_relay_url.clone()]
-        );
+            stack.expected_connectivity_urls.as_deref(),
+            "desktop b accepted",
+        )?;
         assert!(!accepted_a.restart_required);
         assert!(!accepted_b.restart_required);
         push_named_step(&mut steps, "accept_consents", started_at);
@@ -277,22 +303,24 @@ pub(crate) async fn run_community_node_connectivity(
         assert!(refreshed_b.auth_state.authenticated);
         assert!(!refreshed_a.restart_required);
         assert!(!refreshed_b.restart_required);
-        assert_eq!(
-            refreshed_a
+        expect_connectivity_urls(
+            &refreshed_a
                 .resolved_urls
                 .as_ref()
                 .expect("resolved urls a after consent")
                 .connectivity_urls,
-            vec![stack.iroh_relay_url.clone()]
-        );
-        assert_eq!(
-            refreshed_b
+            stack.expected_connectivity_urls.as_deref(),
+            "desktop a refreshed",
+        )?;
+        expect_connectivity_urls(
+            &refreshed_b
                 .resolved_urls
                 .as_ref()
                 .expect("resolved urls b after consent")
                 .connectivity_urls,
-            vec![stack.iroh_relay_url.clone()]
-        );
+            stack.expected_connectivity_urls.as_deref(),
+            "desktop b refreshed",
+        )?;
         match identity_mode {
             CommunityNodeIdentityMode::DistinctUsers => {
                 assert_ne!(sync_a.local_author_pubkey, sync_b.local_author_pubkey);
@@ -909,7 +937,7 @@ pub(crate) async fn run_community_node_connectivity(
         shutdown_runtime(runtime_b, "desktop b reconnect pre-shutdown")
             .await
             .context("community-node reconnect shutdown timed out")?;
-        let runtime_b = DesktopRuntime::new_with_config(&db_b, TransportNetworkConfig::loopback())
+        let runtime_b = DesktopRuntime::new_with_config(&db_b, network_config)
             .await
             .context("failed to restart community-node desktop b for reconnect")?;
         let _ = runtime_b

--- a/crates/transport/src/iroh/peer_state.rs
+++ b/crates/transport/src/iroh/peer_state.rs
@@ -154,9 +154,16 @@ impl IrohGossipTransport {
             &self.endpoint.bound_sockets(),
             &self.network_config,
         );
-        Ok(Some(encode_endpoint_ticket(
-            &endpoint_addr,
-            &ticket_config,
-        )?))
+        match encode_endpoint_ticket(&endpoint_addr, &ticket_config) {
+            Ok(ticket) => Ok(Some(ticket)),
+            Err(error)
+                if error
+                    .to_string()
+                    .contains("could not determine advertised host") =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
     }
 }

--- a/crates/transport/src/tickets.rs
+++ b/crates/transport/src/tickets.rs
@@ -58,18 +58,21 @@ pub fn encode_endpoint_ticket(
     let advertised_host = config
         .advertised_host
         .clone()
-        .or_else(|| {
-            endpoint_addr
-                .ip_addrs()
-                .filter(|addr| is_reachable_ip(addr.ip()))
-                .map(|addr| addr.ip().to_string())
-                .next()
-        })
         .or_else(|| match config.bind_addr.ip() {
             ip if is_reachable_ip(ip) => Some(ip.to_string()),
             IpAddr::V4(ip) if ip.is_loopback() => Some(ip.to_string()),
             IpAddr::V6(ip) if ip.is_loopback() => Some(ip.to_string()),
             _ => None,
+        })
+        .or_else(|| {
+            if config.bind_addr.ip().is_unspecified() {
+                return None;
+            }
+            endpoint_addr
+                .ip_addrs()
+                .filter(|addr| is_reachable_ip(addr.ip()))
+                .map(|addr| addr.ip().to_string())
+                .next()
         })
         .ok_or_else(|| anyhow!("could not determine advertised host"))?;
 
@@ -116,6 +119,9 @@ pub(crate) fn ticket_network_config(
     config: &TransportNetworkConfig,
 ) -> TransportNetworkConfig {
     let advertised_host = config.advertised_host.clone().or_else(|| {
+        if config.bind_addr.ip().is_unspecified() {
+            return None;
+        }
         bound_sockets
             .iter()
             .find(|addr| is_reachable_ip(addr.ip()) || addr.ip().is_loopback())
@@ -310,6 +316,25 @@ mod tests {
     }
 
     #[test]
+    fn encode_ticket_does_not_use_observed_addr_for_unspecified_bind() {
+        let endpoint_id = EndpointId::from_str(
+            "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+        )
+        .expect("endpoint id");
+        let endpoint_addr = EndpointAddr::new(endpoint_id)
+            .with_ip_addr("10.73.0.1:40123".parse().expect("observed socket addr"));
+        let config = TransportNetworkConfig {
+            bind_addr: "0.0.0.0:40123".parse().expect("bind addr"),
+            advertised_host: None,
+            advertised_port: None,
+        };
+
+        let error = encode_endpoint_ticket(&endpoint_addr, &config).expect_err("ticket error");
+
+        assert!(error.to_string().contains("advertised host"));
+    }
+
+    #[test]
     fn ticket_network_config_uses_bound_loopback_socket_for_port_zero_bind() {
         let endpoint_id = EndpointId::from_str(
             "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
@@ -326,6 +351,26 @@ mod tests {
         );
 
         assert_eq!(resolved.advertised_host.as_deref(), Some("127.0.0.1"));
+        assert_eq!(resolved.advertised_port, Some(40123));
+    }
+
+    #[test]
+    fn ticket_network_config_ignores_bound_socket_host_for_unspecified_bind() {
+        let endpoint_id = EndpointId::from_str(
+            "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+        )
+        .expect("endpoint id");
+        let endpoint_addr =
+            EndpointAddr::new(endpoint_id).with_ip_addr("0.0.0.0:0".parse().expect("socket addr"));
+        let config = TransportNetworkConfig::default();
+
+        let resolved = ticket_network_config(
+            &endpoint_addr,
+            &["10.73.0.1:40123".parse().expect("observed socket")],
+            &config,
+        );
+
+        assert_eq!(resolved.advertised_host, None);
         assert_eq!(resolved.advertised_port, Some(40123));
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -605,6 +605,9 @@ fn with_cn_postgres<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
 }
 
 fn scenario_requires_cn_postgres(name: &str) -> bool {
+    if std::env::var_os("KUKURI_HARNESS_COMMUNITY_NODE_BASE_URL").is_some() {
+        return false;
+    }
     matches!(
         name,
         "community_node_public_connectivity" | "community_node_multi_device_connectivity"


### PR DESCRIPTION
## Summary

- Fix external community-node relay-assisted public sync by forwarding `restart_replica_sync` through the reloadable desktop docs wrapper.
- Avoid publishing auto-derived private or virtual-interface addr hints when relay-assisted community-node connectivity is available, and replace cached stale addr hints with endpoint-only CN metadata.
- Keep docs-assisted recovery probing when a live gossip peer is visible but docs content has not arrived, and add external relay/CN scenario coverage.

## Root Cause

DesktopRuntime uses `ReloadableDocsSync`, but it did not override `restart_replica_sync`. Calls from hint misses, public recovery, and local-post restart paths fell back to the trait default, which only opened the replica and did not restart iroh docs sync against the current relay-assisted peers. In the real CN/VPS route this left clients reporting `Live` peer connectivity while docs rows never hydrated.

## Validation

- `cargo xtask scenario community_node_public_connectivity` with `KUKURI_HARNESS_COMMUNITY_NODE_BASE_URL=https://api.kukuri.app` and `KUKURI_HARNESS_COMMUNITY_NODE_CONNECTIVITY_URLS=https://iroh-relay.kukuri.app`
- `cargo xtask check`
- `cargo test -p kukuri-desktop-runtime external_relay_endpoint_only_seed_peers_backfill_desktop_public_timeline -- --nocapture`
- `cargo test -p kukuri-app-api external_relay_endpoint_only_seeds_sync_post_between_apps -- --nocapture`
- `cargo test -p kukuri-docs-sync public_replica_syncs_over_external_relay_when_configured -- --nocapture`