### PR TITLE
[codex] Add store migration fixture

### DIFF
--- a/crates/store/fixtures/sqlite/pre-metaverse-game-room-columns.fixture
+++ b/crates/store/fixtures/sqlite/pre-metaverse-game-room-columns.fixture
@@ -1,0 +1,6 @@
+# SQLite store fixture: pre-metaverse game room columns
+#
+# This fixture describes a release-era SQLite database with migrations applied through
+# 20260413000000_unfiltered_projection_indexes. Tests materialize the database from the embedded
+# migration SQL and the embedded sqlx checksums, then verify that the current store can migrate it.
+applied_through=20260413000000

--- a/crates/store/src/tests/migrations.rs
+++ b/crates/store/src/tests/migrations.rs
@@ -1,4 +1,11 @@
 use super::*;
+use anyhow::Result;
+use sqlx::Row;
+use sqlx::sqlite::SqliteConnectOptions;
+use std::str::FromStr;
+
+const PRE_METAVERSE_FIXTURE: &str =
+    include_str!("../../fixtures/sqlite/pre-metaverse-game-room-columns.fixture");
 
 #[tokio::test]
 async fn connect_file_repairs_line_ending_only_migration_checksum_mismatches() {
@@ -115,4 +122,144 @@ async fn connect_file_applies_unfiltered_projection_indexes() {
     .expect("load unfiltered projection indexes after reopen");
     reopened_indexes.sort();
     assert_eq!(reopened_indexes, expected_indexes);
+}
+
+#[tokio::test]
+async fn connect_file_migrates_pre_metaverse_game_room_fixture() {
+    let tempdir = tempdir().expect("tempdir");
+    let db_path = tempdir.path().join("pre-metaverse.db");
+    let applied_through = fixture_applied_through(PRE_METAVERSE_FIXTURE);
+    materialize_sqlite_fixture(&db_path, applied_through)
+        .await
+        .expect("materialize old sqlite fixture");
+
+    let database_url = format!("sqlite://{}", db_path.display());
+    let pre_migration_pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(&database_url)
+        .await
+        .expect("open old sqlite fixture");
+    assert!(
+        !sqlite_column_exists(&pre_migration_pool, "game_room_cache", "room_kind")
+            .await
+            .expect("check old fixture room_kind column"),
+        "fixture should represent the pre-metaverse game_room_cache schema"
+    );
+    pre_migration_pool.close().await;
+
+    let migrated = SqliteStore::connect_file(&db_path)
+        .await
+        .expect("migrate old sqlite fixture");
+
+    assert!(
+        sqlite_column_exists(migrated.pool(), "game_room_cache", "room_kind")
+            .await
+            .expect("check migrated room_kind column")
+    );
+    assert!(
+        sqlite_column_exists(migrated.pool(), "game_room_cache", "metaverse_json")
+            .await
+            .expect("check migrated metaverse_json column")
+    );
+    let index_exists = sqlx::query_scalar::<_, i64>(
+        r#"
+        SELECT 1
+        FROM sqlite_master
+        WHERE type = 'index'
+          AND name = 'idx_game_room_cache_topic_kind_updated'
+        LIMIT 1
+        "#,
+    )
+    .fetch_optional(migrated.pool())
+    .await
+    .expect("check migrated game room kind index")
+    .is_some();
+    assert!(index_exists);
+
+    let latest_migration = sqlx::query_scalar::<_, i64>(
+        "SELECT 1 FROM _sqlx_migrations WHERE version = ?1 AND success = true",
+    )
+    .bind(20260527000000_i64)
+    .fetch_optional(migrated.pool())
+    .await
+    .expect("check latest migration record")
+    .is_some();
+    assert!(latest_migration);
+}
+
+fn fixture_applied_through(fixture: &str) -> i64 {
+    fixture
+        .lines()
+        .find_map(|line| line.strip_prefix("applied_through="))
+        .expect("fixture applied_through")
+        .parse()
+        .expect("fixture applied_through version")
+}
+
+async fn materialize_sqlite_fixture(db_path: &std::path::Path, applied_through: i64) -> Result<()> {
+    let options = SqliteConnectOptions::from_str(&format!("sqlite://{}", db_path.display()))?
+        .create_if_missing(true);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await?;
+
+    sqlx::query(
+        r#"
+        CREATE TABLE _sqlx_migrations (
+            version BIGINT PRIMARY KEY,
+            description TEXT NOT NULL,
+            installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            success BOOLEAN NOT NULL,
+            checksum BLOB NOT NULL,
+            execution_time BIGINT NOT NULL
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await?;
+
+    for migration in STORE_MIGRATOR
+        .iter()
+        .filter(|migration| {
+            migration.version <= applied_through && !migration.migration_type.is_down_migration()
+        })
+        .collect::<Vec<_>>()
+    {
+        sqlx::raw_sql(migration.sql.as_ref()).execute(&pool).await?;
+        sqlx::query(
+            r#"
+            INSERT INTO _sqlx_migrations (
+                version,
+                description,
+                success,
+                checksum,
+                execution_time
+            )
+            VALUES (?1, ?2, true, ?3, 0)
+            "#,
+        )
+        .bind(migration.version)
+        .bind(migration.description.as_ref())
+        .bind(migration.checksum.as_ref())
+        .execute(&pool)
+        .await?;
+    }
+
+    pool.close().await;
+    Ok(())
+}
+
+async fn sqlite_column_exists(
+    pool: &sqlx::Pool<sqlx::Sqlite>,
+    table_name: &str,
+    column_name: &str,
+) -> Result<bool> {
+    let rows = sqlx::query("SELECT name FROM pragma_table_info(?1)")
+        .bind(table_name)
+        .fetch_all(pool)
+        .await?;
+    Ok(rows
+        .iter()
+        .any(|row| row.get::<String, _>("name") == column_name))
 }

--- a/docs/progress/2026-06-11-release-readiness-execution-plan.md
+++ b/docs/progress/2026-06-11-release-readiness-execution-plan.md
@@ -264,7 +264,8 @@
   - ローカル通知を受信または作成する。
   - 新ビルドへ更新する。
   - すべての状態が残っていることを確認する。
-- [ ] 少なくとも 1 つの旧版 DB fixture を追加する。
+- [x] 少なくとも 1 つの旧版 DB fixture を追加する。
+  - `crates/store/fixtures/sqlite/pre-metaverse-game-room-columns.fixture` を追加し、`20260413000000` まで適用済みの旧 SQLite store を materialize して現行 migration で開けることを確認。
 - [x] 再インストール時にデータを保持するか削除するかを文書化する。
 - [x] keyring fallback と file fallback のリスクを文書化する。
 - [ ] マイグレーション失敗または DB open 失敗時のユーザー向け起動エラーを追加する。


### PR DESCRIPTION
## Summary

- Add a SQLite store fixture descriptor for a pre-metaverse game-room schema state.
- Materialize the fixture from embedded store migrations and sqlx checksums in migration tests.
- Verify current migrations add `room_kind`, `metaverse_json`, the game-room kind index, and the latest migration record.
- Mark the DB fixture release readiness item complete.

## Impact

This gives release readiness a concrete old database fixture path without committing a binary SQLite database, and protects future store migrations against breaking an older schema state.

## Validation

- `cargo test -p kukuri-store connect_file_migrates_pre_metaverse_game_room_fixture`
- `cargo test -p kukuri-store`
- `git diff --check`