### PR TITLE
[codex] Add startup database error screen

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-tauri"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "kukuri-app-api",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod live_game;
 pub mod posts;
 pub mod profile;
 pub mod reactions;
+pub mod startup;

--- a/apps/desktop/src-tauri/src/commands/startup.rs
+++ b/apps/desktop/src-tauri/src/commands/startup.rs
@@ -1,0 +1,8 @@
+use crate::state::{DesktopStartupState, DesktopStartupStatus};
+
+#[tauri::command]
+pub fn get_desktop_startup_status(
+    state: tauri::State<'_, DesktopStartupState>,
+) -> DesktopStartupStatus {
+    state.status()
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,11 +2,14 @@ mod commands;
 mod state;
 mod tracing;
 
-use ::tracing::info;
+use ::tracing::{error, info};
 use tauri::Manager;
 use tauri_plugin_deep_link::DeepLinkExt;
 
-use crate::{state::build_desktop_state, tracing::init_tracing};
+use crate::{
+    state::{DesktopStartupState, build_desktop_state, resolve_db_path},
+    tracing::init_tracing,
+};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -26,14 +29,25 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
         .setup(|app| {
-            let state = build_desktop_state(app.handle())?;
+            let startup_state = match build_desktop_state(app.handle()) {
+                Ok(state) => {
+                    info!("initialized kukuri desktop runtime");
+                    app.manage(state);
+                    DesktopStartupState::ready()
+                }
+                Err(error) => {
+                    error!(%error, "failed to initialize desktop runtime");
+                    let db_path = resolve_db_path(app.handle()).ok();
+                    DesktopStartupState::failed(error, db_path)
+                }
+            };
+            app.manage(startup_state);
             #[cfg(any(windows, target_os = "linux"))]
             app.deep_link().register_all()?;
-            info!("initialized kukuri desktop runtime");
-            app.manage(state);
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            commands::startup::get_desktop_startup_status,
             commands::posts::create_post,
             commands::posts::create_repost,
             commands::reactions::toggle_reaction,

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -1,10 +1,65 @@
 use std::{path::PathBuf, sync::Arc};
 
 use kukuri_desktop_runtime::{DesktopRuntime, resolve_db_path_from_env};
+use serde::Serialize;
 use tauri::Manager;
 
 pub(crate) struct DesktopState {
     pub(crate) runtime: Arc<DesktopRuntime>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub(crate) enum DesktopStartupStatus {
+    Ready,
+    Failed {
+        error: DesktopStartupErrorView,
+    },
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct DesktopStartupErrorView {
+    pub(crate) kind: DesktopStartupErrorKind,
+    pub(crate) message: String,
+    pub(crate) detail: String,
+    pub(crate) db_path: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DesktopStartupErrorKind {
+    DatabaseOpen,
+    DatabaseMigration,
+    Unknown,
+}
+
+pub(crate) struct DesktopStartupState {
+    status: DesktopStartupStatus,
+}
+
+impl DesktopStartupState {
+    pub(crate) fn ready() -> Self {
+        Self {
+            status: DesktopStartupStatus::Ready,
+        }
+    }
+
+    pub(crate) fn failed(error: String, db_path: Option<PathBuf>) -> Self {
+        Self {
+            status: DesktopStartupStatus::Failed {
+                error: DesktopStartupErrorView {
+                    kind: classify_startup_error(&error),
+                    message: "kukuri could not open the local app database.".to_string(),
+                    detail: error,
+                    db_path: db_path.map(|path| path.display().to_string()),
+                },
+            },
+        }
+    }
+
+    pub(crate) fn status(&self) -> DesktopStartupStatus {
+        self.status.clone()
+    }
 }
 
 pub(crate) fn map_error(error: anyhow::Error) -> String {
@@ -27,4 +82,18 @@ pub(crate) fn build_desktop_state(app_handle: &tauri::AppHandle) -> Result<Deskt
     Ok(DesktopState {
         runtime: Arc::new(runtime),
     })
+}
+
+fn classify_startup_error(error: &str) -> DesktopStartupErrorKind {
+    let normalized = error.to_lowercase();
+    if normalized.contains("migration") || normalized.contains("_sqlx_migrations") {
+        return DesktopStartupErrorKind::DatabaseMigration;
+    }
+    if normalized.contains("failed to connect sqlite database")
+        || normalized.contains("sqlite")
+        || normalized.contains("database")
+    {
+        return DesktopStartupErrorKind::DatabaseOpen;
+    }
+    DesktopStartupErrorKind::Unknown
 }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, expect, test } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}));
 
 import { App } from '@/App';
 import { DESKTOP_THEME_STORAGE_KEY } from '@/lib/theme';
@@ -16,6 +24,8 @@ beforeEach(() => {
   window.history.replaceState(null, '', '/');
   window.localStorage.clear();
   document.documentElement.removeAttribute('data-theme');
+  invokeMock.mockReset();
+  delete window.__KUKURI_DESKTOP__;
 });
 
 test('desktop app bootstraps the shell with the default timeline workspace', async () => {
@@ -51,4 +61,23 @@ test('preview release banner opens release settings', async () => {
 
   expect(screen.getByRole('dialog', { name: 'Settings' })).toBeInTheDocument();
   expect(screen.getByRole('heading', { name: 'Release' })).toBeInTheDocument();
+});
+
+test('desktop app renders a startup error when the local database cannot be opened', async () => {
+  invokeMock.mockResolvedValueOnce({
+    status: 'failed',
+    error: {
+      kind: 'database_migration',
+      message: 'kukuri could not open the local app database.',
+      detail: 'migration checksum mismatch',
+      db_path: 'C:\\Users\\tester\\AppData\\Roaming\\kukuri\\kukuri.db',
+    },
+  });
+
+  render(<App />);
+
+  expect(await screen.findByText('kukuri could not open the local database.')).toBeInTheDocument();
+  expect(screen.getByText('Migration failure')).toBeInTheDocument();
+  expect(screen.getByDisplayValue(/migration checksum mismatch/)).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Publish' })).not.toBeInTheDocument();
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { HashRouter } from 'react-router-dom';
 
+import { Button } from '@/components/ui/button';
+import { Notice } from '@/components/ui/notice';
 import { DesktopShellPage } from '@/shell/DesktopShellPage';
 import {
   type AppProps,
@@ -8,14 +11,29 @@ import {
   createDesktopShellStore,
 } from '@/shell/store';
 import {
+  type DesktopStartupErrorView,
+  type DesktopStartupStatus,
+  getDesktopStartupStatus,
+} from '@/lib/api';
+import { BACKEND_UNAVAILABLE_MESSAGE } from '@/lib/api/invoke/error';
+import {
   type DesktopTheme,
   readDesktopTheme,
   writeDesktopTheme,
 } from '@/lib/theme';
+import { copyTextToClipboard } from '@/lib/utils';
+
+type StartupGateState =
+  | { status: 'checking' }
+  | { status: 'ready' }
+  | { status: 'failed'; error: DesktopStartupErrorView };
 
 export function App(props: AppProps) {
   const [store] = useState(() => createDesktopShellStore());
   const [theme, setTheme] = useState<DesktopTheme>(() => readDesktopTheme());
+  const [startupGate, setStartupGate] = useState<StartupGateState>(() =>
+    props.api ? { status: 'ready' } : { status: 'checking' }
+  );
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
@@ -25,11 +43,120 @@ export function App(props: AppProps) {
     writeDesktopTheme(theme);
   }, [theme]);
 
+  useEffect(() => {
+    if (props.api) {
+      setStartupGate({ status: 'ready' });
+      return;
+    }
+
+    let active = true;
+    getDesktopStartupStatus()
+      .then((status: DesktopStartupStatus) => {
+        if (!active) {
+          return;
+        }
+        setStartupGate(status.status === 'failed' ? status : { status: 'ready' });
+      })
+      .catch((error: unknown) => {
+        if (!active) {
+          return;
+        }
+        if (error instanceof Error && error.message === BACKEND_UNAVAILABLE_MESSAGE) {
+          setStartupGate({ status: 'ready' });
+          return;
+        }
+        setStartupGate({
+          status: 'failed',
+          error: {
+            kind: 'unknown',
+            message: 'kukuri could not finish desktop startup.',
+            detail: error instanceof Error ? error.message : String(error),
+            db_path: null,
+          },
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [props.api]);
+
+  if (startupGate.status === 'checking') {
+    return <StartupStatusScreen status='checking' />;
+  }
+
+  if (startupGate.status === 'failed') {
+    return <StartupStatusScreen status='failed' error={startupGate.error} />;
+  }
+
   return (
     <DesktopShellStoreContext.Provider value={store}>
       <HashRouter>
         <DesktopShellPage {...props} theme={theme} onThemeChange={setTheme} />
       </HashRouter>
     </DesktopShellStoreContext.Provider>
+  );
+}
+
+function StartupStatusScreen({
+  status,
+  error,
+}: {
+  status: 'checking' | 'failed';
+  error?: DesktopStartupErrorView;
+}) {
+  const { t } = useTranslation(['common']);
+  const detail = error
+    ? [
+        `kind: ${error.kind}`,
+        `db_path: ${error.db_path ?? 'unknown'}`,
+        '',
+        error.detail,
+      ].join('\n')
+    : '';
+
+  return (
+    <main className='startup-error-screen'>
+      <section className='startup-error-panel' aria-live='polite'>
+        {status === 'checking' ? (
+          <Notice>{t('startup.checking')}</Notice>
+        ) : (
+          <>
+            <Notice tone='destructive'>
+              <strong>{t('startup.title')}</strong>
+              <span>{t('startup.description')}</span>
+            </Notice>
+            <div className='startup-error-actions'>
+              <Button type='button' onClick={() => window.location.reload()}>
+                {t('actions.retry')}
+              </Button>
+              <Button
+                type='button'
+                variant='secondary'
+                onClick={() => void copyTextToClipboard(detail)}
+              >
+                {t('startup.copyDetails')}
+              </Button>
+            </div>
+            <dl className='startup-error-summary'>
+              <div>
+                <dt>{t('startup.kind')}</dt>
+                <dd>{t(`startup.kinds.${error?.kind ?? 'unknown'}`)}</dd>
+              </div>
+              <div>
+                <dt>{t('startup.dbPath')}</dt>
+                <dd>{error?.db_path ?? t('fallbacks.unknown')}</dd>
+              </div>
+            </dl>
+            <textarea
+              className='startup-error-detail'
+              value={detail}
+              readOnly
+              aria-label={t('startup.detailLabel')}
+            />
+          </>
+        )}
+      </section>
+    </main>
   );
 }

--- a/apps/desktop/src/i18n/locales/en/common.json
+++ b/apps/desktop/src/i18n/locales/en/common.json
@@ -91,6 +91,20 @@
   "feedback": {
     "copiedToClipboard": "Copied to clipboard."
   },
+  "startup": {
+    "checking": "Checking startup status…",
+    "title": "kukuri could not open the local database.",
+    "description": "Your data was not deleted. Retry startup, and include the diagnostic details below if the issue continues.",
+    "copyDetails": "Copy details",
+    "kind": "Kind",
+    "dbPath": "DB path",
+    "detailLabel": "Startup error details",
+    "kinds": {
+      "database_open": "DB open failure",
+      "database_migration": "Migration failure",
+      "unknown": "Unknown startup error"
+    }
+  },
   "fallbacks": {
     "attachment": "attachment",
     "authorDetail": "Author Detail",

--- a/apps/desktop/src/i18n/locales/ja/common.json
+++ b/apps/desktop/src/i18n/locales/ja/common.json
@@ -91,6 +91,20 @@
   "feedback": {
     "copiedToClipboard": "クリップボードにコピーしました。"
   },
+  "startup": {
+    "checking": "起動状態を確認しています…",
+    "title": "ローカルデータベースを開けませんでした。",
+    "description": "データは削除されていません。再試行しても直らない場合は、下記の診断情報を添えて報告してください。",
+    "copyDetails": "詳細をコピー",
+    "kind": "分類",
+    "dbPath": "DB パス",
+    "detailLabel": "起動エラー詳細",
+    "kinds": {
+      "database_open": "DB open 失敗",
+      "database_migration": "マイグレーション失敗",
+      "unknown": "不明な起動エラー"
+    }
+  },
   "fallbacks": {
     "attachment": "添付",
     "authorDetail": "著者詳細",

--- a/apps/desktop/src/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/common.json
@@ -84,6 +84,20 @@
   "feedback": {
     "copiedToClipboard": "已复制到剪贴板。"
   },
+  "startup": {
+    "checking": "正在检查启动状态…",
+    "title": "kukuri 无法打开本地数据库。",
+    "description": "数据未被删除。请重试启动；如果问题持续，请附上下面的诊断信息。",
+    "copyDetails": "复制详情",
+    "kind": "分类",
+    "dbPath": "DB 路径",
+    "detailLabel": "启动错误详情",
+    "kinds": {
+      "database_open": "DB open 失败",
+      "database_migration": "迁移失败",
+      "unknown": "未知启动错误"
+    }
+  },
   "fallbacks": {
     "attachment": "附件",
     "authorDetail": "作者详情",

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -1,2 +1,3 @@
 export * from './api/types';
+export { getDesktopStartupStatus } from './api/startupStatus';
 export { runtimeApi } from './api/commands/runtimeApi';

--- a/apps/desktop/src/lib/api/startupStatus.ts
+++ b/apps/desktop/src/lib/api/startupStatus.ts
@@ -1,0 +1,10 @@
+import type { DesktopStartupStatus } from './types';
+
+import { invokeDesktop } from './invoke/desktop';
+
+export async function getDesktopStartupStatus(): Promise<DesktopStartupStatus> {
+  if (window.__KUKURI_DESKTOP__) {
+    return { status: 'ready' };
+  }
+  return invokeDesktop<DesktopStartupStatus>('get_desktop_startup_status');
+}

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -12,6 +12,19 @@ export type TimelineScope =
   | { kind: 'all_joined' }
   | { kind: 'channel'; channel_id: string };
 
+export type DesktopStartupErrorKind = 'database_open' | 'database_migration' | 'unknown';
+
+export type DesktopStartupErrorView = {
+  kind: DesktopStartupErrorKind;
+  message: string;
+  detail: string;
+  db_path?: string | null;
+};
+
+export type DesktopStartupStatus =
+  | { status: 'ready' }
+  | { status: 'failed'; error: DesktopStartupErrorView };
+
 export type ChannelAudienceKind = 'invite_only' | 'friend_only' | 'friend_plus';
 export type ChannelSharingState = 'open' | 'frozen';
 

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -51,6 +51,94 @@ button:disabled {
   border: 0;
 }
 
+.startup-error-screen {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  background: var(--shell-background);
+  color: var(--foreground);
+}
+
+.startup-error-panel {
+  width: min(760px, 100%);
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-panel);
+  background: var(--surface-panel);
+  box-shadow: var(--shadow-panel);
+}
+
+.startup-error-panel strong,
+.startup-error-panel span {
+  display: block;
+}
+
+.startup-error-panel strong {
+  margin-bottom: 4px;
+}
+
+.startup-error-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.startup-error-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.startup-error-summary div {
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-input);
+  background: var(--surface-panel-muted);
+}
+
+.startup-error-summary dt {
+  margin-bottom: 6px;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+}
+
+.startup-error-summary dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.startup-error-detail {
+  width: 100%;
+  min-height: 220px;
+  resize: vertical;
+  padding: 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-input);
+  background: var(--surface-input);
+  color: var(--foreground);
+  line-height: 1.55;
+}
+
+@media (max-width: 720px) {
+  .startup-error-screen {
+    padding: 16px;
+    place-items: stretch;
+  }
+
+  .startup-error-panel {
+    padding: 18px;
+  }
+
+  .startup-error-summary {
+    grid-template-columns: 1fr;
+  }
+}
+
 *::-webkit-scrollbar {
   width: 12px;
   height: 12px;

--- a/docs/progress/2026-06-11-release-readiness-execution-plan.md
+++ b/docs/progress/2026-06-11-release-readiness-execution-plan.md
@@ -268,7 +268,10 @@
   - `crates/store/fixtures/sqlite/pre-metaverse-game-room-columns.fixture` を追加し、`20260413000000` まで適用済みの旧 SQLite store を materialize して現行 migration で開けることを確認。
 - [x] 再インストール時にデータを保持するか削除するかを文書化する。
 - [x] keyring fallback と file fallback のリスクを文書化する。
-- [ ] マイグレーション失敗または DB open 失敗時のユーザー向け起動エラーを追加する。
+- [x] マイグレーション失敗または DB open 失敗時のユーザー向け起動エラーを追加する。
+  - Tauri setup で desktop runtime 初期化に失敗してもウィンドウを維持し、`get_desktop_startup_status` で起動失敗状態を返すようにした。
+  - frontend boot 時に startup status を確認し、DB open / migration 失敗時は shell を描画せず、分類、DB パス、詳細、再試行、詳細コピーを表示する起動エラー画面を追加した。
+  - `App.test.tsx` で migration 失敗時に起動エラー画面が表示され、通常 shell が表示されないことを確認した。
 
 完了条件:
 


### PR DESCRIPTION
## Summary

- Keep the Tauri window alive when desktop runtime initialization fails because the local SQLite database cannot be opened or migrated.
- Add `get_desktop_startup_status` so the frontend can render a dedicated startup failure view before loading the main shell.
- Show a localized startup error screen with failure kind, DB path, diagnostic details, retry, and copy-details actions.
- Mark the release readiness plan item for DB open / migration startup errors as complete.

## Why

Previously a DB open or migration failure could fail Tauri setup before the user saw actionable UI. This made update or reinstall failures look like a blank or aborted startup instead of a recoverable diagnostic state.

## Validation

- `cargo fmt --all --check`
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `cd apps/desktop; npx pnpm@10.16.1 test -- App.test.tsx`
- `cd apps/desktop; npx pnpm@10.16.1 typecheck`
- `cd apps/desktop; npx pnpm@10.16.1 lint`
