### PR TITLE
[codex] Improve metaverse play screen controls

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
@@ -130,6 +130,30 @@ function avatarEvent(peerId: string, animation: string | null, seq: number): Met
   };
 }
 
+function presenceLeaveEvent(peerId: string, seq: number): MetaverseRoomEventView {
+  return {
+    envelope_id: `event-${seq}`,
+    content: {
+      event_id: `event-${seq}`,
+      topic_id: 'kukuri:topic:demo',
+      channel_id: null,
+      room_id: room.room_id,
+      peer_id: peerId,
+      seq,
+      sent_at: seq,
+      event: {
+        type: 'presence_leave',
+        room_id: room.room_id,
+        peer_id: peerId,
+        left_at: seq,
+      },
+    },
+    envelope: {},
+    received_at: seq,
+    source_peer: peerId,
+  };
+}
+
 type RenderPanelOptions = {
   rooms?: GameRoomView[];
   syncStatus?: SyncStatus;
@@ -231,6 +255,32 @@ describe('MetaverseRoomPanel animation sharing', () => {
     });
   });
 
+  test('leaves a joined room and publishes presence leave', async () => {
+    const user = userEvent.setup();
+    const baseApi = createDesktopMockApi();
+    const publishMetaverseRoomEvent = vi.fn(baseApi.publishMetaverseRoomEvent);
+    const api: DesktopApi = {
+      ...baseApi,
+      publishMetaverseRoomEvent,
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+
+    renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+    expect(screen.getByLabelText('Metaverse room viewport')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Leave room' }));
+
+    expect(screen.queryByLabelText('Metaverse room viewport')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        publishMetaverseRoomEvent.mock.calls.some(
+          ([, roomId, , , event]) => roomId === room.room_id && event.type === 'presence_leave'
+        )
+      ).toBe(true);
+    });
+  });
+
   test('room HUD can be collapsed without a resize mode', async () => {
     const user = userEvent.setup();
     const baseApi = createDesktopMockApi();
@@ -275,6 +325,43 @@ describe('MetaverseRoomPanel animation sharing', () => {
     expect(screen.queryByLabelText('ROOM Chat')).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Open room chat' }));
     expect(screen.getByLabelText('ROOM Chat')).toBeInTheDocument();
+  });
+
+  test('enter opens room chat and focuses the message input while playing', async () => {
+    const user = userEvent.setup();
+    const api = {
+      ...createDesktopMockApi(),
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+
+    renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+    await user.click(screen.getByRole('button', { name: 'Hide room chat' }));
+    expect(screen.queryByLabelText('ROOM Chat')).not.toBeInTheDocument();
+
+    await user.keyboard('{Enter}');
+
+    const input = await screen.findByPlaceholderText('Say something in the room');
+    await waitFor(() => {
+      expect(input).toHaveFocus();
+    });
+  });
+
+  test('enter inside an editable control does not open room chat', async () => {
+    const user = userEvent.setup();
+    const api = {
+      ...createDesktopMockApi(),
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([]),
+    };
+
+    renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+    await user.click(screen.getByRole('button', { name: 'Hide room chat' }));
+    await user.click(screen.getByRole('button', { name: 'Create metaverse room' }));
+    await user.click(screen.getByPlaceholderText('Atrium'));
+    await user.keyboard('{Enter}');
+
+    expect(screen.queryByLabelText('ROOM Chat')).not.toBeInTheDocument();
   });
 
   test('keeps create room controls collapsed until opened', async () => {
@@ -363,6 +450,26 @@ describe('MetaverseRoomPanel animation sharing', () => {
       expect(screen.getByText(/jump-rem:jump/)).toBeInTheDocument();
       expect(screen.getByText(/sitting-:sitting/)).toBeInTheDocument();
       expect(screen.getByText(/unknown-:idle/)).toBeInTheDocument();
+    });
+  });
+
+  test('removes a remote avatar when a presence leave event arrives', async () => {
+    const user = userEvent.setup();
+    const baseApi = createDesktopMockApi();
+    const api: DesktopApi = {
+      ...baseApi,
+      listMetaverseRoomEvents: vi.fn().mockResolvedValue([
+        avatarEvent('leaving-remote', 'walk', 1),
+        presenceLeaveEvent('leaving-remote', 2),
+      ]),
+    };
+
+    renderPanel(api);
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+    await user.click(screen.getByRole('button', { name: 'Debug details' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Remote animation: none')).toBeInTheDocument();
     });
   });
 

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -1,10 +1,11 @@
 ﻿import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
 import {
-  AlertTriangle,
   Box,
   ChevronDown,
   Cuboid,
+  LogOut,
   MessageSquare,
+  MonitorPause,
   Move3D,
   PanelRightClose,
   PanelRightOpen,
@@ -137,6 +138,14 @@ function latestChatBubbleFromMessage(message: RoomChatMessage, now = Date.now())
   };
 }
 
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  return tagName === 'input' || tagName === 'textarea' || tagName === 'select' || target.isContentEditable;
+}
+
 function ConnectionStateIcon({ state }: { state: MetaverseRoomConnectionState }) {
   if (state === 'live') {
     return <Wifi className='size-4' aria-hidden='true' />;
@@ -145,7 +154,7 @@ function ConnectionStateIcon({ state }: { state: MetaverseRoomConnectionState })
     return <RefreshCw className='size-4' aria-hidden='true' />;
   }
   if (state === 'stale') {
-    return <AlertTriangle className='size-4' aria-hidden='true' />;
+    return <MonitorPause className='size-4' aria-hidden='true' />;
   }
   return <WifiOff className='size-4' aria-hidden='true' />;
 }
@@ -192,6 +201,7 @@ export function MetaverseRoomPanel({
   const lastRecoveryAtRef = useRef(0);
   const pendingCreatedRoomIdRef = useRef<string | null>(null);
   const sharedObjectRef = useRef<SharedRoomObjectV1>(DEFAULT_SHARED_OBJECT);
+  const messageInputRef = useRef<HTMLInputElement | null>(null);
   const localPeerSeed = useId().replaceAll(':', '');
   const localPeerId = `${syncStatus.discovery.local_endpoint_id || syncStatus.local_author_pubkey || 'local'}:${localPeerSeed}`;
   const lastSentTransformRef = useRef<AvatarTransform | null>(null);
@@ -315,6 +325,23 @@ export function MetaverseRoomPanel({
           ...current,
           [data.presence.peerId]: data.presence,
         }));
+      }
+      if (data.type === 'presence.leave' && data.peerId !== localPeerId) {
+        setPeerPresence((current) => {
+          const next = { ...current };
+          delete next[data.peerId];
+          return next;
+        });
+        setRemoteTransforms((current) => {
+          const next = { ...current };
+          delete next[data.peerId];
+          return next;
+        });
+        setLatestChatByPeer((current) => {
+          const next = { ...current };
+          delete next[data.peerId];
+          return next;
+        });
       }
       if (data.type === 'avatar.transform' && data.transform.peerId !== localPeerId) {
         setRemoteTransforms((current) => ({
@@ -489,6 +516,23 @@ export function MetaverseRoomPanel({
             });
         }
       }
+      if (event.type === 'presence_leave' && event.peer_id !== localPeerId) {
+        setPeerPresence((current) => {
+          const next = { ...current };
+          delete next[event.peer_id];
+          return next;
+        });
+        setRemoteTransforms((current) => {
+          const next = { ...current };
+          delete next[event.peer_id];
+          return next;
+        });
+        setLatestChatByPeer((current) => {
+          const next = { ...current };
+          delete next[event.peer_id];
+          return next;
+        });
+      }
       if (event.type === 'avatar_transform' && event.transform.peer_id !== localPeerId) {
         setRemoteTransforms((current) => ({
           ...current,
@@ -609,9 +653,45 @@ export function MetaverseRoomPanel({
     channelRef.current?.postMessage(event);
   }
 
+  function resetRoomRuntimeState() {
+    setRemoteTransforms({});
+    setPeerPresence({});
+    setLatestChatByPeer({});
+    setPollErrorCount(0);
+    setLastRoomActivityAt(Date.now());
+    setRecoveringUntil(0);
+    setLastSentSeq(0);
+    lastSentTransformRef.current = null;
+    lastBackendEventEnvelopeIdRef.current = null;
+  }
+
   function handleJoinRoom(roomId: string) {
     setJoinedRoomIds((current) => new Set(current).add(roomId));
     setSelectedRoomId(roomId);
+  }
+
+  function handleLeaveRoom() {
+    if (!selectedRoom) {
+      return;
+    }
+    const roomId = selectedRoom.room_id;
+    const leftAt = Date.now();
+    emit({ type: 'presence.leave', roomId, peerId: localPeerId, leftAt });
+    void api.publishMetaverseRoomEvent(activeTopic, roomId, localPeerId, leftAt, {
+      type: 'presence_leave',
+      room_id: roomId,
+      peer_id: localPeerId,
+      left_at: leftAt,
+    }).catch((leaveError) => {
+      setError(leaveError instanceof Error ? leaveError.message : 'Failed to publish room leave');
+    });
+    setJoinedRoomIds((current) => {
+      const next = new Set(current);
+      next.delete(roomId);
+      return next;
+    });
+    setSelectedRoomId(null);
+    resetRoomRuntimeState();
   }
 
   function hostAuthor(room: GameRoomView): Profile | AuthorSocialView | null {
@@ -745,6 +825,33 @@ export function MetaverseRoomPanel({
     persistSharedObject(nextObject, room);
   }
 
+  useEffect(() => {
+    if (!selectedRoom) {
+      return;
+    }
+    let focusFrameId = 0;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter' || isEditableTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      setChatOpen(true);
+      if (focusFrameId) {
+        window.cancelAnimationFrame(focusFrameId);
+      }
+      focusFrameId = window.requestAnimationFrame(() => {
+        messageInputRef.current?.focus();
+      });
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      if (focusFrameId) {
+        window.cancelAnimationFrame(focusFrameId);
+      }
+    };
+  }, [selectedRoom]);
+
   return (
     <div className='metaverse-panel'>
       <Card className='shell-workspace-card metaverse-discovery-card'>
@@ -868,6 +975,16 @@ export function MetaverseRoomPanel({
                     <span>{connectionStateLabel(roomConnectionState)}</span>
                   </div>
                   <div className='metaverse-hud-toolbar' data-open={hudOpen}>
+                    <Button
+                      variant='ghost'
+                      size='icon'
+                      className='metaverse-hud-icon-button'
+                      type='button'
+                      aria-label='Leave room'
+                      onClick={handleLeaveRoom}
+                    >
+                      <LogOut className='size-4' aria-hidden='true' />
+                    </Button>
                     <Button
                       variant='ghost'
                       size='icon'
@@ -1003,6 +1120,7 @@ export function MetaverseRoomPanel({
                         <Label>
                           <span className='sr-only'>Room chat message</span>
                           <Input
+                            ref={messageInputRef}
                             value={messageDraft}
                             placeholder='Say something in the room'
                             onChange={(event) => setMessageDraft(event.target.value)}

--- a/apps/desktop/src/components/extended/MetaverseScene.test.ts
+++ b/apps/desktop/src/components/extended/MetaverseScene.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 import {
   METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS,
   METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS,
+  METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS,
   METAVERSE_ROOM_STALE_MS,
   isNewerRemoteTransform,
   isNewerSharedObject,
@@ -17,6 +18,7 @@ describe('metaverse avatar animation state', () => {
   test('uses low-latency transform intervals and a longer stale threshold', () => {
     expect(METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS).toBe(30);
     expect(METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS).toBe(150);
+    expect(METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS).toBe(0.14);
     expect(METAVERSE_ROOM_STALE_MS).toBe(45_000);
   });
 

--- a/apps/desktop/src/components/extended/MetaverseScene.tsx
+++ b/apps/desktop/src/components/extended/MetaverseScene.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { Html } from '@react-three/drei';
-import { AlertTriangle } from 'lucide-react';
+import { MonitorPause } from 'lucide-react';
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { VRMLoaderPlugin, VRMUtils, type VRM } from '@pixiv/three-vrm';
@@ -116,7 +116,7 @@ function AvatarStaleIndicator({ stale }: { stale: boolean }) {
   return (
     <Html position={[0.32, 1.9, 0]} center distanceFactor={8} occlude={false}>
       <div className='metaverse-avatar-stale-icon' aria-label='Remote avatar stale'>
-        <AlertTriangle className='size-3' aria-hidden='true' />
+        <MonitorPause className='size-3' aria-hidden='true' />
       </div>
     </Html>
   );

--- a/apps/desktop/src/components/extended/MetaverseSceneModel.ts
+++ b/apps/desktop/src/components/extended/MetaverseSceneModel.ts
@@ -83,6 +83,7 @@ export type MetaverseRoomConnectionState = 'live' | 'stale' | 'recovering' | 'of
 
 export type MetaverseRoomEvent =
   | { type: 'presence.join'; presence: PeerPresence }
+  | { type: 'presence.leave'; roomId: string; peerId: string; leftAt: number }
   | { type: 'avatar.transform'; transform: AvatarTransform }
   | { type: 'chat.message'; message: RoomChatMessage }
   | { type: 'object.update'; roomId: string; object: SharedRoomObjectV1 };
@@ -109,7 +110,7 @@ export const METAVERSE_ROOM_HEARTBEAT_MS = 5_000;
 export const METAVERSE_ROOM_RECOVERY_MS = 10_000;
 export const METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS = 30;
 export const METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS = 150;
-export const METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS = 0.06;
+export const METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS = 0.14;
 
 export const AVATAR_GROUND_Y = 0;
 export const AVATAR_JUMP_VELOCITY = 520;

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -509,10 +509,12 @@
   bottom: 0.75rem;
   z-index: 2;
   display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   gap: 0.55rem;
   width: min(27rem, calc(100% - 1.5rem));
-  max-height: 42%;
+  max-height: min(24rem, calc(100% - 5.5rem));
   padding: 0.7rem;
+  overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--border-subtle) 82%, transparent);
   border-radius: 0.5rem;
   background: color-mix(in srgb, var(--surface-panel) 80%, transparent);
@@ -557,12 +559,22 @@
 }
 
 .metaverse-room-chat-log .metaverse-chat-form {
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) max-content;
   align-items: center;
+}
+
+.metaverse-room-chat-log .metaverse-chat-form label,
+.metaverse-room-chat-log .metaverse-chat-form input {
+  min-width: 0;
+}
+
+.metaverse-room-chat-log .metaverse-chat-form .button {
+  white-space: nowrap;
 }
 
 .metaverse-room-chat-log .metaverse-chat-list {
   max-height: 9rem;
+  min-height: 0;
 }
 
 .metaverse-room-chat-log .metaverse-chat-list li {
@@ -658,7 +670,7 @@
   .metaverse-room-chat-log {
     right: 0.75rem;
     width: auto;
-    max-height: 34%;
+    max-height: min(18rem, calc(100% - 5.5rem));
   }
 }
 


### PR DESCRIPTION
## Summary
- replace metaverse stale warning icons with monitor-pause icons
- slow remote avatar smoothing to reduce visible jitter
- add room leave handling with presence_leave publishing and remote leave cleanup
- add Enter-to-chat focus behavior and fix chat form layout

## Notes
- Inspected `apps/desktop/public/blumochichi.vrm`; direct binary correction did not look stable enough, so the VRM file was left unchanged and no default-asset-specific loader correction was added.

## Validation
- `npx pnpm@10.16.1 test -- MetaverseScene.test.ts MetaverseRoomPanel.test.tsx`
- `npx pnpm@10.16.1 typecheck`
- `cargo xtask desktop-ui-check`