### PR TITLE
fix: OS通知をRustバックエンド経由に変更しWindowsで発火するように修正 (#313)

### DIFF
--- a/apps/desktop/src/components/settings/ReleasePanel.tsx
+++ b/apps/desktop/src/components/settings/ReleasePanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { Download, FileText, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -54,12 +55,19 @@ export function ReleasePanel() {
       return;
     }
     let cancelled = false;
-    void import('@tauri-apps/plugin-notification').then(async (plugin) => {
-      const granted = await plugin.isPermissionGranted();
-      if (!cancelled) {
-        setOsNotificationPermission(granted ? 'granted' : 'prompt');
-      }
-    });
+    // Query the Tauri backend directly instead of the WebView Web Notification
+    // API, whose permission state is volatile and unreliable on Windows (#313).
+    void invoke<boolean | null>('plugin:notification|is_permission_granted')
+      .then((granted) => {
+        if (!cancelled) {
+          setOsNotificationPermission(granted ? 'granted' : 'prompt');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setOsNotificationPermission('prompt');
+        }
+      });
     return () => {
       cancelled = true;
     };
@@ -82,10 +90,10 @@ export function ReleasePanel() {
       setOsNotificationPermission('unavailable');
       return;
     }
-    const plugin = await import('@tauri-apps/plugin-notification');
-    const permission = await plugin.requestPermission();
-    setOsNotificationPermission(permission);
-    if (permission === 'granted') {
+    const permission = await invoke<string>('plugin:notification|request_permission');
+    const normalized = permission.toLowerCase();
+    setOsNotificationPermission(normalized);
+    if (normalized === 'granted') {
       updateOsNotificationSetting({ enabled: true });
     }
   }, [updateOsNotificationSetting]);

--- a/apps/desktop/src/shell/useOsNotificationBridge.ts
+++ b/apps/desktop/src/shell/useOsNotificationBridge.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 
 import type { NotificationView } from '@/lib/api';
 import {
@@ -44,28 +45,34 @@ export function useOsNotificationBridge(
     }
 
     let cancelled = false;
-    void import('@tauri-apps/plugin-notification').then(async (plugin) => {
-      const granted = await plugin.isPermissionGranted();
-      if (!granted || cancelled) {
-        return;
-      }
+    // Route through the Tauri backend `notify` command directly. The
+    // `@tauri-apps/plugin-notification` JS helpers go through the WebView2 Web
+    // Notification API, which does not produce real Windows toasts and reports a
+    // volatile permission state (see issue #313). The Rust backend grants
+    // permission unconditionally on desktop and emits a proper OS toast.
+    void (async () => {
       for (const notification of unseen) {
-        plugin.sendNotification({
-          id: nextOsNotificationId(notification.notification_id),
-          title: notificationTitle(notification),
-          body: notificationBody(notification, settings),
-          silent: settings.quietMode,
-          autoCancel: true,
-          extra: {
-            notificationId: notification.notification_id,
-            topicId: notification.topic_id ?? '',
-            dmId: notification.dm_id ?? '',
-          },
-        });
-        seenNotificationIdsRef.current.add(notification.notification_id);
+        if (cancelled) {
+          break;
+        }
+        try {
+          await invoke('plugin:notification|notify', {
+            options: {
+              id: nextOsNotificationId(notification.notification_id),
+              title: notificationTitle(notification),
+              body: notificationBody(notification, settings),
+              silent: settings.quietMode,
+            },
+          });
+          seenNotificationIdsRef.current.add(notification.notification_id);
+        } catch {
+          // best effort OS notification
+        }
       }
-      writeSeenOsNotificationIds(seenNotificationIdsRef.current);
-    });
+      if (!cancelled) {
+        writeSeenOsNotificationIds(seenNotificationIdsRef.current);
+      }
+    })();
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## 概要

Fixes #313

アプリ内通知 inbox は機能しているのに OS（デスクトップ）通知が発火しないバグを修正します。Windows 11（preview.4・インストール版）での症状:

- OS 通知権限を granted にしても、アプリを再起動するとパネル表示が `prompt` に戻る。
- 権限が `granted` でも、返信/DM 受信時に Windows トーストが一切出ない。

## 根本原因

`@tauri-apps/plugin-notification` v2.3.3 の **JS バインディングが Tauri の Rust バックエンドではなく WebView2 の Web Notification API を経由**していた:

- `isPermissionGranted()` → `window.Notification.permission` を参照
- `requestPermission()` → `window.Notification.requestPermission()`
- `sendNotification()` → `new window.Notification(...)`

WebView2 ではこれらが Windows 上で信頼できず、権限値は揮発的（再起動で `default`/`prompt` に戻り実 OS 状態でもない）で、`new Notification()` は実トーストを生成しない。これが両症状の原因。

一方、Rust バックエンド（`tauri-plugin-notification` の `desktop.rs`）はデスクトップで常に `Granted` を返し、`notify` コマンドは `notify_rust` トーストを構築、インストール版では `System.AppUserModel.ID` をアプリ識別子（`app.kukuri.desktop`）に設定する。

## 変更内容

壊れた WebView JS バインディングを迂回し、Rust バックエンドのコマンドを `invoke` で直接呼ぶように変更（Rust プラグインは登録済み・`notification:default` capability も付与済みのため Rust/設定側の変更は不要）。

- **`useOsNotificationBridge.ts`**: `sendNotification()` を `invoke('plugin:notification|notify', ...)` に置き換え。WebView ベースの権限ゲートを除去（有効/無効は既存の `shouldSendOsNotification` で制御）。各送信を try/catch で best-effort 化。
- **`ReleasePanel.tsx`**: 権限の取得/要求を `invoke('plugin:notification|is_permission_granted')` / `invoke('plugin:notification|request_permission')` に置き換え。表示が再起動後も安定する。

## 検証

- `tsc --noEmit`: エラーなし
- vitest（`App.test.tsx` / `releaseReadiness.test.ts` / `api.test.ts`）: 11 件 pass
- ESLint（変更2ファイル）: エラーなし

⚠️ エンドツーエンドの最終確認（実際に Windows トーストが出るか）は、AppUserModelID が設定される **インストール版/preview ビルド** で行う必要があります（`target/debug` 実行では AUMID が設定されないため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)