### PR TITLE
[codex] Fix community node Rust builder version

### DIFF
--- a/docker/cn/Dockerfile
+++ b/docker/cn/Dockerfile
@@ -1,10 +1,11 @@
-FROM rust:1.89-bookworm AS builder
+ARG RUST_VERSION=1.91.0
+FROM rust:${RUST_VERSION}-bookworm AS builder
 
 WORKDIR /workspace
 
 ARG TARGET_PACKAGE
 
-COPY Cargo.toml Cargo.lock ./
+COPY rust-toolchain.toml Cargo.toml Cargo.lock ./
 COPY xtask ./xtask
 COPY crates ./crates
 


### PR DESCRIPTION
## Summary

- Update the community-node Docker builder image from Rust 1.89 to Rust 1.91.0.
- Copy `rust-toolchain.toml` into the Docker build context so container builds see the workspace toolchain pin.

## Root Cause

The root workspace is pinned to Rust 1.91.0, but `docker/cn/Dockerfile` still used `rust:1.89-bookworm`. Community-node compose builds therefore compiled with an older rustc than the workspace requires.

## Validation

- `cargo xtask cn-check`
- `docker compose -f docker-compose.community-node.yml build cn-migrate`