### PR TITLE
[codex] Fix release workflow validation setup

### DIFF
--- a/.github/workflows/kukuri-release.yml
+++ b/.github/workflows/kukuri-release.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           toolchain: 1.91.0
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Release version gate
         run: cargo xtask release-check ${{ steps.release.outputs.release_tag }}
 

--- a/docs/progress/2026-06-11-release-readiness-execution-plan.md
+++ b/docs/progress/2026-06-11-release-readiness-execution-plan.md
@@ -139,7 +139,7 @@
 - [x] 初回プレビュータグ形式を決める。例: `v0.1.0-preview.1`。
 - [ ] リリースチェックリスト issue または追跡ボードを作る。
 - [x] 対象 OS を確認する。パッケージ配布は Windows 10 / Windows 11、Linux はソース起動のみとする。
-- [ ] リリースブランチ方針を確認する。`main` から直接タグを打つか、リリースブランチを使うかを決める。
+- [x] リリースブランチ方針を確認する。`main` から直接タグを打つか、リリースブランチを使うかを決める。
 - [x] release workflow は既存の `cargo xtask desktop-package` / `.github/workflows/kukuri-release.yml` を拡張する方針で固定し、初回プレビューでは `tauri-action` への全面移行を行わない。
 - [x] GitHub Actions の実行トリガーを整理する。
   - `push tags: v*` もまず draft release を作る。
@@ -216,9 +216,9 @@
   - 更新用バンドル。
   - `.sig` ファイル。
   - 必要に応じて通常 installer と updater bundle を区別できる artifact 名。
-- [ ] updater 秘密鍵を GitHub Actions secrets に保存する。
+- [x] updater 秘密鍵を GitHub Actions secrets に保存する。
 - [x] updater build では `TAURI_SIGNING_PRIVATE_KEY` と、必要であれば `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` を GitHub Actions secrets から渡す。
-- [ ] updater 公開鍵はリポジトリ設定に保持する。
+- [x] updater 公開鍵はリポジトリ設定に保持する。
 - [x] `release-assets` で次を生成する。
   - `latest-preview.json`
   - `SHA256SUMS.txt`


### PR DESCRIPTION
## Summary

- Add sccache setup to the release workflow validation job so the global `RUSTC_WRAPPER=sccache` env resolves before `cargo xtask release-check` runs.
- Mark the completed release-plan manual items for updater signing secrets and the main-tag branch policy.

## Validation

- `cargo xtask release-check v0.1.0-preview.2`
- `git diff --check`

## Context

The `v0.1.0-preview.1` tag-triggered release run failed in `validate-release-inputs` before packaging because the job did not install sccache.