### PR TITLE
[codex] Document community node VPS edge hosting

### DIFF
--- a/.env.community-node.example
+++ b/.env.community-node.example
@@ -30,17 +30,15 @@ CN_IROH_RELAY_TLS_CERT_PATH=
 CN_IROH_RELAY_TLS_KEY_PATH=
 CN_IROH_RELAY_CERTS_HOST_PATH=./docker/cn/certs
 
-# Public manual smoke example:
+# Public manual smoke example with WireGuard + Caddy VPS edge:
 # CN_BASE_URL=https://api.kukuri.app
 # CN_PUBLIC_BASE_URL=https://api.kukuri.app
 # COMMUNITY_NODE_CONNECTIVITY_URLS=https://iroh-relay.kukuri.app
-# Cloudflare Tunnel + direct QUIC mode:
+# CN_USER_API_HOST_BIND_IP=10.73.0.2
+# CN_IROH_RELAY_HTTP_HOST_BIND_IP=10.73.0.2
 # CN_IROH_RELAY_QUIC_BIND_ADDR=0.0.0.0:7842
 # CN_IROH_RELAY_QUIC_HOST_BIND_IP=10.73.0.2
 # CN_IROH_RELAY_QUIC_PORT=7842
 # CN_IROH_RELAY_TLS_CERT_PATH=/certs/default.crt
 # CN_IROH_RELAY_TLS_KEY_PATH=/certs/default.key
-#
-# Direct HTTPS + direct QUIC mode:
-# CN_IROH_RELAY_HTTPS_BIND_ADDR=0.0.0.0:3443
-# CN_IROH_RELAY_HTTPS_PORT=13443
+# CN_IROH_RELAY_CERTS_HOST_PATH=./docker/cn/certs

--- a/docs/runbooks/community-node-self-host-vps.md
+++ b/docs/runbooks/community-node-self-host-vps.md
@@ -1,0 +1,187 @@
+# Community Node Self-Host With VPS Edge
+
+最終更新日: 2026-06-05
+
+## 目的
+
+- community-node の公開経路を `WireGuard + Caddy` の VPS edge に一本化する。
+- `cn-user-api`, `cn-iroh-relay`, Postgres, Valkey は Home 側に置く。
+- VPS は public IP, DNS, TLS termination, UDP forward だけを担当する。
+- Public contract は `https://api.kukuri.app` と `https://iroh-relay.kukuri.app`
+
+## 構成
+
+```mermaid
+flowchart LR
+  Client["kukuri client"] --> ApiDns["api.kukuri.app:443"]
+  Client --> RelayHttps["iroh-relay.kukuri.app:443"]
+  Client --> RelayQuic["iroh-relay.kukuri.app:7842/udp"]
+
+  ApiDns --> VPS["VPS<br/>Caddy + nftables + WireGuard"]
+  RelayHttps --> VPS
+  RelayQuic --> VPS
+
+  VPS -->|wg0 10.73.0.1/24 -> 10.73.0.2/24| Home["Home server<br/>cn-user-api + cn-iroh-relay"]
+  Home --> PrivateState["Postgres + Valkey<br/>private bind only"]
+```
+
+既定値:
+
+- WireGuard subnet: `10.73.0.0/24`
+- VPS tunnel IP: `10.73.0.1`
+- Home tunnel IP: `10.73.0.2`
+- Public API domain: `api.kukuri.app`
+- Public iroh relay domain: `iroh-relay.kukuri.app`
+- Public WireGuard port: `51820/udp`
+- Public iroh relay QUIC port: `7842/udp`
+
+## VPS 側
+
+DNS と firewall:
+
+- `api.kukuri.app` と `iroh-relay.kukuri.app` を VPS の public IP に向ける。
+- Cloudflare を使う場合は DNS only にする。
+- VPS / cloud firewall で `22/tcp`, `80/tcp`, `443/tcp`, `51820/udp`, `7842/udp` を許可する。
+
+セットアップ:
+
+```bash
+git clone https://github.com/<your-org>/kukuri.git
+cd kukuri
+cp scripts/vps/community-node-edge.env.example scripts/vps/community-node-edge.env
+```
+
+`scripts/vps/community-node-edge.env` の必須値:
+
+```dotenv
+PUBLIC_IFACE=eth0
+WG_ENDPOINT_HOST=api.kukuri.app
+WG_VPS_ADDRESS=10.73.0.1/24
+WG_HOME_CLIENT_ADDRESS=10.73.0.2/24
+WG_HOME_ALLOWED_IPS=10.73.0.2/32
+HOME_WG_IP=10.73.0.2
+WG_SERVER_PRIVATE_KEY=<vps-private-key>
+WG_HOME_PUBLIC_KEY=<home-public-key>
+WG_HOME_PRESHARED_KEY=<shared-psk>
+API_DOMAIN=api.kukuri.app
+IROH_RELAY_DOMAIN=iroh-relay.kukuri.app
+HOME_CN_USER_API_PORT=18080
+HOME_IROH_RELAY_HTTP_PORT=13340
+HOME_IROH_RELAY_QUIC_PORT=7842
+```
+
+実行:
+
+```bash
+sudo ./scripts/vps/setup-community-node-edge.sh scripts/vps/community-node-edge.env
+```
+
+生成物:
+
+- `/etc/wireguard/wg0.conf`
+- `/etc/caddy/sites-enabled/kukuri-community-node-edge.caddy`
+- `/etc/nftables.conf`
+- `/root/wg0-home-client.conf`
+
+Caddy は `api.kukuri.app -> http://10.73.0.2:18080` と `iroh-relay.kukuri.app -> http://10.73.0.2:13340` を reverse proxy する。`7842/udp` は Caddy を通さず nftables で Home 側へ DNAT する。
+
+## Home 側
+
+WireGuard:
+
+VPS 側が生成した `/root/wg0-home-client.conf` を Home 側へコピーし、`PrivateKey` を埋めて `/etc/wireguard/wg0.conf` として配置する。
+
+```ini
+[Interface]
+Address = 10.73.0.2/24
+PrivateKey = <home-private-key>
+
+[Peer]
+PublicKey = <server-public-key>
+PresharedKey = <same-as-WG_HOME_PRESHARED_KEY>
+Endpoint = api.kukuri.app:51820
+AllowedIPs = 10.73.0.1/32
+PersistentKeepalive = 25
+```
+
+起動:
+
+```bash
+sudo systemctl enable --now wg-quick@wg0
+```
+
+`.env.community-node`:
+
+```dotenv
+CN_BASE_URL=https://api.kukuri.app
+CN_PUBLIC_BASE_URL=https://api.kukuri.app
+COMMUNITY_NODE_CONNECTIVITY_URLS=https://iroh-relay.kukuri.app
+
+CN_POSTGRES_HOST_BIND_IP=127.0.0.1
+CN_VALKEY_HOST_BIND_IP=127.0.0.1
+CN_USER_API_HOST_BIND_IP=10.73.0.2
+CN_USER_API_PORT=18080
+CN_IROH_RELAY_HTTP_HOST_BIND_IP=10.73.0.2
+CN_IROH_RELAY_PORT=13340
+CN_IROH_RELAY_QUIC_BIND_ADDR=0.0.0.0:7842
+CN_IROH_RELAY_QUIC_HOST_BIND_IP=10.73.0.2
+CN_IROH_RELAY_QUIC_PORT=7842
+CN_IROH_RELAY_TLS_CERT_PATH=/certs/default.crt
+CN_IROH_RELAY_TLS_KEY_PATH=/certs/default.key
+CN_IROH_RELAY_CERTS_HOST_PATH=./docker/cn/certs
+```
+
+`CN_POSTGRES_PASSWORD` と `COMMUNITY_NODE_JWT_SECRET` は必ず本番用の値に変える。Postgres と Valkey は public に bind しない。
+
+## iroh relay 証明書
+
+`cn-iroh-relay` の `7842/udp` は Home 側コンテナが直接応答するため、`iroh-relay.kukuri.app` 用の証明書と秘密鍵を Home 側へ置く。
+
+VPS 上で Caddy の証明書を探す:
+
+```bash
+sudo find /var/lib/caddy/.local/share/caddy/certificates -path '*iroh-relay.kukuri.app*'
+```
+
+Home 側へ配置:
+
+```bash
+mkdir -p docker/cn/certs
+cp /path/to/iroh-relay.kukuri.app.crt docker/cn/certs/default.crt
+cp /path/to/iroh-relay.kukuri.app.key docker/cn/certs/default.key
+```
+
+## 起動
+
+```bash
+docker compose --env-file .env.community-node -f docker-compose.community-node.yml run --rm cn-migrate
+docker compose --env-file .env.community-node -f docker-compose.community-node.yml up -d --build cn-user-api cn-iroh-relay
+```
+
+## 確認
+
+VPS:
+
+```bash
+sudo wg show
+sudo systemctl status wg-quick@wg0
+sudo systemctl status caddy
+sudo nft list ruleset
+curl -fsS https://api.kukuri.app/healthz
+curl -fsS https://iroh-relay.kukuri.app/ping
+```
+
+Home:
+
+```bash
+ip addr show wg0
+ss -ltnup | grep -E '(:18080|:13340|:7842)'
+docker compose --env-file .env.community-node -f docker-compose.community-node.yml ps
+```
+
+期待値:
+
+- `https://api.kukuri.app/healthz` が成功する。
+- `https://iroh-relay.kukuri.app/ping` が成功する。
+- Home 側の `18080/tcp`, `13340/tcp`, `7842/udp` は `10.73.0.2` に bind される。
+- desktop client は `Save Nodes -> Authenticate -> Accept` 後、`connectivity_urls` として `https://iroh-relay.kukuri.app` を受け取る。

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -66,27 +66,23 @@ docker compose --env-file .env.community-node -f docker-compose.community-node.y
 - `COMMUNITY_NODE_DATABASE_URL` は compose 内では `cn-postgres` 向けに組み立てる。外部 Postgres を使う場合だけ個別に差し替える
 
 ## community-node 公開 manual smoke
-公開 URL を current community-node 構成で出す場合は、`.env.community-node` に最低限この 3 つを入れる。
+公開 URL を current community-node 構成で出す場合は、`WireGuard + Caddy` の VPS edge を用いる。詳細な self-host 手順は `docs/runbooks/community-node-self-host-vps.md` を参照する。
+
+VPS 側:
+
+- `api.kukuri.app` と `iroh-relay.kukuri.app` は VPS の public IP へ向ける
+- Caddy は `api.kukuri.app -> http://10.73.0.2:18080`, `iroh-relay.kukuri.app -> http://10.73.0.2:13340` を reverse proxy する
+- nftables は `7842/udp` を Home 側 `10.73.0.2:7842` へ WireGuard 経由で forward する
+
+Home 側の `.env.community-node` には最低限この値を入れる。
 
 ```dotenv
 CN_BASE_URL=https://api.kukuri.app
 CN_PUBLIC_BASE_URL=https://api.kukuri.app
 COMMUNITY_NODE_CONNECTIVITY_URLS=https://iroh-relay.kukuri.app
-```
 
-- `api.kukuri.app` は `cn-user-api` を向ける
-- `iroh-relay.kukuri.app` は `cn-iroh-relay` を向ける
-- desktop は `connectivity_urls` を server から受け取るので、websocket relay 前提は使わない
-
-TCP 公開を Cloudflare Tunnel で行う場合:
-
-- `CN_USER_API_HOST_BIND_IP=127.0.0.1`
-- `CN_IROH_RELAY_HTTP_HOST_BIND_IP=127.0.0.1`
-- tunnel 側で `api.kukuri.app -> 127.0.0.1:${CN_USER_API_PORT}`, `iroh-relay.kukuri.app -> 127.0.0.1:${CN_IROH_RELAY_PORT}` を割り当てる
-
-`iroh-relay` の `7842/udp` を WireGuard/VPS edge 経由で公開する場合:
-
-```dotenv
+CN_USER_API_HOST_BIND_IP=10.73.0.2
+CN_IROH_RELAY_HTTP_HOST_BIND_IP=10.73.0.2
 CN_IROH_RELAY_QUIC_BIND_ADDR=0.0.0.0:7842
 CN_IROH_RELAY_QUIC_HOST_BIND_IP=10.73.0.2
 CN_IROH_RELAY_QUIC_PORT=7842
@@ -95,12 +91,11 @@ CN_IROH_RELAY_TLS_KEY_PATH=/certs/default.key
 CN_IROH_RELAY_CERTS_HOST_PATH=./docker/cn/certs
 ```
 
-- Cloudflare Tunnel は UDP を運べないので、`7842/udp` は WireGuard/VPS edge で home 側へ直接 forward する
-- QUIC は tunnel を迂回するので、`docker/cn/certs/` には `iroh-relay.kukuri.app` 用の公開証明書と秘密鍵を置く
-- `CN_IROH_RELAY_QUIC_HOST_BIND_IP` は WireGuard で到達可能な home 側 IP に合わせる
-- Cloudflare Tunnel で `iroh-relay.kukuri.app` の TCP を公開しつつ QUIC を直公開したい場合は、`CN_IROH_RELAY_HTTPS_BIND_ADDR` を空のままにして `iroh-relay.kukuri.app -> http://127.0.0.1:${CN_IROH_RELAY_PORT}` を向ける
-- `CN_IROH_RELAY_HTTPS_BIND_ADDR` を設定した場合、local HTTP listener は captive portal 用の `/generate_204` しか返さない。`/`, `/ping`, `/relay`, `/healthz` を Cloudflare Tunnel で通したいなら `iroh-relay.kukuri.app -> https://127.0.0.1:${CN_IROH_RELAY_HTTPS_PORT}` を向ける
-- `https://iroh-relay.kukuri.app/ping` が `404 Not Found` を返す場合は、Cloudflare Tunnel が HTTP origin (`${CN_IROH_RELAY_PORT}`) に向いているのに `CN_IROH_RELAY_HTTPS_BIND_ADDR` が有効な構成になっている
+- `api.kukuri.app` は `cn-user-api` を向ける
+- `iroh-relay.kukuri.app` は `cn-iroh-relay` の HTTP/TCP と QUIC/UDP を向ける
+- desktop は `connectivity_urls` を server から受け取るので、websocket relay 前提は使わない
+- `docker/cn/certs/` には `iroh-relay.kukuri.app` 用の公開証明書と秘密鍵を `default.crt` / `default.key` として置く
+- Postgres と Valkey は Home 側 private bind のままにし、VPS や public internet へ公開しない
 
 起動:
 

--- a/scripts/vps/community-node-edge.env.example
+++ b/scripts/vps/community-node-edge.env.example
@@ -1,0 +1,24 @@
+# Copy to scripts/vps/community-node-edge.env and fill the secrets before running:
+#   sudo ./scripts/vps/setup-community-node-edge.sh scripts/vps/community-node-edge.env
+
+PUBLIC_IFACE=eth0
+SSH_PORT=22
+
+WG_IFACE=wg0
+WG_PORT=51820
+WG_ENDPOINT_HOST=api.kukuri.app
+WG_VPS_ADDRESS=10.73.0.1/24
+WG_HOME_CLIENT_ADDRESS=10.73.0.2/24
+WG_HOME_ALLOWED_IPS=10.73.0.2/32
+HOME_WG_IP=10.73.0.2
+WG_SERVER_PRIVATE_KEY=
+WG_HOME_PUBLIC_KEY=
+WG_HOME_PRESHARED_KEY=
+
+API_DOMAIN=api.kukuri.app
+IROH_RELAY_DOMAIN=iroh-relay.kukuri.app
+CADDY_EMAIL=
+
+HOME_CN_USER_API_PORT=18080
+HOME_IROH_RELAY_HTTP_PORT=13340
+HOME_IROH_RELAY_QUIC_PORT=7842

--- a/scripts/vps/community-node-edge.home-wg.conf.example
+++ b/scripts/vps/community-node-edge.home-wg.conf.example
@@ -1,0 +1,10 @@
+[Interface]
+Address = 10.73.0.2/24
+PrivateKey = <home-private-key>
+
+[Peer]
+PublicKey = <server-public-key>
+PresharedKey = <same-as-WG_HOME_PRESHARED_KEY>
+Endpoint = api.kukuri.app:51820
+AllowedIPs = 10.73.0.1/32
+PersistentKeepalive = 25

--- a/scripts/vps/setup-community-node-edge.sh
+++ b/scripts/vps/setup-community-node-edge.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ENV_FILE="${SCRIPT_DIR}/community-node-edge.env"
+CADDY_SITES_DIR="/etc/caddy/sites-enabled"
+CADDY_IMPORT_GLOB="${CADDY_SITES_DIR}/*.caddy"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  sudo ./scripts/vps/setup-community-node-edge.sh [env-file]
+
+Behavior:
+  - installs wireguard-tools, nftables, and caddy
+  - supports Debian/Ubuntu and Rocky/Alma/RHEL-like hosts
+  - configures wg0 on the VPS
+  - configures Caddy for api.kukuri.app and iroh-relay.kukuri.app
+  - forwards UDP 7842 from the VPS to the home community node over WireGuard
+
+Prepare first:
+  cp scripts/vps/community-node-edge.env.example scripts/vps/community-node-edge.env
+  edit scripts/vps/community-node-edge.env
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+ENV_FILE="${1:-${DEFAULT_ENV_FILE}}"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "env file not found: ${ENV_FILE}" >&2
+  exit 1
+fi
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "run as root: sudo $0 ${ENV_FILE}" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+set +a
+
+if [[ -z "${PUBLIC_IFACE:-}" ]]; then
+  PUBLIC_IFACE="$(ip route show default 0.0.0.0/0 | awk '/default/ { print $5; exit }')"
+fi
+
+required_vars=(
+  PUBLIC_IFACE
+  SSH_PORT
+  WG_IFACE
+  WG_PORT
+  WG_ENDPOINT_HOST
+  WG_VPS_ADDRESS
+  WG_HOME_CLIENT_ADDRESS
+  WG_HOME_ALLOWED_IPS
+  HOME_WG_IP
+  WG_SERVER_PRIVATE_KEY
+  WG_HOME_PUBLIC_KEY
+  API_DOMAIN
+  IROH_RELAY_DOMAIN
+  HOME_CN_USER_API_PORT
+  HOME_IROH_RELAY_HTTP_PORT
+  HOME_IROH_RELAY_QUIC_PORT
+)
+
+for var_name in "${required_vars[@]}"; do
+  if [[ -z "${!var_name:-}" ]]; then
+    echo "missing required variable: ${var_name}" >&2
+    exit 1
+  fi
+done
+
+backup_if_exists() {
+  local path="$1"
+  if [[ -f "${path}" ]]; then
+    cp "${path}" "${path}.bak.$(date +%Y%m%d%H%M%S)"
+  fi
+}
+
+install_text_file() {
+  local target_path="$1"
+  local source_path="$2"
+  local mode="${3:-644}"
+
+  install -D -m "${mode}" "${source_path}" "${target_path}"
+}
+
+log() {
+  printf '[setup-community-node-edge] %s\n' "$*"
+}
+
+service_exists() {
+  local service_name="$1"
+  systemctl show "${service_name}" --property=LoadState --value 2>/dev/null | grep -Fqx 'loaded'
+}
+
+disable_service_if_present() {
+  local service_name="$1"
+  if ! service_exists "${service_name}"; then
+    return
+  fi
+
+  if systemctl is-active --quiet "${service_name}" || systemctl is-enabled --quiet "${service_name}" >/dev/null 2>&1; then
+    log "disabling conflicting firewall service: ${service_name}"
+    systemctl stop "${service_name}" || true
+    systemctl disable "${service_name}" || true
+  fi
+}
+
+detect_platform_family() {
+  local os_id=""
+  local os_like=""
+
+  if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    source /etc/os-release
+    os_id="${ID:-}"
+    os_like="${ID_LIKE:-}"
+  fi
+
+  case " ${os_id} ${os_like} " in
+    *" debian "*|*" ubuntu "*)
+      printf 'debian\n'
+      return
+      ;;
+    *" rocky "*|*" almalinux "*|*" centos "*|*" rhel "*|*" fedora "*)
+      printf 'rhel\n'
+      return
+      ;;
+  esac
+
+  if command -v apt-get >/dev/null 2>&1; then
+    printf 'debian\n'
+    return
+  fi
+
+  if command -v dnf >/dev/null 2>&1; then
+    printf 'rhel\n'
+    return
+  fi
+
+  echo "unsupported platform: could not determine Debian-like or RHEL-like package manager" >&2
+  exit 1
+}
+
+install_packages_debian() {
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    ca-certificates \
+    caddy \
+    nftables \
+    wireguard-tools
+}
+
+install_packages_rhel() {
+  if ! command -v dnf >/dev/null 2>&1; then
+    echo "dnf is required on RHEL-like hosts" >&2
+    exit 1
+  fi
+
+  dnf install -y ca-certificates dnf-plugins-core
+
+  if ! rpm -q epel-release >/dev/null 2>&1; then
+    log "installing EPEL repository for wireguard-tools"
+    if ! dnf install -y epel-release; then
+      echo "failed to install epel-release; enable EPEL on this host and rerun" >&2
+      exit 1
+    fi
+  fi
+
+  log "ensuring the official Caddy rpm repository is configured"
+  dnf config-manager --add-repo https://dl.cloudsmith.io/public/caddy/stable/rpm.repo >/dev/null
+  dnf makecache -y
+  dnf install -y caddy nftables wireguard-tools
+}
+
+install_packages() {
+  local platform_family
+  platform_family="$(detect_platform_family)"
+  log "detected platform family: ${platform_family}"
+
+  case "${platform_family}" in
+    debian)
+      install_packages_debian
+      ;;
+    rhel)
+      install_packages_rhel
+      ;;
+    *)
+      echo "unsupported platform family: ${platform_family}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+disable_conflicting_firewall_services() {
+  disable_service_if_present firewalld.service
+  disable_service_if_present ufw.service
+}
+
+write_sysctl() {
+  local sysctl_conf="/etc/sysctl.d/99-kukuri-community-node-edge.conf"
+  cat > "${sysctl_conf}" <<'EOF'
+net.ipv4.ip_forward=1
+net.ipv6.conf.all.forwarding=1
+EOF
+  sysctl --system >/dev/null
+}
+
+write_wireguard() {
+  local wg_conf="/etc/wireguard/${WG_IFACE}.conf"
+  backup_if_exists "${wg_conf}"
+  mkdir -p /etc/wireguard
+
+  cat > "${wg_conf}" <<EOF
+[Interface]
+Address = ${WG_VPS_ADDRESS}
+ListenPort = ${WG_PORT}
+PrivateKey = ${WG_SERVER_PRIVATE_KEY}
+
+[Peer]
+PublicKey = ${WG_HOME_PUBLIC_KEY}
+AllowedIPs = ${WG_HOME_ALLOWED_IPS}
+EOF
+
+  if [[ -n "${WG_HOME_PRESHARED_KEY:-}" ]]; then
+    cat >> "${wg_conf}" <<EOF
+PresharedKey = ${WG_HOME_PRESHARED_KEY}
+EOF
+  fi
+
+  chmod 600 "${wg_conf}"
+}
+
+ensure_caddy_import() {
+  mkdir -p "${CADDY_SITES_DIR}"
+
+  if [[ ! -f /etc/caddy/Caddyfile ]]; then
+    local tmp_caddyfile
+    tmp_caddyfile="$(mktemp)"
+
+    if [[ -n "${CADDY_EMAIL:-}" ]]; then
+      cat > "${tmp_caddyfile}" <<EOF
+{
+	email ${CADDY_EMAIL}
+}
+
+import ${CADDY_IMPORT_GLOB}
+EOF
+    else
+      cat > "${tmp_caddyfile}" <<'EOF'
+import /etc/caddy/sites-enabled/*.caddy
+EOF
+    fi
+
+    install_text_file /etc/caddy/Caddyfile "${tmp_caddyfile}" 644
+    rm -f "${tmp_caddyfile}"
+    return
+  fi
+
+  local tmp_caddyfile
+  tmp_caddyfile="$(mktemp)"
+
+  awk -v desired="import ${CADDY_IMPORT_GLOB}" '
+    BEGIN {
+      normalized = 0
+    }
+    /^import \/etc\/caddy\/sites-enabled\/\*/ {
+      if (!normalized) {
+        print desired
+        normalized = 1
+      }
+      next
+    }
+    {
+      print
+    }
+    END {
+      if (!normalized) {
+        print desired
+      }
+    }
+  ' /etc/caddy/Caddyfile > "${tmp_caddyfile}"
+
+  install_text_file /etc/caddy/Caddyfile "${tmp_caddyfile}" 644
+  rm -f "${tmp_caddyfile}"
+}
+
+write_caddy_site() {
+  local caddy_site="/etc/caddy/sites-enabled/kukuri-community-node-edge.caddy"
+  local tmp_caddy_site
+  backup_if_exists "${caddy_site}"
+  tmp_caddy_site="$(mktemp)"
+
+  cat > "${tmp_caddy_site}" <<EOF
+${API_DOMAIN} {
+	encode zstd gzip
+	reverse_proxy http://${HOME_WG_IP}:${HOME_CN_USER_API_PORT} {
+		transport http {
+			versions h1
+			dial_timeout 10s
+			response_header_timeout 30s
+		}
+	}
+}
+
+${IROH_RELAY_DOMAIN} {
+	encode zstd gzip
+	reverse_proxy http://${HOME_WG_IP}:${HOME_IROH_RELAY_HTTP_PORT} {
+		flush_interval -1
+		transport http {
+			versions h1
+			dial_timeout 10s
+			response_header_timeout 0
+			read_timeout 0
+			write_timeout 0
+		}
+	}
+}
+EOF
+
+  install_text_file "${caddy_site}" "${tmp_caddy_site}" 644
+  rm -f "${tmp_caddy_site}"
+
+  caddy validate --config /etc/caddy/Caddyfile
+}
+
+write_nftables() {
+  local nft_conf="/etc/nftables.conf"
+  backup_if_exists "${nft_conf}"
+
+  cat > "${nft_conf}" <<EOF
+#!/usr/sbin/nft -f
+flush ruleset
+
+table inet filter {
+  chain input {
+    type filter hook input priority 0; policy drop;
+    iifname "lo" accept
+    ct state established,related accept
+    tcp dport ${SSH_PORT} accept
+    udp dport ${WG_PORT} accept
+    tcp dport { 80, 443 } accept
+    udp dport ${HOME_IROH_RELAY_QUIC_PORT} accept
+    iifname "${WG_IFACE}" ip saddr ${HOME_WG_IP} accept
+    counter reject with icmpx type admin-prohibited
+  }
+
+  chain forward {
+    type filter hook forward priority 0; policy drop;
+    ct state established,related accept
+    iifname "${PUBLIC_IFACE}" oifname "${WG_IFACE}" udp dport ${HOME_IROH_RELAY_QUIC_PORT} accept
+    iifname "${WG_IFACE}" oifname "${PUBLIC_IFACE}" udp sport ${HOME_IROH_RELAY_QUIC_PORT} accept
+  }
+
+  chain output {
+    type filter hook output priority 0; policy accept;
+  }
+}
+
+table ip nat {
+  chain prerouting {
+    type nat hook prerouting priority dstnat; policy accept;
+    iifname "${PUBLIC_IFACE}" udp dport ${HOME_IROH_RELAY_QUIC_PORT} dnat to ${HOME_WG_IP}:${HOME_IROH_RELAY_QUIC_PORT}
+  }
+
+  chain postrouting {
+    type nat hook postrouting priority srcnat; policy accept;
+    oifname "${WG_IFACE}" ip daddr ${HOME_WG_IP} udp dport ${HOME_IROH_RELAY_QUIC_PORT} masquerade
+  }
+}
+EOF
+}
+
+write_home_client_template() {
+  local server_public_key
+  local psk_line=""
+  local vps_tunnel_ip
+
+  server_public_key="$(printf '%s' "${WG_SERVER_PRIVATE_KEY}" | wg pubkey)"
+  vps_tunnel_ip="${WG_VPS_ADDRESS%%/*}"
+  if [[ -n "${WG_HOME_PRESHARED_KEY:-}" ]]; then
+    psk_line="PresharedKey = ${WG_HOME_PRESHARED_KEY}"
+  fi
+
+  cat > "/root/${WG_IFACE}-home-client.conf" <<EOF
+[Interface]
+Address = ${WG_HOME_CLIENT_ADDRESS}
+PrivateKey = <home-private-key>
+
+[Peer]
+PublicKey = ${server_public_key}
+${psk_line}
+Endpoint = ${WG_ENDPOINT_HOST}:${WG_PORT}
+AllowedIPs = ${vps_tunnel_ip}/32
+PersistentKeepalive = 25
+EOF
+
+  chmod 600 "/root/${WG_IFACE}-home-client.conf"
+}
+
+restart_services() {
+  systemctl daemon-reload
+  systemctl enable --now "wg-quick@${WG_IFACE}"
+  systemctl restart "wg-quick@${WG_IFACE}"
+  systemctl enable --now nftables
+  systemctl restart nftables
+  systemctl enable --now caddy
+  systemctl restart caddy
+}
+
+install_packages
+disable_conflicting_firewall_services
+write_sysctl
+write_wireguard
+ensure_caddy_import
+write_caddy_site
+write_nftables
+write_home_client_template
+restart_services
+
+cat <<EOF
+VPS community-node edge setup completed.
+
+Generated files:
+  /etc/wireguard/${WG_IFACE}.conf
+  /etc/caddy/sites-enabled/kukuri-community-node-edge.caddy
+  /etc/nftables.conf
+  /root/${WG_IFACE}-home-client.conf
+
+Next steps:
+  1. Copy /root/${WG_IFACE}-home-client.conf to the home server and complete the private key.
+  2. Set .env.community-node on the home server from .env.community-node.example.
+  3. Copy the public certificate/key for ${IROH_RELAY_DOMAIN} from the VPS Caddy store to docker/cn/certs/default.crt and docker/cn/certs/default.key on the home server before enabling QUIC.
+  4. Start the home server with:
+     docker compose --env-file .env.community-node -f docker-compose.community-node.yml run --rm cn-migrate
+     docker compose --env-file .env.community-node -f docker-compose.community-node.yml up -d --build cn-user-api cn-iroh-relay
+  5. Confirm:
+     curl -fsS https://${API_DOMAIN}/healthz
+     curl -fsS https://${IROH_RELAY_DOMAIN}/ping
+     systemctl status wg-quick@${WG_IFACE}
+     nft list ruleset
+EOF


### PR DESCRIPTION
## Summary
- Add a self-host runbook for publishing community-node through a WireGuard + Caddy VPS edge.
- Add VPS setup artifacts under `scripts/vps` for the current `cn-user-api` / `cn-iroh-relay` stack.
- Update the community-node env example and dev runbook to remove the old split TCP/tunnel guidance from the published path.

## Impact
- Operators get one documented public path: VPS terminates TCP/TLS and forwards `7842/udp` to the home community node over WireGuard.
- The public contract remains `https://api.kukuri.app` and `https://iroh-relay.kukuri.app`.
- Postgres and Valkey remain private on the home host.

## Validation
- `bash -n scripts/vps/setup-community-node-edge.sh`
- `bash scripts/vps/setup-community-node-edge.sh --help`
- `rg -n -P "Cloudflare Tunnel|cn-relay|(?<!iroh-)relay\\.kukuri\\.app|11223/udp" docs/runbooks .env.community-node.example scripts/vps -S`
- `git diff --check`
- `cargo xtask cn-check`
- `cargo xtask cn-test`

Manual public smoke was not run because it requires the real VPS/Home deployment.