### PR TITLE
[codex] Improve metaverse room reliability and chat

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -98,6 +98,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,7 +911,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3689,6 +3699,7 @@ dependencies = [
  "chrono",
  "jsonwebtoken",
  "kukuri-core",
+ "redis",
  "serde",
  "serde_json",
  "sqlx",
@@ -3708,6 +3719,7 @@ dependencies = [
  "chacha20poly1305",
  "hex",
  "hkdf",
+ "hmac",
  "secp256k1",
  "serde",
  "serde_json",
@@ -5671,6 +5683,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "redis"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6b5f4d8ef33944e833e2b1859ad478deab6e431d7337b30ee2efe21f7543"
+dependencies = [
+ "arcstr",
+ "async-lock",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -9287,6 +9322,12 @@ checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
 dependencies = [
  "xml-rs",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yasna"

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
@@ -18,6 +18,8 @@ vi.mock('./MetaverseScene', () => ({
     room: GameRoomView;
     localPeerId: string;
     sharedObject: SharedRoomObjectV1;
+    latestChatByPeer: Record<string, { body: string }>;
+    connectionState: 'live' | 'stale' | 'recovering' | 'offline';
     onLocalTransform: (transform: {
       roomId: string;
       peerId: string;
@@ -51,6 +53,10 @@ vi.mock('./MetaverseScene', () => ({
         Mark animation fallback
       </button>
       <span>{props.sharedObject.object_id}</span>
+      <span>Scene connection: {props.connectionState}</span>
+      {Object.entries(props.latestChatByPeer).map(([peerId, bubble]) => (
+        <span key={peerId}>{`Bubble ${peerId}: ${bubble.body}`}</span>
+      ))}
       {props.hud}
     </div>
   ),
@@ -381,5 +387,102 @@ describe('MetaverseRoomPanel animation sharing', () => {
 
     expect(screen.getByLabelText('Metaverse room viewport')).toBeInTheDocument();
     expect(screen.getByText(/fallback-primitive/)).toBeInTheDocument();
+  });
+
+  test('renders durable room chat history when joining a room', async () => {
+    const user = userEvent.setup();
+    const api = {
+      ...createDesktopMockApi(),
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+    const roomWithHistory: GameRoomView = {
+      ...room,
+      metaverse: {
+        ...room.metaverse!,
+        chat_history: [
+          {
+            room_id: room.room_id,
+            message_id: 'durable-chat-1',
+            author_peer_id: 'peer-history',
+            display_name: 'History Peer',
+            body: 'durable hello',
+            created_at: 12,
+          },
+        ],
+      },
+    };
+
+    renderPanel(api, { rooms: [roomWithHistory] });
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+
+    expect(screen.getByLabelText('ROOM Chat')).toBeInTheDocument();
+    expect(screen.getByText('History Peer')).toBeInTheDocument();
+    expect(screen.getByText('durable hello')).toBeInTheDocument();
+  });
+
+  test('shows offline room status when sync connectivity is unhealthy', async () => {
+    const user = userEvent.setup();
+    const api = {
+      ...createDesktopMockApi(),
+      listMetaverseRoomEvents: vi.fn().mockRejectedValue(new Error('poll failed')),
+    };
+    const offlineStatus = {
+      ...createSyncStatus(),
+      connected: false,
+      delivery_state: 'Offline' as const,
+      peer_count: 0,
+    };
+
+    renderPanel(api, { syncStatus: offlineStatus });
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+
+    expect(screen.getByText('Offline')).toBeInTheDocument();
+    expect(screen.getByText('Scene connection: offline')).toBeInTheDocument();
+  });
+
+  test('sends room chat to the log, backend event, and avatar bubble', async () => {
+    const user = userEvent.setup();
+    const baseApi = createDesktopMockApi();
+    const publishMetaverseRoomEvent = vi.fn(baseApi.publishMetaverseRoomEvent);
+    const api: DesktopApi = {
+      ...baseApi,
+      publishMetaverseRoomEvent,
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+
+    renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+    await user.type(screen.getByPlaceholderText('Say something in the room'), 'hello room');
+    await user.click(screen.getByRole('button', { name: 'Send' }));
+
+    expect(screen.getByText('hello room')).toBeInTheDocument();
+    expect(screen.getByText(/Bubble .*hello room/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        publishMetaverseRoomEvent.mock.calls.some(
+          ([, , , , event]) => event.type === 'chat_message' && event.message.body === 'hello room'
+        )
+      ).toBe(true);
+    });
+  });
+
+  test('shared object movement persists without closing the room viewport', async () => {
+    const user = userEvent.setup();
+    const baseApi = createDesktopMockApi();
+    const updateMetaverseRoom = vi.fn(baseApi.updateMetaverseRoom);
+    const api: DesktopApi = {
+      ...baseApi,
+      updateMetaverseRoom,
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+
+    renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+    await user.click(screen.getByRole('button', { name: /Forward/ }));
+
+    await waitFor(() => {
+      expect(updateMetaverseRoom).toHaveBeenCalled();
+    });
+    expect(screen.getByLabelText('Metaverse room viewport')).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -1,5 +1,6 @@
 ﻿import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
 import {
+  AlertTriangle,
   Box,
   ChevronDown,
   Cuboid,
@@ -10,7 +11,10 @@ import {
   PanelRightClose,
   PanelRightOpen,
   Play,
+  RefreshCw,
   Send,
+  Wifi,
+  WifiOff,
 } from 'lucide-react';
 
 import { AuthorAvatar } from '@/components/core/AuthorAvatar';
@@ -40,9 +44,16 @@ import {
   DEFAULT_AVATAR_ASSET_NAME,
   DEFAULT_AVATAR_ASSET_URL,
   DEFAULT_SHARED_OBJECT,
+  METAVERSE_CHAT_BUBBLE_TTL_MS,
+  METAVERSE_ROOM_HEARTBEAT_MS,
+  METAVERSE_ROOM_RECOVERY_MS,
+  METAVERSE_ROOM_STALE_MS,
+  mergeRoomChatMessages,
   normalizeAvatarAnimationState,
   type AvatarAssetStatus,
   type AvatarTransform,
+  type LatestChatBubble,
+  type MetaverseRoomConnectionState,
   type MetaverseRoomEvent,
   type MetaverseVec3,
   type PeerPresence,
@@ -61,6 +72,83 @@ type MetaverseRoomPanelProps = {
   mediaObjectUrls?: Record<string, string | null>;
   onRefresh: () => Promise<void>;
 };
+
+const EMPTY_ROOM_CHAT_HISTORY: NonNullable<
+  NonNullable<GameRoomView['metaverse']>['chat_history']
+> = [];
+
+function chatMessageFromApi(message: {
+  room_id: string;
+  message_id: string;
+  author_peer_id: string;
+  display_name?: string | null;
+  body: string;
+  created_at: number;
+}): RoomChatMessage {
+  return {
+    roomId: message.room_id,
+    messageId: message.message_id,
+    authorPeerId: message.author_peer_id,
+    displayName: message.display_name ?? null,
+    body: message.body,
+    createdAt: message.created_at,
+  };
+}
+
+function topicDiagnosticFor(syncStatus: SyncStatus, topic: string) {
+  return syncStatus.topic_diagnostics.find(
+    (diagnostic) => diagnostic.topic === topic || diagnostic.topic === `hint/${topic}`
+  );
+}
+
+function connectionStateLabel(state: MetaverseRoomConnectionState) {
+  if (state === 'live') {
+    return 'Live';
+  }
+  if (state === 'recovering') {
+    return 'Recovering';
+  }
+  if (state === 'stale') {
+    return 'Stale';
+  }
+  return 'Offline';
+}
+
+function connectionStateDetail(state: MetaverseRoomConnectionState) {
+  if (state === 'live') {
+    return 'Room events are flowing';
+  }
+  if (state === 'recovering') {
+    return 'Refreshing room connectivity';
+  }
+  if (state === 'stale') {
+    return 'No room activity recently';
+  }
+  return 'Peer connectivity is unavailable';
+}
+
+function latestChatBubbleFromMessage(message: RoomChatMessage, now = Date.now()): LatestChatBubble {
+  return {
+    peerId: message.authorPeerId,
+    displayName: message.displayName ?? null,
+    body: message.body,
+    createdAt: message.createdAt,
+    expiresAt: now + METAVERSE_CHAT_BUBBLE_TTL_MS,
+  };
+}
+
+function ConnectionStateIcon({ state }: { state: MetaverseRoomConnectionState }) {
+  if (state === 'live') {
+    return <Wifi className='size-4' aria-hidden='true' />;
+  }
+  if (state === 'recovering') {
+    return <RefreshCw className='size-4' aria-hidden='true' />;
+  }
+  if (state === 'stale') {
+    return <AlertTriangle className='size-4' aria-hidden='true' />;
+  }
+  return <WifiOff className='size-4' aria-hidden='true' />;
+}
 
 export function MetaverseRoomPanel({
   api,
@@ -88,14 +176,20 @@ export function MetaverseRoomPanel({
   const [remoteTransforms, setRemoteTransforms] = useState<Record<string, AvatarTransform>>({});
   const [peerPresence, setPeerPresence] = useState<Record<string, PeerPresence>>({});
   const [messages, setMessages] = useState<RoomChatMessage[]>([]);
+  const [latestChatByPeer, setLatestChatByPeer] = useState<Record<string, LatestChatBubble>>({});
   const [messageDraft, setMessageDraft] = useState('');
   const [sharedObject, setSharedObject] = useState<SharedRoomObjectV1>(DEFAULT_SHARED_OBJECT);
   const [lastSentSeq, setLastSentSeq] = useState(0);
   const [avatarAssetStatus, setAvatarAssetStatus] = useState<AvatarAssetStatus>('loading');
   const [localAvatarAssetRef, setLocalAvatarAssetRef] = useState<MetaverseAssetRef | null>(null);
   const [localAvatarAssetUrl, setLocalAvatarAssetUrl] = useState<string | null>(null);
+  const [pollErrorCount, setPollErrorCount] = useState(0);
+  const [lastRoomActivityAt, setLastRoomActivityAt] = useState(() => Date.now());
+  const [recoveringUntil, setRecoveringUntil] = useState(0);
+  const [clockNow, setClockNow] = useState(() => Date.now());
   const channelRef = useRef<BroadcastChannel | null>(null);
   const lastBackendEventEnvelopeIdRef = useRef<string | null>(null);
+  const lastRecoveryAtRef = useRef(0);
   const pendingCreatedRoomIdRef = useRef<string | null>(null);
   const localPeerSeed = useId().replaceAll(':', '');
   const localPeerId = `${syncStatus.discovery.local_endpoint_id || syncStatus.local_author_pubkey || 'local'}:${localPeerSeed}`;
@@ -115,6 +209,44 @@ export function MetaverseRoomPanel({
   const selectedRoom = selectedRoomId
     ? rooms.find((room) => room.room_id === selectedRoomId) ?? null
     : null;
+  const selectedRoomRoomId = selectedRoom?.room_id ?? null;
+  const selectedRoomSharedObject = selectedRoom?.metaverse?.scene.shared_object ?? null;
+  const selectedRoomChatHistory = selectedRoom?.metaverse?.chat_history ?? EMPTY_ROOM_CHAT_HISTORY;
+  const activeTopicDiagnostic = useMemo(
+    () => topicDiagnosticFor(syncStatus, activeTopic),
+    [activeTopic, syncStatus]
+  );
+  const roomConnectionState: MetaverseRoomConnectionState = useMemo(() => {
+    if (!selectedRoom) {
+      return 'offline';
+    }
+    if (recoveringUntil > clockNow) {
+      return 'recovering';
+    }
+    const topicPeerCount = activeTopicDiagnostic?.peer_count ?? syncStatus.peer_count;
+    const topicError = activeTopicDiagnostic?.last_error ?? syncStatus.last_error ?? null;
+    if (
+      !syncStatus.connected ||
+      syncStatus.delivery_state === 'Offline' ||
+      topicPeerCount === 0 ||
+      pollErrorCount >= 3 ||
+      topicError
+    ) {
+      return 'offline';
+    }
+    if (clockNow - lastRoomActivityAt > METAVERSE_ROOM_STALE_MS) {
+      return 'stale';
+    }
+    return 'live';
+  }, [
+    activeTopicDiagnostic,
+    clockNow,
+    lastRoomActivityAt,
+    pollErrorCount,
+    recoveringUntil,
+    selectedRoom,
+    syncStatus,
+  ]);
   const knownPeerCount = Object.keys(remoteTransforms).length;
   const localDisplayName = localProfile?.display_name?.trim() || localProfile?.name?.trim() || null;
 
@@ -134,24 +266,44 @@ export function MetaverseRoomPanel({
   }, [rooms, selectedRoomId]);
 
   useEffect(() => {
-    if (!selectedRoom) {
+    const intervalId = window.setInterval(() => {
+      const now = Date.now();
+      setClockNow(now);
+      setLatestChatByPeer((current) => {
+        const next = Object.fromEntries(
+          Object.entries(current).filter(([, bubble]) => bubble.expiresAt > now)
+        );
+        return Object.keys(next).length === Object.keys(current).length ? current : next;
+      });
+    }, 1000);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedRoomRoomId) {
       return;
     }
-    setSharedObject(selectedRoom.metaverse?.scene.shared_object ?? DEFAULT_SHARED_OBJECT);
+    setSharedObject(DEFAULT_SHARED_OBJECT);
     setRemoteTransforms({});
     setPeerPresence({});
     setMessages([]);
+    setLatestChatByPeer({});
+    setPollErrorCount(0);
+    setLastRoomActivityAt(Date.now());
     lastBackendEventEnvelopeIdRef.current = null;
     if (typeof BroadcastChannel === 'undefined') {
       return;
     }
-    const channel = new BroadcastChannel(`kukuri-metaverse-room:${selectedRoom.room_id}`);
+    const channel = new BroadcastChannel(`kukuri-metaverse-room:${selectedRoomRoomId}`);
     channelRef.current = channel;
     channel.onmessage = (event: MessageEvent<MetaverseRoomEvent>) => {
       const data = event.data;
       if (!data || !('type' in data)) {
         return;
       }
+      setLastRoomActivityAt(Date.now());
       if (data.type === 'presence.join' && data.presence.peerId !== localPeerId) {
         setPeerPresence((current) => ({
           ...current,
@@ -164,8 +316,12 @@ export function MetaverseRoomPanel({
           [data.transform.peerId]: data.transform,
         }));
       }
-      if (data.type === 'chat.message' && data.message.authorPeerId !== localPeerId) {
-        setMessages((current) => [...current, data.message].slice(-64));
+      if (data.type === 'chat.message') {
+        setMessages((current) => mergeRoomChatMessages(current, [data.message]));
+        setLatestChatByPeer((current) => ({
+          ...current,
+          [data.message.authorPeerId]: latestChatBubbleFromMessage(data.message),
+        }));
       }
       if (data.type === 'object.update' && data.object.updated_by !== localPeerId) {
         setSharedObject(data.object);
@@ -175,36 +331,61 @@ export function MetaverseRoomPanel({
       channel.close();
       channelRef.current = null;
     };
-  }, [localPeerId, selectedRoom]);
+  }, [localPeerId, selectedRoomRoomId]);
+
+  useEffect(() => {
+    setSharedObject(selectedRoomSharedObject ?? DEFAULT_SHARED_OBJECT);
+  }, [selectedRoomSharedObject]);
+
+  useEffect(() => {
+    const durableMessages = selectedRoomChatHistory.map(chatMessageFromApi);
+    setMessages((current) => mergeRoomChatMessages(current, durableMessages));
+  }, [selectedRoomChatHistory, selectedRoomRoomId]);
 
   useEffect(() => {
     if (!selectedRoom) {
       return;
     }
-    const now = Date.now();
-    const presence: PeerPresence = {
-      peerId: localPeerId,
-      displayName: localDisplayName,
-      avatarAssetRef: localAvatarAssetRef,
-      avatarAssetUrl: localAvatarAssetUrl,
-      joinedAt: now,
-      lastSeenAt: now,
+    const joinedAt = Date.now();
+    const publishPresence = () => {
+      const now = Date.now();
+      const presence: PeerPresence = {
+        peerId: localPeerId,
+        displayName: localDisplayName,
+        avatarAssetRef: localAvatarAssetRef,
+        avatarAssetUrl: localAvatarAssetUrl,
+        joinedAt,
+        lastSeenAt: now,
+      };
+      emit({ type: 'presence.join', presence });
+      void api.publishMetaverseRoomEvent(activeTopic, selectedRoom.room_id, localPeerId, now, {
+        type: 'presence_join',
+        presence: {
+          room_id: selectedRoom.room_id,
+          peer_id: localPeerId,
+          display_name: localDisplayName,
+          avatar_asset_ref: localAvatarAssetRef,
+          joined_at: joinedAt,
+          last_seen_at: now,
+        },
+      }).catch(() => {
+        // Browser-only fallback is handled by the local scene.
+      });
     };
-    emit({ type: 'presence.join', presence });
-    void api.publishMetaverseRoomEvent(activeTopic, selectedRoom.room_id, localPeerId, now, {
-      type: 'presence_join',
-      presence: {
-        room_id: selectedRoom.room_id,
-        peer_id: localPeerId,
-        display_name: localDisplayName,
-        avatar_asset_ref: localAvatarAssetRef,
-        joined_at: now,
-        last_seen_at: now,
-      },
-    }).catch(() => {
-      // Browser-only fallback is handled by the local scene.
-    });
-  }, [activeTopic, api, localAvatarAssetRef, localAvatarAssetUrl, localDisplayName, localPeerId, selectedRoom]);
+    publishPresence();
+    const intervalId = window.setInterval(publishPresence, METAVERSE_ROOM_HEARTBEAT_MS);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [
+    activeTopic,
+    api,
+    localAvatarAssetRef,
+    localAvatarAssetUrl,
+    localDisplayName,
+    localPeerId,
+    selectedRoom,
+  ]);
 
   async function importAvatarBlob(blob: Blob, name: string) {
     if (!selectedRoom) {
@@ -251,6 +432,7 @@ export function MetaverseRoomPanel({
     let timeoutId = 0;
     const applyBackendEvent = (view: MetaverseRoomEventView) => {
       const event = view.content.event;
+      setLastRoomActivityAt(Date.now());
       if (event.type === 'presence_join' && event.presence.peer_id !== localPeerId) {
         const presence: PeerPresence = {
           peerId: event.presence.peer_id,
@@ -302,17 +484,13 @@ export function MetaverseRoomPanel({
           },
         }));
       }
-      if (event.type === 'chat_message' && event.message.author_peer_id !== localPeerId) {
-        setMessages((current) => [
+      if (event.type === 'chat_message') {
+        const message = chatMessageFromApi(event.message);
+        setMessages((current) => mergeRoomChatMessages(current, [message]));
+        setLatestChatByPeer((current) => ({
           ...current,
-          {
-            roomId: event.message.room_id,
-            messageId: event.message.message_id,
-            authorPeerId: event.message.author_peer_id,
-            body: event.message.body,
-            createdAt: event.message.created_at,
-          },
-        ].slice(-64));
+          [message.authorPeerId]: latestChatBubbleFromMessage(message),
+        }));
       }
       if (event.type === 'object_update' && event.object.updated_by !== localPeerId) {
         setSharedObject(event.object);
@@ -332,7 +510,13 @@ export function MetaverseRoomPanel({
           }
           lastBackendEventEnvelopeIdRef.current = events[events.length - 1].envelope_id;
         }
+        if (!cancelled) {
+          setPollErrorCount(0);
+        }
       } catch {
+        if (!cancelled) {
+          setPollErrorCount((current) => current + 1);
+        }
         // The browser-only dev shell has no Tauri backend. BroadcastChannel remains the local fallback.
       } finally {
         if (!cancelled) {
@@ -346,6 +530,24 @@ export function MetaverseRoomPanel({
       window.clearTimeout(timeoutId);
     };
   }, [activeTopic, api, localPeerId, selectedRoom]);
+
+  useEffect(() => {
+    if (!selectedRoom || (roomConnectionState !== 'stale' && roomConnectionState !== 'offline')) {
+      return;
+    }
+    const now = Date.now();
+    if (now - lastRecoveryAtRef.current < METAVERSE_ROOM_RECOVERY_MS) {
+      return;
+    }
+    lastRecoveryAtRef.current = now;
+    lastBackendEventEnvelopeIdRef.current = null;
+    if (roomConnectionState === 'stale') {
+      setRecoveringUntil(now + 3_000);
+    }
+    void Promise.resolve(onRefresh()).catch(() => {
+      setPollErrorCount((current) => current + 1);
+    });
+  }, [onRefresh, roomConnectionState, selectedRoom]);
 
   async function handleCreateRoom(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -437,10 +639,15 @@ export function MetaverseRoomPanel({
       roomId: selectedRoom.room_id,
       messageId: `${localPeerId}-${Date.now()}`,
       authorPeerId: localPeerId,
+      displayName: localDisplayName,
       body: messageDraft.trim(),
       createdAt: Date.now(),
     };
-    setMessages((current) => [...current, message].slice(-64));
+    setMessages((current) => mergeRoomChatMessages(current, [message]));
+    setLatestChatByPeer((current) => ({
+      ...current,
+      [message.authorPeerId]: latestChatBubbleFromMessage(message),
+    }));
     setMessageDraft('');
     emit({ type: 'chat.message', message });
     void api.publishMetaverseRoomEvent(
@@ -454,7 +661,7 @@ export function MetaverseRoomPanel({
           room_id: message.roomId,
           message_id: message.messageId,
           author_peer_id: message.authorPeerId,
-          display_name: null,
+          display_name: message.displayName,
           body: message.body,
           created_at: message.createdAt,
         },
@@ -614,10 +821,21 @@ export function MetaverseRoomPanel({
               peerPresence={peerPresence}
               sharedObject={sharedObject}
               avatarAssetUrl={localAvatarAssetUrl}
+              latestChatByPeer={latestChatByPeer}
+              connectionState={roomConnectionState}
+              now={clockNow}
               onLocalTransform={handleLocalTransform}
               onAvatarAssetStatus={setAvatarAssetStatus}
               hud={(
                 <>
+                  <div
+                    className='metaverse-connection-badge'
+                    data-state={roomConnectionState}
+                    title={connectionStateDetail(roomConnectionState)}
+                  >
+                    <ConnectionStateIcon state={roomConnectionState} />
+                    <span>{connectionStateLabel(roomConnectionState)}</span>
+                  </div>
                   <div className='metaverse-hud-toolbar' data-open={hudOpen}>
                     <Button
                       variant='ghost'
@@ -727,40 +945,45 @@ export function MetaverseRoomPanel({
                           <Button size='sm' variant='secondary' type='button' onClick={() => void moveSharedObject([0, 0, 50])}>Back</Button>
                         </div>
                       </div>
-                      <form className='metaverse-chat-form' onSubmit={handleSendMessage}>
-                        <Label>
-                          <span>
-                            <MessageSquare className='size-4' aria-hidden='true' />
-                            Room chat
-                          </span>
-                          <Input
-                            value={messageDraft}
-                            placeholder='Say something in the room'
-                            onChange={(event) => setMessageDraft(event.target.value)}
-                          />
-                        </Label>
-                        <Button size='sm' type='submit'>
-                          <Send className='size-4' aria-hidden='true' />
-                          Send
-                        </Button>
-                      </form>
-                      <ul className='metaverse-chat-list'>
-                        {messages.map((message) => (
-                          <li key={message.messageId}>
-                            <strong>
-                              {message.authorPeerId === localPeerId ? 'You' : message.authorPeerId.slice(0, 12)}
-                              <small>{formatLocalizedTime(message.createdAt, locale)}</small>
-                            </strong>
-                            <span>{message.body}</span>
-                          </li>
-                        ))}
-                      </ul>
                     </aside>
                     <span className='metaverse-hud-scrollbar-indicator' aria-hidden='true'>
                       <span />
                     </span>
                     </>
                   ) : null}
+                  <section className='metaverse-room-chat-log' aria-label='ROOM Chat'>
+                    <div className='metaverse-room-chat-log-header'>
+                      <MessageSquare className='size-4' aria-hidden='true' />
+                      <span>ROOM Chat</span>
+                    </div>
+                    <ul className='metaverse-chat-list'>
+                      {messages.map((message) => (
+                        <li key={message.messageId}>
+                          <strong>
+                            {message.authorPeerId === localPeerId
+                              ? 'You'
+                              : message.displayName || message.authorPeerId.slice(0, 12)}
+                            <small>{formatLocalizedTime(message.createdAt, locale)}</small>
+                          </strong>
+                          <span>{message.body}</span>
+                        </li>
+                      ))}
+                    </ul>
+                    <form className='metaverse-chat-form' onSubmit={handleSendMessage}>
+                      <Label>
+                        <span className='sr-only'>Room chat message</span>
+                        <Input
+                          value={messageDraft}
+                          placeholder='Say something in the room'
+                          onChange={(event) => setMessageDraft(event.target.value)}
+                        />
+                      </Label>
+                      <Button size='sm' type='submit'>
+                        <Send className='size-4' aria-hidden='true' />
+                        Send
+                      </Button>
+                    </form>
+                  </section>
                 </>
               )}
             />

--- a/apps/desktop/src/components/extended/MetaverseScene.test.ts
+++ b/apps/desktop/src/components/extended/MetaverseScene.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 import {
   isNewerRemoteTransform,
   avatarAnimationForInput,
+  mergeRoomChatMessages,
   normalizeAvatarAnimationState,
   stepAvatarJump,
   type AvatarTransform,
@@ -52,5 +53,45 @@ describe('metaverse avatar animation state', () => {
     expect(isNewerRemoteTransform(current, { ...current, seq: 2, sentAt: 400 })).toBe(false);
     expect(isNewerRemoteTransform(current, { ...current, seq: 4, sentAt: 250 })).toBe(true);
     expect(isNewerRemoteTransform(current, { ...current, sentAt: 301 })).toBe(true);
+  });
+
+  test('deduplicates and caps room chat messages', () => {
+    const current = Array.from({ length: 99 }, (_, index) => ({
+      roomId: 'room',
+      messageId: `chat-${index}`,
+      authorPeerId: 'peer',
+      body: `message ${index}`,
+      createdAt: index,
+    }));
+    const merged = mergeRoomChatMessages(current, [
+      {
+        roomId: 'room',
+        messageId: 'chat-98',
+        authorPeerId: 'peer',
+        body: 'message 98 edited by arrival order',
+        createdAt: 98,
+      },
+      {
+        roomId: 'room',
+        messageId: 'chat-100',
+        authorPeerId: 'peer',
+        body: 'message 100',
+        createdAt: 100,
+      },
+      {
+        roomId: 'room',
+        messageId: 'chat-101',
+        authorPeerId: 'peer',
+        body: 'message 101',
+        createdAt: 101,
+      },
+    ]);
+
+    expect(merged).toHaveLength(100);
+    expect(merged[0].messageId).toBe('chat-1');
+    expect(merged.find((message) => message.messageId === 'chat-98')?.body).toBe(
+      'message 98 edited by arrival order'
+    );
+    expect(merged.at(-1)?.messageId).toBe('chat-101');
   });
 });

--- a/apps/desktop/src/components/extended/MetaverseScene.tsx
+++ b/apps/desktop/src/components/extended/MetaverseScene.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { VRMLoaderPlugin, VRMUtils, type VRM } from '@pixiv/three-vrm';
@@ -21,6 +22,8 @@ import {
   type AvatarAssetStatus,
   type AvatarPhysicsState,
   type AvatarTransform,
+  type LatestChatBubble,
+  type MetaverseRoomConnectionState,
   type MetaverseVec3,
   type PeerPresence,
 } from './MetaverseSceneModel';
@@ -32,6 +35,9 @@ type SceneProps = {
   peerPresence: Record<string, PeerPresence>;
   sharedObject: SharedRoomObjectV1;
   avatarAssetUrl: string | null;
+  latestChatByPeer: Record<string, LatestChatBubble>;
+  connectionState: MetaverseRoomConnectionState;
+  now: number;
   hud: ReactNode;
   onLocalTransform: (transform: AvatarTransform) => void;
   onAvatarAssetStatus: (status: AvatarAssetStatus) => void;
@@ -82,6 +88,19 @@ function makePrimitiveAvatar(color: number) {
         <meshStandardMaterial color={0xf5d0c5} roughness={0.65} />
       </mesh>
     </>
+  );
+}
+
+function AvatarChatBubble({ bubble, stale }: { bubble?: LatestChatBubble; stale?: boolean }) {
+  if (!bubble && !stale) {
+    return null;
+  }
+  return (
+    <Html position={[0, 1.9, 0]} center distanceFactor={8} occlude={false}>
+      <div className='metaverse-avatar-bubble' data-stale={stale ? 'true' : 'false'}>
+        {bubble ? <span>{bubble.body}</span> : <span>stale</span>}
+      </div>
+    </Html>
   );
 }
 
@@ -372,12 +391,17 @@ function LocalAvatar({
   room,
   localPeerId,
   avatarAssetUrl,
+  chatBubble,
   onLocalTransform,
   onAvatarAssetStatus,
-}: Pick<SceneProps, 'room' | 'localPeerId' | 'avatarAssetUrl' | 'onLocalTransform' | 'onAvatarAssetStatus'>) {
+}: Pick<SceneProps, 'room' | 'localPeerId' | 'avatarAssetUrl' | 'onLocalTransform' | 'onAvatarAssetStatus'> & {
+  chatBubble?: LatestChatBubble;
+}) {
   const groupRef = useRef<THREE.Group | null>(null);
   const spawnPosition = room.metaverse?.default_spawn.position;
   const spawnRotation = room.metaverse?.default_spawn.rotation;
+  const spawnPositionKey = spawnPosition?.join(',');
+  const spawnRotationKey = spawnRotation?.join(',');
   const transformRef = useRef(initialAvatarTransform(room.room_id, localPeerId, spawnPosition, spawnRotation));
   const physicsRef = useRef<AvatarPhysicsState>({ verticalVelocity: 0, grounded: true });
   const seqRef = useRef(0);
@@ -394,7 +418,13 @@ function LocalAvatar({
   }, [onLocalTransform]);
 
   useEffect(() => {
-    const nextTransform = initialAvatarTransform(room.room_id, localPeerId, spawnPosition, spawnRotation);
+    const nextSpawnPosition = spawnPositionKey
+      ? (spawnPositionKey.split(',').map(Number) as MetaverseVec3)
+      : undefined;
+    const nextSpawnRotation = spawnRotationKey
+      ? (spawnRotationKey.split(',').map(Number) as MetaverseVec3)
+      : undefined;
+    const nextTransform = initialAvatarTransform(room.room_id, localPeerId, nextSpawnPosition, nextSpawnRotation);
     transformRef.current = nextTransform;
     physicsRef.current = { verticalVelocity: 0, grounded: nextTransform.position[1] <= AVATAR_GROUND_Y };
     seqRef.current = 0;
@@ -405,7 +435,7 @@ function LocalAvatar({
       groupRef.current.position.copy(scenePosition(nextTransform.position));
       groupRef.current.rotation.y = THREE.MathUtils.degToRad(nextTransform.rotation[1]);
     }
-  }, [localPeerId, room.room_id, spawnPosition, spawnRotation]);
+  }, [localPeerId, room.room_id, spawnPositionKey, spawnRotationKey]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -512,6 +542,7 @@ function LocalAvatar({
         animationRef={animationRef}
         statusTarget={onAvatarAssetStatus}
       />
+      <AvatarChatBubble bubble={chatBubble} />
     </group>
   );
 }
@@ -519,13 +550,20 @@ function LocalAvatar({
 function RemoteAvatar({
   transform,
   presence,
+  chatBubble,
+  connectionState,
+  now,
 }: {
   transform: AvatarTransform;
   presence: PeerPresence | null;
+  chatBubble?: LatestChatBubble;
+  connectionState: MetaverseRoomConnectionState;
+  now: number;
 }) {
   const groupRef = useRef<THREE.Group | null>(null);
   const targetRef = useRef(transform);
   const animationRef = useRef<AvatarAnimationState>(transform.animation);
+  const initializedRef = useRef(false);
 
   useEffect(() => {
     if (isNewerRemoteTransform(targetRef.current, transform)) {
@@ -541,18 +579,23 @@ function RemoteAvatar({
     }
     const target = targetRef.current;
     const targetPosition = scenePosition(target.position);
-    const alpha = Math.min(1, deltaSeconds * 12);
-    group.position.lerp(targetPosition, alpha);
+    if (!initializedRef.current) {
+      group.position.copy(targetPosition);
+      group.rotation.y = THREE.MathUtils.degToRad(target.rotation[1]);
+      initializedRef.current = true;
+      return;
+    }
+    const alpha = 1 - Math.exp(-deltaSeconds / 0.12);
+    group.position.lerp(targetPosition, Math.min(1, alpha));
     const targetYaw = THREE.MathUtils.degToRad(target.rotation[1]);
-    group.rotation.y = THREE.MathUtils.lerp(group.rotation.y, targetYaw, alpha);
-    group.visible = Date.now() - target.sentAt < 15_000;
+    group.rotation.y = THREE.MathUtils.lerp(group.rotation.y, targetYaw, Math.min(1, alpha));
   });
+
+  const stale = connectionState !== 'live' || now - transform.sentAt > 15_000;
 
   return (
     <group
       ref={groupRef}
-      position={scenePosition(transform.position)}
-      rotation={[0, THREE.MathUtils.degToRad(transform.rotation[1]), 0]}
       userData={{ displayName: presence?.displayName ?? transform.peerId }}
     >
       <AvatarModel
@@ -560,6 +603,7 @@ function RemoteAvatar({
         color={0xe37070}
         animationRef={animationRef}
       />
+      <AvatarChatBubble bubble={chatBubble} stale={stale && !chatBubble} />
     </group>
   );
 }
@@ -592,6 +636,9 @@ function SceneContents({
   peerPresence,
   sharedObject,
   avatarAssetUrl,
+  latestChatByPeer,
+  connectionState,
+  now,
   onLocalTransform,
   onAvatarAssetStatus,
 }: Omit<SceneProps, 'hud'>) {
@@ -617,6 +664,7 @@ function SceneContents({
         room={room}
         localPeerId={localPeerId}
         avatarAssetUrl={avatarAssetUrl}
+        chatBubble={latestChatByPeer[localPeerId]}
         onLocalTransform={onLocalTransform}
         onAvatarAssetStatus={onAvatarAssetStatus}
       />
@@ -625,6 +673,9 @@ function SceneContents({
           key={peerId}
           transform={transform}
           presence={peerPresence[peerId] ?? null}
+          chatBubble={latestChatByPeer[peerId]}
+          connectionState={connectionState}
+          now={now}
         />
       ))}
       <SharedObject object={sharedObject} />
@@ -639,6 +690,9 @@ export function MetaverseScene({
   peerPresence,
   sharedObject,
   avatarAssetUrl,
+  latestChatByPeer,
+  connectionState,
+  now,
   hud,
   onLocalTransform,
   onAvatarAssetStatus,
@@ -658,6 +712,9 @@ export function MetaverseScene({
           peerPresence={peerPresence}
           sharedObject={sharedObject}
           avatarAssetUrl={avatarAssetUrl}
+          latestChatByPeer={latestChatByPeer}
+          connectionState={connectionState}
+          now={now}
           onLocalTransform={onLocalTransform}
           onAvatarAssetStatus={onAvatarAssetStatus}
         />

--- a/apps/desktop/src/components/extended/MetaverseSceneModel.ts
+++ b/apps/desktop/src/components/extended/MetaverseSceneModel.ts
@@ -66,9 +66,20 @@ export type RoomChatMessage = {
   roomId: string;
   messageId: string;
   authorPeerId: string;
+  displayName?: string | null;
   body: string;
   createdAt: number;
 };
+
+export type LatestChatBubble = {
+  peerId: string;
+  displayName: string | null;
+  body: string;
+  createdAt: number;
+  expiresAt: number;
+};
+
+export type MetaverseRoomConnectionState = 'live' | 'stale' | 'recovering' | 'offline';
 
 export type MetaverseRoomEvent =
   | { type: 'presence.join'; presence: PeerPresence }
@@ -91,6 +102,11 @@ export const DEFAULT_SHARED_OBJECT: SharedRoomObjectV1 = {
 
 export const DEFAULT_AVATAR_ASSET_NAME = 'blumochichi.vrm';
 export const DEFAULT_AVATAR_ASSET_URL = `/${DEFAULT_AVATAR_ASSET_NAME}`;
+export const METAVERSE_CHAT_HISTORY_LIMIT = 100;
+export const METAVERSE_CHAT_BUBBLE_TTL_MS = 8_000;
+export const METAVERSE_ROOM_STALE_MS = 15_000;
+export const METAVERSE_ROOM_HEARTBEAT_MS = 5_000;
+export const METAVERSE_ROOM_RECOVERY_MS = 10_000;
 
 export const AVATAR_GROUND_Y = 0;
 export const AVATAR_JUMP_VELOCITY = 520;
@@ -149,4 +165,17 @@ export function isNewerRemoteTransform(
     return incoming.seq > current.seq;
   }
   return incoming.sentAt > current.sentAt;
+}
+
+export function mergeRoomChatMessages(
+  current: RoomChatMessage[],
+  incoming: RoomChatMessage[]
+): RoomChatMessage[] {
+  const byId = new Map<string, RoomChatMessage>();
+  for (const message of [...current, ...incoming]) {
+    byId.set(message.messageId, message);
+  }
+  return Array.from(byId.values())
+    .sort((left, right) => left.createdAt - right.createdAt || left.messageId.localeCompare(right.messageId))
+    .slice(-METAVERSE_CHAT_HISTORY_LIMIT);
 }

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -493,6 +493,7 @@ export type MetaverseRoomStateV1 = {
     rotation: [number, number, number];
   };
   asset_refs: MetaverseAssetRef[];
+  chat_history?: MetaverseRoomChatMessageV1[];
 };
 
 export type MetaverseRoomPresenceV1 = {

--- a/apps/desktop/src/mocks/desktopApiMock.ts
+++ b/apps/desktop/src/mocks/desktopApiMock.ts
@@ -967,6 +967,7 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
               rotation: [0, 180, 0],
             },
             asset_refs: [],
+            chat_history: [],
           },
           manifest_blob_hash: `mock-${roomId}`,
           updated_at: now,
@@ -1272,6 +1273,28 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       };
       const key = `${topic}::${roomId}`;
       metaverseRoomEventsByRoom[key] = [...(metaverseRoomEventsByRoom[key] ?? []), view].slice(-512);
+      if (event.type === 'chat_message') {
+        gameRoomsByTopic[topic] = (gameRoomsByTopic[topic] ?? []).map((room) => {
+          if (room.room_id !== roomId || !room.metaverse) {
+            return room;
+          }
+          const chatHistory = [
+            ...(room.metaverse.chat_history ?? []).filter(
+              (message) => message.message_id !== event.message.message_id
+            ),
+            event.message,
+          ].slice(-100);
+          return withGameRoomDefaults({
+            ...room,
+            metaverse: {
+              ...room.metaverse,
+              chat_history: chatHistory,
+            },
+            updated_at: now,
+            manifest_blob_hash: `mock-${roomId}-${now}`,
+          });
+        });
+      }
       return view;
     },
     async listMetaverseRoomEvents(topic, roomId, afterEnvelopeId = null, limit = null) {

--- a/apps/desktop/src/mocks/desktopMockModel.ts
+++ b/apps/desktop/src/mocks/desktopMockModel.ts
@@ -208,7 +208,12 @@ export function withGameRoomDefaults(room: GameRoomView): GameRoomView {
     audience_label: room.audience_label ?? (room.channel_id ? 'Private channel' : 'Public'),
     scores: room.scores.map((score) => ({ ...score })),
     room_kind: room.room_kind ?? 'score_game',
-    metaverse: room.metaverse ?? null,
+    metaverse: room.metaverse
+      ? {
+          ...room.metaverse,
+          chat_history: [...(room.metaverse.chat_history ?? [])],
+        }
+      : null,
     manifest_blob_hash: room.manifest_blob_hash ?? `mock-${room.room_id}`,
   };
 }

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -293,6 +293,39 @@
   border-radius: 0.4rem;
 }
 
+.metaverse-connection-badge {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 82%, transparent);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--surface-panel) 86%, transparent);
+  color: var(--foreground);
+  font-size: 0.82rem;
+  font-weight: 700;
+  box-shadow: var(--shadow-panel);
+  backdrop-filter: blur(14px);
+}
+
+.metaverse-connection-badge[data-state='live'] {
+  color: var(--accent);
+}
+
+.metaverse-connection-badge[data-state='stale'],
+.metaverse-connection-badge[data-state='recovering'] {
+  color: var(--warning);
+}
+
+.metaverse-connection-badge[data-state='offline'] {
+  color: var(--danger);
+}
+
 .metaverse-room-hud {
   position: absolute;
   top: 4rem;
@@ -474,6 +507,46 @@
   gap: 0.6rem;
 }
 
+.metaverse-room-chat-log {
+  position: absolute;
+  left: 0.75rem;
+  bottom: 0.75rem;
+  z-index: 2;
+  display: grid;
+  gap: 0.55rem;
+  width: min(27rem, calc(100% - 1.5rem));
+  max-height: 42%;
+  padding: 0.7rem;
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 82%, transparent);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--surface-panel) 80%, transparent);
+  box-shadow: var(--shadow-panel);
+  backdrop-filter: blur(14px);
+}
+
+.metaverse-room-chat-log-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--muted-foreground);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.metaverse-room-chat-log .metaverse-chat-form {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.metaverse-room-chat-log .metaverse-chat-list {
+  max-height: 9rem;
+}
+
+.metaverse-room-chat-log .metaverse-chat-list li {
+  background: color-mix(in srgb, var(--surface-raised) 54%, transparent);
+}
+
 .metaverse-chat-list {
   display: grid;
   gap: 0.5rem;
@@ -501,6 +574,26 @@
 .metaverse-chat-list small {
   color: var(--text-muted);
   font-weight: 500;
+}
+
+.metaverse-avatar-bubble {
+  max-width: 14rem;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--border-subtle) 82%, transparent);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--surface-panel) 90%, transparent);
+  color: var(--foreground);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+  text-align: center;
+  box-shadow: var(--shadow-panel);
+  white-space: normal;
+}
+
+.metaverse-avatar-bubble[data-stale='true'] {
+  color: var(--warning);
 }
 
 @media (max-width: 900px) {
@@ -532,6 +625,12 @@
     right: 1rem;
     bottom: 1.6rem;
     height: calc(46% - 1.7rem);
+  }
+
+  .metaverse-room-chat-log {
+    right: 0.75rem;
+    width: auto;
+    max-height: 34%;
   }
 }
 

--- a/crates/app-api/src/game.rs
+++ b/crates/app-api/src/game.rs
@@ -1,6 +1,8 @@
 use crate::service::*;
 use kukuri_core::MetaverseRoomEventV1;
 
+const METAVERSE_CHAT_HISTORY_LIMIT: usize = 100;
+
 impl AppService {
     pub async fn list_game_rooms(&self, topic_id: &str) -> Result<Vec<GameRoomView>> {
         self.list_game_rooms_scoped(topic_id, TimelineScope::Public)
@@ -236,6 +238,7 @@ impl AppService {
                 rotation: [0, 180, 0],
             },
             asset_refs: Vec::new(),
+            chat_history: Vec::new(),
         };
         let manifest = GameRoomManifestBlobV1 {
             room_id: room_id.clone(),
@@ -451,7 +454,7 @@ impl AppService {
         input: PublishMetaverseRoomEventInput,
     ) -> Result<MetaverseRoomEventView> {
         self.ensure_topic_subscription(topic_id).await?;
-        let (_, state, manifest) = self
+        let (source_replica_id, state, mut manifest) = self
             .fetch_game_room_state_and_manifest(topic_id, input.room_id.as_str())
             .await?
             .ok_or_else(|| anyhow::anyhow!("metaverse room not found"))?;
@@ -492,6 +495,43 @@ impl AppService {
         let view = parse_metaverse_room_event_envelope(envelope.clone(), now, "local".to_string())?
             .ok_or_else(|| anyhow::anyhow!("failed to build metaverse room event"))?;
         push_metaverse_room_event_buffer(&self.metaverse_room_events, view.clone()).await;
+        if let MetaverseRoomEventV1::ChatMessage { message } = &content.event {
+            let Some(metaverse) = manifest.metaverse.as_mut() else {
+                anyhow::bail!("metaverse room state is missing");
+            };
+            if !metaverse
+                .chat_history
+                .iter()
+                .any(|existing| existing.message_id == message.message_id)
+            {
+                metaverse.chat_history.push(message.clone());
+                if metaverse.chat_history.len() > METAVERSE_CHAT_HISTORY_LIMIT {
+                    let overflow = metaverse
+                        .chat_history
+                        .len()
+                        .saturating_sub(METAVERSE_CHAT_HISTORY_LIMIT);
+                    metaverse.chat_history.drain(0..overflow);
+                }
+                manifest.updated_at = now;
+                let persisted = self
+                    .persist_game_room_manifest(
+                        &source_replica_id,
+                        topic_id,
+                        manifest.clone(),
+                        state.created_at,
+                        envelope.id.clone(),
+                    )
+                    .await?;
+                self.projection_store
+                    .upsert_game_room_cache(game_projection_row_from_state(
+                        &persisted,
+                        &manifest,
+                        topic_id,
+                        &source_replica_id,
+                    ))
+                    .await?;
+            }
+        }
         self.hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, state.channel_id.as_ref()),

--- a/crates/app-api/src/tests/game.rs
+++ b/crates/app-api/src/tests/game.rs
@@ -392,6 +392,183 @@ async fn metaverse_room_events_are_signed_and_delivered_over_hint_transport() {
 }
 
 #[tokio::test]
+async fn metaverse_chat_messages_persist_to_recent_room_history() {
+    let store = Arc::new(MemoryStore::default());
+    let transport = Arc::new(FakeTransport::new("self", FakeNetwork::default()));
+    let app = AppService::new(store, transport);
+    let topic = "kukuri:topic:metaverse-chat-history";
+    let room_id = app
+        .create_metaverse_room(
+            topic,
+            CreateMetaverseRoomInput {
+                title: "chat history".into(),
+                description: "recent messages".into(),
+                max_peers: Some(4),
+            },
+        )
+        .await
+        .expect("create metaverse room");
+
+    app.publish_metaverse_room_event(
+        topic,
+        PublishMetaverseRoomEventInput {
+            room_id: room_id.clone(),
+            peer_id: "peer-a".into(),
+            seq: 1,
+            event: MetaverseRoomEventV1::ChatMessage {
+                message: MetaverseRoomChatMessageV1 {
+                    room_id: room_id.clone(),
+                    message_id: "chat-1".into(),
+                    author_peer_id: "peer-a".into(),
+                    display_name: Some("Peer A".into()),
+                    body: "persistent hello".into(),
+                    created_at: Utc::now().timestamp_millis(),
+                },
+            },
+        },
+    )
+    .await
+    .expect("publish chat message");
+
+    let room = app
+        .list_game_rooms(topic)
+        .await
+        .expect("list rooms")
+        .into_iter()
+        .find(|room| room.room_id == room_id)
+        .expect("metaverse room");
+    let history = &room.metaverse.as_ref().expect("metaverse").chat_history;
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].message_id, "chat-1");
+    assert_eq!(history[0].body, "persistent hello");
+}
+
+#[tokio::test]
+async fn metaverse_avatar_transforms_do_not_mutate_room_history() {
+    let store = Arc::new(MemoryStore::default());
+    let transport = Arc::new(FakeTransport::new("self", FakeNetwork::default()));
+    let app = AppService::new(store, transport);
+    let topic = "kukuri:topic:metaverse-transform-ephemeral";
+    let room_id = app
+        .create_metaverse_room(
+            topic,
+            CreateMetaverseRoomInput {
+                title: "ephemeral transforms".into(),
+                description: "no durable writes".into(),
+                max_peers: Some(4),
+            },
+        )
+        .await
+        .expect("create metaverse room");
+    let before = app
+        .list_game_rooms(topic)
+        .await
+        .expect("list rooms before")
+        .into_iter()
+        .find(|room| room.room_id == room_id)
+        .expect("room before");
+
+    app.publish_metaverse_room_event(
+        topic,
+        PublishMetaverseRoomEventInput {
+            room_id: room_id.clone(),
+            peer_id: "peer-a".into(),
+            seq: 1,
+            event: MetaverseRoomEventV1::AvatarTransform {
+                transform: MetaverseAvatarTransformV1 {
+                    room_id: room_id.clone(),
+                    peer_id: "peer-a".into(),
+                    seq: 1,
+                    position: [100, 0, -50],
+                    rotation: [0, 90, 0],
+                    animation: Some("walk".into()),
+                    sent_at: Utc::now().timestamp_millis(),
+                },
+            },
+        },
+    )
+    .await
+    .expect("publish transform");
+
+    let after = app
+        .list_game_rooms(topic)
+        .await
+        .expect("list rooms after")
+        .into_iter()
+        .find(|room| room.room_id == room_id)
+        .expect("room after");
+    assert_eq!(after.manifest_blob_hash, before.manifest_blob_hash);
+    assert!(
+        after
+            .metaverse
+            .as_ref()
+            .expect("metaverse")
+            .chat_history
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn metaverse_chat_history_keeps_latest_one_hundred_messages() {
+    let store = Arc::new(MemoryStore::default());
+    let transport = Arc::new(FakeTransport::new("self", FakeNetwork::default()));
+    let app = AppService::new(store, transport);
+    let topic = "kukuri:topic:metaverse-chat-cap";
+    let room_id = app
+        .create_metaverse_room(
+            topic,
+            CreateMetaverseRoomInput {
+                title: "chat cap".into(),
+                description: "recent only".into(),
+                max_peers: Some(4),
+            },
+        )
+        .await
+        .expect("create metaverse room");
+
+    for seq in 0..105_u64 {
+        app.publish_metaverse_room_event(
+            topic,
+            PublishMetaverseRoomEventInput {
+                room_id: room_id.clone(),
+                peer_id: "peer-a".into(),
+                seq,
+                event: MetaverseRoomEventV1::ChatMessage {
+                    message: MetaverseRoomChatMessageV1 {
+                        room_id: room_id.clone(),
+                        message_id: format!("chat-{seq}"),
+                        author_peer_id: "peer-a".into(),
+                        display_name: None,
+                        body: format!("message {seq}"),
+                        created_at: Utc::now().timestamp_millis(),
+                    },
+                },
+            },
+        )
+        .await
+        .expect("publish chat message");
+    }
+
+    let room = app
+        .list_game_rooms(topic)
+        .await
+        .expect("list rooms")
+        .into_iter()
+        .find(|room| room.room_id == room_id)
+        .expect("metaverse room");
+    let history = &room.metaverse.as_ref().expect("metaverse").chat_history;
+    assert_eq!(history.len(), 100);
+    assert_eq!(
+        history.first().map(|message| message.message_id.as_str()),
+        Some("chat-5")
+    );
+    assert_eq!(
+        history.last().map(|message| message.message_id.as_str()),
+        Some("chat-104")
+    );
+}
+
+#[tokio::test]
 async fn metaverse_room_event_rejects_mismatched_payload_identity() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(FakeTransport::new("self", FakeNetwork::default()));
@@ -610,6 +787,26 @@ async fn metaverse_room_manifest_restores_after_restart_from_docs_and_blobs() {
     )
     .await
     .expect("update shared object");
+    app.publish_metaverse_room_event(
+        topic,
+        PublishMetaverseRoomEventInput {
+            room_id: room_id.clone(),
+            peer_id: "peer-a".into(),
+            seq: 1,
+            event: MetaverseRoomEventV1::ChatMessage {
+                message: MetaverseRoomChatMessageV1 {
+                    room_id: room_id.clone(),
+                    message_id: "restart-chat-1".into(),
+                    author_peer_id: "peer-a".into(),
+                    display_name: Some("Peer A".into()),
+                    body: "restored room chat".into(),
+                    created_at: Utc::now().timestamp_millis(),
+                },
+            },
+        },
+    )
+    .await
+    .expect("publish restart chat");
 
     let restarted_store = Arc::new(MemoryStore::default());
     let restarted = AppService::new_with_services(
@@ -637,6 +834,14 @@ async fn metaverse_room_manifest_restores_after_restart_from_docs_and_blobs() {
             .as_ref()
             .map(|state| state.scene.shared_object.position),
         Some([150, 50, -90])
+    );
+    assert_eq!(
+        restored
+            .metaverse
+            .as_ref()
+            .and_then(|state| state.chat_history.first())
+            .map(|message| message.body.as_str()),
+        Some("restored room chat")
     );
     assert!(!restored.manifest_blob_hash.trim().is_empty());
 }

--- a/crates/core/src/game.rs
+++ b/crates/core/src/game.rs
@@ -153,6 +153,8 @@ pub struct MetaverseRoomStateV1 {
     pub scene: MetaverseRoomSceneV1,
     pub default_spawn: MetaverseRoomSpawnV1,
     pub asset_refs: Vec<MetaverseAssetRef>,
+    #[serde(default)]
+    pub chat_history: Vec<MetaverseRoomChatMessageV1>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Keep remote avatars visible while the room remains connected, add heartbeat/recovery state handling, and surface live/stale/recovering/offline connection badges.
- Smooth remote avatar movement with frame-based interpolation and avoid resetting the local avatar when shared objects or room manifests refresh.
- Add ROOM Chat with durable recent history, live event delivery, dedupe, viewport chat log, and avatar-following chat bubbles.

## Root Cause
The room UI treated sparse avatar events as a visibility signal and refreshed room manifests through state paths that could reset local avatar state. Chat events were ephemeral only, so room chat had no durable initial state or always-visible room UI.

## Validation
- PASS: `cargo test -p kukuri-app-api metaverse`
- PASS: `cd apps/desktop && npx pnpm@10.16.1 test -- MetaverseRoomPanel.test.tsx MetaverseScene.test.ts`
- PASS: `cd apps/desktop && npx pnpm@10.16.1 typecheck`
- PASS: `cd apps/desktop && npx pnpm@10.16.1 lint`
- PASS: `cd apps/desktop && npx pnpm@10.16.1 test`
- PASS: `cargo xtask check`
- PASS: `cargo xtask desktop-ui-check`
- FAIL: `cargo xtask test` completed but 3 existing seeded DHT transport tests timed out: `seeded_dht_backfills_docs_and_blobs_with_id_only_seed`, `seeded_dht_syncs_post_between_apps_without_ticket_import`, and `seeded_dht_updates_existing_topic_subscription_after_seed_update`. Metaverse tests passed in that run.