### PR TITLE
[codex] fix metaverse room UX sync

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
@@ -53,6 +53,7 @@ vi.mock('./MetaverseScene', () => ({
         Mark animation fallback
       </button>
       <span>{props.sharedObject.object_id}</span>
+      <span>Shared object position: {props.sharedObject.position.join(',')}</span>
       <span>Scene connection: {props.connectionState}</span>
       {Object.entries(props.latestChatByPeer).map(([peerId, bubble]) => (
         <span key={peerId}>{`Bubble ${peerId}: ${bubble.body}`}</span>
@@ -230,7 +231,7 @@ describe('MetaverseRoomPanel animation sharing', () => {
     });
   });
 
-  test('room HUD can be resized and collapsed', async () => {
+  test('room HUD can be collapsed without a resize mode', async () => {
     const user = userEvent.setup();
     const baseApi = createDesktopMockApi();
     const api: DesktopApi = {
@@ -249,15 +250,31 @@ describe('MetaverseRoomPanel animation sharing', () => {
     await user.click(screen.getByRole('button', { name: 'Debug details' }));
     expect(screen.getByText(/Topic: kukuri:topic:demo/)).toBeInTheDocument();
 
-    expect(document.querySelector('.metaverse-room-hud')).toHaveAttribute('data-size', 'compact');
-    await user.click(screen.getByRole('button', { name: 'Expand room HUD' }));
-    expect(document.querySelector('.metaverse-room-hud')).toHaveAttribute('data-size', 'wide');
-    expect(screen.getByRole('button', { name: 'Shrink room HUD' })).toBeInTheDocument();
+    expect(document.querySelector('.metaverse-room-hud')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Expand room HUD' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Shrink room HUD' })).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Hide room HUD' }));
     expect(document.querySelector('.metaverse-room-hud')).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Open room HUD' }));
-    expect(document.querySelector('.metaverse-room-hud')).toHaveAttribute('data-size', 'wide');
+    expect(document.querySelector('.metaverse-room-hud')).toBeInTheDocument();
+  });
+
+  test('room chat can be closed and reopened', async () => {
+    const user = userEvent.setup();
+    const api = {
+      ...createDesktopMockApi(),
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+
+    renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+
+    expect(screen.getByLabelText('ROOM Chat')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Hide room chat' }));
+    expect(screen.queryByLabelText('ROOM Chat')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Open room chat' }));
+    expect(screen.getByLabelText('ROOM Chat')).toBeInTheDocument();
   });
 
   test('keeps create room controls collapsed until opened', async () => {
@@ -484,5 +501,35 @@ describe('MetaverseRoomPanel animation sharing', () => {
       expect(updateMetaverseRoom).toHaveBeenCalled();
     });
     expect(screen.getByLabelText('Metaverse room viewport')).toBeInTheDocument();
+  });
+
+  test('shared object optimistic movement is not rolled back by a stale refreshed room', async () => {
+    const user = userEvent.setup();
+    const baseApi = createDesktopMockApi();
+    const api: DesktopApi = {
+      ...baseApi,
+      updateMetaverseRoom: vi.fn().mockResolvedValue(undefined),
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+
+    function StaleRefreshHarness() {
+      const [rooms, setRooms] = useState<GameRoomView[]>([room]);
+      return panelElement(api, {
+        rooms,
+        onRefresh: async () => {
+          setRooms([{ ...room }]);
+        },
+      });
+    }
+
+    render(<StaleRefreshHarness />);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+    expect(screen.getByText('Shared object position: 0,50,-240')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Forward/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Shared object position: 0,50,-290')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -4,9 +4,7 @@ import {
   Box,
   ChevronDown,
   Cuboid,
-  Maximize2,
   MessageSquare,
-  Minimize2,
   Move3D,
   PanelRightClose,
   PanelRightOpen,
@@ -15,6 +13,7 @@ import {
   Send,
   Wifi,
   WifiOff,
+  X,
 } from 'lucide-react';
 
 import { AuthorAvatar } from '@/components/core/AuthorAvatar';
@@ -48,6 +47,7 @@ import {
   METAVERSE_ROOM_HEARTBEAT_MS,
   METAVERSE_ROOM_RECOVERY_MS,
   METAVERSE_ROOM_STALE_MS,
+  isNewerSharedObject,
   mergeRoomChatMessages,
   normalizeAvatarAnimationState,
   type AvatarAssetStatus,
@@ -171,7 +171,7 @@ export function MetaverseRoomPanel({
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const [joinedRoomIds, setJoinedRoomIds] = useState<Set<string>>(() => new Set());
   const [hudOpen, setHudOpen] = useState(true);
-  const [hudSize, setHudSize] = useState<'compact' | 'wide'>('compact');
+  const [chatOpen, setChatOpen] = useState(true);
   const [hudDebugOpen, setHudDebugOpen] = useState(false);
   const [remoteTransforms, setRemoteTransforms] = useState<Record<string, AvatarTransform>>({});
   const [peerPresence, setPeerPresence] = useState<Record<string, PeerPresence>>({});
@@ -191,6 +191,7 @@ export function MetaverseRoomPanel({
   const lastBackendEventEnvelopeIdRef = useRef<string | null>(null);
   const lastRecoveryAtRef = useRef(0);
   const pendingCreatedRoomIdRef = useRef<string | null>(null);
+  const sharedObjectRef = useRef<SharedRoomObjectV1>(DEFAULT_SHARED_OBJECT);
   const localPeerSeed = useId().replaceAll(':', '');
   const localPeerId = `${syncStatus.discovery.local_endpoint_id || syncStatus.local_author_pubkey || 'local'}:${localPeerSeed}`;
   const lastSentTransformRef = useRef<AvatarTransform | null>(null);
@@ -251,6 +252,10 @@ export function MetaverseRoomPanel({
   const localDisplayName = localProfile?.display_name?.trim() || localProfile?.name?.trim() || null;
 
   useEffect(() => {
+    sharedObjectRef.current = sharedObject;
+  }, [sharedObject]);
+
+  useEffect(() => {
     if (!selectedRoomId) {
       return;
     }
@@ -285,6 +290,7 @@ export function MetaverseRoomPanel({
     if (!selectedRoomRoomId) {
       return;
     }
+    sharedObjectRef.current = DEFAULT_SHARED_OBJECT;
     setSharedObject(DEFAULT_SHARED_OBJECT);
     setRemoteTransforms({});
     setPeerPresence({});
@@ -324,7 +330,13 @@ export function MetaverseRoomPanel({
         }));
       }
       if (data.type === 'object.update' && data.object.updated_by !== localPeerId) {
-        setSharedObject(data.object);
+        setSharedObject((current) => {
+          if (!isNewerSharedObject(current, data.object)) {
+            return current;
+          }
+          sharedObjectRef.current = data.object;
+          return data.object;
+        });
       }
     };
     return () => {
@@ -334,7 +346,14 @@ export function MetaverseRoomPanel({
   }, [localPeerId, selectedRoomRoomId]);
 
   useEffect(() => {
-    setSharedObject(selectedRoomSharedObject ?? DEFAULT_SHARED_OBJECT);
+    const nextObject = selectedRoomSharedObject ?? DEFAULT_SHARED_OBJECT;
+    setSharedObject((current) => {
+      if (!isNewerSharedObject(current, nextObject)) {
+        return current;
+      }
+      sharedObjectRef.current = nextObject;
+      return nextObject;
+    });
   }, [selectedRoomSharedObject]);
 
   useEffect(() => {
@@ -493,7 +512,13 @@ export function MetaverseRoomPanel({
         }));
       }
       if (event.type === 'object_update' && event.object.updated_by !== localPeerId) {
-        setSharedObject(event.object);
+        setSharedObject((current) => {
+          if (!isNewerSharedObject(current, event.object)) {
+            return current;
+          }
+          sharedObjectRef.current = event.object;
+          return event.object;
+        });
       }
     };
     const poll = async () => {
@@ -671,25 +696,11 @@ export function MetaverseRoomPanel({
     });
   }
 
-  async function moveSharedObject(delta: MetaverseVec3) {
-    if (!selectedRoom) {
-      return;
-    }
-    const nextObject: SharedRoomObjectV1 = {
-      ...sharedObject,
-      position: [
-        sharedObject.position[0] + delta[0],
-        sharedObject.position[1] + delta[1],
-        sharedObject.position[2] + delta[2],
-      ],
-      updated_by: localPeerId,
-      updated_at: Date.now(),
-    };
-    setSharedObject(nextObject);
-    emit({ type: 'object.update', roomId: selectedRoom.room_id, object: nextObject });
+  function persistSharedObject(nextObject: SharedRoomObjectV1, room: GameRoomView) {
+    emit({ type: 'object.update', roomId: room.room_id, object: nextObject });
     void api.publishMetaverseRoomEvent(
       activeTopic,
-      selectedRoom.room_id,
+      room.room_id,
       localPeerId,
       Date.now(),
       {
@@ -699,19 +710,39 @@ export function MetaverseRoomPanel({
     ).catch(() => {
       // Browser-only fallback is handled by BroadcastChannel.
     });
-    try {
-      await api.updateMetaverseRoom(
-        activeTopic,
-        selectedRoom.room_id,
-        selectedRoom.status,
-        nextObject.position,
-        nextObject.rotation,
-        nextObject.scale
-      );
-      await onRefresh();
-    } catch (updateError) {
-      setError(updateError instanceof Error ? updateError.message : 'Failed to persist shared object');
+    void api.updateMetaverseRoom(
+      activeTopic,
+      room.room_id,
+      room.status,
+      nextObject.position,
+      nextObject.rotation,
+      nextObject.scale
+    )
+      .then(() => onRefresh())
+      .catch((updateError) => {
+        setError(updateError instanceof Error ? updateError.message : 'Failed to persist shared object');
+      });
+  }
+
+  function moveSharedObject(delta: MetaverseVec3) {
+    if (!selectedRoom) {
+      return;
     }
+    const room = selectedRoom;
+    const current = sharedObjectRef.current;
+    const nextObject: SharedRoomObjectV1 = {
+      ...current,
+      position: [
+        current.position[0] + delta[0],
+        current.position[1] + delta[1],
+        current.position[2] + delta[2],
+      ],
+      updated_by: localPeerId,
+      updated_at: Date.now(),
+    };
+    sharedObjectRef.current = nextObject;
+    setSharedObject(nextObject);
+    persistSharedObject(nextObject, room);
   }
 
   return (
@@ -851,24 +882,10 @@ export function MetaverseRoomPanel({
                         <PanelRightOpen className='size-4' aria-hidden='true' />
                       )}
                     </Button>
-                    <Button
-                      variant='ghost'
-                      size='icon'
-                      className='metaverse-hud-icon-button'
-                      type='button'
-                      aria-label={hudSize === 'compact' ? 'Expand room HUD' : 'Shrink room HUD'}
-                      onClick={() => setHudSize((size) => (size === 'compact' ? 'wide' : 'compact'))}
-                    >
-                      {hudSize === 'compact' ? (
-                        <Maximize2 className='size-4' aria-hidden='true' />
-                      ) : (
-                        <Minimize2 className='size-4' aria-hidden='true' />
-                      )}
-                    </Button>
                   </div>
                   {hudOpen ? (
                     <>
-                    <aside className='metaverse-room-hud' data-size={hudSize}>
+                    <aside className='metaverse-room-hud'>
                       <div className='panel-header metaverse-hud-header'>
                         <div>
                           <h3>{selectedRoom.title}</h3>
@@ -951,39 +968,64 @@ export function MetaverseRoomPanel({
                     </span>
                     </>
                   ) : null}
-                  <section className='metaverse-room-chat-log' aria-label='ROOM Chat'>
-                    <div className='metaverse-room-chat-log-header'>
+                  {chatOpen ? (
+                    <section className='metaverse-room-chat-log' aria-label='ROOM Chat'>
+                      <div className='metaverse-room-chat-log-header'>
+                        <span>
+                          <MessageSquare className='size-4' aria-hidden='true' />
+                          ROOM Chat
+                        </span>
+                        <Button
+                          variant='ghost'
+                          size='icon'
+                          className='metaverse-chat-close-button'
+                          type='button'
+                          aria-label='Hide room chat'
+                          onClick={() => setChatOpen(false)}
+                        >
+                          <X className='size-4' aria-hidden='true' />
+                        </Button>
+                      </div>
+                      <ul className='metaverse-chat-list'>
+                        {messages.map((message) => (
+                          <li key={message.messageId}>
+                            <strong>
+                              {message.authorPeerId === localPeerId
+                                ? 'You'
+                                : message.displayName || message.authorPeerId.slice(0, 12)}
+                              <small>{formatLocalizedTime(message.createdAt, locale)}</small>
+                            </strong>
+                            <span>{message.body}</span>
+                          </li>
+                        ))}
+                      </ul>
+                      <form className='metaverse-chat-form' onSubmit={handleSendMessage}>
+                        <Label>
+                          <span className='sr-only'>Room chat message</span>
+                          <Input
+                            value={messageDraft}
+                            placeholder='Say something in the room'
+                            onChange={(event) => setMessageDraft(event.target.value)}
+                          />
+                        </Label>
+                        <Button size='sm' type='submit'>
+                          <Send className='size-4' aria-hidden='true' />
+                          Send
+                        </Button>
+                      </form>
+                    </section>
+                  ) : (
+                    <Button
+                      variant='secondary'
+                      size='icon'
+                      className='metaverse-chat-toggle'
+                      type='button'
+                      aria-label='Open room chat'
+                      onClick={() => setChatOpen(true)}
+                    >
                       <MessageSquare className='size-4' aria-hidden='true' />
-                      <span>ROOM Chat</span>
-                    </div>
-                    <ul className='metaverse-chat-list'>
-                      {messages.map((message) => (
-                        <li key={message.messageId}>
-                          <strong>
-                            {message.authorPeerId === localPeerId
-                              ? 'You'
-                              : message.displayName || message.authorPeerId.slice(0, 12)}
-                            <small>{formatLocalizedTime(message.createdAt, locale)}</small>
-                          </strong>
-                          <span>{message.body}</span>
-                        </li>
-                      ))}
-                    </ul>
-                    <form className='metaverse-chat-form' onSubmit={handleSendMessage}>
-                      <Label>
-                        <span className='sr-only'>Room chat message</span>
-                        <Input
-                          value={messageDraft}
-                          placeholder='Say something in the room'
-                          onChange={(event) => setMessageDraft(event.target.value)}
-                        />
-                      </Label>
-                      <Button size='sm' type='submit'>
-                        <Send className='size-4' aria-hidden='true' />
-                        Send
-                      </Button>
-                    </form>
-                  </section>
+                    </Button>
+                  )}
                 </>
               )}
             />

--- a/apps/desktop/src/components/extended/MetaverseScene.test.ts
+++ b/apps/desktop/src/components/extended/MetaverseScene.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS,
+  METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS,
+  METAVERSE_ROOM_STALE_MS,
   isNewerRemoteTransform,
+  isNewerSharedObject,
   avatarAnimationForInput,
   mergeRoomChatMessages,
   normalizeAvatarAnimationState,
@@ -10,6 +14,12 @@ import {
 } from './MetaverseSceneModel';
 
 describe('metaverse avatar animation state', () => {
+  test('uses low-latency transform intervals and a longer stale threshold', () => {
+    expect(METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS).toBe(30);
+    expect(METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS).toBe(150);
+    expect(METAVERSE_ROOM_STALE_MS).toBe(45_000);
+  });
+
   test('derives keyboard animation state', () => {
     expect(avatarAnimationForInput([], false)).toBe('idle');
     expect(avatarAnimationForInput(['w'], false)).toBe('walk');
@@ -53,6 +63,22 @@ describe('metaverse avatar animation state', () => {
     expect(isNewerRemoteTransform(current, { ...current, seq: 2, sentAt: 400 })).toBe(false);
     expect(isNewerRemoteTransform(current, { ...current, seq: 4, sentAt: 250 })).toBe(true);
     expect(isNewerRemoteTransform(current, { ...current, sentAt: 301 })).toBe(true);
+  });
+
+  test('accepts only newer shared object updates', () => {
+    const current = {
+      object_id: 'mvp-object-1',
+      asset_ref: null,
+      primitive_fallback: 'cube' as const,
+      position: [0, 50, -240] as [number, number, number],
+      rotation: [0, 0, 0] as [number, number, number],
+      scale: [100, 100, 100] as [number, number, number],
+      updated_by: 'peer-a',
+      updated_at: 20,
+    };
+
+    expect(isNewerSharedObject(current, { ...current, position: [0, 50, -290], updated_at: 19 })).toBe(false);
+    expect(isNewerSharedObject(current, { ...current, position: [0, 50, -290], updated_at: 21 })).toBe(true);
   });
 
   test('deduplicates and caps room chat messages', () => {

--- a/apps/desktop/src/components/extended/MetaverseScene.tsx
+++ b/apps/desktop/src/components/extended/MetaverseScene.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
+import { AlertTriangle } from 'lucide-react';
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { VRMLoaderPlugin, VRMUtils, type VRM } from '@pixiv/three-vrm';
@@ -14,6 +15,10 @@ import type { GameRoomView, SharedRoomObjectV1 } from '@/lib/api';
 import {
   AVATAR_GROUND_Y,
   DEFAULT_AVATAR_ASSET_URL,
+  METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS,
+  METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS,
+  METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS,
+  METAVERSE_ROOM_STALE_MS,
   avatarAnimationForInput,
   initialAvatarTransform,
   isNewerRemoteTransform,
@@ -91,14 +96,27 @@ function makePrimitiveAvatar(color: number) {
   );
 }
 
-function AvatarChatBubble({ bubble, stale }: { bubble?: LatestChatBubble; stale?: boolean }) {
-  if (!bubble && !stale) {
+function AvatarChatBubble({ bubble }: { bubble?: LatestChatBubble }) {
+  if (!bubble) {
     return null;
   }
   return (
     <Html position={[0, 1.9, 0]} center distanceFactor={8} occlude={false}>
-      <div className='metaverse-avatar-bubble' data-stale={stale ? 'true' : 'false'}>
-        {bubble ? <span>{bubble.body}</span> : <span>stale</span>}
+      <div className='metaverse-avatar-bubble'>
+        <span>{bubble.body}</span>
+      </div>
+    </Html>
+  );
+}
+
+function AvatarStaleIndicator({ stale }: { stale: boolean }) {
+  if (!stale) {
+    return null;
+  }
+  return (
+    <Html position={[0.32, 1.9, 0]} center distanceFactor={8} occlude={false}>
+      <div className='metaverse-avatar-stale-icon' aria-label='Remote avatar stale'>
+        <AlertTriangle className='size-3' aria-hidden='true' />
       </div>
     </Html>
   );
@@ -516,7 +534,10 @@ function LocalAvatar({
       groupRef.current.rotation.y = THREE.MathUtils.degToRad(nextRotation[1]);
     }
 
-    const sendInterval = moving || animation === 'jump' ? 50 : 220;
+    const sendInterval =
+      moving || animation === 'jump'
+        ? METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS
+        : METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS;
     const frameAt = performance.now();
     if (frameAt - lastSentAtRef.current >= sendInterval) {
       lastSentAtRef.current = frameAt;
@@ -585,13 +606,13 @@ function RemoteAvatar({
       initializedRef.current = true;
       return;
     }
-    const alpha = 1 - Math.exp(-deltaSeconds / 0.12);
+    const alpha = 1 - Math.exp(-deltaSeconds / METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS);
     group.position.lerp(targetPosition, Math.min(1, alpha));
     const targetYaw = THREE.MathUtils.degToRad(target.rotation[1]);
     group.rotation.y = THREE.MathUtils.lerp(group.rotation.y, targetYaw, Math.min(1, alpha));
   });
 
-  const stale = connectionState !== 'live' || now - transform.sentAt > 15_000;
+  const stale = connectionState !== 'live' || now - transform.sentAt > METAVERSE_ROOM_STALE_MS;
 
   return (
     <group
@@ -603,7 +624,8 @@ function RemoteAvatar({
         color={0xe37070}
         animationRef={animationRef}
       />
-      <AvatarChatBubble bubble={chatBubble} stale={stale && !chatBubble} />
+      <AvatarChatBubble bubble={chatBubble} />
+      <AvatarStaleIndicator stale={stale} />
     </group>
   );
 }

--- a/apps/desktop/src/components/extended/MetaverseSceneModel.ts
+++ b/apps/desktop/src/components/extended/MetaverseSceneModel.ts
@@ -104,9 +104,12 @@ export const DEFAULT_AVATAR_ASSET_NAME = 'blumochichi.vrm';
 export const DEFAULT_AVATAR_ASSET_URL = `/${DEFAULT_AVATAR_ASSET_NAME}`;
 export const METAVERSE_CHAT_HISTORY_LIMIT = 100;
 export const METAVERSE_CHAT_BUBBLE_TTL_MS = 8_000;
-export const METAVERSE_ROOM_STALE_MS = 15_000;
+export const METAVERSE_ROOM_STALE_MS = 45_000;
 export const METAVERSE_ROOM_HEARTBEAT_MS = 5_000;
 export const METAVERSE_ROOM_RECOVERY_MS = 10_000;
+export const METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS = 30;
+export const METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS = 150;
+export const METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS = 0.06;
 
 export const AVATAR_GROUND_Y = 0;
 export const AVATAR_JUMP_VELOCITY = 520;
@@ -165,6 +168,16 @@ export function isNewerRemoteTransform(
     return incoming.seq > current.seq;
   }
   return incoming.sentAt > current.sentAt;
+}
+
+export function isNewerSharedObject(
+  current: SharedRoomObjectV1 | null | undefined,
+  incoming: SharedRoomObjectV1
+): boolean {
+  if (!current) {
+    return true;
+  }
+  return incoming.updated_at > current.updated_at;
 }
 
 export function mergeRoomChatMessages(

--- a/apps/desktop/src/shell/DesktopShellPage.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.test.tsx
@@ -2105,7 +2105,7 @@ test('desktop shell primary nav jumps focus and settings drawer restores trigger
   const gameNav = within(getWorkspaceTabs()).getByRole('tab', { name: 'Game' });
   await user.click(gameNav);
 
-  const gameSection = screen.getByText('Game Rooms').closest('.shell-section');
+  const gameSection = screen.getByText('Metaverse Rooms').closest('.shell-section');
   if (!(gameSection instanceof HTMLElement)) {
     throw new Error('game section not found');
   }
@@ -2473,7 +2473,7 @@ test('share token smart link previews before import and joins only after confirm
   });
 });
 
-test('copy link actions write canonical hash routes for topic, post, live, and game', async () => {
+test('copy link actions write canonical hash routes for topic, post, and live', async () => {
   const user = userEvent.setup();
   const writeText = vi.fn().mockResolvedValue(undefined);
   Object.defineProperty(window.navigator, 'clipboard', {
@@ -2583,17 +2583,8 @@ test('copy link actions write canonical hash routes for topic, post, live, and g
   });
 
   await selectWorkspace(user, 'Game');
-  const gameArticle = screen.getByText('Room Demo').closest('article');
-  if (!(gameArticle instanceof HTMLElement)) {
-    throw new Error('expected game article');
-  }
-  await user.click(within(gameArticle).getByRole('button', { name: 'Copy link' }));
-  expect(writeText).toHaveBeenLastCalledWith(
-    '#/game?topic=kukuri%3Atopic%3Ademo&roomId=room-demo'
-  );
-  await waitFor(() => {
-    expect(screen.getAllByRole('status')).toHaveLength(1);
-  });
+  expect(screen.getByText('Metaverse Rooms')).toBeInTheDocument();
+  expect(screen.queryByText('Room Demo')).not.toBeInTheDocument();
 });
 
 test('channel settings copy removes duplicate summary and share button icon', async () => {
@@ -2714,7 +2705,7 @@ test('thread focus auto-scroll runs only once even when the thread loads additio
   expect(scrollIntoView).toHaveBeenCalledTimes(1);
 });
 
-test('desktop shell can create and update a game room', async () => {
+test('desktop shell game workspace hides score game room list and keeps metaverse rooms', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
@@ -2725,24 +2716,13 @@ test('desktop shell can create and update a game room', async () => {
   await user.click(within(gameDialog).getByRole('button', { name: 'Create Room' }));
 
   await waitFor(() => {
-    expect(screen.getByText('Grand Finals')).toBeInTheDocument();
-    expect(screen.getByLabelText(/game-.*-status/)).toBeInTheDocument();
+    expect(screen.getByText('Metaverse Rooms')).toBeInTheDocument();
   });
-  expect(screen.getByText('set one')).toBeInTheDocument();
-  expect(screen.getByLabelText(/game-.*-Alice-score/)).toBeInTheDocument();
-
-  await user.selectOptions(screen.getByLabelText(/game-.*-status/), 'Running');
-  await user.clear(screen.getByLabelText(/game-.*-phase/));
-  await user.type(screen.getByLabelText(/game-.*-phase/), 'Round 3');
-  await user.clear(screen.getByLabelText(/game-.*-Alice-score/));
-  await user.type(screen.getByLabelText(/game-.*-Alice-score/), '2');
-  await user.click(screen.getByRole('button', { name: 'Save Room' }));
-
-  await waitFor(() => {
-    expect(screen.getByLabelText(/game-.*-status/)).toHaveValue('Running');
-  });
-  expect(screen.getByText('phase: Round 3')).toBeInTheDocument();
-  expect(screen.getByDisplayValue('2')).toBeInTheDocument();
+  expect(screen.queryByText('Game Rooms')).not.toBeInTheDocument();
+  expect(screen.queryByText('No game rooms')).not.toBeInTheDocument();
+  expect(screen.queryByText('Grand Finals')).not.toBeInTheDocument();
+  expect(screen.queryByText('set one')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText(/game-.*-status/)).not.toBeInTheDocument();
 });
 
 test('single attach button classifies mixed image and video files', async () => {
@@ -3715,7 +3695,8 @@ test('profile social management updates follow and mute lists and muted authors 
   await waitFor(() => {
     expect(screen.queryByText('Muted Room')).not.toBeInTheDocument();
   });
-  expect(screen.getByText('Visible Room')).toBeInTheDocument();
+  expect(screen.queryByText('Visible Room')).not.toBeInTheDocument();
+  expect(screen.getByText('Metaverse Rooms')).toBeInTheDocument();
 });
 
 test('author detail shows via authors and follow action updates relationship', async () => {

--- a/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
@@ -9,22 +9,18 @@ import { ProfileEditorPanel } from '@/components/extended/ProfileEditorPanel';
 import { ProfileOverviewPanel } from '@/components/extended/ProfileOverviewPanel';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Notice } from '@/components/ui/notice';
-import { Select } from '@/components/ui/select';
 import { SmartReferenceText } from '@/components/core/SmartReferenceText';
 import type { PrimarySection, ProfileConnectionsView } from '@/components/shell/types';
 
 import type {
   DesktopApi,
-  GameRoomStatus,
   PostView,
   ReactionKeyInput,
 } from '@/lib/api';
 import { formatLocalizedTime } from '@/i18n/format';
 import type { SupportedLocale } from '@/i18n';
-import { buildGameLink, buildLiveLink, type InternalSmartReference } from '@/lib/internalLinks';
+import { buildLiveLink, type InternalSmartReference } from '@/lib/internalLinks';
 import {
   timelineScopeStorageKey,
   type GameEditorDraft,
@@ -35,7 +31,6 @@ import {
   formatCount,
   localizeAudienceLabel,
   resolveProfilePictureSrc,
-  translateGameStatus,
   translateLiveStatus,
 } from '@/shell/selectors';
 import { useDesktopShellViewModels } from '@/shell/useDesktopShellViewModels';
@@ -145,8 +140,6 @@ export function DesktopShellPrimaryWorkspace({
   handleJoinLiveSession,
   handleLeaveLiveSession,
   handleEndLiveSession,
-  updateGameDraft,
-  handleUpdateGameRoom,
   openProfileOverview,
   openProfileEditor,
   openProfileConnections,
@@ -164,8 +157,6 @@ export function DesktopShellPrimaryWorkspace({
     bookmarkedPosts,
     bookmarkedReactionAssets,
     composerError,
-    gameError,
-    gameSavingByRoomId,
     knownAuthorsByPubkey,
     liveError,
     localProfile,
@@ -178,7 +169,6 @@ export function DesktopShellPrimaryWorkspace({
     profilePanelState,
     profileSaving,
     recentReactions,
-    selectedGameRoomId,
     selectedLiveSessionId,
     selectedThread,
     shellChromeState,
@@ -199,10 +189,6 @@ export function DesktopShellPrimaryWorkspace({
   const activeTimelineLoadingMore = timelineLoadingMoreByKey[activeTimelineKey] ?? false;
   const metaverseRooms = useMemo(
     () => viewModels.activeGameRooms.filter((room) => room.room_kind === 'metaverse_room'),
-    [viewModels.activeGameRooms]
-  );
-  const scoreGameRooms = useMemo(
-    () => viewModels.activeGameRooms.filter((room) => room.room_kind !== 'metaverse_room'),
     [viewModels.activeGameRooms]
   );
   const profileMode = shellChromeState.profileMode;
@@ -477,175 +463,18 @@ export function DesktopShellPrimaryWorkspace({
         ) : null}
 
         {shellChromeState.activePrimarySection === 'game' ? (
-          <>
-            <Card className='shell-workspace-card'>
-              <div className='panel-header'>
-                <div>
-                  <h3>{t('game:title')}</h3>
-                  <small>{t('game:summary', { count: scoreGameRooms.length })}</small>
-                </div>
-              </div>
-              {viewModels.activeGamePanelState.status === 'loading' ? (
-                <Notice>{t('game:loading')}</Notice>
-              ) : null}
-              {viewModels.activeGamePanelState.status === 'error' &&
-              (gameError ?? viewModels.activeGamePanelState.error) ? (
-                <Notice tone='destructive'>{gameError ?? viewModels.activeGamePanelState.error}</Notice>
-              ) : null}
-            </Card>
-            <Card className='shell-workspace-card'>
-              {scoreGameRooms.length === 0 &&
-              viewModels.activeGamePanelState.status === 'ready' ? (
-                <p className='empty-state'>{t('game:empty')}</p>
-              ) : null}
-              <ul className='post-list'>
-                {scoreGameRooms.map((room) => {
-                  const draft = viewModels.gameDraftViews[room.room_id];
-                  const isOwner = room.host_pubkey === syncStatus.local_author_pubkey;
-                  const pending = Boolean(gameSavingByRoomId[room.room_id]);
-
-                  return (
-                    <li key={room.room_id}>
-                      <article
-                        className={`post-card${
-                          selectedGameRoomId === room.room_id ? ' post-card-targeted' : ''
-                        }`}
-                        aria-busy={pending}
-                        data-game-room-id={room.room_id}
-                        tabIndex={selectedGameRoomId === room.room_id ? -1 : undefined}
-                      >
-                        <div className='post-meta'>
-                          <span>{room.title}</span>
-                          <span>{translateGameStatus(room.status)}</span>
-                          <span className='reply-chip'>
-                            {localizeAudienceLabel(room.audience_label)}
-                          </span>
-                        </div>
-                        <div className='post-body'>
-                          <strong className='post-title post-copy-wrap'>
-                            <SmartReferenceText
-                              text={room.description || t('common:fallbacks.noDescription')}
-                              className='post-copy-wrap'
-                              onActivateReference={(reference) => void handleActivateReference(reference)}
-                            />
-                          </strong>
-                        </div>
-                        <small>{room.room_id}</small>
-                        <div className='topic-diagnostic topic-diagnostic-secondary'>
-                          <span>
-                            {t('common:labels.phase')}: {room.phase_label ?? t('common:fallbacks.none')}
-                          </span>
-                          <span>
-                            {t('common:labels.updated')}: {formatLocalizedTime(room.updated_at, locale)}
-                          </span>
-                        </div>
-                        <ul className='draft-attachment-list'>
-                          {room.scores.map((score) => (
-                            <li key={score.participant_id} className='draft-attachment-item score-row'>
-                              <div className='draft-attachment-content'>
-                                <strong>{score.label}</strong>
-                              </div>
-                              {isOwner ? (
-                                <Input
-                                  aria-label={`${room.room_id}-${score.label}-score`}
-                                  value={draft?.scores[score.participant_id] ?? String(score.score)}
-                                  disabled={pending}
-                                  onChange={(event) =>
-                                    updateGameDraft(room.room_id, (current) => ({
-                                      ...current,
-                                      scores: {
-                                        ...current.scores,
-                                        [score.participant_id]: event.target.value,
-                                      },
-                                    }))
-                                  }
-                                />
-                              ) : (
-                                <span>{score.score}</span>
-                              )}
-                            </li>
-                          ))}
-                        </ul>
-                        {isOwner && draft ? (
-                          <div className='composer composer-compact'>
-                            <Label>
-                              <span>{t('game:fields.status')}</span>
-                              <Select
-                                aria-label={`${room.room_id}-status`}
-                                value={draft.status}
-                                disabled={pending}
-                                onChange={(event) =>
-                                  updateGameDraft(room.room_id, (current) => ({
-                                    ...current,
-                                    status: event.target.value as GameRoomStatus,
-                                  }))
-                                }
-                              >
-                                <option value='Waiting'>{t('game:statuses.Waiting')}</option>
-                                <option value='Running'>{t('game:statuses.Running')}</option>
-                                <option value='Paused'>{t('game:statuses.Paused')}</option>
-                                <option value='Ended'>{t('game:statuses.Ended')}</option>
-                              </Select>
-                            </Label>
-                            <Label>
-                              <span>{t('game:fields.phase')}</span>
-                              <Input
-                                aria-label={`${room.room_id}-phase`}
-                                value={draft.phaseLabel}
-                                disabled={pending}
-                                onChange={(event) =>
-                                  updateGameDraft(room.room_id, (current) => ({
-                                    ...current,
-                                    phase_label: event.target.value,
-                                  }))
-                                }
-                              />
-                            </Label>
-                            <Button
-                              variant='secondary'
-                              type='button'
-                              disabled={pending}
-                              onClick={() => void handleUpdateGameRoom(room.room_id)}
-                            >
-                              {t('game:actions.saveRoom')}
-                            </Button>
-                          </div>
-                        ) : null}
-                        <div className='post-actions'>
-                          <Button
-                            variant='secondary'
-                            size='icon'
-                            className='post-action-button'
-                            type='button'
-                            aria-label={t('common:actions.copyLink')}
-                            onClick={() =>
-                              handleCopyInternalLink(
-                                buildGameLink(activeTopic, room.room_id, room.channel_id ?? null)
-                              )
-                            }
-                          >
-                            <Link2 className='size-4' aria-hidden='true' />
-                          </Button>
-                        </div>
-                      </article>
-                    </li>
-                  );
-                })}
-              </ul>
-            </Card>
-            <MetaverseRoomPanel
-              api={api}
-              activeTopic={activeTopic}
-              activeComposeChannel={viewModels.activeComposeChannel}
-              rooms={metaverseRooms}
-              syncStatus={syncStatus}
-              locale={locale}
-              localProfile={localProfile}
-              knownAuthorsByPubkey={knownAuthorsByPubkey}
-              mediaObjectUrls={mediaObjectUrls}
-              onRefresh={refreshCurrentTopic}
-            />
-          </>
+          <MetaverseRoomPanel
+            api={api}
+            activeTopic={activeTopic}
+            activeComposeChannel={viewModels.activeComposeChannel}
+            rooms={metaverseRooms}
+            syncStatus={syncStatus}
+            locale={locale}
+            localProfile={localProfile}
+            knownAuthorsByPubkey={knownAuthorsByPubkey}
+            mediaObjectUrls={mediaObjectUrls}
+            onRefresh={refreshCurrentTopic}
+          />
         ) : null}
 
         {shellChromeState.activePrimarySection === 'notifications' ? notificationsWorkspace : null}

--- a/apps/desktop/src/shell/routes.test.tsx
+++ b/apps/desktop/src/shell/routes.test.tsx
@@ -349,7 +349,7 @@ test('live session route restores and normalizes invalid session targets without
   expect(screen.getByRole('heading', { name: 'Live Sessions' })).toBeInTheDocument();
 });
 
-test('game room route restores and normalizes invalid room targets without leaving game', async () => {
+test('game route restores and normalizes invalid score room targets without showing score rooms', async () => {
   const firstRender = renderAtHash(
     '#/game?topic=kukuri%3Atopic%3Ademo&roomId=room-demo',
     createDesktopMockApi({
@@ -375,7 +375,8 @@ test('game room route restores and normalizes invalid room targets without leavi
   await waitFor(() => {
     expect(window.location.hash).toBe('#/game?topic=kukuri%3Atopic%3Ademo&roomId=room-demo');
   });
-  expect(screen.getByText('Room Demo').closest('article')).toHaveClass('post-card-targeted');
+  expect(screen.getByRole('heading', { name: 'Metaverse Rooms' })).toBeInTheDocument();
+  expect(screen.queryByText('Room Demo')).not.toBeInTheDocument();
 
   firstRender.unmount();
 
@@ -404,7 +405,8 @@ test('game room route restores and normalizes invalid room targets without leavi
   await waitFor(() => {
     expect(window.location.hash).toBe('#/game?topic=kukuri%3Atopic%3Ademo');
   });
-  expect(screen.getByRole('heading', { name: 'Game Rooms' })).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Metaverse Rooms' })).toBeInTheDocument();
+  expect(screen.queryByText('Room Demo')).not.toBeInTheDocument();
 });
 
 test('profile connections route restores the requested view', async () => {

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -350,10 +350,6 @@
   scrollbar-width: thin;
 }
 
-.metaverse-room-hud[data-size='wide'] {
-  width: min(25rem, calc(100% - 1.5rem));
-}
-
 .metaverse-hud-scrollbar-indicator {
   position: absolute;
   top: 4.85rem;
@@ -525,13 +521,39 @@
 }
 
 .metaverse-room-chat-log-header {
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.45rem;
   color: var(--muted-foreground);
   font-size: 0.78rem;
   font-weight: 800;
   text-transform: uppercase;
+}
+
+.metaverse-room-chat-log-header span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.metaverse-chat-close-button {
+  width: 1.8rem;
+  height: 1.8rem;
+  min-height: 1.8rem;
+  padding: 0;
+}
+
+.metaverse-chat-toggle {
+  position: absolute;
+  left: 0.75rem;
+  bottom: 0.75rem;
+  z-index: 2;
+  width: 2.5rem;
+  height: 2.5rem;
+  min-height: 2.5rem;
+  border-radius: 0.5rem;
+  box-shadow: var(--shadow-panel);
 }
 
 .metaverse-room-chat-log .metaverse-chat-form {
@@ -577,7 +599,9 @@
 }
 
 .metaverse-avatar-bubble {
-  max-width: 14rem;
+  width: max-content;
+  min-width: 8rem;
+  max-width: min(24rem, 68vw);
   padding: 0.35rem 0.55rem;
   border: 1px solid color-mix(in srgb, var(--border-subtle) 82%, transparent);
   border-radius: 0.5rem;
@@ -592,8 +616,17 @@
   white-space: normal;
 }
 
-.metaverse-avatar-bubble[data-stale='true'] {
+.metaverse-avatar-stale-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.65rem;
+  height: 1.65rem;
+  border: 1px solid color-mix(in srgb, var(--warning) 72%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-panel) 88%, transparent);
   color: var(--warning);
+  box-shadow: var(--shadow-panel);
 }
 
 @media (max-width: 900px) {
@@ -613,11 +646,6 @@
     top: auto;
     width: auto;
     max-height: 46%;
-  }
-
-  .metaverse-room-hud[data-size='wide'] {
-    width: auto;
-    max-height: 62%;
   }
 
   .metaverse-hud-scrollbar-indicator {

--- a/apps/desktop/tests/playwright/extended-flow.spec.ts
+++ b/apps/desktop/tests/playwright/extended-flow.spec.ts
@@ -82,17 +82,18 @@ test('browser mock shell can run profile, private channel, live, and game flows'
   ).toBeVisible();
 
   await page.goto('/#/game');
+  await expect(page.getByRole('heading', { name: 'Metaverse Rooms' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Game Rooms' })).toHaveCount(0);
+  await expect(page.getByText('No game rooms', { exact: true })).toHaveCount(0);
   const gameDialog = await openFloatingActionDialog(page);
   await gameDialog.getByPlaceholder('Top 8 Finals').fill('Grand Finals');
   await gameDialog.getByPlaceholder('match summary').fill('set one');
   await gameDialog.getByPlaceholder('Alice, Bob').fill('Alice, Bob');
   await gameDialog.getByRole('button', { name: 'Create Room' }).click();
-  await expect(page.getByText('Grand Finals')).toBeVisible();
-  await page.getByLabel(/game-.*-status/).selectOption('Running');
-  await page.getByLabel(/game-.*-phase/).fill('Round 3');
-  await page.getByLabel(/game-.*-Alice-score/).fill('2');
-  await page.getByRole('button', { name: 'Save Room' }).click();
-  await expect(page.getByText('phase: Round 3')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Metaverse Rooms' })).toBeVisible();
+  await expect(page.getByText('Grand Finals')).toHaveCount(0);
+  await expect(page.getByText('set one')).toHaveCount(0);
+  await expect(page.getByLabel(/game-.*-status/)).toHaveCount(0);
 
   await page.goto('/#/profile?profileMode=edit');
   await page.getByPlaceholder('Visible label').fill('Browser Author');


### PR DESCRIPTION
## Summary
- tune metaverse avatar transform send intervals and remote smoothing to reduce movement lag
- separate stale avatar state from chat bubbles, widen avatar chat bubbles, and make room chat collapsible
- remove the ineffective right HUD resize mode and hide nonfunctional score-game room UI from the game workspace
- prevent shared object rollback by accepting only newer object state updates

## Root Cause
The metaverse room UI mixed ephemeral state and durable refresh state in a way that allowed stale manifests to overwrite local object movement. Remote avatar smoothing and stale timing were also tuned too conservatively for responsive movement, and stale status reused the chat bubble surface.

## Validation
- `cd apps/desktop && npx pnpm@10.16.1 test -- src/components/extended/MetaverseScene.test.ts src/components/extended/MetaverseRoomPanel.test.tsx`
- `cd apps/desktop && npx pnpm@10.16.1 test -- src/shell/DesktopShellPage.test.tsx`
- `cd apps/desktop && npx pnpm@10.16.1 typecheck`
- `cd apps/desktop && npx pnpm@10.16.1 test`
- `cd apps/desktop && npx pnpm@10.16.1 lint`
- Vite + Playwright smoke for `#/game`: confirmed Metaverse Rooms remains visible and Game Rooms / No game rooms do not render