### PR TITLE
[codex] Improve metaverse room UX

### DIFF
--- a/.github/workflows/kukuri-fast.yml
+++ b/.github/workflows/kukuri-fast.yml
@@ -424,6 +424,9 @@ jobs:
           shared-key: kukuri-fast-${{ runner.os }}-${{ github.job }}
 
       - name: Community-node connectivity scenario
+        env:
+          CN_POSTGRES_PORT: "55433"
+          COMMUNITY_NODE_DATABASE_URL: postgres://cn:cn_password@127.0.0.1:55433/cn
         run: cargo xtask scenario community_node_public_connectivity
 
       - name: Upload community-node artifacts

--- a/.github/workflows/kukuri-nightly.yml
+++ b/.github/workflows/kukuri-nightly.yml
@@ -395,6 +395,9 @@ jobs:
           shared-key: kukuri-nightly-${{ runner.os }}-${{ github.job }}
 
       - name: Community-node connectivity scenario
+        env:
+          CN_POSTGRES_PORT: "55433"
+          COMMUNITY_NODE_DATABASE_URL: postgres://cn:cn_password@127.0.0.1:55433/cn
         run: cargo xtask scenario community_node_public_connectivity
 
       - name: Upload community-node artifacts
@@ -449,6 +452,9 @@ jobs:
           shared-key: kukuri-nightly-${{ runner.os }}-${{ github.job }}
 
       - name: Community-node multi-device scenario
+        env:
+          CN_POSTGRES_PORT: "55434"
+          COMMUNITY_NODE_DATABASE_URL: postgres://cn:cn_password@127.0.0.1:55434/cn
         run: cargo xtask scenario community_node_multi_device_connectivity
 
       - name: Upload multi-device artifacts

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,6 +23,8 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "class-variance-authority": "^0.7.1",

--- a/apps/desktop/pnpm-lock.yaml
+++ b/apps/desktop/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-three/drei':
+        specifier: ^10.7.7
+        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.184.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0)
+      '@react-three/fiber':
+        specifier: ^9.6.1
+        version: 9.6.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0)
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
@@ -557,6 +563,14 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@mediapipe/tasks-vision@0.10.17':
+    resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
+
+  '@monogrid/gainmap-js@3.4.0':
+    resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -900,6 +914,42 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@react-three/drei@10.7.7':
+    resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
+    peerDependencies:
+      '@react-three/fiber': ^9.0.0
+      react: ^19
+      react-dom: ^19
+      three: '>=0.159'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  '@react-three/fiber@9.6.1':
+    resolution: {integrity: sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==}
@@ -1303,6 +1353,9 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
+  '@types/draco3d@1.4.10':
+    resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -1318,10 +1371,18 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -1396,6 +1457,14 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.0':
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@use-gesture/core@10.3.1':
+    resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
+
+  '@use-gesture/react@10.3.1':
+    resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
+    peerDependencies:
+      react: '>= 16.8.0'
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -1502,6 +1571,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.10:
     resolution: {integrity: sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==}
     engines: {node: '>=6.0.0'}
@@ -1519,9 +1591,18 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  camera-controls@3.1.2:
+    resolution: {integrity: sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==}
+    engines: {node: '>=22.0.0', npm: '>=10.5.1'}
+    peerDependencies:
+      three: '>=0.126.1'
 
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
@@ -1551,6 +1632,11 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1605,6 +1691,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-gpu@5.0.70:
+    resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1621,6 +1710,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  draco3d@1.5.7:
+    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
 
   electron-to-chromium@1.5.321:
     resolution: {integrity: sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==}
@@ -1739,6 +1831,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.6.10:
+    resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
+
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
@@ -1790,6 +1885,9 @@ packages:
     resolution: {integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==}
     engines: {node: '>=18'}
 
+  glsl-noise@0.0.0:
+    resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1802,6 +1900,9 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -1821,6 +1922,9 @@ packages:
       typescript:
         optional: true
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1828,6 +1932,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -1862,12 +1969,20 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1910,6 +2025,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2004,11 +2122,22 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  maath@0.10.8:
+    resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
+    peerDependencies:
+      '@types/three': '>=0.134.0'
+      three: '>=0.134.0'
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  meshline@3.3.1:
+    resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
+    peerDependencies:
+      three: '>=0.137'
 
   meshoptimizer@1.1.1:
     resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
@@ -2111,6 +2240,9 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@1.0.2:
+    resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2118,6 +2250,9 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  promise-worker-transferable@1.0.4:
+    resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2203,6 +2338,15 @@ packages:
       '@types/react':
         optional: true
 
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -2274,6 +2418,15 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stats-gl@2.4.2:
+    resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
+    peerDependencies:
+      '@types/three': '*'
+      three: '*'
+
+  stats.js@0.17.0:
+    resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
@@ -2302,6 +2455,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -2314,6 +2472,16 @@ packages:
   tapable@2.3.1:
     resolution: {integrity: sha512-b+u3CEM6FjDHru+nhUSjDofpWSBp2rINziJWgApm72wwGasQ/wKXftZe4tI2Y5HPv6OpzXSZHOFq87H4vfsgsw==}
     engines: {node: '>=6'}
+
+  three-mesh-bvh@0.8.3:
+    resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
+  three-stdlib@2.36.1:
+    resolution: {integrity: sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==}
+    peerDependencies:
+      three: '>=0.128.0'
 
   three@0.184.0:
     resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
@@ -2363,6 +2531,19 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  troika-three-text@0.52.4:
+    resolution: {integrity: sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-three-utils@0.52.4:
+    resolution: {integrity: sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-worker-utils@0.52.0:
+    resolution: {integrity: sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2379,6 +2560,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tunnel-rat@0.1.2:
+    resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2440,6 +2624,10 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
 
   vite@8.0.9:
     resolution: {integrity: sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==}
@@ -2533,6 +2721,12 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  webgl-constants@1.1.1:
+    resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
+
+  webgl-sdf-generator@1.1.1:
+    resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -2600,6 +2794,21 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
@@ -2966,6 +3175,13 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.5
 
+  '@mediapipe/tasks-vision@0.10.17': {}
+
+  '@monogrid/gainmap-js@3.4.0(three@0.184.0)':
+    dependencies:
+      promise-worker-transferable: 1.0.4
+      three: 0.184.0
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -3293,6 +3509,59 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.184.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mediapipe/tasks-vision': 0.10.17
+      '@monogrid/gainmap-js': 3.4.0(three@0.184.0)
+      '@react-three/fiber': 9.6.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0)
+      '@use-gesture/react': 10.3.1(react@19.2.5)
+      camera-controls: 3.1.2(three@0.184.0)
+      cross-env: 7.0.3
+      detect-gpu: 5.0.70
+      glsl-noise: 0.0.0
+      hls.js: 1.6.16
+      maath: 0.10.8(@types/three@0.184.1)(three@0.184.0)
+      meshline: 3.3.1(three@0.184.0)
+      react: 19.2.5
+      stats-gl: 2.4.2(@types/three@0.184.1)(three@0.184.0)
+      stats.js: 0.17.0
+      suspend-react: 0.1.3(react@19.2.5)
+      three: 0.184.0
+      three-mesh-bvh: 0.8.3(three@0.184.0)
+      three-stdlib: 2.36.1(three@0.184.0)
+      troika-three-text: 0.52.4(three@0.184.0)
+      tunnel-rat: 0.1.2(@types/react@19.2.14)(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+      utility-types: 3.11.0
+      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/three'
+      - immer
+
+  '@react-three/fiber@9.6.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-use-measure: 2.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.5)
+      three: 0.184.0
+      use-sync-external-store: 1.6.0(react@19.2.5)
+      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
 
   '@rolldown/binding-android-arm64@1.0.0-rc.16':
     optional: true
@@ -3640,6 +3909,8 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
+  '@types/draco3d@1.4.10': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -3652,7 +3923,13 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/offscreencanvas@2019.7.3': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react-reconciler@0.28.9(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
 
@@ -3766,6 +4043,13 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
+  '@use-gesture/core@10.3.1': {}
+
+  '@use-gesture/react@10.3.1(react@19.2.5)':
+    dependencies:
+      '@use-gesture/core': 10.3.1
+      react: 19.2.5
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -3873,6 +4157,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.10: {}
 
   bidi-js@1.0.3:
@@ -3891,9 +4177,18 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  camera-controls@3.1.2(three@0.184.0):
+    dependencies:
+      three: 0.184.0
 
   caniuse-lite@1.0.30001780: {}
 
@@ -3918,6 +4213,10 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3962,6 +4261,10 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-gpu@5.0.70:
+    dependencies:
+      webgl-constants: 1.1.1
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
@@ -3973,6 +4276,8 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  draco3d@1.5.7: {}
 
   electron-to-chromium@1.5.321: {}
 
@@ -4125,6 +4430,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.6.10: {}
+
   fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
@@ -4167,6 +4474,8 @@ snapshots:
 
   globals@17.5.0: {}
 
+  glsl-noise@0.0.0: {}
+
   graceful-fs@4.2.11: {}
 
   hasown@2.0.2:
@@ -4178,6 +4487,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hls.js@1.6.16: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -4199,9 +4510,13 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immediate@3.0.6: {}
 
   imurmurhash@0.1.4: {}
 
@@ -4225,11 +4540,20 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@2.2.2: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
+
+  its-fine@2.0.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.14)
+      react: 19.2.5
+    transitivePeerDependencies:
+      - '@types/react'
 
   jiti@2.6.1: {}
 
@@ -4279,6 +4603,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4347,11 +4675,20 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  maath@0.10.8(@types/three@0.184.1)(three@0.184.0):
+    dependencies:
+      '@types/three': 0.184.1
+      three: 0.184.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   mdn-data@2.27.1: {}
+
+  meshline@3.3.1(three@0.184.0):
+    dependencies:
+      three: 0.184.0
 
   meshoptimizer@1.1.1: {}
 
@@ -4438,6 +4775,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@1.0.2: {}
+
   prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
@@ -4445,6 +4784,11 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  promise-worker-transferable@1.0.4:
+    dependencies:
+      is-promise: 2.2.2
+      lie: 3.3.0
 
   punycode@2.3.1: {}
 
@@ -4526,6 +4870,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  react-use-measure@2.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+
   react@19.2.5: {}
 
   recast@0.23.11:
@@ -4598,6 +4948,13 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stats-gl@2.4.2(@types/three@0.184.1)(three@0.184.0):
+    dependencies:
+      '@types/three': 0.184.1
+      three: 0.184.0
+
+  stats.js@0.17.0: {}
+
   std-env@4.0.0: {}
 
   storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
@@ -4632,6 +4989,10 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  suspend-react@0.1.3(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
   symbol-tree@3.2.4: {}
 
   tailwind-merge@3.5.0: {}
@@ -4639,6 +5000,20 @@ snapshots:
   tailwindcss@4.2.4: {}
 
   tapable@2.3.1: {}
+
+  three-mesh-bvh@0.8.3(three@0.184.0):
+    dependencies:
+      three: 0.184.0
+
+  three-stdlib@2.36.1(three@0.184.0):
+    dependencies:
+      '@types/draco3d': 1.4.10
+      '@types/offscreencanvas': 2019.7.3
+      '@types/webxr': 0.5.24
+      draco3d: 1.5.7
+      fflate: 0.6.10
+      potpack: 1.0.2
+      three: 0.184.0
 
   three@0.184.0: {}
 
@@ -4678,6 +5053,20 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  troika-three-text@0.52.4(three@0.184.0):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.184.0
+      troika-three-utils: 0.52.4(three@0.184.0)
+      troika-worker-utils: 0.52.0
+      webgl-sdf-generator: 1.1.1
+
+  troika-three-utils@0.52.4(three@0.184.0):
+    dependencies:
+      three: 0.184.0
+
+  troika-worker-utils@0.52.0: {}
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -4691,6 +5080,14 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tunnel-rat@0.1.2(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
 
   type-check@0.4.0:
     dependencies:
@@ -4749,6 +5146,8 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  utility-types@3.11.0: {}
+
   vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1):
     dependencies:
       lightningcss: 1.32.0
@@ -4796,6 +5195,10 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  webgl-constants@1.1.1: {}
+
+  webgl-sdf-generator@1.1.1: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -4840,6 +5243,13 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5
 
   zustand@5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
     optionalDependencies:

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
+import { useState, type ReactNode } from 'react';
 
 import { createDesktopMockApi } from '@/mocks/desktopApiMock';
 import type {
@@ -27,6 +28,7 @@ vi.mock('./MetaverseScene', () => ({
       sentAt: number;
     }) => void;
     onAvatarAssetStatus: (status: 'loading' | 'sample-vrm' | 'blob-vrm' | 'fallback-primitive') => void;
+    hud: ReactNode;
   }) => (
     <div aria-label='Metaverse room viewport'>
       <button
@@ -49,6 +51,7 @@ vi.mock('./MetaverseScene', () => ({
         Mark animation fallback
       </button>
       <span>{props.sharedObject.object_id}</span>
+      {props.hud}
     </div>
   ),
 }));
@@ -120,44 +123,195 @@ function avatarEvent(peerId: string, animation: string | null, seq: number): Met
   };
 }
 
-function renderPanel(api: DesktopApi, syncStatus?: SyncStatus) {
-  return render(
+type RenderPanelOptions = {
+  rooms?: GameRoomView[];
+  syncStatus?: SyncStatus;
+  onRefresh?: () => Promise<void>;
+};
+
+function createSyncStatus(): SyncStatus {
+  return {
+    connected: true,
+    delivery_state: 'Live',
+    peer_count: 1,
+    pending_events: 0,
+    status_detail: 'connected',
+    configured_peers: [],
+    subscribed_topics: ['kukuri:topic:demo'],
+    topic_diagnostics: [],
+    local_author_pubkey: 'f'.repeat(64),
+    discovery: {
+      mode: 'seeded_dht' as const,
+      connect_mode: 'direct_only' as const,
+      env_locked: false,
+      configured_seed_peer_ids: [],
+      bootstrap_seed_peer_ids: [],
+      manual_ticket_peer_ids: [],
+      connected_peer_ids: [],
+      docs_assist_peer_ids: [],
+      blob_assist_peer_ids: [],
+      local_endpoint_id: 'local-endpoint-a',
+    },
+  };
+}
+
+function panelElement(api: DesktopApi, options: RenderPanelOptions = {}) {
+  const effectiveSyncStatus = options.syncStatus ?? createSyncStatus();
+  return (
     <MetaverseRoomPanel
       api={api}
       activeTopic='kukuri:topic:demo'
       activeComposeChannel={{ kind: 'public' }}
-      rooms={[room]}
-      syncStatus={syncStatus ?? {
-        connected: true,
-        delivery_state: 'Live',
-        peer_count: 1,
-        pending_events: 0,
-        status_detail: 'connected',
-        configured_peers: [],
-        subscribed_topics: ['kukuri:topic:demo'],
-        topic_diagnostics: [],
-        local_author_pubkey: 'f'.repeat(64),
-        discovery: {
-          mode: 'seeded_dht',
-          connect_mode: 'direct_only',
-          env_locked: false,
-          configured_seed_peer_ids: [],
-          bootstrap_seed_peer_ids: [],
-          manual_ticket_peer_ids: [],
-          connected_peer_ids: [],
-          docs_assist_peer_ids: [],
-          blob_assist_peer_ids: [],
-          local_endpoint_id: 'local-endpoint-a',
-        },
-      }}
+      rooms={options.rooms ?? [room]}
+      syncStatus={effectiveSyncStatus}
       locale='en'
-      onRefresh={vi.fn()}
+      localProfile={{
+        pubkey: effectiveSyncStatus.local_author_pubkey,
+        name: 'host',
+        display_name: 'Host Author',
+        about: null,
+        picture: 'https://example.com/host.png',
+        picture_asset: null,
+        updated_at: 1,
+      }}
+      onRefresh={options.onRefresh ?? vi.fn()}
     />
   );
 }
 
+function renderPanel(api: DesktopApi, options: RenderPanelOptions = {}) {
+  return render(panelElement(api, options));
+}
+
 describe('MetaverseRoomPanel animation sharing', () => {
+  test('does not join an existing room until Join Room is clicked', async () => {
+    const baseApi = createDesktopMockApi();
+    const publishMetaverseRoomEvent = vi.fn(baseApi.publishMetaverseRoomEvent);
+    const api: DesktopApi = {
+      ...baseApi,
+      publishMetaverseRoomEvent,
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+
+    renderPanel(api);
+
+    expect(screen.queryByLabelText('Metaverse room viewport')).not.toBeInTheDocument();
+    expect(publishMetaverseRoomEvent).not.toHaveBeenCalled();
+  });
+
+  test('joins a room from the explicit Join Room action', async () => {
+    const user = userEvent.setup();
+    const baseApi = createDesktopMockApi();
+    const publishMetaverseRoomEvent = vi.fn(baseApi.publishMetaverseRoomEvent);
+    const api: DesktopApi = {
+      ...baseApi,
+      publishMetaverseRoomEvent,
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+
+    renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+
+    expect(screen.getByLabelText('Metaverse room viewport')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        publishMetaverseRoomEvent.mock.calls.some(([, , , , event]) => event.type === 'presence_join')
+      ).toBe(true);
+    });
+  });
+
+  test('room HUD can be resized and collapsed', async () => {
+    const user = userEvent.setup();
+    const baseApi = createDesktopMockApi();
+    const api: DesktopApi = {
+      ...baseApi,
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+
+    renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+
+    expect(screen.queryByText(/Topic: kukuri:topic:demo/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Debug details' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    await user.click(screen.getByRole('button', { name: 'Debug details' }));
+    expect(screen.getByText(/Topic: kukuri:topic:demo/)).toBeInTheDocument();
+
+    expect(document.querySelector('.metaverse-room-hud')).toHaveAttribute('data-size', 'compact');
+    await user.click(screen.getByRole('button', { name: 'Expand room HUD' }));
+    expect(document.querySelector('.metaverse-room-hud')).toHaveAttribute('data-size', 'wide');
+    expect(screen.getByRole('button', { name: 'Shrink room HUD' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Hide room HUD' }));
+    expect(document.querySelector('.metaverse-room-hud')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Open room HUD' }));
+    expect(document.querySelector('.metaverse-room-hud')).toHaveAttribute('data-size', 'wide');
+  });
+
+  test('keeps create room controls collapsed until opened', async () => {
+    const user = userEvent.setup();
+    const api = createDesktopMockApi();
+
+    renderPanel(api);
+
+    expect(screen.queryByPlaceholderText('Atrium')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Create metaverse room' }));
+    expect(screen.getByPlaceholderText('Atrium')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Small social space')).toBeInTheDocument();
+  });
+
+  test('opens the created room after refreshed rooms include it', async () => {
+    const user = userEvent.setup();
+    const baseApi = createDesktopMockApi();
+    const createdRoom = {
+      ...room,
+      room_id: 'created-metaverse-room',
+      title: 'Created room',
+      manifest_blob_hash: 'mock-created-metaverse-room',
+    };
+    const api: DesktopApi = {
+      ...baseApi,
+      createMetaverseRoom: vi.fn().mockResolvedValue(createdRoom.room_id),
+      publishMetaverseRoomEvent: vi.fn(baseApi.publishMetaverseRoomEvent),
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+    function CreatedRoomHarness() {
+      const [rooms, setRooms] = useState<GameRoomView[]>([]);
+      return panelElement(api, {
+        rooms,
+        onRefresh: async () => {
+          setRooms([createdRoom]);
+        },
+      });
+    }
+
+    render(<CreatedRoomHarness />);
+    await user.click(screen.getByRole('button', { name: 'Create metaverse room' }));
+    await user.type(screen.getByPlaceholderText('Atrium'), 'Created room');
+    await user.click(screen.getAllByRole('button', { name: 'Create metaverse room' })[1]);
+
+    expect(screen.getByLabelText('Metaverse room viewport')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(api.publishMetaverseRoomEvent).toHaveBeenCalled();
+    });
+  });
+
+  test('renders host identity from profile data', () => {
+    const api = createDesktopMockApi();
+
+    renderPanel(api);
+
+    expect(screen.getByText('Host: Host Author')).toBeInTheDocument();
+    expect(screen.getByText('Host: Host Author').previousElementSibling).toHaveAttribute(
+      'data-avatar-src',
+      'https://example.com/host.png'
+    );
+  });
+
   test('normalizes backend avatar animation states', async () => {
+    const user = userEvent.setup();
     const baseApi = createDesktopMockApi();
     const api: DesktopApi = {
       ...baseApi,
@@ -172,6 +326,8 @@ describe('MetaverseRoomPanel animation sharing', () => {
     };
 
     renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+    await user.click(screen.getByRole('button', { name: 'Debug details' }));
 
     await waitFor(() => {
       expect(screen.getByText(/idle-rem:idle/)).toBeInTheDocument();
@@ -194,6 +350,7 @@ describe('MetaverseRoomPanel animation sharing', () => {
     };
 
     renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
     await user.click(screen.getByRole('button', { name: 'Emit sprint transform' }));
 
     await waitFor(() => {
@@ -214,7 +371,9 @@ describe('MetaverseRoomPanel animation sharing', () => {
     const api = createDesktopMockApi();
 
     renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
     await user.click(screen.getByRole('button', { name: 'Mark animation fallback' }));
+    await user.click(screen.getByRole('button', { name: 'Debug details' }));
 
     expect(screen.getByLabelText('Metaverse room viewport')).toBeInTheDocument();
     expect(screen.getByText(/fallback-primitive/)).toBeInTheDocument();

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -1,6 +1,19 @@
 ﻿import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
-import { Box, Cuboid, MessageSquare, Move3D, Play, Send } from 'lucide-react';
+import {
+  Box,
+  ChevronDown,
+  Cuboid,
+  Maximize2,
+  MessageSquare,
+  Minimize2,
+  Move3D,
+  PanelRightClose,
+  PanelRightOpen,
+  Play,
+  Send,
+} from 'lucide-react';
 
+import { AuthorAvatar } from '@/components/core/AuthorAvatar';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -14,6 +27,8 @@ import type {
   MetaverseAssetRef,
   MetaverseRoomEventView,
   MetaverseRoomEventV1,
+  AuthorSocialView,
+  Profile,
   SharedRoomObjectV1,
   SyncStatus,
 } from '@/lib/api';
@@ -30,6 +45,7 @@ import {
   type AvatarTransform,
   type MetaverseRoomEvent,
   type MetaverseVec3,
+  type PeerPresence,
   type RoomChatMessage,
 } from './MetaverseSceneModel';
 
@@ -40,6 +56,9 @@ type MetaverseRoomPanelProps = {
   rooms: GameRoomView[];
   syncStatus: SyncStatus;
   locale: SupportedLocale;
+  localProfile?: Profile | null;
+  knownAuthorsByPubkey?: Record<string, AuthorSocialView>;
+  mediaObjectUrls?: Record<string, string | null>;
   onRefresh: () => Promise<void>;
 };
 
@@ -50,26 +69,34 @@ export function MetaverseRoomPanel({
   rooms,
   syncStatus,
   locale,
+  localProfile = null,
+  knownAuthorsByPubkey = {},
+  mediaObjectUrls = {},
   onRefresh,
 }: MetaverseRoomPanelProps) {
+  const [createOpen, setCreateOpen] = useState(false);
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [maxPeers, setMaxPeers] = useState('8');
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
-  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(rooms[0]?.room_id ?? null);
+  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
+  const [joinedRoomIds, setJoinedRoomIds] = useState<Set<string>>(() => new Set());
+  const [hudOpen, setHudOpen] = useState(true);
+  const [hudSize, setHudSize] = useState<'compact' | 'wide'>('compact');
+  const [hudDebugOpen, setHudDebugOpen] = useState(false);
   const [remoteTransforms, setRemoteTransforms] = useState<Record<string, AvatarTransform>>({});
+  const [peerPresence, setPeerPresence] = useState<Record<string, PeerPresence>>({});
   const [messages, setMessages] = useState<RoomChatMessage[]>([]);
   const [messageDraft, setMessageDraft] = useState('');
-  const [sharedObject, setSharedObject] = useState<SharedRoomObjectV1>(
-    rooms[0]?.metaverse?.scene.shared_object ?? DEFAULT_SHARED_OBJECT
-  );
+  const [sharedObject, setSharedObject] = useState<SharedRoomObjectV1>(DEFAULT_SHARED_OBJECT);
   const [lastSentSeq, setLastSentSeq] = useState(0);
   const [avatarAssetStatus, setAvatarAssetStatus] = useState<AvatarAssetStatus>('loading');
   const [localAvatarAssetRef, setLocalAvatarAssetRef] = useState<MetaverseAssetRef | null>(null);
   const [localAvatarAssetUrl, setLocalAvatarAssetUrl] = useState<string | null>(null);
   const channelRef = useRef<BroadcastChannel | null>(null);
   const lastBackendEventEnvelopeIdRef = useRef<string | null>(null);
+  const pendingCreatedRoomIdRef = useRef<string | null>(null);
   const localPeerSeed = useId().replaceAll(':', '');
   const localPeerId = `${syncStatus.discovery.local_endpoint_id || syncStatus.local_author_pubkey || 'local'}:${localPeerSeed}`;
   const lastSentTransformRef = useRef<AvatarTransform | null>(null);
@@ -85,15 +112,26 @@ export function MetaverseRoomPanel({
     [remoteTransforms]
   );
 
-  const selectedRoom =
-    rooms.find((room) => room.room_id === selectedRoomId) ?? rooms[0] ?? null;
+  const selectedRoom = selectedRoomId
+    ? rooms.find((room) => room.room_id === selectedRoomId) ?? null
+    : null;
   const knownPeerCount = Object.keys(remoteTransforms).length;
+  const localDisplayName = localProfile?.display_name?.trim() || localProfile?.name?.trim() || null;
 
   useEffect(() => {
-    if (!selectedRoom && rooms[0]) {
-      setSelectedRoomId(rooms[0].room_id);
+    if (!selectedRoomId) {
+      return;
     }
-  }, [rooms, selectedRoom]);
+    if (rooms.some((room) => room.room_id === selectedRoomId)) {
+      if (pendingCreatedRoomIdRef.current === selectedRoomId) {
+        pendingCreatedRoomIdRef.current = null;
+      }
+      return;
+    }
+    if (pendingCreatedRoomIdRef.current !== selectedRoomId) {
+      setSelectedRoomId(null);
+    }
+  }, [rooms, selectedRoomId]);
 
   useEffect(() => {
     if (!selectedRoom) {
@@ -101,6 +139,7 @@ export function MetaverseRoomPanel({
     }
     setSharedObject(selectedRoom.metaverse?.scene.shared_object ?? DEFAULT_SHARED_OBJECT);
     setRemoteTransforms({});
+    setPeerPresence({});
     setMessages([]);
     lastBackendEventEnvelopeIdRef.current = null;
     if (typeof BroadcastChannel === 'undefined') {
@@ -108,11 +147,16 @@ export function MetaverseRoomPanel({
     }
     const channel = new BroadcastChannel(`kukuri-metaverse-room:${selectedRoom.room_id}`);
     channelRef.current = channel;
-    const publish = (event: MetaverseRoomEvent) => channel.postMessage(event);
     channel.onmessage = (event: MessageEvent<MetaverseRoomEvent>) => {
       const data = event.data;
       if (!data || !('type' in data)) {
         return;
+      }
+      if (data.type === 'presence.join' && data.presence.peerId !== localPeerId) {
+        setPeerPresence((current) => ({
+          ...current,
+          [data.presence.peerId]: data.presence,
+        }));
       }
       if (data.type === 'avatar.transform' && data.transform.peerId !== localPeerId) {
         setRemoteTransforms((current) => ({
@@ -127,7 +171,6 @@ export function MetaverseRoomPanel({
         setSharedObject(data.object);
       }
     };
-    publish({ type: 'presence.join', roomId: selectedRoom.room_id, peerId: localPeerId, at: Date.now() });
     return () => {
       channel.close();
       channelRef.current = null;
@@ -139,12 +182,21 @@ export function MetaverseRoomPanel({
       return;
     }
     const now = Date.now();
+    const presence: PeerPresence = {
+      peerId: localPeerId,
+      displayName: localDisplayName,
+      avatarAssetRef: localAvatarAssetRef,
+      avatarAssetUrl: localAvatarAssetUrl,
+      joinedAt: now,
+      lastSeenAt: now,
+    };
+    emit({ type: 'presence.join', presence });
     void api.publishMetaverseRoomEvent(activeTopic, selectedRoom.room_id, localPeerId, now, {
       type: 'presence_join',
       presence: {
         room_id: selectedRoom.room_id,
         peer_id: localPeerId,
-        display_name: null,
+        display_name: localDisplayName,
         avatar_asset_ref: localAvatarAssetRef,
         joined_at: now,
         last_seen_at: now,
@@ -152,7 +204,7 @@ export function MetaverseRoomPanel({
     }).catch(() => {
       // Browser-only fallback is handled by the local scene.
     });
-  }, [activeTopic, api, localAvatarAssetRef, localPeerId, selectedRoom]);
+  }, [activeTopic, api, localAvatarAssetRef, localAvatarAssetUrl, localDisplayName, localPeerId, selectedRoom]);
 
   async function importAvatarBlob(blob: Blob, name: string) {
     if (!selectedRoom) {
@@ -199,6 +251,43 @@ export function MetaverseRoomPanel({
     let timeoutId = 0;
     const applyBackendEvent = (view: MetaverseRoomEventView) => {
       const event = view.content.event;
+      if (event.type === 'presence_join' && event.presence.peer_id !== localPeerId) {
+        const presence: PeerPresence = {
+          peerId: event.presence.peer_id,
+          displayName: event.presence.display_name ?? null,
+          avatarAssetRef: event.presence.avatar_asset_ref ?? null,
+          joinedAt: event.presence.joined_at,
+          lastSeenAt: event.presence.last_seen_at,
+        };
+        setPeerPresence((current) => ({
+          ...current,
+          [presence.peerId]: {
+            ...current[presence.peerId],
+            ...presence,
+          },
+        }));
+        if (presence.avatarAssetRef) {
+          void api
+            .getBlobPreviewUrl(
+              presence.avatarAssetRef.blob_hash,
+              presence.avatarAssetRef.mime_type ?? 'model/vrm'
+            )
+            .then((avatarAssetUrl) => {
+              if (!cancelled && avatarAssetUrl) {
+                setPeerPresence((current) => ({
+                  ...current,
+                  [presence.peerId]: {
+                    ...current[presence.peerId],
+                    avatarAssetUrl,
+                  },
+                }));
+              }
+            })
+            .catch(() => {
+              // Missing remote avatar blobs fall back to the bundled default VRM.
+            });
+        }
+      }
       if (event.type === 'avatar_transform' && event.transform.peer_id !== localPeerId) {
         setRemoteTransforms((current) => ({
           ...current,
@@ -247,7 +336,7 @@ export function MetaverseRoomPanel({
         // The browser-only dev shell has no Tauri backend. BroadcastChannel remains the local fallback.
       } finally {
         if (!cancelled) {
-          timeoutId = window.setTimeout(() => void poll(), 600);
+          timeoutId = window.setTimeout(() => void poll(), 180);
         }
       }
     };
@@ -278,6 +367,8 @@ export function MetaverseRoomPanel({
       setDescription('');
       setMaxPeers('8');
       setError(null);
+      pendingCreatedRoomIdRef.current = roomId;
+      setJoinedRoomIds((current) => new Set(current).add(roomId));
       setSelectedRoomId(roomId);
       await onRefresh();
     } catch (createError) {
@@ -289,6 +380,31 @@ export function MetaverseRoomPanel({
 
   function emit(event: MetaverseRoomEvent) {
     channelRef.current?.postMessage(event);
+  }
+
+  function handleJoinRoom(roomId: string) {
+    setJoinedRoomIds((current) => new Set(current).add(roomId));
+    setSelectedRoomId(roomId);
+  }
+
+  function hostAuthor(room: GameRoomView): Profile | AuthorSocialView | null {
+    return room.host_pubkey === syncStatus.local_author_pubkey
+      ? localProfile
+      : knownAuthorsByPubkey[room.host_pubkey] ?? null;
+  }
+
+  function hostLabel(room: GameRoomView) {
+    const host = hostAuthor(room);
+    return host?.display_name?.trim() || host?.name?.trim() || room.host_pubkey.slice(0, 10);
+  }
+
+  function hostPicture(room: GameRoomView) {
+    const host = hostAuthor(room);
+    const pictureAssetHash = host?.picture_asset?.hash;
+    if (pictureAssetHash && typeof mediaObjectUrls[pictureAssetHash] === 'string') {
+      return mediaObjectUrls[pictureAssetHash];
+    }
+    return host?.picture ?? null;
   }
 
   function handleLocalTransform(transform: AvatarTransform) {
@@ -401,38 +517,56 @@ export function MetaverseRoomPanel({
           </div>
         </div>
         {error ? <Notice tone='destructive'>{error}</Notice> : null}
-        <form className='composer composer-compact metaverse-create-form' onSubmit={handleCreateRoom}>
-          <Label>
-            <span>Room title</span>
-            <Input
-              value={title}
-              placeholder='Atrium'
-              disabled={pending}
-              onChange={(event) => setTitle(event.target.value)}
-            />
-          </Label>
-          <Label>
-            <span>Description</span>
-            <Textarea
-              value={description}
-              placeholder='Small social space'
-              disabled={pending}
-              onChange={(event) => setDescription(event.target.value)}
-            />
-          </Label>
-          <Label>
-            <span>Max peers</span>
-            <Input
-              value={maxPeers}
-              disabled={pending}
-              onChange={(event) => setMaxPeers(event.target.value)}
-            />
-          </Label>
-          <Button type='submit' disabled={pending}>
+        <section className='shell-nav-accordion metaverse-create-accordion' data-open={createOpen}>
+          <button
+            className='shell-nav-accordion-trigger'
+            type='button'
+            aria-expanded={createOpen}
+            onClick={() => setCreateOpen((current) => !current)}
+          >
             <Cuboid className='size-4' aria-hidden='true' />
-            Create metaverse room
-          </Button>
-        </form>
+            <span className='shell-nav-accordion-title'>Create metaverse room</span>
+            <ChevronDown className='shell-nav-accordion-icon size-4' aria-hidden='true' />
+          </button>
+          {createOpen ? (
+            <form className='composer composer-compact metaverse-create-form' onSubmit={handleCreateRoom}>
+              <div className='metaverse-create-form-primary'>
+                <Label>
+                  <span>Room title</span>
+                  <Input
+                    value={title}
+                    placeholder='Atrium'
+                    disabled={pending}
+                    onChange={(event) => setTitle(event.target.value)}
+                  />
+                </Label>
+                <Label>
+                  <span>Max peers</span>
+                  <Input
+                    value={maxPeers}
+                    disabled={pending}
+                    onChange={(event) => setMaxPeers(event.target.value)}
+                  />
+                </Label>
+              </div>
+              <Label className='metaverse-create-form-description'>
+                <span>Description</span>
+                <Textarea
+                  value={description}
+                  placeholder='Small social space'
+                  disabled={pending}
+                  onChange={(event) => setDescription(event.target.value)}
+                />
+              </Label>
+              <div className='metaverse-create-form-actions'>
+                <Button type='submit' disabled={pending}>
+                  <Cuboid className='size-4' aria-hidden='true' />
+                  Create metaverse room
+                </Button>
+              </div>
+            </form>
+          ) : null}
+        </section>
         {rooms.length === 0 ? <p className='empty-state'>No metaverse rooms in this topic.</p> : null}
         <ul className='metaverse-room-grid'>
           {rooms.map((room) => (
@@ -444,9 +578,13 @@ export function MetaverseRoomPanel({
                   <span className='reply-chip'>{room.audience_label}</span>
                 </div>
                 <p>{room.description || 'No description'}</p>
+                <div className='metaverse-room-host'>
+                  <AuthorAvatar label={hostLabel(room)} picture={hostPicture(room)} size='sm' />
+                  <span>Host: {hostLabel(room)}</span>
+                </div>
                 <div className='topic-diagnostic topic-diagnostic-secondary'>
-                  <span>Host: {room.host_pubkey.slice(0, 10)}</span>
                   <span>Updated: {formatLocalizedTime(room.updated_at, locale)}</span>
+                  <span>{joinedRoomIds.has(room.room_id) ? 'Joined' : 'Not joined'}</span>
                 </div>
                 <div className='topic-diagnostic topic-diagnostic-secondary'>
                   <span>Manifest: {room.manifest_blob_hash ?? 'pending'}</span>
@@ -455,10 +593,10 @@ export function MetaverseRoomPanel({
                 <Button
                   variant='secondary'
                   type='button'
-                  onClick={() => setSelectedRoomId(room.room_id)}
+                  onClick={() => handleJoinRoom(room.room_id)}
                 >
                   <Play className='size-4' aria-hidden='true' />
-                  Open room
+                  Join Room
                 </Button>
               </article>
             </li>
@@ -473,104 +611,159 @@ export function MetaverseRoomPanel({
               room={selectedRoom}
               localPeerId={localPeerId}
               remoteTransforms={remoteTransforms}
+              peerPresence={peerPresence}
               sharedObject={sharedObject}
               avatarAssetUrl={localAvatarAssetUrl}
               onLocalTransform={handleLocalTransform}
               onAvatarAssetStatus={setAvatarAssetStatus}
+              hud={(
+                <>
+                  <div className='metaverse-hud-toolbar' data-open={hudOpen}>
+                    <Button
+                      variant='ghost'
+                      size='icon'
+                      className='metaverse-hud-icon-button'
+                      type='button'
+                      aria-label={hudOpen ? 'Hide room HUD' : 'Open room HUD'}
+                      onClick={() => setHudOpen((open) => !open)}
+                    >
+                      {hudOpen ? (
+                        <PanelRightClose className='size-4' aria-hidden='true' />
+                      ) : (
+                        <PanelRightOpen className='size-4' aria-hidden='true' />
+                      )}
+                    </Button>
+                    <Button
+                      variant='ghost'
+                      size='icon'
+                      className='metaverse-hud-icon-button'
+                      type='button'
+                      aria-label={hudSize === 'compact' ? 'Expand room HUD' : 'Shrink room HUD'}
+                      onClick={() => setHudSize((size) => (size === 'compact' ? 'wide' : 'compact'))}
+                    >
+                      {hudSize === 'compact' ? (
+                        <Maximize2 className='size-4' aria-hidden='true' />
+                      ) : (
+                        <Minimize2 className='size-4' aria-hidden='true' />
+                      )}
+                    </Button>
+                  </div>
+                  {hudOpen ? (
+                    <>
+                    <aside className='metaverse-room-hud' data-size={hudSize}>
+                      <div className='panel-header metaverse-hud-header'>
+                        <div>
+                          <h3>{selectedRoom.title}</h3>
+                          <small>{selectedRoom.room_id}</small>
+                        </div>
+                      </div>
+                      <section className='metaverse-hud-accordion' data-open={hudDebugOpen}>
+                        <button
+                          type='button'
+                          className='metaverse-hud-accordion-trigger'
+                          aria-expanded={hudDebugOpen}
+                          onClick={() => setHudDebugOpen((open) => !open)}
+                        >
+                          <span>Debug details</span>
+                          <ChevronDown className='size-4' aria-hidden='true' />
+                        </button>
+                        {hudDebugOpen ? (
+                          <div className='metaverse-room-diagnostics'>
+                            <span>Topic: {activeTopic}</span>
+                            <span>Local peer: {localPeerId}</span>
+                            <span>Known peers: {knownPeerCount}</span>
+                            <span>Last sent seq: {lastSentSeq}</span>
+                            <span>Last received: {lastReceivedAt ? formatLocalizedTime(lastReceivedAt, locale) : 'none'}</span>
+                            <span>Remote animation: {remoteAnimationSummary || 'none'}</span>
+                            <span>
+                              Avatar asset:{' '}
+                              {avatarAssetStatus === 'sample-vrm'
+                                ? 'sample VRM loaded'
+                                : avatarAssetStatus === 'blob-vrm'
+                                  ? 'blob VRM loaded'
+                                  : avatarAssetStatus}
+                            </span>
+                            <span>Blob asset resolve: {localAvatarAssetRef?.blob_hash ?? 'public sample / fallback-ready'}</span>
+                            <span>Persistence: manifest blob {selectedRoom.manifest_blob_hash ?? 'pending'}</span>
+                            <span>Community assist: {syncStatus.discovery.bootstrap_seed_peer_ids.length > 0 ? 'available' : 'optional'}</span>
+                          </div>
+                        ) : null}
+                      </section>
+                      <div className='metaverse-object-controls'>
+                        <strong>Avatar asset</strong>
+                        <div className='metaverse-avatar-asset-controls'>
+                          <Label>
+                            <span className='sr-only'>VRM file</span>
+                            <Input
+                              type='file'
+                              accept='.vrm,model/vrm,application/octet-stream'
+                              disabled={pending}
+                              onChange={(event) => {
+                                const file = event.target.files?.[0];
+                                if (file) {
+                                  void importAvatarBlob(file, file.name);
+                                }
+                                event.currentTarget.value = '';
+                              }}
+                            />
+                          </Label>
+                          <Button size='sm' variant='secondary' type='button' disabled={pending} onClick={() => void handleSampleAvatarImport()}>
+                            Default
+                          </Button>
+                        </div>
+                      </div>
+                      <div className='metaverse-object-controls'>
+                        <strong>
+                          <Box className='size-4' aria-hidden='true' />
+                          Shared object
+                        </strong>
+                        <div className='metaverse-nudge-grid'>
+                          <Button size='sm' variant='secondary' type='button' onClick={() => void moveSharedObject([0, 0, -50])}>
+                            <Move3D className='size-4' aria-hidden='true' />
+                            Forward
+                          </Button>
+                          <Button size='sm' variant='secondary' type='button' onClick={() => void moveSharedObject([-50, 0, 0])}>Left</Button>
+                          <Button size='sm' variant='secondary' type='button' onClick={() => void moveSharedObject([50, 0, 0])}>Right</Button>
+                          <Button size='sm' variant='secondary' type='button' onClick={() => void moveSharedObject([0, 0, 50])}>Back</Button>
+                        </div>
+                      </div>
+                      <form className='metaverse-chat-form' onSubmit={handleSendMessage}>
+                        <Label>
+                          <span>
+                            <MessageSquare className='size-4' aria-hidden='true' />
+                            Room chat
+                          </span>
+                          <Input
+                            value={messageDraft}
+                            placeholder='Say something in the room'
+                            onChange={(event) => setMessageDraft(event.target.value)}
+                          />
+                        </Label>
+                        <Button size='sm' type='submit'>
+                          <Send className='size-4' aria-hidden='true' />
+                          Send
+                        </Button>
+                      </form>
+                      <ul className='metaverse-chat-list'>
+                        {messages.map((message) => (
+                          <li key={message.messageId}>
+                            <strong>
+                              {message.authorPeerId === localPeerId ? 'You' : message.authorPeerId.slice(0, 12)}
+                              <small>{formatLocalizedTime(message.createdAt, locale)}</small>
+                            </strong>
+                            <span>{message.body}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </aside>
+                    <span className='metaverse-hud-scrollbar-indicator' aria-hidden='true'>
+                      <span />
+                    </span>
+                    </>
+                  ) : null}
+                </>
+              )}
             />
-            <aside className='metaverse-room-sidebar'>
-              <div className='panel-header'>
-                <div>
-                  <h3>{selectedRoom.title}</h3>
-                  <small>{selectedRoom.room_id}</small>
-                </div>
-              </div>
-              <div className='topic-diagnostic'>
-                <span>Topic: {activeTopic}</span>
-                <span>Local peer: {localPeerId}</span>
-                <span>Known peers: {knownPeerCount}</span>
-                <span>Last sent seq: {lastSentSeq}</span>
-                <span>Last received: {lastReceivedAt ? formatLocalizedTime(lastReceivedAt, locale) : 'none'}</span>
-                <span>Remote animation: {remoteAnimationSummary || 'none'}</span>
-                <span>
-                  Avatar asset:{' '}
-                  {avatarAssetStatus === 'sample-vrm'
-                    ? 'sample VRM loaded'
-                    : avatarAssetStatus === 'blob-vrm'
-                      ? 'blob VRM loaded'
-                      : avatarAssetStatus}
-                </span>
-                <span>Blob asset resolve: {localAvatarAssetRef?.blob_hash ?? 'public sample / fallback-ready'}</span>
-                <span>Persistence: manifest blob {selectedRoom.manifest_blob_hash ?? 'pending'}</span>
-                <span>Community assist: {syncStatus.discovery.bootstrap_seed_peer_ids.length > 0 ? 'available' : 'optional'}</span>
-              </div>
-              <div className='metaverse-object-controls'>
-                <strong>Avatar asset</strong>
-                <div className='metaverse-nudge-grid'>
-                  <Button variant='secondary' type='button' disabled={pending} onClick={() => void handleSampleAvatarImport()}>
-                    Sample VRM
-                  </Button>
-                  <Label>
-                    <span>VRM file</span>
-                    <Input
-                      type='file'
-                      accept='.vrm,model/vrm,application/octet-stream'
-                      disabled={pending}
-                      onChange={(event) => {
-                        const file = event.target.files?.[0];
-                        if (file) {
-                          void importAvatarBlob(file, file.name);
-                        }
-                        event.currentTarget.value = '';
-                      }}
-                    />
-                  </Label>
-                </div>
-              </div>
-              <div className='metaverse-object-controls'>
-                <strong>
-                  <Box className='size-4' aria-hidden='true' />
-                  Shared object
-                </strong>
-                <div className='metaverse-nudge-grid'>
-                  <Button variant='secondary' type='button' onClick={() => void moveSharedObject([0, 0, -50])}>
-                    <Move3D className='size-4' aria-hidden='true' />
-                    Forward
-                  </Button>
-                  <Button variant='secondary' type='button' onClick={() => void moveSharedObject([-50, 0, 0])}>Left</Button>
-                  <Button variant='secondary' type='button' onClick={() => void moveSharedObject([50, 0, 0])}>Right</Button>
-                  <Button variant='secondary' type='button' onClick={() => void moveSharedObject([0, 0, 50])}>Back</Button>
-                </div>
-              </div>
-              <form className='metaverse-chat-form' onSubmit={handleSendMessage}>
-                <Label>
-                  <span>
-                    <MessageSquare className='size-4' aria-hidden='true' />
-                    Room chat
-                  </span>
-                  <Input
-                    value={messageDraft}
-                    placeholder='Say something in the room'
-                    onChange={(event) => setMessageDraft(event.target.value)}
-                  />
-                </Label>
-                <Button type='submit'>
-                  <Send className='size-4' aria-hidden='true' />
-                  Send
-                </Button>
-              </form>
-              <ul className='metaverse-chat-list'>
-                {messages.map((message) => (
-                  <li key={message.messageId}>
-                    <strong>
-                      {message.authorPeerId === localPeerId ? 'You' : message.authorPeerId.slice(0, 12)}
-                      <small>{formatLocalizedTime(message.createdAt, locale)}</small>
-                    </strong>
-                    <span>{message.body}</span>
-                  </li>
-                ))}
-              </ul>
-            </aside>
           </div>
         </Card>
       ) : null}

--- a/apps/desktop/src/components/extended/MetaverseScene.test.ts
+++ b/apps/desktop/src/components/extended/MetaverseScene.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'vitest';
 
-import { avatarAnimationForInput, normalizeAvatarAnimationState } from './MetaverseSceneModel';
+import {
+  isNewerRemoteTransform,
+  avatarAnimationForInput,
+  normalizeAvatarAnimationState,
+  stepAvatarJump,
+  type AvatarTransform,
+} from './MetaverseSceneModel';
 
 describe('metaverse avatar animation state', () => {
   test('derives keyboard animation state', () => {
@@ -18,5 +24,33 @@ describe('metaverse avatar animation state', () => {
     expect(normalizeAvatarAnimationState('sitting')).toBe('sitting');
     expect(normalizeAvatarAnimationState('Sittiing')).toBe('idle');
     expect(normalizeAvatarAnimationState(null)).toBe('idle');
+  });
+
+  test('jump movement changes height and lands on the ground', () => {
+    const launched = stepAvatarJump([0, 0, 0], { verticalVelocity: 0, grounded: true }, 0.1, true);
+    expect(launched.position[1]).toBeGreaterThan(0);
+    expect(launched.physics.grounded).toBe(false);
+
+    let step = launched;
+    for (let index = 0; index < 20; index += 1) {
+      step = stepAvatarJump(step.position, step.physics, 0.1, false);
+    }
+    expect(step.position[1]).toBe(0);
+    expect(step.physics.grounded).toBe(true);
+  });
+
+  test('detects stale remote transforms by seq and timestamp', () => {
+    const current: AvatarTransform = {
+      roomId: 'room',
+      peerId: 'peer',
+      seq: 3,
+      position: [0, 0, 0],
+      rotation: [0, 0, 0],
+      animation: 'idle',
+      sentAt: 300,
+    };
+    expect(isNewerRemoteTransform(current, { ...current, seq: 2, sentAt: 400 })).toBe(false);
+    expect(isNewerRemoteTransform(current, { ...current, seq: 4, sentAt: 250 })).toBe(true);
+    expect(isNewerRemoteTransform(current, { ...current, sentAt: 301 })).toBe(true);
   });
 });

--- a/apps/desktop/src/components/extended/MetaverseScene.tsx
+++ b/apps/desktop/src/components/extended/MetaverseScene.tsx
@@ -1,4 +1,5 @@
-﻿import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { VRMLoaderPlugin, VRMUtils, type VRM } from '@pixiv/three-vrm';
@@ -10,20 +11,28 @@ import {
 
 import type { GameRoomView, SharedRoomObjectV1 } from '@/lib/api';
 import {
+  AVATAR_GROUND_Y,
   DEFAULT_AVATAR_ASSET_URL,
   avatarAnimationForInput,
+  initialAvatarTransform,
+  isNewerRemoteTransform,
+  stepAvatarJump,
   type AvatarAnimationState,
   type AvatarAssetStatus,
+  type AvatarPhysicsState,
   type AvatarTransform,
   type MetaverseVec3,
+  type PeerPresence,
 } from './MetaverseSceneModel';
 
 type SceneProps = {
   room: GameRoomView;
   localPeerId: string;
   remoteTransforms: Record<string, AvatarTransform>;
+  peerPresence: Record<string, PeerPresence>;
   sharedObject: SharedRoomObjectV1;
   avatarAssetUrl: string | null;
+  hud: ReactNode;
   onLocalTransform: (transform: AvatarTransform) => void;
   onAvatarAssetStatus: (status: AvatarAssetStatus) => void;
 };
@@ -61,20 +70,19 @@ function scenePosition(values: MetaverseVec3) {
   return new THREE.Vector3(toSceneUnit(values[0]), toSceneUnit(values[1]), toSceneUnit(values[2]));
 }
 
-function makeAvatarMesh(color: number) {
-  const group = new THREE.Group();
-  const body = new THREE.Mesh(
-    new THREE.CapsuleGeometry(0.28, 0.72, 6, 12),
-    new THREE.MeshStandardMaterial({ color, roughness: 0.7 })
+function makePrimitiveAvatar(color: number) {
+  return (
+    <>
+      <mesh position={[0, 0.72, 0]}>
+        <capsuleGeometry args={[0.28, 0.72, 6, 12]} />
+        <meshStandardMaterial color={color} roughness={0.7} />
+      </mesh>
+      <mesh position={[0, 1.34, 0]}>
+        <sphereGeometry args={[0.22, 16, 16]} />
+        <meshStandardMaterial color={0xf5d0c5} roughness={0.65} />
+      </mesh>
+    </>
   );
-  body.position.y = 0.72;
-  const head = new THREE.Mesh(
-    new THREE.SphereGeometry(0.22, 16, 16),
-    new THREE.MeshStandardMaterial({ color: 0xf5d0c5, roughness: 0.65 })
-  );
-  head.position.y = 1.34;
-  group.add(body, head);
-  return group;
 }
 
 function disposeObjectTree(object: THREE.Object3D) {
@@ -87,23 +95,6 @@ function disposeObjectTree(object: THREE.Object3D) {
       }
     }
   });
-}
-
-function initialAvatarTransform(
-  roomId: string,
-  localPeerId: string,
-  spawnPosition?: MetaverseVec3,
-  spawnRotation?: MetaverseVec3
-): AvatarTransform {
-  return {
-    roomId,
-    peerId: localPeerId,
-    seq: 0,
-    position: spawnPosition ?? [0, 0, 260],
-    rotation: spawnRotation ?? [0, 180, 0],
-    animation: 'idle',
-    sentAt: 0,
-  };
 }
 
 function isEditableTarget(target: EventTarget | null) {
@@ -214,131 +205,41 @@ function playSittingExit(runtime: AvatarAnimationRuntime, nextAnimation: AvatarA
   }, 300);
 }
 
-export function MetaverseScene({
-  room,
-  localPeerId,
-  remoteTransforms,
-  sharedObject,
-  avatarAssetUrl,
-  onLocalTransform,
-  onAvatarAssetStatus,
-}: SceneProps) {
-  const mountRef = useRef<HTMLDivElement | null>(null);
-  const spawnPosition = room.metaverse?.default_spawn.position;
-  const spawnRotation = room.metaverse?.default_spawn.rotation;
-  const localTransformRef = useRef<AvatarTransform>(
-    initialAvatarTransform(room.room_id, localPeerId, spawnPosition, spawnRotation)
-  );
-  const seqRef = useRef(0);
-  const lastSentAtRef = useRef(0);
-  const lastPublishedTransformRef = useRef<AvatarTransform | null>(null);
-  const keysRef = useRef(new Set<string>());
-  const remoteGroupsRef = useRef(new Map<string, THREE.Group>());
-  const localAvatarRef = useRef<THREE.Group | null>(null);
-  const sharedObjectRef = useRef<THREE.Mesh | null>(null);
-  const onLocalTransformRef = useRef(onLocalTransform);
-  const onAvatarAssetStatusRef = useRef(onAvatarAssetStatus);
-  const remoteTransformsRef = useRef(remoteTransforms);
-  const sharedObjectStateRef = useRef(sharedObject);
+function AvatarModel({
+  assetUrl,
+  color,
+  animationRef,
+  statusTarget,
+}: {
+  assetUrl: string;
+  color: number;
+  animationRef?: RefObject<AvatarAnimationState>;
+  statusTarget?: (status: AvatarAssetStatus) => void;
+}) {
+  const groupRef = useRef<THREE.Group | null>(null);
+  const vrmRuntimeRef = useRef<{ vrm: VRM | null; loadedRoot: THREE.Object3D | null }>({
+    vrm: null,
+    loadedRoot: null,
+  });
+  const animationRuntimeRef = useRef<AvatarAnimationRuntime | null>(null);
+  const [visiblePrimitive, setVisiblePrimitive] = useState(true);
 
   useEffect(() => {
-    onLocalTransformRef.current = onLocalTransform;
-  }, [onLocalTransform]);
-
-  useEffect(() => {
-    onAvatarAssetStatusRef.current = onAvatarAssetStatus;
-  }, [onAvatarAssetStatus]);
-
-  useEffect(() => {
-    remoteTransformsRef.current = remoteTransforms;
-  }, [remoteTransforms]);
-
-  useEffect(() => {
-    const nextTransform = initialAvatarTransform(room.room_id, localPeerId, spawnPosition, spawnRotation);
-    localTransformRef.current = nextTransform;
-    seqRef.current = 0;
-    lastSentAtRef.current = 0;
-    lastPublishedTransformRef.current = null;
-    keysRef.current.clear();
-    if (localAvatarRef.current) {
-      localAvatarRef.current.position.copy(scenePosition(nextTransform.position));
-      localAvatarRef.current.rotation.y = THREE.MathUtils.degToRad(nextTransform.rotation[1]);
-    }
-  }, [localPeerId, room.room_id, spawnPosition, spawnRotation]);
-
-  useEffect(() => {
-    sharedObjectStateRef.current = sharedObject;
-    if (sharedObjectRef.current) {
-      sharedObjectRef.current.position.copy(scenePosition(sharedObject.position));
-      sharedObjectRef.current.rotation.set(
-        THREE.MathUtils.degToRad(sharedObject.rotation[0]),
-        THREE.MathUtils.degToRad(sharedObject.rotation[1]),
-        THREE.MathUtils.degToRad(sharedObject.rotation[2])
-      );
-      sharedObjectRef.current.scale.set(
-        Math.max(0.1, toSceneUnit(sharedObject.scale[0])),
-        Math.max(0.1, toSceneUnit(sharedObject.scale[1])),
-        Math.max(0.1, toSceneUnit(sharedObject.scale[2]))
-      );
-    }
-  }, [sharedObject]);
-
-  useEffect(() => {
-    const mount = mountRef.current;
-    if (!mount) {
+    const group = groupRef.current;
+    if (!group) {
       return;
     }
-    const avatarAssetRuntime: { vrm: VRM | null; loadedRoot: THREE.Object3D | null } = {
-      vrm: null,
-      loadedRoot: null,
-    };
-    const animationRuntimeRef: { current: AvatarAnimationRuntime | null } = {
-      current: null,
-    };
     let disposed = false;
-
-    const scene = new THREE.Scene();
-    scene.background = new THREE.Color(0x101318);
-    const camera = new THREE.PerspectiveCamera(58, 1, 0.1, 100);
-    camera.position.set(0, 4.2, 6.5);
-    camera.lookAt(0, 0.8, 0);
-
-    const renderer = new THREE.WebGLRenderer({ antialias: true });
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-    renderer.setSize(mount.clientWidth, mount.clientHeight);
-    mount.appendChild(renderer.domElement);
-
-    const hemi = new THREE.HemisphereLight(0xb7d7ff, 0x29351f, 2.2);
-    const key = new THREE.DirectionalLight(0xffffff, 2.4);
-    key.position.set(4, 8, 3);
-    scene.add(hemi, key);
-
-    const grid = new THREE.GridHelper(12, 12, 0x4f9f78, 0x30423a);
-    scene.add(grid);
-
-    const ground = new THREE.Mesh(
-      new THREE.PlaneGeometry(12, 12),
-      new THREE.MeshStandardMaterial({ color: 0x1c2a25, roughness: 0.9 })
-    );
-    ground.rotation.x = -Math.PI / 2;
-    ground.position.y = -0.01;
-    scene.add(ground);
-
-    const localAvatar = makeAvatarMesh(0x4f9fef);
-    localAvatar.position.copy(scenePosition(localTransformRef.current.position));
-    localAvatarRef.current = localAvatar;
-    scene.add(localAvatar);
-    onAvatarAssetStatusRef.current('loading');
-
+    setVisiblePrimitive(true);
+    statusTarget?.('loading');
     const avatarLoader = new GLTFLoader();
     avatarLoader.register((parser) => new VRMLoaderPlugin(parser));
-    const avatarUrl = avatarAssetUrl ?? DEFAULT_AVATAR_ASSET_URL;
     avatarLoader.load(
-      avatarUrl,
+      assetUrl,
       (gltf) => {
         const vrm = gltf.userData.vrm as VRM | undefined;
         if (disposed || !vrm) {
-          onAvatarAssetStatusRef.current('fallback-primitive');
+          statusTarget?.('fallback-primitive');
           return;
         }
         VRMUtils.removeUnnecessaryVertices(gltf.scene);
@@ -347,15 +248,11 @@ export function MetaverseScene({
         vrmRoot.scale.setScalar(0.9);
         vrmRoot.rotation.y = Math.PI;
         vrmRoot.position.y = 0;
-        while (localAvatar.children.length > 0) {
-          const child = localAvatar.children[0];
-          localAvatar.remove(child);
-          disposeObjectTree(child);
-        }
-        localAvatar.add(vrmRoot);
-        avatarAssetRuntime.vrm = vrm;
-        avatarAssetRuntime.loadedRoot = vrmRoot;
-        onAvatarAssetStatusRef.current(avatarAssetUrl ? 'blob-vrm' : 'sample-vrm');
+        group.add(vrmRoot);
+        setVisiblePrimitive(false);
+        vrmRuntimeRef.current = { vrm, loadedRoot: vrmRoot };
+        statusTarget?.(assetUrl === DEFAULT_AVATAR_ASSET_URL ? 'sample-vrm' : 'blob-vrm');
+
         const animationLoader = new GLTFLoader();
         animationLoader.register((parser) => new VRMAnimationLoaderPlugin(parser));
         const mixer = new THREE.AnimationMixer(vrm.scene);
@@ -383,7 +280,7 @@ export function MetaverseScene({
           }
           if (event.action === runtime.actions.jumpLand) {
             runtime.jumpActive = false;
-            playLoopAnimation(runtime, localTransformRef.current.animation);
+            playLoopAnimation(runtime, 'idle');
             return;
           }
           if (event.action === runtime.actions.sittingEnter) {
@@ -391,7 +288,7 @@ export function MetaverseScene({
             return;
           }
           if (event.action === runtime.actions.sittingExit) {
-            playLoopAnimation(runtime, localTransformRef.current.animation);
+            playLoopAnimation(runtime, 'idle');
           }
         });
         animationRuntimeRef.current = runtime;
@@ -412,31 +309,105 @@ export function MetaverseScene({
           })
         ).then(() => {
           if (!disposed) {
-            playLoopAnimation(runtime, localTransformRef.current.animation);
+            playLoopAnimation(runtime, 'idle');
           }
         });
       },
       undefined,
       () => {
         if (!disposed) {
-          onAvatarAssetStatusRef.current('fallback-primitive');
+          statusTarget?.('fallback-primitive');
         }
       }
     );
 
-    const objectMesh = new THREE.Mesh(
-      new THREE.BoxGeometry(1, 1, 1),
-      new THREE.MeshStandardMaterial({ color: 0xf3b35d, roughness: 0.55 })
-    );
-    objectMesh.position.copy(scenePosition(sharedObjectStateRef.current.position));
-    objectMesh.scale.set(1, 1, 1);
-    sharedObjectRef.current = objectMesh;
-    scene.add(objectMesh);
+    return () => {
+      disposed = true;
+      const runtime = animationRuntimeRef.current;
+      if (runtime?.jumpLoopTimeoutId) {
+        window.clearTimeout(runtime.jumpLoopTimeoutId);
+      }
+      if (runtime?.sittingExitTimeoutId) {
+        window.clearTimeout(runtime.sittingExitTimeoutId);
+      }
+      runtime?.mixer.stopAllAction();
+      if (vrmRuntimeRef.current.vrm) {
+        runtime?.mixer.uncacheRoot(vrmRuntimeRef.current.vrm.scene);
+      }
+      if (vrmRuntimeRef.current.loadedRoot) {
+        group.remove(vrmRuntimeRef.current.loadedRoot);
+        disposeObjectTree(vrmRuntimeRef.current.loadedRoot);
+      }
+      animationRuntimeRef.current = null;
+      vrmRuntimeRef.current = { vrm: null, loadedRoot: null };
+    };
+  }, [assetUrl, statusTarget]);
 
-    let sittingRequested = false;
-    let jumpRequested = false;
-    let primitiveJumpUntil = 0;
+  useFrame((_, delta) => {
+    const runtime = animationRuntimeRef.current;
+    const animation = animationRef?.current ?? 'idle';
+    if (runtime) {
+      if (animation === 'jump') {
+        playJumpAnimation(runtime);
+      } else if (animation === 'sitting' && !runtime.sittingActive) {
+        playSittingEnter(runtime);
+      } else if (animation !== 'sitting' && runtime.sittingActive) {
+        playSittingExit(runtime, animation);
+      } else if (!runtime.jumpActive && !runtime.sittingActive && runtime.activeKey !== 'sittingExit') {
+        playLoopAnimation(runtime, animation);
+      }
+    }
+    runtime?.mixer.update(delta);
+    vrmRuntimeRef.current.vrm?.update(delta);
+  });
 
+  return (
+    <group ref={groupRef}>
+      {visiblePrimitive ? makePrimitiveAvatar(color) : null}
+    </group>
+  );
+}
+
+function LocalAvatar({
+  room,
+  localPeerId,
+  avatarAssetUrl,
+  onLocalTransform,
+  onAvatarAssetStatus,
+}: Pick<SceneProps, 'room' | 'localPeerId' | 'avatarAssetUrl' | 'onLocalTransform' | 'onAvatarAssetStatus'>) {
+  const groupRef = useRef<THREE.Group | null>(null);
+  const spawnPosition = room.metaverse?.default_spawn.position;
+  const spawnRotation = room.metaverse?.default_spawn.rotation;
+  const transformRef = useRef(initialAvatarTransform(room.room_id, localPeerId, spawnPosition, spawnRotation));
+  const physicsRef = useRef<AvatarPhysicsState>({ verticalVelocity: 0, grounded: true });
+  const seqRef = useRef(0);
+  const lastSentAtRef = useRef(0);
+  const lastPublishedTransformRef = useRef<AvatarTransform | null>(null);
+  const keysRef = useRef(new Set<string>());
+  const animationRef = useRef<AvatarAnimationState>('idle');
+  const jumpRequestedRef = useRef(false);
+  const sittingRequestedRef = useRef(false);
+  const onLocalTransformRef = useRef(onLocalTransform);
+
+  useEffect(() => {
+    onLocalTransformRef.current = onLocalTransform;
+  }, [onLocalTransform]);
+
+  useEffect(() => {
+    const nextTransform = initialAvatarTransform(room.room_id, localPeerId, spawnPosition, spawnRotation);
+    transformRef.current = nextTransform;
+    physicsRef.current = { verticalVelocity: 0, grounded: nextTransform.position[1] <= AVATAR_GROUND_Y };
+    seqRef.current = 0;
+    lastSentAtRef.current = 0;
+    lastPublishedTransformRef.current = null;
+    keysRef.current.clear();
+    if (groupRef.current) {
+      groupRef.current.position.copy(scenePosition(nextTransform.position));
+      groupRef.current.rotation.y = THREE.MathUtils.degToRad(nextTransform.rotation[1]);
+    }
+  }, [localPeerId, room.room_id, spawnPosition, spawnRotation]);
+
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (isEditableTarget(event.target)) {
         return;
@@ -448,24 +419,18 @@ export function MetaverseScene({
       }
       if (event.code === 'Space') {
         event.preventDefault();
-        if (!event.repeat && !sittingRequested) {
-          jumpRequested = true;
+        if (!event.repeat && !sittingRequestedRef.current) {
+          jumpRequestedRef.current = true;
         }
         return;
       }
       if (key === 'c') {
         if (!event.repeat) {
-          sittingRequested = !sittingRequested;
+          sittingRequestedRef.current = !sittingRequestedRef.current;
         }
         return;
       }
-      if (
-        key === 'w' ||
-        key === 'a' ||
-        key === 's' ||
-        key === 'd' ||
-        event.key.startsWith('Arrow')
-      ) {
+      if (key === 'w' || key === 'a' || key === 's' || key === 'd' || event.key.startsWith('Arrow')) {
         keysRef.current.add(key);
       }
     };
@@ -477,140 +442,227 @@ export function MetaverseScene({
     };
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
-
-    const resizeObserver = new ResizeObserver(([entry]) => {
-      const width = Math.max(1, entry.contentRect.width);
-      const height = Math.max(1, entry.contentRect.height);
-      camera.aspect = width / height;
-      camera.updateProjectionMatrix();
-      renderer.setSize(width, height);
-    });
-    resizeObserver.observe(mount);
-
-    let frameId = 0;
-    let lastFrameAt = performance.now();
-    const tick = (frameAt: number) => {
-      const deltaSeconds = Math.min(0.05, (frameAt - lastFrameAt) / 1000);
-      lastFrameAt = frameAt;
-      const keys = keysRef.current;
-      const { x, z, moving } = movementVectorFromKeys(keys);
-      const runtime = animationRuntimeRef.current;
-      if (jumpRequested) {
-        if (runtime) {
-          playJumpAnimation(runtime);
-        }
-        primitiveJumpUntil = frameAt + 650;
-        jumpRequested = false;
-      }
-      const baseAnimation = avatarAnimationForInput(keys, sittingRequested);
-      const currentRuntimeState = runtime?.jumpActive || frameAt < primitiveJumpUntil ? 'jump' : baseAnimation;
-      if (runtime && baseAnimation === 'sitting' && !runtime.sittingActive) {
-        playSittingEnter(runtime);
-      } else if (runtime && baseAnimation !== 'sitting' && runtime.sittingActive) {
-        playSittingExit(runtime, baseAnimation);
-      } else if (runtime && !runtime.jumpActive && !runtime.sittingActive && runtime.activeKey !== 'sittingExit') {
-        playLoopAnimation(runtime, baseAnimation);
-      }
-
-      if (moving && baseAnimation !== 'sitting') {
-        const length = Math.hypot(x, z) || 1;
-        const speed = baseAnimation === 'sprint' ? 380 : 220;
-        const current = localTransformRef.current;
-        const nextPosition: MetaverseVec3 = [
-          current.position[0] + Math.round((x / length) * speed * deltaSeconds),
-          current.position[1],
-          current.position[2] + Math.round((z / length) * speed * deltaSeconds),
-        ];
-        const yaw = Math.round(THREE.MathUtils.radToDeg(Math.atan2(x, z)));
-        localTransformRef.current = {
-          ...current,
-          seq: seqRef.current,
-          position: nextPosition,
-          rotation: [0, yaw, 0],
-          animation: currentRuntimeState,
-          sentAt: Date.now(),
-        };
-        localAvatar.position.copy(scenePosition(nextPosition));
-        localAvatar.rotation.y = THREE.MathUtils.degToRad(yaw);
-      } else if (localTransformRef.current.animation !== currentRuntimeState) {
-        localTransformRef.current = {
-          ...localTransformRef.current,
-          seq: seqRef.current,
-          animation: currentRuntimeState,
-          sentAt: Date.now(),
-        };
-      }
-      runtime?.mixer.update(deltaSeconds);
-      avatarAssetRuntime.vrm?.update(deltaSeconds);
-
-      if (frameAt - lastSentAtRef.current >= 100) {
-        lastSentAtRef.current = frameAt;
-        const nextTransform = {
-          ...localTransformRef.current,
-          seq: seqRef.current + 1,
-          sentAt: Date.now(),
-        };
-        if (!avatarTransformsEqual(lastPublishedTransformRef.current, nextTransform)) {
-          seqRef.current += 1;
-          lastPublishedTransformRef.current = nextTransform;
-          onLocalTransformRef.current(nextTransform);
-        }
-      }
-
-      const seenPeers = new Set(Object.keys(remoteTransformsRef.current));
-      for (const [peerId, transform] of Object.entries(remoteTransformsRef.current)) {
-        let group = remoteGroupsRef.current.get(peerId);
-        if (!group) {
-          group = makeAvatarMesh(0xe37070);
-          remoteGroupsRef.current.set(peerId, group);
-          scene.add(group);
-        }
-        group.position.copy(scenePosition(transform.position));
-        group.rotation.y = THREE.MathUtils.degToRad(transform.rotation[1]);
-        group.visible = Date.now() - transform.sentAt < 15_000;
-      }
-      for (const [peerId, group] of remoteGroupsRef.current) {
-        if (!seenPeers.has(peerId)) {
-          scene.remove(group);
-          remoteGroupsRef.current.delete(peerId);
-        }
-      }
-
-      objectMesh.rotation.y += 0.25 * deltaSeconds;
-      renderer.render(scene, camera);
-      frameId = window.requestAnimationFrame(tick);
-    };
-    frameId = window.requestAnimationFrame(tick);
-
     return () => {
-      window.cancelAnimationFrame(frameId);
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
-      resizeObserver.disconnect();
-      renderer.dispose();
-      mount.removeChild(renderer.domElement);
-      localAvatarRef.current = null;
-      sharedObjectRef.current = null;
-      if (animationRuntimeRef.current?.jumpLoopTimeoutId) {
-        window.clearTimeout(animationRuntimeRef.current.jumpLoopTimeoutId);
-      }
-      if (animationRuntimeRef.current?.sittingExitTimeoutId) {
-        window.clearTimeout(animationRuntimeRef.current.sittingExitTimeoutId);
-      }
-      animationRuntimeRef.current?.mixer.stopAllAction();
-      if (avatarAssetRuntime.vrm) {
-        animationRuntimeRef.current?.mixer.uncacheRoot(avatarAssetRuntime.vrm.scene);
-      }
-      animationRuntimeRef.current = null;
-      if (avatarAssetRuntime.loadedRoot) {
-        disposeObjectTree(avatarAssetRuntime.loadedRoot);
-      }
-      avatarAssetRuntime.vrm = null;
-      avatarAssetRuntime.loadedRoot = null;
-      disposed = true;
     };
-  }, [avatarAssetUrl, localPeerId, room.room_id, room.metaverse?.default_spawn.position, room.metaverse?.default_spawn.rotation]);
+  }, []);
 
-  return <div className='metaverse-viewport' ref={mountRef} aria-label='Metaverse room viewport' />;
+  useFrame((_, deltaSeconds) => {
+    const delta = Math.min(0.05, deltaSeconds);
+    const keys = keysRef.current;
+    const { x, z, moving } = movementVectorFromKeys(keys);
+    const baseAnimation = avatarAnimationForInput(keys, sittingRequestedRef.current);
+    const current = transformRef.current;
+    const jumpStep = stepAvatarJump(current.position, physicsRef.current, delta, jumpRequestedRef.current);
+    jumpRequestedRef.current = false;
+    physicsRef.current = jumpStep.physics;
+
+    let nextPosition = jumpStep.position;
+    let nextRotation = current.rotation;
+    if (moving && baseAnimation !== 'sitting') {
+      const length = Math.hypot(x, z) || 1;
+      const speed = baseAnimation === 'sprint' ? 380 : 220;
+      nextPosition = [
+        nextPosition[0] + Math.round((x / length) * speed * delta),
+        nextPosition[1],
+        nextPosition[2] + Math.round((z / length) * speed * delta),
+      ];
+      nextRotation = [0, Math.round(THREE.MathUtils.radToDeg(Math.atan2(x, z))), 0];
+    }
+
+    const animation = !physicsRef.current.grounded ? 'jump' : baseAnimation;
+    animationRef.current = animation;
+    transformRef.current = {
+      ...current,
+      position: nextPosition,
+      rotation: nextRotation,
+      animation,
+      sentAt: Date.now(),
+    };
+
+    if (groupRef.current) {
+      groupRef.current.position.copy(scenePosition(nextPosition));
+      groupRef.current.rotation.y = THREE.MathUtils.degToRad(nextRotation[1]);
+    }
+
+    const sendInterval = moving || animation === 'jump' ? 50 : 220;
+    const frameAt = performance.now();
+    if (frameAt - lastSentAtRef.current >= sendInterval) {
+      lastSentAtRef.current = frameAt;
+      const nextTransform = {
+        ...transformRef.current,
+        seq: seqRef.current + 1,
+        sentAt: Date.now(),
+      };
+      if (!avatarTransformsEqual(lastPublishedTransformRef.current, nextTransform)) {
+        seqRef.current += 1;
+        lastPublishedTransformRef.current = nextTransform;
+        transformRef.current = nextTransform;
+        onLocalTransformRef.current(nextTransform);
+      }
+    }
+  });
+
+  return (
+    <group ref={groupRef}>
+      <AvatarModel
+        assetUrl={avatarAssetUrl ?? DEFAULT_AVATAR_ASSET_URL}
+        color={0x4f9fef}
+        animationRef={animationRef}
+        statusTarget={onAvatarAssetStatus}
+      />
+    </group>
+  );
 }
 
+function RemoteAvatar({
+  transform,
+  presence,
+}: {
+  transform: AvatarTransform;
+  presence: PeerPresence | null;
+}) {
+  const groupRef = useRef<THREE.Group | null>(null);
+  const targetRef = useRef(transform);
+  const animationRef = useRef<AvatarAnimationState>(transform.animation);
+
+  useEffect(() => {
+    if (isNewerRemoteTransform(targetRef.current, transform)) {
+      targetRef.current = transform;
+      animationRef.current = transform.animation;
+    }
+  }, [transform]);
+
+  useFrame((_, deltaSeconds) => {
+    const group = groupRef.current;
+    if (!group) {
+      return;
+    }
+    const target = targetRef.current;
+    const targetPosition = scenePosition(target.position);
+    const alpha = Math.min(1, deltaSeconds * 12);
+    group.position.lerp(targetPosition, alpha);
+    const targetYaw = THREE.MathUtils.degToRad(target.rotation[1]);
+    group.rotation.y = THREE.MathUtils.lerp(group.rotation.y, targetYaw, alpha);
+    group.visible = Date.now() - target.sentAt < 15_000;
+  });
+
+  return (
+    <group
+      ref={groupRef}
+      position={scenePosition(transform.position)}
+      rotation={[0, THREE.MathUtils.degToRad(transform.rotation[1]), 0]}
+      userData={{ displayName: presence?.displayName ?? transform.peerId }}
+    >
+      <AvatarModel
+        assetUrl={presence?.avatarAssetUrl || DEFAULT_AVATAR_ASSET_URL}
+        color={0xe37070}
+        animationRef={animationRef}
+      />
+    </group>
+  );
+}
+
+function SharedObject({ object }: { object: SharedRoomObjectV1 }) {
+  const position = scenePosition(object.position);
+  const rotation: [number, number, number] = [
+    THREE.MathUtils.degToRad(object.rotation[0]),
+    THREE.MathUtils.degToRad(object.rotation[1]),
+    THREE.MathUtils.degToRad(object.rotation[2]),
+  ];
+  const scale: [number, number, number] = [
+    Math.max(0.1, toSceneUnit(object.scale[0])),
+    Math.max(0.1, toSceneUnit(object.scale[1])),
+    Math.max(0.1, toSceneUnit(object.scale[2])),
+  ];
+
+  return (
+    <mesh position={position} rotation={rotation} scale={scale}>
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color={0xf3b35d} roughness={0.55} />
+    </mesh>
+  );
+}
+
+function SceneContents({
+  room,
+  localPeerId,
+  remoteTransforms,
+  peerPresence,
+  sharedObject,
+  avatarAssetUrl,
+  onLocalTransform,
+  onAvatarAssetStatus,
+}: Omit<SceneProps, 'hud'>) {
+  const remoteEntries = useMemo(() => Object.entries(remoteTransforms), [remoteTransforms]);
+  const { camera } = useThree();
+
+  useEffect(() => {
+    camera.lookAt(0, 0.8, 0);
+  }, [camera]);
+
+  return (
+    <>
+      <color attach='background' args={[0x101318]} />
+      <ambientLight intensity={0.4} />
+      <hemisphereLight args={[0xb7d7ff, 0x29351f, 2.2]} />
+      <directionalLight position={[4, 8, 3]} intensity={2.4} />
+      <gridHelper args={[12, 12, 0x4f9f78, 0x30423a]} />
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.01, 0]}>
+        <planeGeometry args={[12, 12]} />
+        <meshStandardMaterial color={0x1c2a25} roughness={0.9} />
+      </mesh>
+      <LocalAvatar
+        room={room}
+        localPeerId={localPeerId}
+        avatarAssetUrl={avatarAssetUrl}
+        onLocalTransform={onLocalTransform}
+        onAvatarAssetStatus={onAvatarAssetStatus}
+      />
+      {remoteEntries.map(([peerId, transform]) => (
+        <RemoteAvatar
+          key={peerId}
+          transform={transform}
+          presence={peerPresence[peerId] ?? null}
+        />
+      ))}
+      <SharedObject object={sharedObject} />
+    </>
+  );
+}
+
+export function MetaverseScene({
+  room,
+  localPeerId,
+  remoteTransforms,
+  peerPresence,
+  sharedObject,
+  avatarAssetUrl,
+  hud,
+  onLocalTransform,
+  onAvatarAssetStatus,
+}: SceneProps) {
+  return (
+    <div className='metaverse-viewport-shell' aria-label='Metaverse room viewport'>
+      <Canvas
+        className='metaverse-viewport-canvas'
+        camera={{ position: [0, 4.2, 6.5], fov: 58 }}
+        gl={{ antialias: true }}
+        dpr={[1, 2]}
+      >
+        <SceneContents
+          room={room}
+          localPeerId={localPeerId}
+          remoteTransforms={remoteTransforms}
+          peerPresence={peerPresence}
+          sharedObject={sharedObject}
+          avatarAssetUrl={avatarAssetUrl}
+          onLocalTransform={onLocalTransform}
+          onAvatarAssetStatus={onAvatarAssetStatus}
+        />
+      </Canvas>
+      {hud}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/extended/MetaverseSceneModel.ts
+++ b/apps/desktop/src/components/extended/MetaverseSceneModel.ts
@@ -1,4 +1,4 @@
-import type { SharedRoomObjectV1 } from '@/lib/api';
+import type { MetaverseAssetRef, SharedRoomObjectV1 } from '@/lib/api';
 
 export type MetaverseVec3 = [number, number, number];
 
@@ -43,6 +43,25 @@ export type AvatarTransform = {
   sentAt: number;
 };
 
+export type AvatarPhysicsState = {
+  verticalVelocity: number;
+  grounded: boolean;
+};
+
+export type AvatarMovementStep = {
+  position: MetaverseVec3;
+  physics: AvatarPhysicsState;
+};
+
+export type PeerPresence = {
+  peerId: string;
+  displayName: string | null;
+  avatarAssetRef: MetaverseAssetRef | null;
+  avatarAssetUrl?: string | null;
+  joinedAt: number;
+  lastSeenAt: number;
+};
+
 export type RoomChatMessage = {
   roomId: string;
   messageId: string;
@@ -52,7 +71,7 @@ export type RoomChatMessage = {
 };
 
 export type MetaverseRoomEvent =
-  | { type: 'presence.join'; roomId: string; peerId: string; at: number }
+  | { type: 'presence.join'; presence: PeerPresence }
   | { type: 'avatar.transform'; transform: AvatarTransform }
   | { type: 'chat.message'; message: RoomChatMessage }
   | { type: 'object.update'; roomId: string; object: SharedRoomObjectV1 };
@@ -72,3 +91,62 @@ export const DEFAULT_SHARED_OBJECT: SharedRoomObjectV1 = {
 
 export const DEFAULT_AVATAR_ASSET_NAME = 'blumochichi.vrm';
 export const DEFAULT_AVATAR_ASSET_URL = `/${DEFAULT_AVATAR_ASSET_NAME}`;
+
+export const AVATAR_GROUND_Y = 0;
+export const AVATAR_JUMP_VELOCITY = 520;
+export const AVATAR_GRAVITY = 1600;
+
+export function initialAvatarTransform(
+  roomId: string,
+  localPeerId: string,
+  spawnPosition?: MetaverseVec3,
+  spawnRotation?: MetaverseVec3
+): AvatarTransform {
+  return {
+    roomId,
+    peerId: localPeerId,
+    seq: 0,
+    position: spawnPosition ?? [0, AVATAR_GROUND_Y, 260],
+    rotation: spawnRotation ?? [0, 180, 0],
+    animation: 'idle',
+    sentAt: 0,
+  };
+}
+
+export function stepAvatarJump(
+  position: MetaverseVec3,
+  physics: AvatarPhysicsState,
+  deltaSeconds: number,
+  jumpRequested: boolean
+): AvatarMovementStep {
+  let verticalVelocity =
+    jumpRequested && physics.grounded ? AVATAR_JUMP_VELOCITY : physics.verticalVelocity;
+  let nextY = position[1] + verticalVelocity * deltaSeconds;
+  verticalVelocity -= AVATAR_GRAVITY * deltaSeconds;
+
+  if (nextY <= AVATAR_GROUND_Y) {
+    nextY = AVATAR_GROUND_Y;
+    verticalVelocity = 0;
+  }
+
+  return {
+    position: [position[0], Math.round(nextY), position[2]],
+    physics: {
+      verticalVelocity,
+      grounded: nextY === AVATAR_GROUND_Y,
+    },
+  };
+}
+
+export function isNewerRemoteTransform(
+  current: AvatarTransform | null | undefined,
+  incoming: AvatarTransform
+): boolean {
+  if (!current) {
+    return true;
+  }
+  if (incoming.seq !== current.seq) {
+    return incoming.seq > current.seq;
+  }
+  return incoming.sentAt > current.sentAt;
+}

--- a/apps/desktop/src/components/ui/card.tsx
+++ b/apps/desktop/src/components/ui/card.tsx
@@ -16,19 +16,19 @@ const cardVariants = cva('panel', {
   },
 });
 
-type CardOwnProps<T extends React.ElementType> = {
-  as?: T;
-} & VariantProps<typeof cardVariants>;
+type CardElement = 'article' | 'aside' | 'div' | 'section';
 
-type CardProps<T extends React.ElementType> = CardOwnProps<T> &
-  Omit<React.ComponentPropsWithoutRef<T>, keyof CardOwnProps<T>>;
+type CardProps = {
+  as?: CardElement;
+} & VariantProps<typeof cardVariants> &
+  Omit<React.ComponentPropsWithoutRef<CardElement>, 'as'>;
 
-export function Card<T extends React.ElementType = 'section'>({
+export function Card({
   as,
   tone,
   className,
   ...props
-}: CardProps<T>) {
+}: CardProps) {
   const Component = as ?? 'section';
 
   return <Component className={cn(cardVariants({ tone }), className)} {...props} />;

--- a/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
@@ -166,6 +166,7 @@ export function DesktopShellPrimaryWorkspace({
     composerError,
     gameError,
     gameSavingByRoomId,
+    knownAuthorsByPubkey,
     liveError,
     localProfile,
     mediaObjectUrls,
@@ -639,6 +640,9 @@ export function DesktopShellPrimaryWorkspace({
               rooms={metaverseRooms}
               syncStatus={syncStatus}
               locale={locale}
+              localProfile={localProfile}
+              knownAuthorsByPubkey={knownAuthorsByPubkey}
+              mediaObjectUrls={mediaObjectUrls}
               onRefresh={refreshCurrentTopic}
             />
           </>

--- a/apps/desktop/src/shell/useDesktopShellData.ts
+++ b/apps/desktop/src/shell/useDesktopShellData.ts
@@ -1,6 +1,7 @@
 import {
   startTransition,
   useCallback,
+  useEffect,
   useRef,
   type MutableRefObject,
 } from 'react';
@@ -173,6 +174,51 @@ export function useDesktopShellData({
   const setGameDrafts = useDesktopShellFieldSetter('gameDrafts');
   const setReactionPanelState = useDesktopShellFieldSetter('reactionPanelState');
   const setError = useDesktopShellFieldSetter('error');
+
+  useEffect(() => {
+    if (shellChromeState.activePrimarySection !== 'game') {
+      return;
+    }
+    const missingHostPubkeys = Array.from(
+      new Set(
+        activeGameRooms
+          .map((room) => room.host_pubkey)
+          .filter(
+            (pubkey) =>
+              pubkey &&
+              pubkey !== localProfile?.pubkey &&
+              pubkey !== state.syncStatus.local_author_pubkey &&
+              !knownAuthorsByPubkey[pubkey]
+          )
+      )
+    );
+    if (missingHostPubkeys.length === 0) {
+      return;
+    }
+    let disposed = false;
+    void Promise.all(
+      missingHostPubkeys.map((pubkey) => api.getAuthorSocialView(pubkey).catch(() => null))
+    ).then((authors) => {
+      if (disposed) {
+        return;
+      }
+      const resolvedAuthors = authors.filter((author) => author !== null);
+      if (resolvedAuthors.length > 0) {
+        setKnownAuthorsByPubkey((current) => mergeKnownAuthors(current, resolvedAuthors));
+      }
+    });
+    return () => {
+      disposed = true;
+    };
+  }, [
+    activeGameRooms,
+    api,
+    knownAuthorsByPubkey,
+    localProfile?.pubkey,
+    setKnownAuthorsByPubkey,
+    shellChromeState.activePrimarySection,
+    state.syncStatus.local_author_pubkey,
+  ]);
 
   const previewableMediaAttachments = usePreviewableMediaAttachments({
     activeTimeline,

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -176,8 +176,40 @@
 }
 
 .metaverse-create-form {
-  grid-template-columns: minmax(10rem, 1fr) minmax(12rem, 1.4fr) minmax(6rem, 0.5fr) auto;
+  gap: 0.75rem;
+}
+
+.metaverse-create-accordion {
+  display: grid;
+}
+
+.metaverse-create-form-primary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(7rem, 0.32fr);
+  gap: 0.75rem;
   align-items: end;
+}
+
+.metaverse-create-form-description textarea {
+  min-height: 5.5rem;
+}
+
+.metaverse-create-form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.metaverse-room-host {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-width: 0;
+  font-weight: 700;
+}
+
+.metaverse-room-host span {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .metaverse-room-grid {
@@ -209,10 +241,21 @@
 }
 
 .metaverse-room-stage {
-  display: grid;
-  grid-template-columns: minmax(0, 1.7fr) minmax(18rem, 0.8fr);
-  gap: 1rem;
   min-height: 34rem;
+}
+
+.metaverse-viewport-shell {
+  position: relative;
+  min-height: 34rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: #101318;
+}
+
+.metaverse-viewport-canvas {
+  position: absolute !important;
+  inset: 0;
 }
 
 .metaverse-viewport {
@@ -223,16 +266,159 @@
   background: #101318;
 }
 
-.metaverse-room-sidebar {
+.metaverse-hud-toolbar {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  z-index: 2;
+  display: inline-flex;
+  gap: 0.35rem;
+  padding: 0.25rem;
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 82%, transparent);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--surface-panel) 86%, transparent);
+  box-shadow: var(--shadow-panel);
+  backdrop-filter: blur(14px);
+}
+
+.metaverse-hud-toolbar[data-open='false'] {
+  background: color-mix(in srgb, var(--surface-panel) 72%, transparent);
+}
+
+.metaverse-hud-icon-button {
+  width: 2.25rem;
+  height: 2.25rem;
+  min-height: 2.25rem;
+  padding: 0;
+  border-radius: 0.4rem;
+}
+
+.metaverse-room-hud {
+  position: absolute;
+  top: 4rem;
+  right: 0.75rem;
+  bottom: 1rem;
+  z-index: 1;
   display: grid;
   align-content: start;
-  gap: 1rem;
+  gap: 0.8rem;
+  width: min(18rem, calc(100% - 1.5rem));
+  max-height: calc(100% - 5rem);
+  padding: 0.8rem;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 82%, transparent);
+  border-radius: 0.65rem;
+  background: color-mix(in srgb, var(--surface-panel) 84%, transparent);
+  box-shadow: var(--shadow-panel);
+  backdrop-filter: blur(14px);
+  scrollbar-color: color-mix(in srgb, var(--accent) 72%, white 8%) color-mix(in srgb, var(--surface-raised) 76%, black 12%);
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+}
+
+.metaverse-room-hud[data-size='wide'] {
+  width: min(25rem, calc(100% - 1.5rem));
+}
+
+.metaverse-hud-scrollbar-indicator {
+  position: absolute;
+  top: 4.85rem;
+  right: 1rem;
+  bottom: 1.85rem;
+  z-index: 3;
+  width: 0.28rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-raised) 82%, black 10%);
+  pointer-events: none;
+}
+
+.metaverse-hud-scrollbar-indicator span {
+  position: absolute;
+  top: 0.35rem;
+  right: 0;
+  left: 0;
+  height: 31%;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--accent) 78%, white 12%);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--surface-panel) 70%, transparent);
+}
+
+.metaverse-room-hud::-webkit-scrollbar,
+.metaverse-chat-list::-webkit-scrollbar {
+  width: 0.85rem;
+}
+
+.metaverse-room-hud::-webkit-scrollbar-track,
+.metaverse-chat-list::-webkit-scrollbar-track {
+  background: color-mix(in srgb, var(--surface-raised) 76%, black 12%);
+  border-radius: 999px;
+}
+
+.metaverse-room-hud::-webkit-scrollbar-thumb,
+.metaverse-chat-list::-webkit-scrollbar-thumb {
+  border: 2px solid color-mix(in srgb, var(--surface-panel) 72%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 72%, white 8%);
+}
+
+.metaverse-hud-header {
+  gap: 0.5rem;
+  padding: 0;
+}
+
+.metaverse-hud-header h3 {
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.metaverse-hud-accordion {
+  display: grid;
+  gap: 0.5rem;
   min-width: 0;
+}
+
+.metaverse-hud-accordion-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--surface-button-secondary) 76%, transparent);
+  color: var(--foreground);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.metaverse-hud-accordion-trigger svg {
+  transition: transform 160ms ease;
+}
+
+.metaverse-hud-accordion[data-open='true'] .metaverse-hud-accordion-trigger svg {
+  transform: rotate(180deg);
+}
+
+.metaverse-room-diagnostics {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 0;
+  color: var(--muted-foreground);
+  font-size: 0.74rem;
+}
+
+.metaverse-room-diagnostics span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .metaverse-object-controls {
   display: grid;
-  gap: 0.6rem;
+  gap: 0.5rem;
 }
 
 .metaverse-object-controls > strong,
@@ -245,7 +431,42 @@
 .metaverse-nudge-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: 0.45rem;
+}
+
+.metaverse-avatar-asset-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
   gap: 0.5rem;
+}
+
+.metaverse-avatar-asset-controls label {
+  min-width: 0;
+}
+
+.metaverse-avatar-asset-controls input[type='file'] {
+  min-height: 2.25rem;
+  padding-top: 0.45rem;
+  padding-bottom: 0.45rem;
+}
+
+.metaverse-avatar-asset-controls .button {
+  min-width: 5.5rem;
+}
+
+.metaverse-room-hud .button {
+  align-self: start;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.65rem;
+  border-radius: 0.5rem;
+  font-size: 0.86rem;
+}
+
+.metaverse-room-hud .button svg {
+  width: 0.95rem;
+  height: 0.95rem;
 }
 
 .metaverse-chat-form {
@@ -283,13 +504,34 @@
 }
 
 @media (max-width: 900px) {
-  .metaverse-create-form,
-  .metaverse-room-stage {
+  .metaverse-create-form-primary {
     grid-template-columns: 1fr;
   }
 
+  .metaverse-viewport-shell,
   .metaverse-viewport {
     min-height: 24rem;
+  }
+
+  .metaverse-room-hud {
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    top: auto;
+    width: auto;
+    max-height: 46%;
+  }
+
+  .metaverse-room-hud[data-size='wide'] {
+    width: auto;
+    max-height: 62%;
+  }
+
+  .metaverse-hud-scrollbar-indicator {
+    top: auto;
+    right: 1rem;
+    bottom: 1.6rem;
+    height: calc(46% - 1.7rem);
   }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -258,7 +258,7 @@ fn cn_check() -> Result<()> {
 
 fn cn_test() -> Result<()> {
     with_cn_postgres(|| {
-        run_with_env(
+        run_with_owned_env(
             "cargo",
             cargo_package_args("test", &CN_PACKAGES),
             &root_dir(),
@@ -422,6 +422,19 @@ fn run_with_env(
     run_spec_with_env(&CommandSpec::direct(binary, args), cwd, envs)
 }
 
+fn run_with_owned_env(
+    binary: &str,
+    args: impl IntoIterator<Item = impl Into<String>>,
+    cwd: &Path,
+    envs: &[(String, String)],
+) -> Result<()> {
+    let env_refs = envs
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect::<Vec<_>>();
+    run_with_env(binary, args, cwd, &env_refs)
+}
+
 fn run_spec_with_env(spec: &CommandSpec, cwd: &Path, envs: &[(&str, &str)]) -> Result<()> {
     let label = format_command(spec);
     run_timed_step(label, || {
@@ -553,14 +566,26 @@ fn cn_compose_envs() -> [(&'static str, &'static str); 2] {
     ]
 }
 
-fn cn_test_envs() -> [(&'static str, &'static str); 2] {
-    [
-        ("KUKURI_CN_RUN_INTEGRATION_TESTS", "1"),
+fn cn_test_envs() -> Vec<(String, String)> {
+    vec![
         (
-            "COMMUNITY_NODE_DATABASE_URL",
-            "postgres://cn:cn_password@127.0.0.1:55432/cn",
+            "KUKURI_CN_RUN_INTEGRATION_TESTS".to_string(),
+            "1".to_string(),
+        ),
+        (
+            "COMMUNITY_NODE_DATABASE_URL".to_string(),
+            cn_test_database_url(),
         ),
     ]
+}
+
+fn cn_test_database_url() -> String {
+    let port = std::env::var("CN_POSTGRES_PORT")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "55432".to_string());
+    format!("postgres://cn:cn_password@127.0.0.1:{port}/cn")
 }
 
 fn with_cn_postgres<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {


### PR DESCRIPTION
﻿## Summary
- Make metaverse room joining explicit and keep room creation collapsed by default.
- Move the metaverse play UI into an in-canvas HUD with collapse, resize, debug accordion, visible scroll rail, and compact avatar/object controls.
- Migrate the scene to React Three Fiber, use default VRM fallback avatars, smooth remote transforms, and add jump height physics.
- Resolve room host profile/avatar display through known author metadata.

## Validation
- `cd apps/desktop && npx pnpm@10.16.1 lint`
- `cd apps/desktop && npx pnpm@10.16.1 test`
- `cd apps/desktop && npx pnpm@10.16.1 test -- MetaverseRoomPanel`
- `git diff --check`
- Local Playwright visual smoke against the browser mock for room creation, HUD collapse/resize, debug accordion default closed, avatar asset controls, visible scroll indicator, and Shared object controls.

## Notes
- `cd apps/desktop && npx pnpm@10.16.1 typecheck` and `cargo xtask desktop-ui-check` still stop on the pre-existing unrelated `src/components/ui/card.tsx` polymorphic Card type error.
- Existing unstaged local change `apps/desktop/src-tauri/Cargo.toml` was intentionally left out of this PR.
