### PR TITLE
[codex] fix metaverse avatar camera

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseScene.test.ts
+++ b/apps/desktop/src/components/extended/MetaverseScene.test.ts
@@ -3,13 +3,14 @@ import { describe, expect, test } from 'vitest';
 import {
   METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS,
   METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS,
-  METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS,
+  METAVERSE_REMOTE_AVATAR_POSITION_SMOOTHING_SECONDS,
   METAVERSE_ROOM_STALE_MS,
   isNewerRemoteTransform,
   isNewerSharedObject,
   avatarAnimationForInput,
   mergeRoomChatMessages,
   normalizeAvatarAnimationState,
+  remoteAvatarYawDegrees,
   stepAvatarJump,
   type AvatarTransform,
 } from './MetaverseSceneModel';
@@ -18,8 +19,12 @@ describe('metaverse avatar animation state', () => {
   test('uses low-latency transform intervals and a longer stale threshold', () => {
     expect(METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS).toBe(30);
     expect(METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS).toBe(150);
-    expect(METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS).toBe(0.14);
+    expect(METAVERSE_REMOTE_AVATAR_POSITION_SMOOTHING_SECONDS).toBe(0.14);
     expect(METAVERSE_ROOM_STALE_MS).toBe(45_000);
+  });
+
+  test('uses the received remote yaw without smoothing', () => {
+    expect(remoteAvatarYawDegrees([0, 135, 0])).toBe(135);
   });
 
   test('derives keyboard animation state', () => {

--- a/apps/desktop/src/components/extended/MetaverseScene.tsx
+++ b/apps/desktop/src/components/extended/MetaverseScene.tsx
@@ -17,11 +17,12 @@ import {
   DEFAULT_AVATAR_ASSET_URL,
   METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS,
   METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS,
-  METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS,
+  METAVERSE_REMOTE_AVATAR_POSITION_SMOOTHING_SECONDS,
   METAVERSE_ROOM_STALE_MS,
   avatarAnimationForInput,
   initialAvatarTransform,
   isNewerRemoteTransform,
+  remoteAvatarYawDegrees,
   stepAvatarJump,
   type AvatarAnimationState,
   type AvatarAssetStatus,
@@ -282,8 +283,8 @@ function AvatarModel({
         VRMUtils.removeUnnecessaryVertices(gltf.scene);
         VRMUtils.removeUnnecessaryJoints(gltf.scene);
         const vrmRoot = vrm.scene;
-        vrmRoot.scale.setScalar(0.9);
-        vrmRoot.rotation.y = Math.PI;
+        vrmRoot.scale.setScalar(1);
+        VRMUtils.rotateVRM0(vrm);
         vrmRoot.position.y = 0;
         group.add(vrmRoot);
         setVisiblePrimitive(false);
@@ -606,10 +607,9 @@ function RemoteAvatar({
       initializedRef.current = true;
       return;
     }
-    const alpha = 1 - Math.exp(-deltaSeconds / METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS);
+    const alpha = 1 - Math.exp(-deltaSeconds / METAVERSE_REMOTE_AVATAR_POSITION_SMOOTHING_SECONDS);
     group.position.lerp(targetPosition, Math.min(1, alpha));
-    const targetYaw = THREE.MathUtils.degToRad(target.rotation[1]);
-    group.rotation.y = THREE.MathUtils.lerp(group.rotation.y, targetYaw, Math.min(1, alpha));
+    group.rotation.y = THREE.MathUtils.degToRad(remoteAvatarYawDegrees(target.rotation));
   });
 
   const stale = connectionState !== 'live' || now - transform.sentAt > METAVERSE_ROOM_STALE_MS;
@@ -668,7 +668,7 @@ function SceneContents({
   const { camera } = useThree();
 
   useEffect(() => {
-    camera.lookAt(0, 0.8, 0);
+    camera.lookAt(0, 0.9, 0);
   }, [camera]);
 
   return (
@@ -723,7 +723,7 @@ export function MetaverseScene({
     <div className='metaverse-viewport-shell' aria-label='Metaverse room viewport'>
       <Canvas
         className='metaverse-viewport-canvas'
-        camera={{ position: [0, 4.2, 6.5], fov: 58 }}
+        camera={{ position: [0, 3.2, 5.2], fov: 54 }}
         gl={{ antialias: true }}
         dpr={[1, 2]}
       >

--- a/apps/desktop/src/components/extended/MetaverseSceneModel.ts
+++ b/apps/desktop/src/components/extended/MetaverseSceneModel.ts
@@ -110,7 +110,7 @@ export const METAVERSE_ROOM_HEARTBEAT_MS = 5_000;
 export const METAVERSE_ROOM_RECOVERY_MS = 10_000;
 export const METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS = 30;
 export const METAVERSE_AVATAR_IDLE_SEND_INTERVAL_MS = 150;
-export const METAVERSE_REMOTE_AVATAR_SMOOTHING_SECONDS = 0.14;
+export const METAVERSE_REMOTE_AVATAR_POSITION_SMOOTHING_SECONDS = 0.14;
 
 export const AVATAR_GROUND_Y = 0;
 export const AVATAR_JUMP_VELOCITY = 520;
@@ -169,6 +169,10 @@ export function isNewerRemoteTransform(
     return incoming.seq > current.seq;
   }
   return incoming.sentAt > current.sentAt;
+}
+
+export function remoteAvatarYawDegrees(rotation: MetaverseVec3): number {
+  return rotation[1];
 }
 
 export function isNewerSharedObject(


### PR DESCRIPTION
## Summary
- Apply VRM0-only avatar facing correction via `VRMUtils.rotateVRM0` while leaving VRM1 orientation unchanged.
- Keep remote avatar position smoothing but apply received yaw immediately so remote rotation matches the local avatar feel.
- Adjust the metaverse camera framing and VRM root scale for the updated `blumochichi.vrm` asset.

## Root Cause
The scene applied a blanket `Math.PI` Y rotation to every loaded VRM. That made VRM1 look correct but reversed VRM0 files. Remote avatars also smoothed yaw with the same interpolation used for position, causing rotation to lag behind local avatar controls.

## Validation
- `npx pnpm@10.16.1 test -- MetaverseScene`
- `npx pnpm@10.16.1 typecheck`
- `cargo xtask desktop-ui-check`