### PR TITLE
fix: 接続エラー復帰後に community-node エラー表示が消えない問題を修正 (#312)

### DIFF
--- a/apps/desktop/src/shell/DesktopShellPage.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.test.tsx
@@ -4224,6 +4224,33 @@ test('workspace shows a community-node unavailable notice when a configured node
   expect(window.location.hash).toContain('settings=community-node');
 });
 
+test('workspace clears the community-node unavailable notice after the node recovers', async () => {
+  let recovered = false;
+  const baseApi = createDesktopMockApi();
+  const baseStatuses = await baseApi.getCommunityNodeStatuses();
+  const api: DesktopApi = {
+    ...baseApi,
+    async getCommunityNodeStatuses() {
+      return baseStatuses.map((status) => ({
+        ...status,
+        last_error: recovered ? null : 'community node timeout',
+        session_phase: recovered ? 'ready' : 'retrying',
+      }));
+    },
+  };
+
+  render(<App api={api} />);
+
+  await screen.findByTestId('community-node-unavailable-notice');
+
+  recovered = true;
+  await new Promise((resolve) => window.setTimeout(resolve, REFRESH_INTERVAL_MS + 300));
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('community-node-unavailable-notice')).not.toBeInTheDocument();
+  });
+});
+
 test('timeline keeps the last successful workspace state when joined channels refresh fails', async () => {
   let failNextJoinedChannelsRefresh = false;
   const baseApi = createDesktopMockApi({

--- a/apps/desktop/src/shell/selectors.test.ts
+++ b/apps/desktop/src/shell/selectors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CommunityNodeNodeStatus } from '../lib/api/types';
+import { mergeCommunityNodeStatus } from './selectors';
+
+function baseStatus(
+  overrides: Partial<CommunityNodeNodeStatus> = {}
+): CommunityNodeNodeStatus {
+  return {
+    base_url: 'https://node.example',
+    auth_state: { authenticated: true },
+    restart_required: false,
+    ...overrides,
+  };
+}
+
+describe('mergeCommunityNodeStatus', () => {
+  it('clears last_error when the node recovers (next reports null)', () => {
+    const previous = baseStatus({ last_error: 'community node timeout' });
+    const next = baseStatus({ last_error: null });
+
+    const merged = mergeCommunityNodeStatus(previous, next);
+
+    expect(merged.last_error).toBeNull();
+  });
+
+  it('keeps a fresh last_error while the node is still failing', () => {
+    const previous = baseStatus({ last_error: 'old failure' });
+    const next = baseStatus({ last_error: 'new failure' });
+
+    const merged = mergeCommunityNodeStatus(previous, next);
+
+    expect(merged.last_error).toBe('new failure');
+  });
+
+  it('preserves config-ish fallbacks from the previous status', () => {
+    const resolvedUrls = {
+      public_base_url: 'https://node.example',
+      connectivity_urls: ['https://node.example/connect'],
+    };
+    const previous = baseStatus({
+      auto_approve: true,
+      resolved_urls: resolvedUrls,
+      last_error: 'old failure',
+    });
+    const next = baseStatus({ last_error: null });
+
+    const merged = mergeCommunityNodeStatus(previous, next);
+
+    expect(merged.auto_approve).toBe(true);
+    expect(merged.resolved_urls).toEqual(resolvedUrls);
+    expect(merged.last_error).toBeNull();
+  });
+});

--- a/apps/desktop/src/shell/selectors.ts
+++ b/apps/desktop/src/shell/selectors.ts
@@ -477,7 +477,7 @@ export function mergeCommunityNodeStatus(
       ? next.consent_state ?? previous?.consent_state ?? null
       : next.consent_state ?? null,
     resolved_urls: next.resolved_urls ?? previous?.resolved_urls ?? null,
-    last_error: next.last_error ?? previous?.last_error ?? null,
+    last_error: next.last_error ?? null,
     session_phase: next.session_phase ?? previous?.session_phase ?? 'idle',
     retry_after: next.retry_after ?? previous?.retry_after ?? null,
   };


### PR DESCRIPTION
## 概要

Issue #312「接続エラー後に復帰してもエラー表示が消えない」を修正します。

ユーザーに見える症状は **community-node 利用不可バナー**（`community-node-unavailable-notice`）が、ノード復帰後も消えないというものでした。

## 原因

community-node ステータスのマージ処理 `mergeCommunityNodeStatus`（`apps/desktop/src/shell/selectors.ts`）で `last_error` が **過去の値を引きずる（sticky）フォールバック** になっていました。

```ts
last_error: next.last_error ?? previous?.last_error ?? null,
```

ノード復帰時、バックエンドは `last_error: null` の新しいステータスを返します。しかし `??` は `null` を nullish として扱うため `previous?.last_error`（=古いエラー文字列）にフォールバックしてしまい、エラーが永久に保持されてバナーが消えませんでした。バックエンドは正しく `null` を返しており、フロント側のマージだけが古いエラーを復活させていました。

## 変更内容

`selectors.ts` の 1 行を修正し、previous へのフォールバックを削除しました（`?? null` は `undefined` を `null` に正規化する目的でのみ残置）。

```ts
last_error: next.last_error ?? null,
```

full refresh / 単一ノード upsert のどちらも `last_error` を常に返すため安全です。スコープはエラー表示を制御する `last_error` のみに限定しています（`AGENTS.md` のガードレール準拠）。

## テスト（failing-first）

「不具合修正は必ず先に failing test で再現してから行う」というガードレールに従い、修正前に失敗するテストを追加しました。

- **ユニットテスト** `apps/desktop/src/shell/selectors.test.ts`（新規）: 復帰時に `last_error` がクリアされること、失敗継続中は最新のエラーを保持すること、設定的フィールドのフォールバックは維持されること。
- **統合テスト** `apps/desktop/src/shell/DesktopShellPage.test.tsx`: バナー表示後、ノード復帰で次の refresh tick にバナーが消えること。

いずれも修正前は失敗、修正後は成功することを確認済み。

## 検証

- `vitest run`（追加した両テスト + 既存 notice テスト）: パス
- `tsc --noEmit`: パス
- `eslint`（変更ファイル）: パス

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)
