### PR TITLE
[codex] fix metaverse VRM avatar forward

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseScene.test.ts
+++ b/apps/desktop/src/components/extended/MetaverseScene.test.ts
@@ -5,9 +5,11 @@ import {
   METAVERSE_AVATAR_MOVING_SEND_INTERVAL_MS,
   METAVERSE_REMOTE_AVATAR_POSITION_SMOOTHING_SECONDS,
   METAVERSE_ROOM_STALE_MS,
+  AVATAR_VRM_FORWARD_YAW_OFFSET_DEGREES,
   isNewerRemoteTransform,
   isNewerSharedObject,
   avatarAnimationForInput,
+  avatarVrmVisualRootYawDegrees,
   mergeRoomChatMessages,
   normalizeAvatarAnimationState,
   remoteAvatarYawDegrees,
@@ -25,6 +27,12 @@ describe('metaverse avatar animation state', () => {
 
   test('uses the received remote yaw without smoothing', () => {
     expect(remoteAvatarYawDegrees([0, 135, 0])).toBe(135);
+  });
+
+  test('flips the normalized VRM visual forward without changing shared yaw', () => {
+    expect(AVATAR_VRM_FORWARD_YAW_OFFSET_DEGREES).toBe(180);
+    expect(avatarVrmVisualRootYawDegrees(0)).toBe(180);
+    expect(avatarVrmVisualRootYawDegrees(180)).toBe(360);
   });
 
   test('derives keyboard animation state', () => {

--- a/apps/desktop/src/components/extended/MetaverseScene.tsx
+++ b/apps/desktop/src/components/extended/MetaverseScene.tsx
@@ -20,6 +20,7 @@ import {
   METAVERSE_REMOTE_AVATAR_POSITION_SMOOTHING_SECONDS,
   METAVERSE_ROOM_STALE_MS,
   avatarAnimationForInput,
+  avatarVrmVisualRootYawDegrees,
   initialAvatarTransform,
   isNewerRemoteTransform,
   remoteAvatarYawDegrees,
@@ -285,6 +286,10 @@ function AvatarModel({
         const vrmRoot = vrm.scene;
         vrmRoot.scale.setScalar(1);
         VRMUtils.rotateVRM0(vrm);
+        // Keep the shared transform yaw unchanged; flip only the normalized VRM visual forward.
+        vrmRoot.rotation.y = THREE.MathUtils.degToRad(
+          avatarVrmVisualRootYawDegrees(THREE.MathUtils.radToDeg(vrmRoot.rotation.y))
+        );
         vrmRoot.position.y = 0;
         group.add(vrmRoot);
         setVisiblePrimitive(false);

--- a/apps/desktop/src/components/extended/MetaverseSceneModel.ts
+++ b/apps/desktop/src/components/extended/MetaverseSceneModel.ts
@@ -115,6 +115,11 @@ export const METAVERSE_REMOTE_AVATAR_POSITION_SMOOTHING_SECONDS = 0.14;
 export const AVATAR_GROUND_Y = 0;
 export const AVATAR_JUMP_VELOCITY = 520;
 export const AVATAR_GRAVITY = 1600;
+export const AVATAR_VRM_FORWARD_YAW_OFFSET_DEGREES = 180;
+
+export function avatarVrmVisualRootYawDegrees(baseYawDegrees: number): number {
+  return baseYawDegrees + AVATAR_VRM_FORWARD_YAW_OFFSET_DEGREES;
+}
 
 export function initialAvatarTransform(
   roomId: string,


### PR DESCRIPTION
## Summary

- Flip the normalized VRM visual root by 180 degrees after VRM0/VRM1 normalization.
- Keep the shared avatar transform yaw unchanged so local and remote peers continue to exchange the same rotation data.
- Add a focused model test for the visual-only VRM forward offset.

## Root Cause

VRM0 and VRM1 were normalized to a consistent orientation, but the normalized visual forward direction was still opposite the movement transform. That made avatars appear to move backward, like moonwalking.

## Validation

- `cd apps/desktop && npx pnpm@10.16.1 test -- MetaverseScene.test.ts`
- `cd apps/desktop && npx pnpm@10.16.1 typecheck`
- `cd apps/desktop && npx pnpm@10.16.1 lint`