### PR TITLE
[codex] Install release validation system deps

### DIFF
--- a/.github/workflows/kukuri-release.yml
+++ b/.github/workflows/kukuri-release.yml
@@ -66,6 +66,19 @@ jobs:
         with:
           toolchain: 1.91.0
 
+      - name: Install Linux system dependencies
+        run: >
+          sudo apt-get update &&
+          sudo apt-get install -y
+          pkg-config
+          libdbus-1-dev
+          libglib2.0-dev
+          libgtk-3-dev
+          libwebkit2gtk-4.1-dev
+          libayatana-appindicator3-dev
+          librsvg2-dev
+          patchelf
+
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 


### PR DESCRIPTION
## Summary

- Install the Linux system packages required by `cargo xtask release-check` in the release workflow validation job.
- This matches the dependency surface already installed by `linux-verify` and fixes the `libdbus-sys` build failure seen in the `v0.1.0-preview.2` release run.

## Validation

- `cargo xtask release-check v0.1.0-preview.3`
- `git diff --check`

## Context

`v0.1.0-preview.2` advanced past sccache setup but failed in `validate-release-inputs` because `libdbus-1-dev` / pkg-config dependencies were missing before compiling xtask.