### PR TITLE
[codex] Refine channel UI flows

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,11 @@
 [test-groups]
 harness-serial = { max-threads = 1 }
+iroh-integration-serial = { max-threads = 1 }
 
 [[profile.default.overrides]]
 filter = "package(kukuri-harness)"
 test-group = "harness-serial"
+
+[[profile.default.overrides]]
+filter = "package(kukuri-app-api) | package(kukuri-desktop-runtime)"
+test-group = "iroh-integration-serial"

--- a/apps/desktop/src/components/core/PostCard.stories.tsx
+++ b/apps/desktop/src/components/core/PostCard.stories.tsx
@@ -24,6 +24,20 @@ const basePost = {
   audience_label: 'Public',
 };
 
+const inviteTokenPostContent = JSON.stringify({
+  envelope: {
+    kind: 'channel-invite',
+    pubkey: 'b'.repeat(64),
+    content: JSON.stringify({
+      channel_id: 'channel-core',
+      topic_id: 'kukuri:topic:demo',
+      channel_label: 'Core Contributors',
+      owner_pubkey: 'b'.repeat(64),
+      epoch_id: 'epoch-1',
+    }),
+  },
+});
+
 function createView(overrides?: Partial<PostCardView>): PostCardView {
   return {
     post: basePost,
@@ -181,6 +195,20 @@ export const UnsupportedVideo: Story = {
         videoPlaybackSrc: null,
         videoUnsupportedOnClient: true,
       },
+    }),
+  },
+};
+
+export const ChannelAccessToken: Story = {
+  args: {
+    view: createView({
+      post: {
+        ...basePost,
+        object_id: 'token-post',
+        envelope_id: 'envelope-token-post',
+        content: inviteTokenPostContent,
+      },
+      threadTargetId: 'token-post',
     }),
   },
 };

--- a/apps/desktop/src/components/core/SmartReferenceText.tsx
+++ b/apps/desktop/src/components/core/SmartReferenceText.tsx
@@ -27,6 +27,19 @@ function tokenKindLabel(
   return t('channels:previewDialog.tokenKinds.share');
 }
 
+function tokenAudienceLabel(
+  tokenKind: 'invite' | 'grant' | 'share',
+  t: ReturnType<typeof useTranslation>['t']
+): string {
+  if (tokenKind === 'invite') {
+    return t('channels:audienceOptions.invite_only');
+  }
+  if (tokenKind === 'grant') {
+    return t('channels:audienceOptions.friend_only');
+  }
+  return t('channels:audienceOptions.friend_plus');
+}
+
 function referenceLabel(
   reference: InternalSmartReference,
   t: ReturnType<typeof useTranslation>['t']
@@ -44,6 +57,11 @@ function referenceLabel(
   }
   if (reference.kind === 'game') {
     return `${t('shell:primarySections.game')} ${shortenReferenceId(reference.roomId)}`;
+  }
+  const channelLabel =
+    reference.metadata.channelLabel?.trim() || reference.metadata.channelId?.trim();
+  if (channelLabel) {
+    return `${channelLabel} / ${tokenAudienceLabel(reference.tokenKind, t)}`;
   }
   return `${tokenKindLabel(reference.tokenKind, t)} ${t('channels:previewDialog.tokenLabelSuffix')}`;
 }
@@ -86,7 +104,7 @@ export function SmartReferenceText({
                 className='smart-reference-chip'
                 title={
                   segment.reference.kind === 'share_token'
-                    ? tokenKindLabel(segment.reference.tokenKind, t)
+                    ? segment.reference.token
                     : segment.reference.route
                 }
                 onClick={(event) =>

--- a/apps/desktop/src/components/core/TopicNavList.stories.tsx
+++ b/apps/desktop/src/components/core/TopicNavList.stories.tsx
@@ -23,6 +23,7 @@ const meta = {
           items={topicItems}
           onSelectTopic={() => undefined}
           onSelectChannel={() => undefined}
+          onOpenChannelSettings={() => undefined}
           onRemoveTopic={() => undefined}
         />
       </Card>

--- a/apps/desktop/src/components/core/TopicNavList.tsx
+++ b/apps/desktop/src/components/core/TopicNavList.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Link2 } from 'lucide-react';
+import { Link2, Settings } from 'lucide-react';
 
 import { type TopicDiagnosticSummary } from './types';
 import { cn } from '@/lib/utils';
@@ -8,6 +8,7 @@ type TopicNavListProps = {
   items: TopicDiagnosticSummary[];
   onSelectTopic: (topic: string) => void;
   onSelectChannel: (topic: string, channelId: string) => void;
+  onOpenChannelSettings?: (topic: string, channelId: string) => void;
   onRemoveTopic: (topic: string) => void;
   onCopyTopicLink?: (topic: string) => void;
 };
@@ -16,10 +17,11 @@ export function TopicNavList({
   items,
   onSelectTopic,
   onSelectChannel,
+  onOpenChannelSettings,
   onRemoveTopic,
   onCopyTopicLink,
 }: TopicNavListProps) {
-  const { t } = useTranslation(['common', 'shell']);
+  const { t } = useTranslation(['channels', 'common', 'shell']);
 
   return (
     <ul>
@@ -92,7 +94,7 @@ export function TopicNavList({
                     <div className='topic-subsection-label'>{t('shell:navigation.channelsGroup')}</div>
                     <ul className='topic-sublist'>
                       {item.channels?.map((channel) => (
-                        <li key={channel.channelId}>
+                        <li key={channel.channelId} className='topic-subitem-row'>
                           <button
                             className={cn(
                               'topic-subitem',
@@ -105,6 +107,18 @@ export function TopicNavList({
                             <span className='shell-topic-link-label'>{channel.label}</span>
                             <small>{t(`channels:audienceOptions.${channel.audienceKind}`)}</small>
                           </button>
+                          {onOpenChannelSettings ? (
+                            <button
+                              className='topic-channel-settings'
+                              type='button'
+                              aria-label={t('channels:actions.openSettings', {
+                                channel: channel.label,
+                              })}
+                              onClick={() => onOpenChannelSettings(item.topic, channel.channelId)}
+                            >
+                              <Settings className='size-4' aria-hidden='true' />
+                            </button>
+                          ) : null}
                         </li>
                       ))}
                     </ul>

--- a/apps/desktop/src/components/extended/ExtendedProductFlow.stories.tsx
+++ b/apps/desktop/src/components/extended/ExtendedProductFlow.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { GameRoomPanel } from './GameRoomPanel';
 import { LiveSessionPanel } from './LiveSessionPanel';
-import { PrivateChannelPanel } from './PrivateChannelPanel';
+import { PrivateChannelPanel, PrivateChannelSettingsPanel } from './PrivateChannelPanel';
 import { ProfileEditorPanel } from './ProfileEditorPanel';
 
 const meta = {
@@ -49,30 +49,17 @@ function ExtendedProductFlowStory({ width }: { width: number }) {
             { value: 'friend_plus', label: 'Friends+' },
           ]}
           inviteTokenInput={inviteToken}
-          inviteOutput='share:kukuri:topic:demo:channel-1'
-          inviteOutputLabel='share'
-          channels={[
-            {
-              active: true,
-              channel: {
-                topic_id: 'kukuri:topic:demo',
-                channel_id: 'channel-1',
-                label: 'Core Contributors',
-                creator_pubkey: 'a'.repeat(64),
-                owner_pubkey: 'a'.repeat(64),
-                joined_via_pubkey: null,
-                audience_kind: 'friend_plus',
-                is_owner: true,
-                current_epoch_id: 'epoch-4',
-                archived_epoch_ids: ['epoch-3'],
-                sharing_state: 'open',
-                rotation_required: false,
-                participant_count: 3,
-                stale_participant_count: 0,
-              },
-            },
-          ]}
-          selectedChannel={{
+          onChannelLabelChange={setChannelLabel}
+          onChannelAudienceChange={() => undefined}
+          onInviteTokenChange={setInviteToken}
+          onCreateChannel={(event) => event.preventDefault()}
+          onJoin={(event) => event.preventDefault()}
+        />
+
+        <PrivateChannelSettingsPanel
+          error={null}
+          pendingAction={null}
+          channel={{
             topic_id: 'kukuri:topic:demo',
             channel_id: 'channel-1',
             label: 'Core Contributors',
@@ -88,12 +75,8 @@ function ExtendedProductFlowStory({ width }: { width: number }) {
             participant_count: 3,
             stale_participant_count: 0,
           }}
-          onChannelLabelChange={setChannelLabel}
-          onChannelAudienceChange={() => undefined}
-          onInviteTokenChange={setInviteToken}
-          onCreateChannel={(event) => event.preventDefault()}
-          onJoin={(event) => event.preventDefault()}
-          onSelectChannel={() => undefined}
+          inviteOutput='share:kukuri:topic:demo:channel-1'
+          inviteOutputLabel='share'
           onShare={() => undefined}
         />
 

--- a/apps/desktop/src/components/extended/PrivateChannelPanel.stories.tsx
+++ b/apps/desktop/src/components/extended/PrivateChannelPanel.stories.tsx
@@ -2,8 +2,8 @@ import { useState, type FormEvent } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import { PrivateChannelPanel } from './PrivateChannelPanel';
-import type { InviteOutputLabel, PrivateChannelListItemView } from './types';
+import { PrivateChannelPanel, PrivateChannelSettingsPanel } from './PrivateChannelPanel';
+import type { PrivateChannelListItemView } from './types';
 
 const meta = {
   title: 'Extended/PrivateChannelPanel',
@@ -67,29 +67,19 @@ const STORY_ARGS = {
     { value: 'friend_plus', label: 'Friends+' },
   ],
   inviteTokenInput: '',
-  inviteOutput: null,
-  inviteOutputLabel: 'invite',
-  channels: BASE_CHANNELS,
-  selectedChannel: BASE_CHANNELS[0].channel,
   onChannelLabelChange: () => undefined,
   onChannelAudienceChange: () => undefined,
   onInviteTokenChange: () => undefined,
   onCreateChannel: (event: FormEvent<HTMLFormElement>) => event.preventDefault(),
   onJoin: (event: FormEvent<HTMLFormElement>) => event.preventDefault(),
-  onSelectChannel: () => undefined,
-  onShare: () => undefined,
 } satisfies React.ComponentProps<typeof PrivateChannelPanel>;
 
 function ChannelStory({
   status = 'ready',
   error = null,
-  inviteOutput = null,
-  inviteOutputLabel = 'invite',
 }: {
   status?: 'loading' | 'ready' | 'error';
   error?: string | null;
-  inviteOutput?: string | null;
-  inviteOutputLabel?: InviteOutputLabel;
 }) {
   const [label, setLabel] = useState('Core Contributors');
   const [audience, setAudience] = useState<'invite_only' | 'friend_only' | 'friend_plus'>(
@@ -110,17 +100,11 @@ function ChannelStory({
         { value: 'friend_plus', label: 'Friends+' },
       ]}
       inviteTokenInput={token}
-      inviteOutput={inviteOutput}
-      inviteOutputLabel={inviteOutputLabel}
-      channels={BASE_CHANNELS}
-      selectedChannel={BASE_CHANNELS[0].channel}
       onChannelLabelChange={setLabel}
       onChannelAudienceChange={setAudience}
       onInviteTokenChange={setToken}
       onCreateChannel={(event) => event.preventDefault()}
       onJoin={(event) => event.preventDefault()}
-      onSelectChannel={() => undefined}
-      onShare={() => undefined}
     />
   );
 }
@@ -131,8 +115,6 @@ export const Ready: Story = {
     <ChannelStory
       status={args.status}
       error={args.error}
-      inviteOutput={args.inviteOutput}
-      inviteOutputLabel={args.inviteOutputLabel}
     />
   ),
 };
@@ -147,8 +129,6 @@ export const ErrorState: Story = {
     <ChannelStory
       status={args.status}
       error={args.error}
-      inviteOutput={args.inviteOutput}
-      inviteOutputLabel={args.inviteOutputLabel}
     />
   ),
 };
@@ -156,15 +136,15 @@ export const ErrorState: Story = {
 export const InviteOutputState: Story = {
   args: {
     ...STORY_ARGS,
-    inviteOutput: 'share:kukuri:topic:demo:channel-1',
-    inviteOutputLabel: 'share',
   },
-  render: (args) => (
-    <ChannelStory
-      status={args.status}
-      error={args.error}
-      inviteOutput={args.inviteOutput}
-      inviteOutputLabel={args.inviteOutputLabel}
+  render: () => (
+    <PrivateChannelSettingsPanel
+      error={null}
+      pendingAction={null}
+      channel={BASE_CHANNELS[0].channel}
+      inviteOutput='share:kukuri:topic:demo:channel-1'
+      inviteOutputLabel='share'
+      onShare={() => undefined}
     />
   ),
 };

--- a/apps/desktop/src/components/extended/PrivateChannelPanel.tsx
+++ b/apps/desktop/src/components/extended/PrivateChannelPanel.tsx
@@ -11,7 +11,6 @@ import { Notice } from '@/components/ui/notice';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { SmartReferenceText } from '@/components/core/SmartReferenceText';
-import { cn } from '@/lib/utils';
 
 import {
   type ChannelAudienceOption,
@@ -52,16 +51,19 @@ type PrivateChannelPanelProps = {
   channelAudience: ChannelAudienceOption['value'];
   channelAudienceOptions: ChannelAudienceOption[];
   inviteTokenInput: string;
-  inviteOutput: string | null;
-  inviteOutputLabel: InviteOutputLabel;
-  channels: PrivateChannelListItemView[];
-  selectedChannel: PrivateChannelListItemView['channel'] | null;
   onChannelLabelChange: (value: string) => void;
   onChannelAudienceChange: (value: ChannelAudienceOption['value']) => void;
   onInviteTokenChange: (value: string) => void;
   onCreateChannel: FormEventHandler<HTMLFormElement>;
   onJoin: FormEventHandler<HTMLFormElement>;
-  onSelectChannel: (channelId: string) => void;
+};
+
+type PrivateChannelSettingsPanelProps = {
+  error: string | null;
+  pendingAction: PrivateChannelPendingAction;
+  channel: PrivateChannelListItemView['channel'];
+  inviteOutput: string | null;
+  inviteOutputLabel: InviteOutputLabel;
   onShare: () => void;
   onActivateReference?: (reference: InternalSmartReference) => void;
   onCopyInviteOutput?: (token: string) => void;
@@ -75,82 +77,139 @@ export function PrivateChannelPanel({
   channelAudience,
   channelAudienceOptions,
   inviteTokenInput,
-  inviteOutput,
-  inviteOutputLabel,
-  channels,
-  selectedChannel,
   onChannelLabelChange,
   onChannelAudienceChange,
   onInviteTokenChange,
   onCreateChannel,
   onJoin,
-  onSelectChannel,
-  onShare,
-  onActivateReference,
-  onCopyInviteOutput,
 }: PrivateChannelPanelProps) {
   const { t } = useTranslation(['channels', 'common']);
   const channelActionDisabled = pendingAction !== null;
-  const selectedChannelId = selectedChannel?.channel_id ?? null;
-  const selectedChannelShareLabel = selectedChannel
-    ? `${selectedChannel.label} / ${t(`channels:audienceOptions.${selectedChannel.audience_kind}`)}`
-    : t('channels:actions.share');
 
   return (
-    <Card className='panel-subsection'>
-      <CardHeader>
-        <h3>{t('channels:title')}</h3>
-        <small>{t('channels:joined', { count: channels.length })}</small>
-      </CardHeader>
-
+    <div className='extended-module-stack'>
       {status === 'loading' ? <Notice>{t('channels:loading')}</Notice> : null}
       {status === 'error' && error ? <Notice tone='destructive'>{error}</Notice> : null}
 
-      <div className='extended-module-stack'>
-        <form className='composer composer-compact' onSubmit={onCreateChannel}>
-          <Label>
-            <span>{t('channels:editor.createChannel')}</span>
-            <Input
-              value={channelLabel}
-              onChange={(event) => onChannelLabelChange(event.target.value)}
-              placeholder={t('channels:editor.placeholders.channelLabel')}
-              disabled={channelActionDisabled}
-            />
-          </Label>
-          <Label>
-            <span>{t('channels:editor.audience')}</span>
-            <Select
-              aria-label={t('channels:editor.audience')}
-              value={channelAudience}
-              onChange={(event) => onChannelAudienceChange(event.target.value as ChannelAudienceOption['value'])}
-              disabled={channelActionDisabled}
-            >
-              {channelAudienceOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </Select>
-          </Label>
-          <Button variant='secondary' type='submit' disabled={channelActionDisabled}>
-            {t('channels:actions.createChannel')}
-          </Button>
-        </form>
+      <div className='private-channel-editor-grid'>
+        <Card className='panel-subsection private-channel-editor-block'>
+          <CardHeader>
+            <h3>{t('channels:editor.createBlockTitle')}</h3>
+          </CardHeader>
+          <form className='composer composer-compact' onSubmit={onCreateChannel}>
+            <Label>
+              <span>{t('channels:editor.channelName')}</span>
+              <Input
+                value={channelLabel}
+                onChange={(event) => onChannelLabelChange(event.target.value)}
+                placeholder={t('channels:editor.placeholders.channelLabel')}
+                disabled={channelActionDisabled}
+              />
+            </Label>
+            <Label>
+              <span>{t('channels:editor.audience')}</span>
+              <Select
+                aria-label={t('channels:editor.audience')}
+                value={channelAudience}
+                onChange={(event) =>
+                  onChannelAudienceChange(event.target.value as ChannelAudienceOption['value'])
+                }
+                disabled={channelActionDisabled}
+              >
+                {channelAudienceOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </Label>
+            <Button variant='secondary' type='submit' disabled={channelActionDisabled}>
+              {t('channels:actions.createChannel')}
+            </Button>
+          </form>
+        </Card>
 
-        <form className='composer composer-compact' onSubmit={onJoin}>
-          <Label>
-            <span>{t('channels:editor.join')}</span>
-            <Textarea
-              value={inviteTokenInput}
-              onChange={(event) => onInviteTokenChange(event.target.value)}
-              placeholder={t('channels:editor.placeholders.inviteToken')}
-              disabled={channelActionDisabled}
-            />
-          </Label>
-          <Button variant='secondary' type='submit' disabled={channelActionDisabled}>
-            {t('channels:actions.join')}
+        <Card className='panel-subsection private-channel-editor-block'>
+          <CardHeader>
+            <h3>{t('channels:editor.joinBlockTitle')}</h3>
+          </CardHeader>
+          <form className='composer composer-compact' onSubmit={onJoin}>
+            <Label>
+              <span>{t('channels:editor.join')}</span>
+              <Textarea
+                value={inviteTokenInput}
+                onChange={(event) => onInviteTokenChange(event.target.value)}
+                placeholder={t('channels:editor.placeholders.inviteToken')}
+                disabled={channelActionDisabled}
+              />
+            </Label>
+            <Button variant='secondary' type='submit' disabled={channelActionDisabled}>
+              {t('channels:actions.join')}
+            </Button>
+          </form>
+        </Card>
+      </div>
+
+      {status !== 'error' && error ? <p className='error error-inline'>{error}</p> : null}
+    </div>
+  );
+}
+
+export function PrivateChannelSettingsPanel({
+  error,
+  pendingAction,
+  channel,
+  inviteOutput,
+  inviteOutputLabel,
+  onShare,
+  onActivateReference,
+  onCopyInviteOutput,
+}: PrivateChannelSettingsPanelProps) {
+  const { t } = useTranslation(['channels', 'common']);
+  const channelActionDisabled = pendingAction !== null;
+  const selectedChannelShareLabel = `${channel.label} / ${t(`channels:audienceOptions.${channel.audience_kind}`)}`;
+
+  return (
+    <Card tone='accent' className='panel-subsection extended-channel-detail'>
+      <CardHeader>
+        <h3>{channel.label}</h3>
+        <small>{policyDescription(channel.audience_kind, t)}</small>
+      </CardHeader>
+
+      <div className='extended-module-stack'>
+        <div className='topic-diagnostic topic-diagnostic-secondary'>
+          <span>
+            {t('common:labels.policy')}: {policyDescription(channel.audience_kind, t)}
+          </span>
+        </div>
+        {(channel.audience_kind === 'friend_only' || channel.audience_kind === 'friend_plus') ? (
+          <div className='topic-diagnostic topic-diagnostic-secondary'>
+            <span>{t('common:labels.participants')}: {channel.participant_count}</span>
+            <span>{t('common:labels.stale')}: {channel.stale_participant_count}</span>
+            <span>
+              {t('common:labels.owner')}: {channel.is_owner ? t('common:states.yes') : t('common:states.no')}
+            </span>
+          </div>
+        ) : null}
+        {channel.audience_kind === 'friend_only' && channel.rotation_required ? (
+          <div className='topic-diagnostic topic-diagnostic-error'>
+            <span>{t('channels:rotationRequired')}</span>
+          </div>
+        ) : null}
+
+        <div className='discovery-actions'>
+          <Button
+            aria-label={selectedChannelShareLabel}
+            className='w-full justify-between gap-3 text-left'
+            variant='secondary'
+            type='button'
+            disabled={channelActionDisabled}
+            onClick={onShare}
+          >
+            <span>{selectedChannelShareLabel}</span>
+            <DoorOpen className='size-4 shrink-0' aria-hidden='true' />
           </Button>
-        </form>
+        </div>
 
         {inviteOutput ? (
           <Notice tone='accent'>
@@ -176,86 +235,7 @@ export function PrivateChannelPanel({
           </Notice>
         ) : null}
 
-        {channels.length === 0 && status === 'ready' ? (
-          <p className='empty-state'>{t('channels:empty')}</p>
-        ) : null}
-
-        {channels.length > 0 ? (
-          <div className='extended-channel-grid'>
-            <ul className='post-list'>
-              {channels.map(({ channel, active }) => (
-                <li key={channel.channel_id}>
-                  <button
-                    className={cn(
-                      'post-card post-link extended-channel-card',
-                      active && 'extended-channel-card-active'
-                    )}
-                    type='button'
-                    aria-pressed={active}
-                    onClick={() => onSelectChannel(channel.channel_id)}
-                  >
-                    <div className='post-meta'>
-                      <span>{channel.label}</span>
-                      <span>{t(`channels:audienceOptions.${channel.audience_kind}`)}</span>
-                    </div>
-                  </button>
-                </li>
-              ))}
-            </ul>
-
-            <Card tone={selectedChannel ? 'accent' : 'default'} className='extended-channel-detail'>
-            <CardHeader>
-                <h4>{selectedChannel?.label ?? t('channels:selectChannel')}</h4>
-                <small>
-                  {selectedChannel
-                    ? policyDescription(selectedChannel.audience_kind, t)
-                    : t('channels:inspectHint')}
-                </small>
-              </CardHeader>
-
-              {selectedChannel ? (
-                <>
-                  <div className='topic-diagnostic topic-diagnostic-secondary'>
-                    <span>
-                      {t('common:labels.policy')}: {policyDescription(selectedChannel.audience_kind, t)}
-                    </span>
-                  </div>
-                  {(selectedChannel.audience_kind === 'friend_only' ||
-                    selectedChannel.audience_kind === 'friend_plus') ? (
-                    <div className='topic-diagnostic topic-diagnostic-secondary'>
-                      <span>{t('common:labels.participants')}: {selectedChannel.participant_count}</span>
-                      <span>{t('common:labels.stale')}: {selectedChannel.stale_participant_count}</span>
-                      <span>{t('common:labels.owner')}: {selectedChannel.is_owner ? t('common:states.yes') : t('common:states.no')}</span>
-                    </div>
-                  ) : null}
-                  {selectedChannel.audience_kind === 'friend_only' &&
-                  selectedChannel.rotation_required ? (
-                    <div className='topic-diagnostic topic-diagnostic-error'>
-                      <span>{t('channels:rotationRequired')}</span>
-                    </div>
-                  ) : null}
-                  <div className='discovery-actions'>
-                    <Button
-                      aria-label={selectedChannelShareLabel}
-                      className='w-full justify-between gap-3 text-left'
-                      variant='secondary'
-                      type='button'
-                      disabled={channelActionDisabled || selectedChannelId === null}
-                      onClick={onShare}
-                    >
-                      <span>{selectedChannelShareLabel}</span>
-                      <DoorOpen className='size-4 shrink-0' aria-hidden='true' />
-                    </Button>
-                  </div>
-                </>
-              ) : (
-                <Notice>{t('channels:selectChannelNotice')}</Notice>
-              )}
-            </Card>
-          </div>
-        ) : null}
-
-        {status !== 'error' && error ? <p className='error error-inline'>{error}</p> : null}
+        {error ? <p className='error error-inline'>{error}</p> : null}
       </div>
     </Card>
   );

--- a/apps/desktop/src/i18n/locales/en/channels.json
+++ b/apps/desktop/src/i18n/locales/en/channels.json
@@ -2,6 +2,7 @@
   "actions": {
     "createChannel": "Create Channel",
     "join": "Join",
+    "openSettings": "Open {{channel}} channel settings",
     "share": "Share"
   },
   "audienceOptions": {
@@ -9,10 +10,14 @@
     "friend_plus": "Friends+",
     "invite_only": "Invite only"
   },
+  "createDialogTitle": "Create Private Channel",
   "editor": {
     "audience": "Audience",
+    "channelName": "Channel name",
+    "createBlockTitle": "Create",
     "createChannel": "Create Channel",
     "join": "Join",
+    "joinBlockTitle": "Join",
     "placeholders": {
       "channelLabel": "core contributors",
       "inviteToken": "paste private channel invite, friend grant, or friends+ share"
@@ -31,7 +36,7 @@
   },
   "inspectHint": "Inspect policy and actions here.",
   "joined": "{{count}} joined",
-  "loading": "Loading private channels…",
+  "loading": "Loading private channels...",
   "latestInvite": "Latest invite",
   "latestShare": "Latest share",
   "policies": {
@@ -39,15 +44,11 @@
     "friend_plus": "Friends+: participants can share to their mutuals",
     "invite_only": "Invite only"
   },
-  "rotationRequired": "rotation required: current participants include non-mutual followers",
   "previewDialog": {
     "title": "Preview Access",
-    "description": "Inspect the channel access token before importing it.",
     "import": "Import / Join",
     "copyToken": "Copy token",
-    "showRaw": "Show raw token",
-    "hideRaw": "Hide raw token",
-    "channel": "channel",
+    "channel": "Channel",
     "channelId": "channel id",
     "inviter": "inviter",
     "sponsor": "sponsor",
@@ -58,7 +59,11 @@
       "share": "Share"
     }
   },
+  "rotationRequired": "rotation required: current participants include non-mutual followers",
   "selectChannel": "Select a channel",
   "selectChannelNotice": "Select a private channel to inspect policy and actions.",
+  "settings": {
+    "title": "Channel Settings"
+  },
   "title": "Private Channels"
 }

--- a/apps/desktop/src/i18n/locales/ja/channels.json
+++ b/apps/desktop/src/i18n/locales/ja/channels.json
@@ -2,6 +2,7 @@
   "actions": {
     "createChannel": "チャンネルを作成",
     "join": "参加",
+    "openSettings": "{{channel}} のチャンネル設定を開く",
     "share": "共有"
   },
   "audienceOptions": {
@@ -9,10 +10,14 @@
     "friend_plus": "友だち+",
     "invite_only": "招待限定"
   },
+  "createDialogTitle": "プライベートチャンネル作成",
   "editor": {
     "audience": "公開範囲",
+    "channelName": "チャンネル名",
+    "createBlockTitle": "作成",
     "createChannel": "チャンネルを作成",
     "join": "参加",
+    "joinBlockTitle": "参加",
     "placeholders": {
       "channelLabel": "コアメンバー",
       "inviteToken": "プライベートチャンネル招待、権限付与、共有トークンを貼り付け"
@@ -31,22 +36,18 @@
   },
   "inspectHint": "ここでポリシーと操作を確認できます。",
   "joined": "{{count}} 件参加中",
-  "loading": "プライベートチャンネルを読み込み中…",
+  "loading": "プライベートチャンネルを読み込み中...",
   "latestInvite": "最新の招待",
   "latestShare": "最新の共有",
   "policies": {
     "friend_only": "友だち限定: 相互フォローの相手だけが参加できます",
     "friend_plus": "友だち+: 参加者が相互フォロー相手へ共有できます",
-    "invite_only": "招待限定: 招待トークンを持つ相手だけが参加できます"
+    "invite_only": "招待限定"
   },
-  "rotationRequired": "ローテーションが必要です: 現在の参加者に相互フォローでない相手が含まれています",
   "previewDialog": {
     "title": "アクセスプレビュー",
-    "description": "インポート前にチャンネルアクセストークンを確認します。",
     "import": "インポート / 参加",
     "copyToken": "トークンをコピー",
-    "showRaw": "生トークンを表示",
-    "hideRaw": "生トークンを隠す",
     "channel": "チャンネル",
     "channelId": "チャンネル ID",
     "inviter": "招待者",
@@ -58,7 +59,11 @@
       "share": "共有"
     }
   },
+  "rotationRequired": "ローテーションが必要です。現在の参加者に相互フォローではない相手が含まれています",
   "selectChannel": "チャンネルを選択",
   "selectChannelNotice": "プライベートチャンネルを選択するとポリシーと操作を確認できます。",
+  "settings": {
+    "title": "チャンネル設定"
+  },
   "title": "プライベートチャンネル"
 }

--- a/apps/desktop/src/i18n/locales/zh-CN/channels.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/channels.json
@@ -2,51 +2,52 @@
   "actions": {
     "createChannel": "创建频道",
     "join": "加入",
-    "share": "共享"
+    "openSettings": "打开 {{channel}} 频道设置",
+    "share": "分享"
   },
   "audienceOptions": {
     "friend_only": "仅好友",
     "friend_plus": "好友+",
     "invite_only": "仅邀请"
   },
+  "createDialogTitle": "创建私密频道",
   "editor": {
-    "audience": "受众",
+    "audience": "可见范围",
+    "channelName": "频道名称",
+    "createBlockTitle": "创建",
     "createChannel": "创建频道",
     "join": "加入",
+    "joinBlockTitle": "加入",
     "placeholders": {
       "channelLabel": "核心成员",
-      "inviteToken": "粘贴私密频道邀请、授权或共享令牌"
+      "inviteToken": "粘贴私密频道邀请、授权或分享令牌"
     }
   },
   "empty": "此主题下还没有已加入的私密频道。",
   "errors": {
     "channelLabelRequired": "频道名称为必填项",
     "inviteTokenRequired": "邀请令牌为必填项",
-    "selectChannelForShare": "创建共享前请先选择私密频道",
+    "selectChannelForShare": "创建分享前请先选择私密频道",
     "failedCreateChannel": "创建频道失败",
     "failedPreviewToken": "预览私密频道令牌失败",
-    "failedCreateShare": "创建共享失败",
+    "failedCreateShare": "创建分享失败",
     "failedJoinChannel": "加入私密频道失败",
-    "failedShareChannel": "共享私密频道失败"
+    "failedShareChannel": "分享私密频道失败"
   },
   "inspectHint": "在这里查看策略和操作。",
   "joined": "已加入 {{count}} 个",
-  "loading": "正在加载私密频道…",
+  "loading": "正在加载私密频道...",
   "latestInvite": "最新邀请",
-  "latestShare": "最新共享",
+  "latestShare": "最新分享",
   "policies": {
     "friend_only": "仅好友: 只有互相关注的用户可以加入",
-    "friend_plus": "好友+: 参与者可以共享给互相关注的人",
-    "invite_only": "仅邀请: 只有持有邀请令牌的用户可以加入"
+    "friend_plus": "好友+: 参与者可以分享给互相关注的人",
+    "invite_only": "仅邀请"
   },
-  "rotationRequired": "需要轮换: 当前参与者中包含非互相关注用户",
   "previewDialog": {
     "title": "访问预览",
-    "description": "在导入前先检查频道访问令牌。",
     "import": "导入 / 加入",
     "copyToken": "复制令牌",
-    "showRaw": "显示原始令牌",
-    "hideRaw": "隐藏原始令牌",
     "channel": "频道",
     "channelId": "频道 ID",
     "inviter": "邀请者",
@@ -55,10 +56,14 @@
     "tokenKinds": {
       "invite": "邀请",
       "grant": "授权",
-      "share": "共享"
+      "share": "分享"
     }
   },
-  "selectChannel": "选择一个频道",
+  "rotationRequired": "需要轮换: 当前参与者中包含非互相关注用户",
+  "selectChannel": "选择频道",
   "selectChannelNotice": "选择私密频道以查看策略和操作。",
+  "settings": {
+    "title": "频道设置"
+  },
   "title": "私密频道"
 }

--- a/apps/desktop/src/lib/internalLinks.ts
+++ b/apps/desktop/src/lib/internalLinks.ts
@@ -35,6 +35,18 @@ export type ShareTokenReference = {
   kind: 'share_token';
   token: string;
   tokenKind: ChannelAccessTokenKind;
+  metadata: ChannelAccessTokenMetadata;
+};
+
+export type ChannelAccessTokenMetadata = {
+  kind: ChannelAccessTokenKind;
+  topicId?: string | null;
+  channelId?: string | null;
+  channelLabel?: string | null;
+  ownerPubkey?: string | null;
+  inviterPubkey?: string | null;
+  sponsorPubkey?: string | null;
+  epochId?: string | null;
 };
 
 export type InternalSmartReference =
@@ -119,19 +131,59 @@ export function shortenReferenceId(value: string): string {
   return `${trimmed.slice(0, 10)}…`;
 }
 
-export function parseShareTokenKind(rawValue: string): ChannelAccessTokenKind | null {
+function tokenKindFromEnvelopeKind(kind: string | null | undefined): ChannelAccessTokenKind | null {
+  if (kind === 'channel-invite') {
+    return 'invite';
+  }
+  if (kind === 'channel-friend-grant') {
+    return 'grant';
+  }
+  if (kind === 'channel-share') {
+    return 'share';
+  }
+  return null;
+}
+
+function parseEnvelopeContent(value: unknown): Record<string, unknown> | null {
+  if (!value) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null;
+    } catch {
+      return null;
+    }
+  }
+  return typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function stringField(content: Record<string, unknown> | null, key: string): string | null {
+  const value = content?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+export function parseChannelAccessTokenMetadata(rawValue: string): ChannelAccessTokenMetadata | null {
   const trimmed = rawValue.trim();
   if (!trimmed) {
     return null;
   }
-  if (trimmed.startsWith('invite:')) {
-    return 'invite';
-  }
-  if (trimmed.startsWith('grant:')) {
-    return 'grant';
-  }
-  if (trimmed.startsWith('share:')) {
-    return 'share';
+  const legacyKind = trimmed.startsWith('invite:')
+    ? 'invite'
+    : trimmed.startsWith('grant:')
+      ? 'grant'
+      : trimmed.startsWith('share:')
+        ? 'share'
+        : null;
+  if (legacyKind) {
+    const lastSeparator = trimmed.lastIndexOf(':');
+    const channelId = lastSeparator > -1 ? trimmed.slice(lastSeparator + 1).trim() : null;
+    return {
+      kind: legacyKind,
+      channelId: channelId || null,
+      channelLabel: channelId || null,
+    };
   }
   if (!trimmed.startsWith('{')) {
     return null;
@@ -140,21 +192,38 @@ export function parseShareTokenKind(rawValue: string): ChannelAccessTokenKind | 
     const parsed = JSON.parse(trimmed) as {
       envelope?: {
         kind?: string;
+        pubkey?: string;
+        content?: unknown;
+        id?: string;
       };
     };
-    if (parsed.envelope?.kind === 'channel-invite') {
-      return 'invite';
+    const kind = tokenKindFromEnvelopeKind(parsed.envelope?.kind);
+    if (!kind) {
+      return null;
     }
-    if (parsed.envelope?.kind === 'channel-friend-grant') {
-      return 'grant';
-    }
-    if (parsed.envelope?.kind === 'channel-share') {
-      return 'share';
-    }
+    const content = parseEnvelopeContent(parsed.envelope?.content);
+    return {
+      kind,
+      topicId: stringField(content, 'topic_id'),
+      channelId: stringField(content, 'channel_id'),
+      channelLabel: stringField(content, 'channel_label'),
+      ownerPubkey: stringField(content, 'owner_pubkey'),
+      inviterPubkey: kind === 'invite' ? parsed.envelope?.pubkey ?? null : null,
+      sponsorPubkey:
+        kind === 'share'
+          ? stringField(content, 'sponsor_pubkey') ?? parsed.envelope?.pubkey ?? null
+          : kind === 'grant'
+            ? stringField(content, 'owner_pubkey')
+            : null,
+      epochId: stringField(content, 'epoch_id'),
+    };
   } catch {
     return null;
   }
-  return null;
+}
+
+export function parseShareTokenKind(rawValue: string): ChannelAccessTokenKind | null {
+  return parseChannelAccessTokenMetadata(rawValue)?.kind ?? null;
 }
 
 export function parseInternalRouteLink(rawValue: string): InternalSmartReference | null {
@@ -280,6 +349,7 @@ export function parseSmartText(value: string): SmartTextSegment[][] {
             kind: 'share_token',
             token: trimmed,
             tokenKind: shareTokenKind,
+            metadata: parseChannelAccessTokenMetadata(trimmed) ?? { kind: shareTokenKind },
           },
         },
       ] satisfies SmartTextSegment[];

--- a/apps/desktop/src/shell/DesktopShellPage.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.test.tsx
@@ -382,7 +382,7 @@ async function publishPost(user: ReturnType<typeof userEvent.setup>, content: st
 
 async function openChannelManager(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('button', { name: 'Private Channels' }));
-  return await screen.findByRole('dialog', { name: 'Private Channels' });
+  return await screen.findByRole('dialog', { name: 'Create Private Channel' });
 }
 
 function getChannelShareButton(
@@ -393,6 +393,13 @@ function getChannelShareButton(
   return within(dialog).getByRole('button', {
     name: `${channelLabel} / ${audienceLabel}`,
   });
+}
+
+async function openChannelSettings(user: ReturnType<typeof userEvent.setup>, channelLabel: string) {
+  await user.click(
+    screen.getByRole('button', { name: `Open ${channelLabel} channel settings` })
+  );
+  return await screen.findByRole('dialog', { name: 'Channel Settings' });
 }
 
 async function openLiveCreateDialog(user: ReturnType<typeof userEvent.setup>) {
@@ -803,11 +810,15 @@ test('channel manager opens as a modal from the navigation summary', async () =>
 
   const dialog = await openChannelManager(user);
   expect(dialog).toBeInTheDocument();
+  expect(dialog).toHaveAccessibleName('Create Private Channel');
+  expect(within(dialog).getByText('Create')).toBeInTheDocument();
+  expect(within(dialog).getAllByText('Join').length).toBeGreaterThan(0);
+  expect(within(dialog).getByText('Channel name')).toBeInTheDocument();
   expect(within(dialog).getByPlaceholderText('core contributors')).toBeInTheDocument();
 
   await user.click(within(dialog).getByRole('button', { name: 'Close dialog' }));
   await waitFor(() => {
-    expect(screen.queryByRole('dialog', { name: 'Private Channels' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Create Private Channel' })).not.toBeInTheDocument();
   });
 });
 
@@ -1235,13 +1246,18 @@ test('tracked topics show public and channel scope separately in the sidebar', a
   await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'core');
   await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
   await waitFor(() => {
-    expect(getChannelShareButton(channelDialog, 'core', 'Invite only')).toBeInTheDocument();
+    expect(window.location.hash).toMatch(
+      /^#\/timeline\?topic=kukuri%3Atopic%3Ademo&channel=channel-\d+$/
+    );
   });
   await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
   await waitFor(() => {
     expect(
-      screen.queryByRole('dialog', { name: 'Private Channels' })
+      screen.queryByRole('dialog', { name: 'Create Private Channel' })
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Open core channel settings' })
+    ).toBeInTheDocument();
   });
 
   const topicItem = screen.getByRole('button', { name: 'kukuri:topic:demo' }).closest('li');
@@ -1281,7 +1297,9 @@ test('sidebar can reselect the same private channel after switching back to publ
   await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'core');
   await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
   await waitFor(() => {
-    expect(getChannelShareButton(channelDialog, 'core', 'Invite only')).toBeInTheDocument();
+    expect(window.location.hash).toMatch(
+      /^#\/timeline\?topic=kukuri%3Atopic%3Ademo&channel=channel-\d+$/
+    );
   });
   await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
 
@@ -1320,9 +1338,7 @@ test('sidebar can switch from one topic public scope to another topic private ch
   await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'second-core');
   await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
   await waitFor(() => {
-    expect(
-      getChannelShareButton(channelDialog, 'second-core', 'Invite only')
-    ).toBeInTheDocument();
+    expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Asecond&channel=channel-1');
   });
   await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
 
@@ -2095,11 +2111,13 @@ test('private channel timeline keeps scope-separated posts and pending counts fr
 
   await waitFor(() => {
     expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1');
-    expect(getChannelShareButton(channelDialog, 'core', 'Invite only')).toBeInTheDocument();
   });
   await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
   await waitFor(() => {
-    expect(screen.queryByRole('dialog', { name: 'Private Channels' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Create Private Channel' })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Open core channel settings' })
+    ).toBeInTheDocument();
     expect(screen.getByText('channel post')).toBeInTheDocument();
   });
   expect(screen.queryByText('public post')).not.toBeInTheDocument();
@@ -2179,12 +2197,14 @@ test('profile overview aggregates public posts across topics and excludes privat
   await user.type(within(channelDialog).getByPlaceholderText('core contributors'), 'core');
   await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
   await waitFor(() => {
-    expect(getChannelShareButton(channelDialog, 'core', 'Invite only')).toBeInTheDocument();
+    expect(window.location.hash).toMatch(
+      /^#\/timeline\?topic=kukuri%3Atopic%3Ademo&channel=channel-\d+$/
+    );
   });
   await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
   await waitFor(() => {
     expect(
-      screen.queryByRole('dialog', { name: 'Private Channels' })
+      screen.queryByRole('dialog', { name: 'Create Private Channel' })
     ).not.toBeInTheDocument();
   });
   await publishPost(user, 'demo private post');
@@ -2432,14 +2452,15 @@ test('desktop shell can create a private channel and export an invite', async ()
   await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
 
   await waitFor(() => {
-    expect(getChannelShareButton(channelDialog, 'core', 'Invite only')).toBeInTheDocument();
     expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1');
   });
+  await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
 
-  await user.click(getChannelShareButton(channelDialog, 'core', 'Invite only'));
+  const settingsDialog = await openChannelSettings(user, 'core');
+  await user.click(getChannelShareButton(settingsDialog, 'core', 'Invite only'));
 
   await waitFor(() => {
-    expect(screen.getByRole('button', { name: /invite token/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /channel-1 \/ Invite only/i })).toBeInTheDocument();
   });
 });
 
@@ -2483,15 +2504,16 @@ test('desktop shell shows friend-only controls and can create a grant', async ()
   await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
 
   await waitFor(() => {
-    expect(getChannelShareButton(channelDialog, 'friends', 'Friends')).toBeInTheDocument();
     expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1');
     expect(screen.queryByRole('button', { name: 'Rotate' })).not.toBeInTheDocument();
   });
+  await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
 
-  await user.click(getChannelShareButton(channelDialog, 'friends', 'Friends'));
+  const settingsDialog = await openChannelSettings(user, 'friends');
+  await user.click(getChannelShareButton(settingsDialog, 'friends', 'Friends'));
 
   await waitFor(() => {
-    expect(screen.getByRole('button', { name: /grant token/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /channel-1 \/ Friends/i })).toBeInTheDocument();
   });
 });
 
@@ -2504,21 +2526,38 @@ test('desktop shell shows friend-plus controls and can create a share', async ()
   await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
 
   await waitFor(() => {
-    expect(getChannelShareButton(channelDialog, 'friends+', 'Friends+')).toBeInTheDocument();
     expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1');
     expect(screen.queryByRole('button', { name: 'Freeze' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Rotate' })).not.toBeInTheDocument();
   });
+  await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
 
-  await user.click(getChannelShareButton(channelDialog, 'friends+', 'Friends+'));
+  const settingsDialog = await openChannelSettings(user, 'friends+');
+  await user.click(getChannelShareButton(settingsDialog, 'friends+', 'Friends+'));
 
   await waitFor(() => {
-    expect(screen.getByRole('button', { name: /share token/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /channel-1 \/ Friends\+/i })).toBeInTheDocument();
   });
 });
 
 test('share token smart link previews before import and joins only after confirmation', async () => {
   const user = userEvent.setup();
+  const ownerPubkey = 'f'.repeat(64);
+  const inviteToken = JSON.stringify({
+    envelope: {
+      kind: 'channel-invite',
+      pubkey: ownerPubkey,
+      content: JSON.stringify({
+        channel_id: 'channel-imported',
+        topic_id: 'kukuri:topic:private-imported',
+        channel_label: 'Imported',
+        owner_pubkey: ownerPubkey,
+        epoch_id: 'epoch-imported-1',
+        namespace_secret_hex: 'a'.repeat(64),
+        expires_at: null,
+      }),
+    },
+  });
   const api = createDesktopMockApi({
     seedPosts: {
       'kukuri:topic:demo': [
@@ -2533,7 +2572,7 @@ test('share token smart link previews before import and joins only after confirm
           mutual: false,
           friend_of_friend: false,
           object_kind: 'post',
-          content: 'invite:kukuri:topic:private-imported:channel-imported',
+          content: inviteToken,
           content_status: 'Available',
           attachments: [],
           created_at: 1,
@@ -2548,8 +2587,8 @@ test('share token smart link previews before import and joins only after confirm
       channel_id: 'channel-imported',
       topic_id: 'kukuri:topic:private-imported',
       channel_label: 'Imported',
-      inviter_pubkey: 'f'.repeat(64),
-      owner_pubkey: 'f'.repeat(64),
+      inviter_pubkey: ownerPubkey,
+      owner_pubkey: ownerPubkey,
       epoch_id: 'epoch-imported-1',
       expires_at: null,
       namespace_secret_hex: 'a'.repeat(64),
@@ -2560,7 +2599,9 @@ test('share token smart link previews before import and joins only after confirm
 
   render(<App api={api} />);
 
-  const tokenChip = await screen.findByText('Invite token', { selector: 'button.smart-reference-chip' });
+  const tokenChip = await screen.findByText('Imported / Invite only', {
+    selector: 'button.smart-reference-chip',
+  });
   await user.click(tokenChip);
 
   const dialog = await screen.findByRole('dialog', { name: 'Preview Access' });
@@ -2568,7 +2609,13 @@ test('share token smart link previews before import and joins only after confirm
     expect(previewSpy).toHaveBeenCalledTimes(1);
     expect(importSpy).not.toHaveBeenCalled();
   });
-  expect(within(dialog).getByText(/channel-imported/)).toBeInTheDocument();
+  expect(within(dialog).getByText('Imported')).toBeInTheDocument();
+  expect(within(dialog).queryByText(/channel-imported/)).not.toBeInTheDocument();
+  expect(within(dialog).queryByText(/epoch-imported-1/)).not.toBeInTheDocument();
+  expect(within(dialog).getByText('Imported').closest('div')).toHaveAttribute(
+    'title',
+    'channel-imported'
+  );
 
   await user.click(within(dialog).getByRole('button', { name: 'Import / Join' }));
 
@@ -2712,7 +2759,16 @@ test('share button uses the selected channel label and audience with a trailing 
   await user.selectOptions(within(channelDialog).getByLabelText('Audience'), 'friend_plus');
   await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
 
-  const shareButton = await within(channelDialog).findByRole('button', {
+  await waitFor(() => {
+    expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1');
+  });
+  expect(
+    within(channelDialog).queryByRole('button', { name: 'friends+ / Friends+' })
+  ).not.toBeInTheDocument();
+  await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
+
+  const settingsDialog = await openChannelSettings(user, 'friends+');
+  const shareButton = await within(settingsDialog).findByRole('button', {
     name: 'friends+ / Friends+',
   });
   expect(shareButton).toHaveTextContent('friends+ / Friends+');

--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -96,6 +96,7 @@ export function DesktopShellPage({
   } = useDesktopShellStore();
   const [composeDialogOpen, setComposeDialogOpen] = useState(false);
   const [channelDialogOpen, setChannelDialogOpen] = useState(false);
+  const [channelSettingsDialogOpen, setChannelSettingsDialogOpen] = useState(false);
   const [liveCreateDialogOpen, setLiveCreateDialogOpen] = useState(false);
   const [gameCreateDialogOpen, setGameCreateDialogOpen] = useState(false);
   const [profileAvatarPreviewUrl, setProfileAvatarPreviewUrl] = useState<string | null>(null);
@@ -107,7 +108,6 @@ export function DesktopShellPage({
   const [sharePreviewData, setSharePreviewData] = useState<ChannelAccessTokenPreview | null>(null);
   const [sharePreviewLoading, setSharePreviewLoading] = useState(false);
   const [sharePreviewError, setSharePreviewError] = useState<string | null>(null);
-  const [sharePreviewShowRaw, setSharePreviewShowRaw] = useState(false);
   const [shareImportPending, setShareImportPending] = useState(false);
   const [clipboardToastId, setClipboardToastId] = useState(0);
   const previousPrimarySectionRef = useRef(shellChromeState.activePrimarySection);
@@ -202,6 +202,8 @@ export function DesktopShellPage({
   const setTimelineScopeByTopic = useDesktopShellFieldSetter('timelineScopeByTopic');
   const setSelectedLiveSessionId = useDesktopShellFieldSetter('selectedLiveSessionId');
   const setSelectedGameRoomId = useDesktopShellFieldSetter('selectedGameRoomId');
+  const setInviteOutput = useDesktopShellFieldSetter('inviteOutput');
+  const setChannelError = useDesktopShellFieldSetter('channelError');
   const draftSequenceRef = useRef(0);
   const mediaFetchAttemptRef = useRef(new Map<string, number>());
   const remoteObjectUrlRef = useRef(new Map<string, string>());
@@ -460,7 +462,6 @@ export function DesktopShellPage({
       setSharePreviewToken(token);
       setSharePreviewData(null);
       setSharePreviewError(null);
-      setSharePreviewShowRaw(false);
       setSharePreviewLoading(true);
       try {
         const preview = await api.previewChannelAccessToken(token);
@@ -722,6 +723,12 @@ export function DesktopShellPage({
       onSelectChannel={(topic, channelId) => {
         handleSelectPrivateChannel(topic, channelId);
       }}
+      onOpenChannelSettings={(topic, channelId) => {
+        setInviteOutput(null);
+        setChannelError(null);
+        handleSelectPrivateChannel(topic, channelId);
+        setChannelSettingsDialogOpen(true);
+      }}
       onRemoveTopic={(topic) => void handleRemoveTopic(topic)}
       onCopyTopicLink={(topic) => handleCopyInternalLink(buildTopicLink(topic))}
     />
@@ -928,6 +935,8 @@ export function DesktopShellPage({
         handleProfileAvatarFile={handleProfileAvatarFile}
         channelDialogOpen={channelDialogOpen}
         setChannelDialogOpen={setChannelDialogOpen}
+        channelSettingsDialogOpen={channelSettingsDialogOpen}
+        setChannelSettingsDialogOpen={setChannelSettingsDialogOpen}
         sharePreviewOpen={sharePreviewOpen}
         setSharePreviewOpen={setSharePreviewOpen}
         sharePreviewToken={sharePreviewToken}
@@ -937,13 +946,10 @@ export function DesktopShellPage({
         sharePreviewLoading={sharePreviewLoading}
         sharePreviewError={sharePreviewError}
         setSharePreviewError={setSharePreviewError}
-        sharePreviewShowRaw={sharePreviewShowRaw}
-        setSharePreviewShowRaw={setSharePreviewShowRaw}
         shareImportPending={shareImportPending}
         handleConfirmShareImport={handleConfirmShareImport}
         handleCreatePrivateChannel={handleCreatePrivateChannel}
         handleJoinChannelAccess={handleJoinChannelAccess}
-        handleSelectPrivateChannel={handleSelectPrivateChannel}
         handleShareChannelAccess={handleShareChannelAccess}
         handleActivateReference={handleActivateReference}
         handleCopyInternalLink={handleCopyInternalLink}

--- a/apps/desktop/src/shell/page/DesktopShellOverlays.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellOverlays.tsx
@@ -3,7 +3,10 @@ import type { ChangeEvent, Dispatch, FormEvent, SetStateAction } from 'react';
 import { Plus } from 'lucide-react';
 
 import { ComposerPanel } from '@/components/core/ComposerPanel';
-import { PrivateChannelPanel } from '@/components/extended/PrivateChannelPanel';
+import {
+  PrivateChannelPanel,
+  PrivateChannelSettingsPanel,
+} from '@/components/extended/PrivateChannelPanel';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -36,7 +39,6 @@ type DesktopShellOverlaysProps = {
     | 'activeComposeAudienceLabel'
     | 'activeChannelPanelState'
     | 'channelAudienceOptions'
-    | 'privateChannelListItems'
     | 'composerDraftViews'
     | 'composerSourcePreview'
     | 'floatingActionLabel'
@@ -50,6 +52,8 @@ type DesktopShellOverlaysProps = {
   handleProfileAvatarFile: (file: File) => Promise<void>;
   channelDialogOpen: boolean;
   setChannelDialogOpen: Dispatch<SetStateAction<boolean>>;
+  channelSettingsDialogOpen: boolean;
+  setChannelSettingsDialogOpen: Dispatch<SetStateAction<boolean>>;
   sharePreviewOpen: boolean;
   setSharePreviewOpen: Dispatch<SetStateAction<boolean>>;
   sharePreviewToken: string | null;
@@ -59,13 +63,10 @@ type DesktopShellOverlaysProps = {
   sharePreviewLoading: boolean;
   sharePreviewError: string | null;
   setSharePreviewError: Dispatch<SetStateAction<string | null>>;
-  sharePreviewShowRaw: boolean;
-  setSharePreviewShowRaw: Dispatch<SetStateAction<boolean>>;
   shareImportPending: boolean;
   handleConfirmShareImport: () => Promise<void>;
   handleCreatePrivateChannel: (event: FormEvent<HTMLFormElement>) => Promise<void>;
   handleJoinChannelAccess: (event: FormEvent<HTMLFormElement>) => Promise<void>;
-  handleSelectPrivateChannel: (topicId: string, channelId: string) => void;
   handleShareChannelAccess: () => Promise<void>;
   handleActivateReference: (reference: InternalSmartReference) => Promise<void>;
   handleCopyInternalLink: (link: string) => void;
@@ -97,6 +98,8 @@ export function DesktopShellOverlays({
   handleProfileAvatarFile,
   channelDialogOpen,
   setChannelDialogOpen,
+  channelSettingsDialogOpen,
+  setChannelSettingsDialogOpen,
   sharePreviewOpen,
   setSharePreviewOpen,
   sharePreviewToken,
@@ -106,13 +109,10 @@ export function DesktopShellOverlays({
   sharePreviewLoading,
   sharePreviewError,
   setSharePreviewError,
-  sharePreviewShowRaw,
-  setSharePreviewShowRaw,
   shareImportPending,
   handleConfirmShareImport,
   handleCreatePrivateChannel,
   handleJoinChannelAccess,
-  handleSelectPrivateChannel,
   handleShareChannelAccess,
   handleActivateReference,
   handleCopyInternalLink,
@@ -136,7 +136,6 @@ export function DesktopShellOverlays({
     activeComposeAudienceLabel,
     activeChannelPanelState,
     channelAudienceOptions,
-    privateChannelListItems,
     composerDraftViews,
     composerSourcePreview,
     floatingActionLabel,
@@ -159,12 +158,15 @@ export function DesktopShellOverlays({
     inviteOutput,
     inviteOutputLabel,
     inviteTokenInput,
+    knownAuthorsByPubkey,
+    localProfile,
     liveCreatePending,
     liveDescription,
     liveError,
     liveTitle,
     replyTarget,
     repostTarget,
+    syncStatus,
   } = useDesktopShellStore();
   const setChannelLabelInput = useDesktopShellFieldSetter('channelLabelInput');
   const setChannelAudienceInput = useDesktopShellFieldSetter('channelAudienceInput');
@@ -175,6 +177,28 @@ export function DesktopShellOverlays({
   const setGameTitle = useDesktopShellFieldSetter('gameTitle');
   const setGameDescription = useDesktopShellFieldSetter('gameDescription');
   const setGameParticipantsInput = useDesktopShellFieldSetter('gameParticipantsInput');
+  const previewOwnerProfile =
+    sharePreviewData?.owner_pubkey === syncStatus.local_author_pubkey
+      ? localProfile
+      : sharePreviewData
+        ? knownAuthorsByPubkey[sharePreviewData.owner_pubkey] ?? null
+        : null;
+  const previewOwnerLabel = sharePreviewData
+    ? authorDisplayLabel(
+        sharePreviewData.owner_pubkey,
+        previewOwnerProfile?.display_name,
+        previewOwnerProfile?.name
+      )
+    : null;
+  const previewAudienceLabel = sharePreviewData
+    ? t(
+        sharePreviewData.kind === 'invite'
+          ? 'channels:audienceOptions.invite_only'
+          : sharePreviewData.kind === 'grant'
+            ? 'channels:audienceOptions.friend_only'
+            : 'channels:audienceOptions.friend_plus'
+      )
+    : null;
 
   return (
     <>
@@ -202,7 +226,7 @@ export function DesktopShellOverlays({
       <Dialog open={channelDialogOpen} onOpenChange={setChannelDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t('channels:title')}</DialogTitle>
+            <DialogTitle>{t('channels:createDialogTitle')}</DialogTitle>
             <DialogDescription>{activeTopic}</DialogDescription>
           </DialogHeader>
           <DialogBody>
@@ -214,20 +238,41 @@ export function DesktopShellOverlays({
               channelAudience={channelAudienceInput}
               channelAudienceOptions={channelAudienceOptions}
               inviteTokenInput={inviteTokenInput}
-              inviteOutput={inviteOutput}
-              inviteOutputLabel={inviteOutputLabel}
-              channels={privateChannelListItems}
-              selectedChannel={activePrivateChannel}
               onChannelLabelChange={setChannelLabelInput}
               onChannelAudienceChange={setChannelAudienceInput}
               onInviteTokenChange={setInviteTokenInput}
               onCreateChannel={(event) => void handleCreatePrivateChannel(event)}
               onJoin={(event) => void handleJoinChannelAccess(event)}
-              onSelectChannel={(channelId) => handleSelectPrivateChannel(activeTopic, channelId)}
-              onShare={() => void handleShareChannelAccess()}
-              onActivateReference={(reference) => void handleActivateReference(reference)}
-              onCopyInviteOutput={handleCopyInternalLink}
             />
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={channelSettingsDialogOpen} onOpenChange={setChannelSettingsDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('channels:settings.title')}</DialogTitle>
+            <DialogDescription>
+              {activePrivateChannel
+                ? `${activePrivateChannel.label} / ${t(`channels:audienceOptions.${activePrivateChannel.audience_kind}`)}`
+                : activeTopic}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            {activePrivateChannel ? (
+              <PrivateChannelSettingsPanel
+                error={channelError ?? activeChannelPanelState.error}
+                pendingAction={channelActionPending}
+                channel={activePrivateChannel}
+                inviteOutput={inviteOutput}
+                inviteOutputLabel={inviteOutputLabel}
+                onShare={() => void handleShareChannelAccess()}
+                onActivateReference={(reference) => void handleActivateReference(reference)}
+                onCopyInviteOutput={handleCopyInternalLink}
+              />
+            ) : (
+              <Notice>{t('channels:selectChannelNotice')}</Notice>
+            )}
           </DialogBody>
         </DialogContent>
       </Dialog>
@@ -237,7 +282,6 @@ export function DesktopShellOverlays({
         onOpenChange={(open) => {
           setSharePreviewOpen(open);
           if (!open) {
-            setSharePreviewShowRaw(false);
             setSharePreviewError(null);
             setSharePreviewData(null);
             setSharePreviewToken(null);
@@ -247,56 +291,29 @@ export function DesktopShellOverlays({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t('channels:previewDialog.title')}</DialogTitle>
-            <DialogDescription>{t('channels:previewDialog.description')}</DialogDescription>
           </DialogHeader>
           <DialogBody>
             {sharePreviewLoading ? <Notice>{t('channels:loading')}</Notice> : null}
             {sharePreviewError ? <Notice tone='destructive'>{sharePreviewError}</Notice> : null}
             {sharePreviewData ? (
-              <>
-                <div className='topic-diagnostic topic-diagnostic-secondary'>
-                  <span>
-                    {t('common:labels.policy')}:{' '}
-                    {t(`channels:previewDialog.tokenKinds.${sharePreviewData.kind}`)}
-                  </span>
-                  <span>
-                    {t('common:labels.epoch')}: {sharePreviewData.epoch_id}
-                  </span>
+              <dl className='access-preview-list'>
+                <div title={sharePreviewData.owner_pubkey}>
+                  <dt>{t('common:labels.owner')}</dt>
+                  <dd>{previewOwnerLabel}</dd>
                 </div>
-                <div className='topic-diagnostic topic-diagnostic-secondary'>
-                  <span>
-                    {t('common:labels.owner')}: {sharePreviewData.owner_pubkey}
-                  </span>
-                  <span>
-                    {t('common:labels.sourceTopic')}: {sharePreviewData.topic_id}
-                  </span>
+                <div title={sharePreviewData.topic_id}>
+                  <dt>{t('common:labels.sourceTopic')}</dt>
+                  <dd>{sharePreviewData.topic_id}</dd>
                 </div>
-                <div className='topic-diagnostic topic-diagnostic-secondary'>
-                  <span>
-                    {t('channels:previewDialog.channel')}: {sharePreviewData.channel_label}
-                  </span>
-                  <span>
-                    {t('channels:previewDialog.channelId')}: {sharePreviewData.channel_id}
-                  </span>
+                <div title={sharePreviewData.channel_id}>
+                  <dt>{t('channels:previewDialog.channel')}</dt>
+                  <dd>{sharePreviewData.channel_label}</dd>
                 </div>
-                {sharePreviewData.inviter_pubkey ? (
-                  <div className='topic-diagnostic topic-diagnostic-secondary'>
-                    <span>
-                      {t('channels:previewDialog.inviter')}: {sharePreviewData.inviter_pubkey}
-                    </span>
-                  </div>
-                ) : null}
-                {sharePreviewData.sponsor_pubkey ? (
-                  <div className='topic-diagnostic topic-diagnostic-secondary'>
-                    <span>
-                      {t('channels:previewDialog.sponsor')}: {sharePreviewData.sponsor_pubkey}
-                    </span>
-                  </div>
-                ) : null}
-              </>
-            ) : null}
-            {sharePreviewShowRaw && sharePreviewToken ? (
-              <code className='extended-inline-code'>{sharePreviewToken}</code>
+                <div title={`${sharePreviewData.kind} / ${sharePreviewData.epoch_id}`}>
+                  <dt>{t('common:labels.audience')}</dt>
+                  <dd>{previewAudienceLabel}</dd>
+                </div>
+              </dl>
             ) : null}
             <div className='ui-dialog-footer'>
               {sharePreviewToken ? (
@@ -306,17 +323,6 @@ export function DesktopShellOverlays({
                   onClick={() => handleCopyInternalLink(sharePreviewToken)}
                 >
                   {t('channels:previewDialog.copyToken')}
-                </Button>
-              ) : null}
-              {sharePreviewToken ? (
-                <Button
-                  variant='secondary'
-                  type='button'
-                  onClick={() => setSharePreviewShowRaw((current) => !current)}
-                >
-                  {sharePreviewShowRaw
-                    ? t('channels:previewDialog.hideRaw')
-                    : t('channels:previewDialog.showRaw')}
                 </Button>
               ) : null}
               <Button

--- a/apps/desktop/src/shell/routes.test.tsx
+++ b/apps/desktop/src/shell/routes.test.tsx
@@ -40,7 +40,7 @@ function getDetailPane(name: 'Thread' | 'Author') {
 
 async function openChannelManager(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('button', { name: 'Private Channels' }));
-  return await screen.findByRole('dialog', { name: 'Private Channels' });
+  return await screen.findByRole('dialog', { name: 'Create Private Channel' });
 }
 
 test('invalid hash routes fall back to the active public timeline and normalize the URL', async () => {

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -1147,6 +1147,15 @@
   gap: 1rem;
 }
 
+.private-channel-editor-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.private-channel-editor-block {
+  margin-top: 0;
+}
+
 .extended-channel-grid {
   display: grid;
   gap: 1rem;
@@ -1171,6 +1180,30 @@
   margin-top: 0.65rem;
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+.access-preview-list {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.access-preview-list div {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.access-preview-list dt {
+  color: var(--muted-foreground-soft);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.access-preview-list dd {
+  margin: 0;
+  color: var(--foreground-strong);
+  overflow-wrap: anywhere;
 }
 
 .shell-pane-header {
@@ -1433,6 +1466,13 @@
   gap: 0.4rem;
 }
 
+.shell-nav .topic-subitem-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.35rem;
+  align-items: stretch;
+}
+
 .shell-nav .topic-subitem {
   width: 100%;
   display: grid;
@@ -1442,6 +1482,24 @@
   border-radius: 14px;
   background: var(--surface-panel-soft);
   text-align: left;
+}
+
+.shell-nav .topic-channel-settings {
+  width: 2.35rem;
+  border: 1px solid transparent;
+  border-radius: 14px;
+  color: inherit;
+  background: var(--surface-panel-soft);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shell-nav .topic-channel-settings:hover,
+.shell-nav .topic-channel-settings:focus-visible {
+  border-color: var(--border-accent);
+  background: var(--surface-active);
 }
 
 .shell-nav .topic-subitem small {

--- a/apps/desktop/tests/playwright/extended-flow.spec.ts
+++ b/apps/desktop/tests/playwright/extended-flow.spec.ts
@@ -1,11 +1,18 @@
 import { expect, test, type Page } from '@playwright/test';
 
 async function openChannelManager(page: Page) {
-  const dialog = page.getByRole('dialog', { name: 'Channels' });
+  const dialog = page.getByRole('dialog', { name: 'Create Private Channel' });
   if (await dialog.isVisible().catch(() => false)) {
     return dialog;
   }
   await page.getByRole('button', { name: 'Channels' }).click();
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+async function openChannelSettings(page: Page, channelLabel: string) {
+  await page.getByRole('button', { name: `Open ${channelLabel} channel settings` }).click();
+  const dialog = page.getByRole('dialog', { name: 'Channel Settings' });
   await expect(dialog).toBeVisible();
   return dialog;
 }
@@ -27,17 +34,25 @@ test('browser mock shell can run profile, private channel, live, and game flows'
   await channelDialog.getByPlaceholder('core contributors').fill('Core Contributors');
   await channelDialog.getByRole('button', { name: 'Create Channel' }).click();
   await expect(page).toHaveURL(/#\/timeline\?topic=.*&channel=channel-1/);
-  await expect(channelDialog.getByRole('heading', { name: 'Core Contributors' })).toBeVisible();
-  await channelDialog
+  await page.keyboard.press('Escape');
+
+  const channelSettingsDialog = await openChannelSettings(page, 'Core Contributors');
+  await channelSettingsDialog
     .getByRole('button', { name: /Core Contributors\s*\/\s*Invite only/i })
     .click();
-  await expect(channelDialog.getByRole('button', { name: 'Invite token' })).toBeVisible();
+  await expect(
+    channelSettingsDialog.getByRole('button', { name: /channel-1\s*\/\s*Invite only/i })
+  ).toBeVisible();
+  await page.keyboard.press('Escape');
 
-  await channelDialog
+  const joinDialog = await openChannelManager(page);
+  await joinDialog
     .getByPlaceholder('paste private channel invite, friend grant, or friends+ share')
     .fill('invite-token');
-  await channelDialog.getByRole('button', { name: 'Join' }).click();
-  await expect(channelDialog.getByText(/Imported/i).first()).toBeVisible();
+  await joinDialog.getByRole('button', { name: 'Join' }).click();
+  await expect(page).toHaveURL(
+    /#\/timeline\?topic=kukuri%3Atopic%3Ademo&channel=channel-imported/
+  );
   await page.keyboard.press('Escape');
 
   await page.goto('/#/live');

--- a/apps/desktop/tests/playwright/hash-routing.spec.ts
+++ b/apps/desktop/tests/playwright/hash-routing.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
 async function openChannelManager(page: Page) {
-  const dialog = page.getByRole('dialog', { name: 'Channels' });
+  const dialog = page.getByRole('dialog', { name: 'Create Private Channel' });
   if (await dialog.isVisible().catch(() => false)) {
     return dialog;
   }


### PR DESCRIPTION
﻿## Summary
- Split private channel UI into a create/join dialog and per-channel settings dialog.
- Add sidebar channel settings buttons and move sharing/management actions into the selected channel settings flow.
- Render access tokens as channel/audience chips when metadata is available, and simplify access preview by hiding raw IDs behind tooltips.
- Update i18n, stories, Vitest coverage, and Playwright flows for the new UI structure.

## Validation
- `cd apps/desktop && npx pnpm@10.16.1 test`
- `cargo xtask desktop-ui-check`
