### PR TITLE
fix: resolve undefined CSS custom-property references in shell styles

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -62,14 +62,16 @@
 | `--surface-warning-soft` | warning 淡面 | `#463423` | `#f6e7d9` |
 | `--border-warning` | warning 境界 | `#a36b40` | `#d1a06d` |
 | `--surface-info-soft` | info 淡面 | `#203449` | `#dce7f4` |
+| `--warning` | warning の前景（文字/アイコン） | `#e6b066` | `#9a6e2a` |
+| `--danger` | danger/error の前景（`--destructive` と統一） | `#ffb48a` | `#b35f46` |
 
-**将来定義**（既存の `-soft` / `-border` ファミリーと整合させ、`shell-phase1.css` が参照する未定義トークンを解消する。評価記録ギャップ1）:
+> `--warning` / `--danger` は #325 で定義し、`shell-phase1.css` の未定義参照（旧 評価記録ギャップ1）を解消した。
+
+**将来定義**（既存の `-soft` ファミリーと対になる前景色。現状コードに consumer が無いため未実装。consumer 追加時に定義する）:
 
 | Token | 役割 | Dark | Light |
 |-------|------|------|-------|
-| `--warning` | warning の前景（文字/アイコン） | `#e6b066` | `#9a6e2a` |
-| `--danger` | danger/error の前景（`--destructive` と統一） | `#ffb48a` | `#b35f46` |
-| `--info` | info の前景 | `#7fb1e0` | `#2c6aa6` |
+| `--info` | info の前景（`--surface-info-soft` と対） | `#7fb1e0` | `#2c6aa6` |
 | `--success` | success の前景（accent teal 寄り） | `#34c39a` | `#2f8f6e` |
 | `--surface-success-soft` | success 淡面 | `#17352c` | `#dff0e6` |
 | `--border-success` | success 境界 | `#2f8f6e` | `#8cc2a6` |

--- a/apps/desktop/src/styles/css-vars.test.ts
+++ b/apps/desktop/src/styles/css-vars.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Shell stylesheets that ship together (see index.css). Any `var(--token)` they
+// reference must resolve to a custom property defined in the same bundle,
+// otherwise the value silently falls back to nothing at runtime.
+const CSS_FILES = ['tokens.css', 'base.css', 'shell-phase1.css', 'shell-phase1-legacy.css'] as const;
+
+// Custom properties intentionally injected at runtime (inline style / JS) rather
+// than declared in the static stylesheets. Tailwind owns the `--tw-*` space.
+const RUNTIME_VARS = new Set(['--shell-detail-pane-index']);
+const RUNTIME_PREFIXES = ['--tw-'];
+
+// Vitest runs with apps/desktop as the working directory (see package.json).
+const STYLES_DIR = resolve(process.cwd(), 'src/styles');
+
+function readCss(name: string): string {
+  return readFileSync(resolve(STYLES_DIR, name), 'utf8');
+}
+
+function collectDefinitions(css: string): Set<string> {
+  const defined = new Set<string>();
+  const declaration = /(--[\w-]+)\s*:/g;
+  let match: RegExpExecArray | null;
+  while ((match = declaration.exec(css)) !== null) {
+    defined.add(match[1]);
+  }
+  return defined;
+}
+
+function collectReferences(css: string): Set<string> {
+  const referenced = new Set<string>();
+  const usage = /var\(\s*(--[\w-]+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = usage.exec(css)) !== null) {
+    referenced.add(match[1]);
+  }
+  return referenced;
+}
+
+describe('shell CSS custom properties', () => {
+  const bundle = CSS_FILES.map(readCss).join('\n');
+  const defined = collectDefinitions(bundle);
+  const referenced = collectReferences(bundle);
+
+  it('defines every custom property referenced via var()', () => {
+    const undefinedRefs = [...referenced]
+      .filter((name) => !defined.has(name))
+      .filter((name) => !RUNTIME_VARS.has(name))
+      .filter((name) => !RUNTIME_PREFIXES.some((prefix) => name.startsWith(prefix)))
+      .sort();
+    expect(undefinedRefs).toEqual([]);
+  });
+});

--- a/apps/desktop/src/styles/shell-phase1-legacy.css
+++ b/apps/desktop/src/styles/shell-phase1-legacy.css
@@ -613,10 +613,10 @@
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-subtle);
   border-radius: 999px;
   padding: 0.28rem 0.6rem;
-  background: var(--surface-card);
+  background: var(--surface-panel);
   color: var(--foreground);
   cursor: pointer;
 }
@@ -754,7 +754,7 @@
   margin-top: 0.75rem;
   padding: 0.85rem;
   border-radius: 1rem;
-  background: var(--surface-subtle);
+  background: var(--surface-panel-muted);
 }
 
 .shell-phase1 .post-reaction-picker-row {
@@ -784,7 +784,7 @@
   width: min(100%, 16rem);
   border-radius: 1rem;
   object-fit: contain;
-  background: var(--surface-subtle);
+  background: var(--surface-panel-muted);
 }
 
 .shell-phase1 .reactions-crop-fields {
@@ -798,7 +798,7 @@
   width: 4rem;
   height: 4rem;
   border-radius: 1rem;
-  background-color: var(--surface-card);
+  background-color: var(--surface-panel);
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
@@ -861,7 +861,7 @@
   padding: 0.5rem;
   border: 1px solid var(--border-subtle);
   border-radius: 1.1rem;
-  background: var(--surface-card);
+  background: var(--surface-panel);
 }
 
 .shell-phase1 .reactions-saved-tile-selected {

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -606,7 +606,7 @@
 }
 
 .metaverse-chat-list small {
-  color: var(--text-muted);
+  color: var(--muted-foreground);
   font-weight: 500;
 }
 
@@ -1023,10 +1023,10 @@
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-subtle);
   border-radius: 999px;
   padding: 0.28rem 0.6rem;
-  background: var(--surface-card);
+  background: var(--surface-panel);
   color: var(--foreground);
   cursor: pointer;
 }
@@ -1251,7 +1251,7 @@
   width: min(100%, 16rem);
   border-radius: 1rem;
   object-fit: contain;
-  background: var(--surface-subtle);
+  background: var(--surface-panel-muted);
 }
 
 .reactions-crop-fields {
@@ -1265,7 +1265,7 @@
   width: 4rem;
   height: 4rem;
   border-radius: 1rem;
-  background-color: var(--surface-card);
+  background-color: var(--surface-panel);
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
@@ -1328,7 +1328,7 @@
   padding: 0.5rem;
   border: 1px solid var(--border-subtle);
   border-radius: 1.1rem;
-  background: var(--surface-card);
+  background: var(--surface-panel);
 }
 
 .reactions-saved-tile-selected {
@@ -2117,7 +2117,7 @@
 }
 
 .notification-item:focus-visible {
-  outline: 2px solid var(--focus-ring);
+  outline: 2px solid var(--ring);
   outline-offset: 2px;
 }
 
@@ -2533,7 +2533,7 @@
     radial-gradient(circle at 30% 30%, color-mix(in srgb, var(--surface-contrast) 28%, transparent), transparent 58%),
     linear-gradient(160deg, color-mix(in srgb, var(--surface-button-primary) 94%, white 6%), color-mix(in srgb, var(--surface-button-primary) 72%, black 28%));
   box-shadow:
-    0 0 0 0.35rem color-mix(in srgb, var(--surface-background) 72%, transparent),
+    0 0 0 0.35rem color-mix(in srgb, var(--background) 72%, transparent),
     var(--shadow-panel);
 }
 

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -49,6 +49,8 @@
   --accent: #00b3a4;
   --accent-foreground: #eafffb;
   --destructive: #ffb48a;
+  --warning: #e6b066;
+  --danger: #ffb48a;
   --ring: rgba(0, 179, 164, 0.45);
   --shadow-panel: 0 18px 60px rgba(2, 7, 15, 0.22);
   --shadow-button-primary: 0 10px 28px rgba(245, 157, 98, 0.16);
@@ -100,6 +102,8 @@
   --accent: #0f8c82;
   --accent-foreground: #143633;
   --destructive: #b35f46;
+  --warning: #9a6e2a;
+  --danger: #b35f46;
   --ring: rgba(15, 140, 130, 0.32);
   --shadow-panel: 0 18px 48px rgba(33, 48, 59, 0.12);
   --shadow-button-primary: 0 10px 24px rgba(215, 125, 69, 0.18);


### PR DESCRIPTION
## 概要

shell スタイルシートが参照していたが **tokens.css に未定義**だった CSS カスタムプロパティ（`var(--x)`）を解消する。これらはランタイムで無効値となり、ステータス色や **通知のフォーカスアウトライン（a11y）** が壊れていた。

#325 の最初の focused スライス（`fix`）。`Refs #325`

着手時に characterization test を先に書いたところ、評価記録（#308）が記録していた `--warning`/`--danger` の 2 件だけでなく、**計 8 件**の未定義参照が見つかった（旧名のままになっていた renamed token 6 件を含む）。

## 種別

`fix`（先に failing な characterization test を追加 → 修正で green 化）

## 変更内容

- **`tokens.css`**: セマンティックトークン `--warning` / `--danger` を dark/light に定義（DESIGN.md §2.2 の値）。metaverse connection badge / stale-avatar の状態色で使用。
- **`shell-phase1.css` + `shell-phase1-legacy.css`**: 旧名トークンを現行名へ repoint。
  | 旧名（未定義） | 現行名 |
  |---|---|
  | `--text-muted` | `--muted-foreground` |
  | `--border` | `--border-subtle` |
  | `--surface-card` | `--surface-panel` |
  | `--surface-subtle` | `--surface-panel-muted` |
  | `--focus-ring` | `--ring`（通知のフォーカスアウトライン復旧） |
  | `--surface-background` | `--background` |
- **`css-vars.test.ts`（新規）**: shell CSS の全 `var(--token)` が定義済みであることを assert。ランタイム注入の `--shell-detail-pane-index`（`ContextPane.tsx`、fallback 付き）は allowlist。本クラスの regression を今後ガード。
- **`DESIGN.md` §2.2**: `--warning`/`--danger` を「将来定義」→ 実装済みへ。`--info`/`--success` は consumer が無いため将来定義のまま。

## 挙動変更

- ステータス色（metaverse: stale/recovering=warning, offline=danger）と通知の `:focus-visible` アウトラインが**意図どおり描画される**ようになった（従来は宣言が無効で未描画）。
- コンポーネント / ルート / API の変更なし。`--surface-subtle` → `--surface-panel-muted` のみ意味解釈による判断（reaction editor 画像の背景）。

## 検証

- `pnpm typecheck` ✓ / `pnpm lint`（--max-warnings 0）✓ / `pnpm test` **219 passed**（新 test 含む）✓ / `pnpm storybook:build` ✓
- `test:e2e:browser`（Playwright）は未実行（フロー/構造変更が無く、env 依存で重いため）。

## リスク

- `--surface-subtle` の解釈マッピングが 1 件ある（低リスク・低頻度の背景色）。
- token 値は DESIGN.md §2.2 と 1:1。

## 後続対応

- #325 の残タスク（タイポ/フォント、spacing/radius、breakpoint、elevation/blur token 化、Storybook foundations）を intent 別の focused PR で継続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)