### PR TITLE
feat: 投稿コンポーザーに@メンション機能を追加 (#303)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
     "@pixiv/three-vrm": "^3.5.3",
     "@pixiv/three-vrm-animation": "^3.5.3",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-hover-card": "^1.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/apps/desktop/pnpm-lock.yaml
+++ b/apps/desktop/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-hover-card':
+        specifier: ^1.1.16
+        version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -658,8 +661,24 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.9':
+    resolution: {integrity: sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -680,8 +699,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -715,6 +752,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.12':
+    resolution: {integrity: sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -726,6 +776,19 @@ packages:
 
   '@radix-ui/react-focus-scope@1.1.7':
     resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.16':
+    resolution: {integrity: sha512-hAileDBtd6CX7nlZOarOnISQ6PP4q0e16BX51ulzdZ+7IzjL0sDTVpFdmSYrIjw6zVNsfQBao5gG6AWr3qwfvA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -772,6 +835,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.3.0':
+    resolution: {integrity: sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.11':
+    resolution: {integrity: sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
@@ -798,8 +887,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.6':
+    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.5':
+    resolution: {integrity: sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -829,6 +944,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.2.5':
+    resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-tooltip@1.2.8':
     resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
     peerDependencies:
@@ -851,8 +975,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -869,8 +1011,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.2':
+    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -887,6 +1047,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-rect@1.1.1':
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
     peerDependencies:
@@ -896,8 +1065,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.2':
+    resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -920,6 +1107,9 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@radix-ui/rect@1.1.2':
+    resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
   '@react-three/drei@10.7.7':
     resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
@@ -3279,9 +3469,20 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/primitive@1.1.4': {}
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-arrow@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -3294,7 +3495,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       react: 19.2.5
     optionalDependencies:
@@ -3335,6 +3548,19 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       react: 19.2.5
@@ -3346,6 +3572,23 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-hover-card@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-popper': 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -3400,6 +3643,34 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-popper@1.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-arrow': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3420,9 +3691,27 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
@@ -3439,6 +3728,13 @@ snapshots:
   '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.5(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
@@ -3469,10 +3765,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
@@ -3484,6 +3794,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
@@ -3491,7 +3808,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       react: 19.2.5
     optionalDependencies:
@@ -3504,9 +3834,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-rect@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
@@ -3521,6 +3865,8 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@radix-ui/rect@1.1.2': {}
 
   '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0))(@types/react@19.2.14)(@types/three@0.184.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.184.0)':
     dependencies:

--- a/apps/desktop/src/components/core/ComposerPanel.test.tsx
+++ b/apps/desktop/src/components/core/ComposerPanel.test.tsx
@@ -1,7 +1,105 @@
+import { useState } from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
 import { ComposerPanel } from './ComposerPanel';
+import { type MentionCandidate } from './types';
+
+const ALICE = 'a'.repeat(64);
+const BOB = 'b'.repeat(64);
+const MENTION_CANDIDATES: MentionCandidate[] = [
+  { pubkey: ALICE, label: 'Alice', displayName: 'Alice', name: 'alice', about: 'Bio', picture: null },
+  { pubkey: BOB, label: 'Bob', displayName: 'Bob', name: 'bob', about: null, picture: null },
+];
+
+function MentionHarness({ candidates = MENTION_CANDIDATES }: { candidates?: MentionCandidate[] }) {
+  const [value, setValue] = useState('');
+  return (
+    <ComposerPanel
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      onValueChange={setValue}
+      mentionCandidates={candidates}
+      onSubmit={(event) => event.preventDefault()}
+      attachmentInputKey={0}
+      onAttachmentSelection={() => undefined}
+      draftMediaItems={[]}
+      onRemoveDraftAttachment={() => undefined}
+      audienceLabel='Public'
+      onClearReply={() => undefined}
+    />
+  );
+}
+
+test('typing @ with a query shows matching mention candidates', async () => {
+  const user = userEvent.setup();
+  render(<MentionHarness />);
+
+  await user.click(screen.getByRole('textbox'));
+  await user.keyboard('@al');
+
+  expect(screen.getByRole('listbox', { name: 'Mention suggestions' })).toBeInTheDocument();
+  expect(screen.getByRole('option', { name: /Alice/ })).toBeInTheDocument();
+  expect(screen.queryByRole('option', { name: /Bob/ })).not.toBeInTheDocument();
+});
+
+test('selecting a candidate with the keyboard inserts the mention token', async () => {
+  const user = userEvent.setup();
+  render(<MentionHarness />);
+
+  const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+  await user.click(textarea);
+  await user.keyboard('hi @al');
+  await user.keyboard('{Enter}');
+
+  expect(textarea.value).toBe(`hi @[Alice](${ALICE}) `);
+  expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+});
+
+test('Escape closes the suggestion list', async () => {
+  const user = userEvent.setup();
+  render(<MentionHarness />);
+
+  await user.click(screen.getByRole('textbox'));
+  await user.keyboard('@al');
+  expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+  await user.keyboard('{Escape}');
+  expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+});
+
+test('a bare @ lists all candidates', async () => {
+  const user = userEvent.setup();
+  render(<MentionHarness />);
+
+  await user.click(screen.getByRole('textbox'));
+  await user.keyboard('@');
+
+  expect(screen.getByRole('option', { name: /Alice/ })).toBeInTheDocument();
+  expect(screen.getByRole('option', { name: /Bob/ })).toBeInTheDocument();
+});
+
+test('mention autocomplete stays inert without onValueChange', async () => {
+  const user = userEvent.setup();
+  render(
+    <ComposerPanel
+      value='@al'
+      onChange={() => undefined}
+      mentionCandidates={MENTION_CANDIDATES}
+      onSubmit={(event) => event.preventDefault()}
+      attachmentInputKey={0}
+      onAttachmentSelection={() => undefined}
+      draftMediaItems={[]}
+      onRemoveDraftAttachment={() => undefined}
+      audienceLabel='Public'
+      onClearReply={() => undefined}
+    />
+  );
+
+  await user.click(screen.getByRole('textbox'));
+  expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+});
 
 test('reply banner keeps only the replying label and a compact clear icon action', () => {
   render(

--- a/apps/desktop/src/components/core/ComposerPanel.tsx
+++ b/apps/desktop/src/components/core/ComposerPanel.tsx
@@ -7,10 +7,30 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { shortPubkey } from '@/shell/selectors';
 
+import { AuthorAvatar } from './AuthorAvatar';
 import { ComposerDraftPreviewList } from './ComposerDraftPreviewList';
+import { MentionHoverCard } from './MentionHoverCard';
 import { PostCard } from './PostCard';
-import { type ComposerDraftMediaView, type PostCardView } from './types';
+import { useMentionAutocomplete } from './useMentionAutocomplete';
+import {
+  type ComposerDraftMediaView,
+  type MentionAuthorView,
+  type MentionCandidate,
+  type PostCardView,
+} from './types';
+
+function mentionAuthorFromCandidate(candidate: MentionCandidate): MentionAuthorView {
+  return {
+    pubkey: candidate.pubkey,
+    label: candidate.label,
+    displayName: candidate.displayName,
+    name: candidate.name,
+    aboutPreview: candidate.about?.slice(0, 50) ?? null,
+    picture: candidate.picture,
+  };
+}
 
 type ReplyTargetView = {
   content: string;
@@ -38,7 +58,11 @@ type ComposerPanelProps = {
   onClearReply: () => void;
   onClearRepost?: () => void;
   attachmentsDisabled?: boolean;
+  mentionCandidates?: MentionCandidate[];
+  onValueChange?: (next: string) => void;
 };
+
+const EMPTY_MENTION_CANDIDATES: MentionCandidate[] = [];
 
 export function ComposerPanel({
   value,
@@ -56,10 +80,26 @@ export function ComposerPanel({
   onClearReply,
   onClearRepost,
   attachmentsDisabled = false,
+  mentionCandidates = EMPTY_MENTION_CANDIDATES,
+  onValueChange,
 }: ComposerPanelProps) {
   const { t } = useTranslation(['common']);
   const clearActiveTarget = replyTarget ? onClearReply : onClearRepost;
   const bannerAriaLabel = replyTarget ? t('composer.clearReply') : t('composer.clearQuoteRepost');
+  const {
+    textareaRef: mentionTextareaRef,
+    isOpen: mentionOpen,
+    items: mentionItems,
+    activeIndex: mentionActiveIndex,
+    onKeyDown: onMentionKeyDown,
+    onSelectionChange: onMentionSelectionChange,
+    selectCandidate: selectMention,
+    setActiveIndex: setMentionActiveIndex,
+  } = useMentionAutocomplete({
+    value,
+    candidates: mentionCandidates,
+    onValueChange,
+  });
 
   return (
     <form className='composer' onSubmit={onSubmit}>
@@ -95,17 +135,71 @@ export function ComposerPanel({
         </div>
       ) : null}
 
-      <Textarea
-        value={value}
-        onChange={onChange}
-        placeholder={
-          replyTarget
-            ? t('composer.writeReply')
-            : repostTarget
-              ? t('composer.writeQuoteRepost')
-              : t('composer.writePost')
-        }
-      />
+      <div className='composer-mention-anchor'>
+        <Textarea
+          ref={mentionTextareaRef}
+          value={value}
+          onChange={(event) => {
+            onChange(event);
+            onMentionSelectionChange();
+          }}
+          onKeyDown={onMentionKeyDown}
+          onKeyUp={onMentionSelectionChange}
+          onClick={onMentionSelectionChange}
+          onSelect={onMentionSelectionChange}
+          aria-expanded={mentionOpen}
+          aria-controls={mentionOpen ? 'composer-mention-listbox' : undefined}
+          placeholder={
+            replyTarget
+              ? t('composer.writeReply')
+              : repostTarget
+                ? t('composer.writeQuoteRepost')
+                : t('composer.writePost')
+          }
+        />
+        {mentionOpen ? (
+          <ul
+            id='composer-mention-listbox'
+            className='composer-mention-list'
+            role='listbox'
+            aria-label={t('composer.mentionSuggestionsLabel')}
+          >
+            {mentionItems.map((candidate, index) => (
+              <li key={candidate.pubkey} role='presentation'>
+                <MentionHoverCard
+                  pubkey={candidate.pubkey}
+                  label={candidate.label}
+                  author={mentionAuthorFromCandidate(candidate)}
+                >
+                  <button
+                    type='button'
+                    role='option'
+                    aria-selected={index === mentionActiveIndex}
+                    className={
+                      index === mentionActiveIndex
+                        ? 'composer-mention-option composer-mention-option-active'
+                        : 'composer-mention-option'
+                    }
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      selectMention(candidate);
+                    }}
+                    onMouseEnter={() => setMentionActiveIndex(index)}
+                  >
+                    <AuthorAvatar label={candidate.label} picture={candidate.picture ?? null} size='sm' />
+                    <span className='composer-mention-option-text'>
+                      <span className='composer-mention-option-label'>{candidate.label}</span>
+                      <span className='composer-mention-option-pubkey'>
+                        {shortPubkey(candidate.pubkey)}
+                      </span>
+                    </span>
+                  </button>
+                </MentionHoverCard>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
 
       <Label className='file-field file-field-compact'>
         <span>{t('common:fallbacks.attachment')}</span>

--- a/apps/desktop/src/components/core/MentionHoverCard.tsx
+++ b/apps/desktop/src/components/core/MentionHoverCard.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
+import { shortPubkey } from '@/shell/selectors';
+
+import { AuthorAvatar } from './AuthorAvatar';
+import { type MentionAuthorView } from './types';
+
+type MentionHoverCardProps = {
+  pubkey: string;
+  label: string;
+  author?: MentionAuthorView | null;
+  children: ReactNode;
+};
+
+export function MentionHoverCard({ pubkey, label, author, children }: MentionHoverCardProps) {
+  const displayLabel = author?.label?.trim() || label;
+
+  return (
+    <HoverCard openDelay={180} closeDelay={120}>
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardContent className='mention-hover-card' align='start'>
+        <div className='mention-hover-card-header'>
+          <AuthorAvatar label={displayLabel} picture={author?.picture ?? null} size='lg' />
+          <div className='mention-hover-card-identity'>
+            <strong className='mention-hover-card-label'>{displayLabel}</strong>
+            {author?.name?.trim() ? (
+              <span className='mention-hover-card-name'>{author.name}</span>
+            ) : null}
+            <span className='mention-hover-card-pubkey'>{shortPubkey(pubkey)}</span>
+          </div>
+        </div>
+        {author?.aboutPreview?.trim() ? (
+          <p className='mention-hover-card-about'>{author.aboutPreview}</p>
+        ) : null}
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/apps/desktop/src/components/core/PostCard.tsx
+++ b/apps/desktop/src/components/core/PostCard.tsx
@@ -253,6 +253,8 @@ export function PostCard({
               text={source.content}
               className='post-copy-wrap'
               onActivateReference={onActivateReference}
+              mentionAuthors={view.mentionAuthors}
+              onOpenMention={onOpenAuthor}
             />
           ) : null}
         </div>
@@ -289,6 +291,8 @@ export function PostCard({
                   text={replyPreview.content}
                   className='post-copy-wrap'
                   onActivateReference={onActivateReference}
+                  mentionAuthors={view.mentionAuthors}
+                  onOpenMention={onOpenAuthor}
                 />
               </div>
             ) : null}
@@ -310,6 +314,8 @@ export function PostCard({
               text={primaryContent}
               className='post-copy-wrap'
               onActivateReference={onActivateReference}
+              mentionAuthors={view.mentionAuthors}
+              onOpenMention={onOpenAuthor}
             />
           </strong>
         ) : null}

--- a/apps/desktop/src/components/core/SmartReferenceText.mention.test.tsx
+++ b/apps/desktop/src/components/core/SmartReferenceText.mention.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test, vi } from 'vitest';
+
+import { SmartReferenceText } from './SmartReferenceText';
+import { type MentionAuthorView } from './types';
+
+const PUBKEY = 'a'.repeat(64);
+
+const MENTION_AUTHORS: Record<string, MentionAuthorView> = {
+  [PUBKEY]: {
+    pubkey: PUBKEY,
+    label: 'Alice',
+    displayName: 'Alice',
+    name: 'alice',
+    aboutPreview: 'Building things',
+    picture: null,
+  },
+};
+
+test('renders a resolved mention as a clickable chip', async () => {
+  const user = userEvent.setup();
+  const onOpenMention = vi.fn();
+  render(
+    <SmartReferenceText
+      text={`hello @[Alice](${PUBKEY})`}
+      mentionAuthors={MENTION_AUTHORS}
+      onOpenMention={onOpenMention}
+    />
+  );
+
+  const chip = screen.getByRole('button', { name: '@Alice' });
+  await user.click(chip);
+  expect(onOpenMention).toHaveBeenCalledWith(PUBKEY);
+});
+
+test('renders an unresolved mention as plain text', () => {
+  render(<SmartReferenceText text={`hi @[Ghost](${PUBKEY})`} mentionAuthors={{}} />);
+
+  expect(screen.queryByRole('button', { name: '@Ghost' })).not.toBeInTheDocument();
+  expect(screen.getByText('@Ghost')).toBeInTheDocument();
+});

--- a/apps/desktop/src/components/core/SmartReferenceText.tsx
+++ b/apps/desktop/src/components/core/SmartReferenceText.tsx
@@ -15,10 +15,15 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
+import { MentionHoverCard } from './MentionHoverCard';
+import { type MentionAuthorView } from './types';
+
 type SmartReferenceTextProps = {
   text: string;
   className?: string;
   onActivateReference?: (reference: InternalSmartReference) => void;
+  mentionAuthors?: Record<string, MentionAuthorView>;
+  onOpenMention?: (pubkey: string) => void;
 };
 
 function tokenKindLabel(
@@ -87,6 +92,8 @@ export function SmartReferenceText({
   text,
   className,
   onActivateReference,
+  mentionAuthors,
+  onOpenMention,
 }: SmartReferenceTextProps) {
   const { t } = useTranslation(['channels', 'common', 'shell']);
   const lines = parseSmartText(text);
@@ -101,6 +108,37 @@ export function SmartReferenceText({
                 <span key={`${lineIndex}-${segmentIndex}`} className={className}>
                   {segment.text}
                 </span>
+              );
+            }
+            if (segment.kind === 'mention') {
+              const author = mentionAuthors?.[segment.pubkey] ?? null;
+              const mentionLabel = `@${author?.label ?? segment.label}`;
+              if (!author) {
+                return (
+                  <span key={`${lineIndex}-${segmentIndex}`} className='smart-mention-plain'>
+                    {mentionLabel}
+                  </span>
+                );
+              }
+              return (
+                <MentionHoverCard
+                  key={`${lineIndex}-${segmentIndex}`}
+                  pubkey={segment.pubkey}
+                  label={segment.label}
+                  author={author}
+                >
+                  <button
+                    type='button'
+                    className='smart-mention-chip'
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      onOpenMention?.(segment.pubkey);
+                    }}
+                  >
+                    {mentionLabel}
+                  </button>
+                </MentionHoverCard>
               );
             }
             const label = referenceLabel(segment.reference, t);

--- a/apps/desktop/src/components/core/types.ts
+++ b/apps/desktop/src/components/core/types.ts
@@ -61,6 +61,27 @@ export type ReferencedAuthorMeta = {
   picture?: string | null;
 };
 
+// Resolved author info for rendering a mention hover card (in the composer
+// suggestion list and in rendered posts).
+export type MentionAuthorView = {
+  pubkey: string;
+  label: string;
+  displayName?: string | null;
+  name?: string | null;
+  aboutPreview?: string | null;
+  picture?: string | null;
+};
+
+// A candidate offered while typing `@` in the composer.
+export type MentionCandidate = {
+  pubkey: string;
+  label: string;
+  displayName?: string | null;
+  name?: string | null;
+  about?: string | null;
+  picture?: string | null;
+};
+
 export type PostCardView = {
   post: PostView;
   context: 'timeline' | 'thread';
@@ -76,6 +97,7 @@ export type PostCardView = {
   repostSourceAuthor?: ReferencedAuthorMeta | null;
   replyParentAuthor?: ReferencedAuthorMeta | null;
   suppressReplyPreview?: boolean;
+  mentionAuthors?: Record<string, MentionAuthorView>;
 };
 
 export type ThreadPanelState = {

--- a/apps/desktop/src/components/core/useMentionAutocomplete.ts
+++ b/apps/desktop/src/components/core/useMentionAutocomplete.ts
@@ -1,0 +1,201 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
+
+import { buildMentionToken } from '@/lib/internalLinks';
+
+import { type MentionCandidate } from './types';
+
+const DEFAULT_MAX_ITEMS = 8;
+
+type ActiveMention = {
+  start: number;
+  query: string;
+  queryEnd: number;
+};
+
+type MentionState = ActiveMention | null;
+
+export function detectActiveMention(value: string, caret: number): ActiveMention | null {
+  let index = caret - 1;
+  while (index >= 0) {
+    const char = value[index];
+    if (char === '@') {
+      const prev = index > 0 ? value[index - 1] : '';
+      if (index === 0 || /\s/.test(prev)) {
+        return { start: index, query: value.slice(index + 1, caret), queryEnd: caret };
+      }
+      return null;
+    }
+    if (/\s/.test(char)) {
+      return null;
+    }
+    index -= 1;
+  }
+  return null;
+}
+
+function filterCandidates(
+  candidates: MentionCandidate[],
+  query: string,
+  maxItems: number
+): MentionCandidate[] {
+  const normalized = query.toLowerCase();
+  const matched =
+    normalized.length === 0
+      ? candidates
+      : candidates.filter(
+          (candidate) =>
+            candidate.label.toLowerCase().includes(normalized) ||
+            (candidate.displayName?.toLowerCase().includes(normalized) ?? false) ||
+            (candidate.name?.toLowerCase().includes(normalized) ?? false) ||
+            candidate.pubkey.toLowerCase().startsWith(normalized)
+        );
+  return matched.slice(0, maxItems);
+}
+
+type UseMentionAutocompleteArgs = {
+  value: string;
+  candidates: MentionCandidate[];
+  onValueChange?: (next: string) => void;
+  maxItems?: number;
+};
+
+export function useMentionAutocomplete({
+  value,
+  candidates,
+  onValueChange,
+  maxItems = DEFAULT_MAX_ITEMS,
+}: UseMentionAutocompleteArgs) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const pendingCaretRef = useRef<number | null>(null);
+  // The token the user dismissed with Escape; suppresses re-opening on the same
+  // token until the query changes or the caret moves elsewhere.
+  const dismissedRef = useRef<string | null>(null);
+  const [mention, setMention] = useState<MentionState>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const enabled = Boolean(onValueChange);
+
+  const items = useMemo(
+    () => (mention ? filterCandidates(candidates, mention.query, maxItems) : []),
+    [candidates, mention, maxItems]
+  );
+  const isOpen = enabled && mention !== null && items.length > 0;
+  const safeActiveIndex = items.length > 0 ? Math.min(activeIndex, items.length - 1) : 0;
+
+  // Controlled textareas reset the caret to the end after a programmatic value
+  // change; restore the intended caret position once the new value is applied.
+  useEffect(() => {
+    if (pendingCaretRef.current === null) {
+      return;
+    }
+    const caret = pendingCaretRef.current;
+    pendingCaretRef.current = null;
+    const element = textareaRef.current;
+    if (!element) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      element.focus();
+      element.setSelectionRange(caret, caret);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [value]);
+
+  const recompute = () => {
+    // Skip while a programmatic value change is in flight: the DOM value/caret
+    // still reflect the pre-insertion text and would re-open the dropdown.
+    if (!enabled || pendingCaretRef.current !== null) {
+      return;
+    }
+    const element = textareaRef.current;
+    if (!element) {
+      return;
+    }
+    const caret = element.selectionStart ?? element.value.length;
+    const detected = detectActiveMention(element.value, caret);
+    if (detected) {
+      const key = `${detected.start}:${detected.query}`;
+      if (dismissedRef.current === key) {
+        setMention((previous) => (previous === null ? previous : null));
+        return;
+      }
+      dismissedRef.current = null;
+    } else {
+      dismissedRef.current = null;
+    }
+    setMention((previous) => {
+      if (!detected) {
+        return previous === null ? previous : null;
+      }
+      if (previous && previous.start === detected.start && previous.query === detected.query) {
+        return previous;
+      }
+      return detected;
+    });
+    if (detected && (!mention || mention.start !== detected.start)) {
+      setActiveIndex(0);
+    }
+  };
+
+  const selectCandidate = (candidate: MentionCandidate) => {
+    const element = textareaRef.current;
+    if (!enabled || !onValueChange || !element || !mention) {
+      return;
+    }
+    const token = buildMentionToken(candidate.label, candidate.pubkey);
+    const insertText = `${token} `;
+    const before = element.value.slice(0, mention.start);
+    const after = element.value.slice(mention.queryEnd);
+    pendingCaretRef.current = mention.start + insertText.length;
+    onValueChange(`${before}${insertText}${after}`);
+    setMention(null);
+    setActiveIndex(0);
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!isOpen) {
+      return;
+    }
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        setActiveIndex((index) => (index + 1) % items.length);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        setActiveIndex((index) => (index - 1 + items.length) % items.length);
+        break;
+      case 'Enter':
+      case 'Tab':
+        event.preventDefault();
+        event.stopPropagation();
+        selectCandidate(items[safeActiveIndex]);
+        break;
+      case 'Escape':
+        event.preventDefault();
+        dismissedRef.current = mention ? `${mention.start}:${mention.query}` : null;
+        setMention(null);
+        setActiveIndex(0);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return {
+    textareaRef,
+    isOpen,
+    items,
+    activeIndex: safeActiveIndex,
+    query: mention?.query ?? null,
+    onKeyDown,
+    onSelectionChange: recompute,
+    selectCandidate,
+    setActiveIndex,
+  };
+}

--- a/apps/desktop/src/components/ui/hover-card.tsx
+++ b/apps/desktop/src/components/ui/hover-card.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable react-refresh/only-export-components */
+import * as React from 'react';
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
+
+import { cn } from '@/lib/utils';
+
+export const HoverCard = HoverCardPrimitive.Root;
+export const HoverCardTrigger = HoverCardPrimitive.Trigger;
+
+export const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, sideOffset = 8, ...props }, ref) => (
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn('ui-hover-card-content panel', className)}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
+));
+
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;

--- a/apps/desktop/src/i18n/locales/en/common.json
+++ b/apps/desktop/src/i18n/locales/en/common.json
@@ -40,6 +40,7 @@
     "quoteReposting": "Quote reposting",
     "clearReply": "Clear reply",
     "replying": "Replying",
+    "mentionSuggestionsLabel": "Mention suggestions",
     "sourcePost": "Original post",
     "writePost": "Write a post",
     "writeQuoteRepost": "Write a quote repost",

--- a/apps/desktop/src/i18n/locales/ja/common.json
+++ b/apps/desktop/src/i18n/locales/ja/common.json
@@ -40,6 +40,7 @@
     "quoteReposting": "引用リポスト中",
     "clearReply": "返信をクリア",
     "replying": "返信中",
+    "mentionSuggestionsLabel": "メンション候補",
     "sourcePost": "元投稿",
     "writePost": "投稿を書く",
     "writeQuoteRepost": "引用リポストを書く",

--- a/apps/desktop/src/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/common.json
@@ -35,6 +35,7 @@
     "quoteReposting": "引用转发中",
     "clearReply": "清除回复",
     "replying": "回复中",
+    "mentionSuggestionsLabel": "提及建议",
     "sourcePost": "原帖",
     "writePost": "写一条帖子",
     "writeQuoteRepost": "写一条引用转发",

--- a/apps/desktop/src/lib/internalLinks.mention.test.ts
+++ b/apps/desktop/src/lib/internalLinks.mention.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  buildMentionToken,
+  extractMentions,
+  parseSmartText,
+} from './internalLinks';
+
+const PUBKEY = 'a'.repeat(64);
+const OTHER_PUBKEY = 'b'.repeat(64);
+
+describe('buildMentionToken', () => {
+  test('produces an @[label](pubkey) token', () => {
+    expect(buildMentionToken('Alice', PUBKEY)).toBe(`@[Alice](${PUBKEY})`);
+  });
+
+  test('sanitizes brackets and newlines in the label', () => {
+    expect(buildMentionToken('Al]ice\nBob', PUBKEY)).toBe(`@[Al ice Bob](${PUBKEY})`);
+  });
+
+  test('falls back to a shortened pubkey when the label is empty', () => {
+    const token = buildMentionToken('   ', PUBKEY);
+    expect(token).toContain(`(${PUBKEY})`);
+    expect(token).not.toBe(`@[](${PUBKEY})`);
+  });
+});
+
+describe('extractMentions', () => {
+  test('returns every mention with its label and pubkey', () => {
+    const text = `hi @[Alice](${PUBKEY}) and @[Bob](${OTHER_PUBKEY})`;
+    expect(extractMentions(text)).toEqual([
+      { label: 'Alice', pubkey: PUBKEY },
+      { label: 'Bob', pubkey: OTHER_PUBKEY },
+    ]);
+  });
+
+  test('ignores tokens with an invalid pubkey length', () => {
+    expect(extractMentions('@[Alice](abc)')).toEqual([]);
+  });
+});
+
+describe('parseSmartText mentions', () => {
+  test('emits a mention segment for a valid token', () => {
+    const segments = parseSmartText(`hello @[Alice](${PUBKEY})!`);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toEqual([
+      { kind: 'text', text: 'hello ' },
+      { kind: 'mention', label: 'Alice', pubkey: PUBKEY },
+      { kind: 'text', text: '!' },
+    ]);
+  });
+
+  test('keeps order relative to a topic reference on the same line', () => {
+    const segments = parseSmartText(`@[Alice](${PUBKEY}) in kukuri:topic:demo`);
+    const line = segments[0];
+    expect(line[0]).toEqual({ kind: 'mention', label: 'Alice', pubkey: PUBKEY });
+    expect(line.some((segment) => segment.kind === 'reference')).toBe(true);
+  });
+
+  test('treats an invalid pubkey length as plain text', () => {
+    const segments = parseSmartText('@[Alice](deadbeef)');
+    expect(segments[0]).toEqual([{ kind: 'text', text: '@[Alice](deadbeef)' }]);
+  });
+
+  test('does not falsely match when the label contains a closing bracket', () => {
+    const segments = parseSmartText(`@[Bad]label](${PUBKEY})`);
+    expect(segments[0].some((segment) => segment.kind === 'mention')).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/internalLinks.ts
+++ b/apps/desktop/src/lib/internalLinks.ts
@@ -56,6 +56,12 @@ export type InternalSmartReference =
   | GameLinkReference
   | ShareTokenReference;
 
+export type MentionSegment = {
+  kind: 'mention';
+  pubkey: string;
+  label: string;
+};
+
 export type SmartTextSegment =
   | {
       kind: 'text';
@@ -64,12 +70,34 @@ export type SmartTextSegment =
   | {
       kind: 'reference';
       reference: InternalSmartReference;
-    };
+    }
+  | MentionSegment;
 
 const TOPIC_PATTERN = /kukuri:topic:[A-Za-z0-9:_-]+/;
 const ROUTE_PATTERN = /#\/(?:timeline|live|game)\?[^\s]+/;
 const CHANNEL_ACCESS_PREVIEW_PATTERN = /kukuri:\/\/access-preview\?[^\s]+/;
 const MAX_CHANNEL_ACCESS_PREVIEW_TOKEN_LENGTH = 16 * 1024;
+
+// Internal mention token format: `@[label](pubkey)` where pubkey is 64 hex chars.
+// The label disallows `]` and newlines so the token stays unambiguous to parse.
+const MENTION_PATTERN_SINGLE = /@\[([^\]\n]+)\]\(([0-9a-fA-F]{64})\)/;
+export const MENTION_PATTERN = /@\[([^\]\n]+)\]\(([0-9a-fA-F]{64})\)/g;
+
+export function buildMentionToken(label: string, pubkey: string): string {
+  const sanitized = label.replace(/[\]\n]/g, ' ').replace(/\s+/g, ' ').trim();
+  const safeLabel = sanitized.length > 0 ? sanitized : shortenReferenceId(pubkey);
+  return `@[${safeLabel}](${pubkey})`;
+}
+
+export function extractMentions(text: string): Array<{ pubkey: string; label: string }> {
+  const results: Array<{ pubkey: string; label: string }> = [];
+  MENTION_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = MENTION_PATTERN.exec(text)) !== null) {
+    results.push({ label: match[1], pubkey: match[2] });
+  }
+  return results;
+}
 
 function buildRoute(pathname: string, params: URLSearchParams): string {
   const search = params.toString();
@@ -341,31 +369,45 @@ function parseTopicReference(rawTopic: string): TopicLinkReference {
 function findNextReference(
   value: string,
   offset: number
-): { index: number; length: number; reference: InternalSmartReference } | null {
+): { index: number; length: number; segment: SmartTextSegment } | null {
   const remaining = value.slice(offset);
   const routeMatch = ROUTE_PATTERN.exec(remaining);
   const accessPreviewMatch = CHANNEL_ACCESS_PREVIEW_PATTERN.exec(remaining);
   const topicMatch = TOPIC_PATTERN.exec(remaining);
+  const mentionMatch = MENTION_PATTERN_SINGLE.exec(remaining);
   const candidates = [
     accessPreviewMatch
       ? {
           index: offset + accessPreviewMatch.index,
           text: accessPreviewMatch[0],
-          reference: parseChannelAccessPreviewDeepLink(accessPreviewMatch[0]),
+          segment: segmentFromReference(
+            parseChannelAccessPreviewDeepLink(accessPreviewMatch[0])
+          ),
         }
       : null,
     routeMatch
       ? {
           index: offset + routeMatch.index,
           text: routeMatch[0],
-          reference: parseInternalRouteLink(routeMatch[0]),
+          segment: segmentFromReference(parseInternalRouteLink(routeMatch[0])),
         }
       : null,
     topicMatch
       ? {
           index: offset + topicMatch.index,
           text: topicMatch[0],
-          reference: parseTopicReference(topicMatch[0]),
+          segment: segmentFromReference(parseTopicReference(topicMatch[0])),
+        }
+      : null,
+    mentionMatch
+      ? {
+          index: offset + mentionMatch.index,
+          text: mentionMatch[0],
+          segment: {
+            kind: 'mention' as const,
+            label: mentionMatch[1],
+            pubkey: mentionMatch[2],
+          },
         }
       : null,
   ].filter(
@@ -374,7 +416,7 @@ function findNextReference(
     ): candidate is {
       index: number;
       text: string;
-      reference: InternalSmartReference | null;
+      segment: SmartTextSegment | null;
     } => candidate !== null
   );
 
@@ -384,14 +426,20 @@ function findNextReference(
 
   candidates.sort((left, right) => left.index - right.index);
   const next = candidates[0];
-  if (!next.reference) {
+  if (!next.segment) {
     return null;
   }
   return {
     index: next.index,
     length: next.text.length,
-    reference: next.reference,
+    segment: next.segment,
   };
+}
+
+function segmentFromReference(
+  reference: InternalSmartReference | null
+): SmartTextSegment | null {
+  return reference ? { kind: 'reference', reference } : null;
 }
 
 export function parseSmartText(value: string): SmartTextSegment[][] {
@@ -440,10 +488,7 @@ export function parseSmartText(value: string): SmartTextSegment[][] {
           text: line.slice(offset, next.index),
         });
       }
-      segments.push({
-        kind: 'reference',
-        reference: next.reference,
-      });
+      segments.push(next.segment);
       offset = next.index + next.length;
     }
 

--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -1,4 +1,5 @@
 import {
+  startTransition,
   useCallback,
   useEffect,
   useMemo,
@@ -40,6 +41,7 @@ import {
 import {
   authorDisplayLabel,
   formatCount,
+  mergeKnownAuthors,
   messageFromError,
   privateComposeTarget,
   privateTimelineScope,
@@ -217,12 +219,40 @@ export function DesktopShellPage({
   const setSelectedGameRoomId = useDesktopShellFieldSetter('selectedGameRoomId');
   const setInviteOutput = useDesktopShellFieldSetter('inviteOutput');
   const setChannelError = useDesktopShellFieldSetter('channelError');
+  const setSocialConnections = useDesktopShellFieldSetter('socialConnections');
+  const setKnownAuthorsByPubkey = useDesktopShellFieldSetter('knownAuthorsByPubkey');
   const draftSequenceRef = useRef(0);
   const mediaFetchAttemptRef = useRef(new Map<string, number>());
   const remoteObjectUrlRef = useRef(new Map<string, string>());
   const draftPreviewUrlRef = useRef(new Map<string, string>());
   const directMessageDraftPreviewUrlRef = useRef(new Map<string, string>());
   const loadTopicsRequestRef = useRef(0);
+
+  // Mention suggestions need the followed-users list, which is otherwise only
+  // loaded in the profile section. Fetch it lazily when the composer opens.
+  useEffect(() => {
+    if (!composeDialogOpen) {
+      return;
+    }
+    let disposed = false;
+    void (async () => {
+      try {
+        const following = await api.listSocialConnections('following');
+        if (disposed) {
+          return;
+        }
+        startTransition(() => {
+          setSocialConnections((current) => ({ ...current, following }));
+          setKnownAuthorsByPubkey((current) => mergeKnownAuthors(current, following));
+        });
+      } catch {
+        // best effort: fall back to already-known authors for suggestions
+      }
+    })();
+    return () => {
+      disposed = true;
+    };
+  }, [api, composeDialogOpen, setKnownAuthorsByPubkey, setSocialConnections]);
   const pendingRouteUrlRef = useRef<string | null>(null);
   const didSyncRouteSectionRef = useRef(false);
   const navTriggerRef = useRef<HTMLButtonElement | null>(null);

--- a/apps/desktop/src/shell/page/DesktopShellOverlays.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellOverlays.tsx
@@ -49,6 +49,7 @@ type DesktopShellOverlaysProps = {
     | 'floatingActionLabel'
     | 'showFloatingActionButton'
     | 'activePrivateChannel'
+    | 'mentionCandidates'
   >;
   profileAvatarCropOpen: boolean;
   profileAvatarCropFile: File | null;
@@ -174,6 +175,7 @@ export function DesktopShellOverlays({
     floatingActionLabel,
     showFloatingActionButton,
     activePrivateChannel,
+    mentionCandidates,
   } = viewModels;
   const {
     attachmentInputKey,
@@ -423,6 +425,8 @@ export function DesktopShellOverlays({
             <ComposerPanel
               value={composer}
               onChange={(event) => setComposer(event.target.value)}
+              onValueChange={setComposer}
+              mentionCandidates={mentionCandidates}
               onSubmit={(event) => void handlePublish(event)}
               attachmentInputKey={attachmentInputKey}
               onAttachmentSelection={(event) => {

--- a/apps/desktop/src/shell/useDesktopShellViewModels.ts
+++ b/apps/desktop/src/shell/useDesktopShellViewModels.ts
@@ -7,6 +7,8 @@ import {
 import type {
   AuthorDetailView,
   ComposerDraftMediaView,
+  MentionAuthorView,
+  MentionCandidate,
   PostCardView,
   ReferencedAuthorMeta,
   ThreadPanelState,
@@ -35,6 +37,7 @@ import type {
 } from '@/lib/api';
 import type { DesktopTheme } from '@/lib/theme';
 
+import { extractMentions } from '@/lib/internalLinks';
 import {
   PRIMARY_SECTION_ITEMS,
   SETTINGS_SECTION_COPY,
@@ -475,6 +478,33 @@ export function useDesktopShellViewModels({
           )
         : null;
 
+      const mentionAuthors: Record<string, MentionAuthorView> = {};
+      for (const source of [post.content, repostSource?.content, replyPreview?.content]) {
+        if (!source) {
+          continue;
+        }
+        for (const { pubkey, label } of extractMentions(source)) {
+          if (mentionAuthors[pubkey]) {
+            continue;
+          }
+          const known =
+            pubkey === syncStatus.local_author_pubkey
+              ? localProfile
+              : knownAuthorsByPubkey[pubkey] ?? null;
+          if (!known) {
+            continue;
+          }
+          mentionAuthors[pubkey] = {
+            pubkey,
+            label: known.display_name?.trim() || known.name?.trim() || label || shortPubkey(pubkey),
+            displayName: known.display_name ?? null,
+            name: known.name ?? null,
+            aboutPreview: known.about?.slice(0, 50) ?? null,
+            picture: resolveProfilePictureSrc(known, mediaObjectUrls),
+          };
+        }
+      }
+
       return {
         post,
         context,
@@ -495,6 +525,7 @@ export function useDesktopShellViewModels({
         canRepost: canCreateRepostFromPost(post),
         repostSourceAuthor,
         replyParentAuthor,
+        mentionAuthors,
         suppressReplyPreview: context === 'thread',
         media: {
           objectId: post.object_id,
@@ -616,6 +647,27 @@ export function useDesktopShellViewModels({
       })),
     [draftMediaItems, locale, translate]
   );
+  const followingConnections = state.socialConnections.following;
+  const mentionCandidates = useMemo<MentionCandidate[]>(() => {
+    const seen = new Set<string>();
+    const result: MentionCandidate[] = [];
+    for (const view of [...followingConnections, ...Object.values(knownAuthorsByPubkey)]) {
+      const pubkey = view.author_pubkey;
+      if (!pubkey || pubkey === syncStatus.local_author_pubkey || seen.has(pubkey)) {
+        continue;
+      }
+      seen.add(pubkey);
+      result.push({
+        pubkey,
+        label: authorDisplayLabel(pubkey, view.display_name, view.name),
+        displayName: view.display_name ?? null,
+        name: view.name ?? null,
+        about: view.about ?? null,
+        picture: resolveProfilePictureSrc(view, mediaObjectUrls),
+      });
+    }
+    return result;
+  }, [followingConnections, knownAuthorsByPubkey, mediaObjectUrls, syncStatus.local_author_pubkey]);
   const directMessageDraftViews = useMemo<ComposerDraftMediaView[]>(
     () =>
       directMessageDraftMediaItems.map((item) => ({
@@ -1019,6 +1071,7 @@ export function useDesktopShellViewModels({
     composerSourcePreview,
     topicNavItems,
     composerDraftViews,
+    mentionCandidates,
     directMessageDraftViews,
     threadPanelState,
     authorDetailView,

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -2543,6 +2543,124 @@
   flex: 0 0 auto;
 }
 
+.smart-mention-chip {
+  display: inline;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--border-accent);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.smart-mention-chip:hover {
+  text-decoration: underline;
+}
+
+.smart-mention-plain {
+  color: var(--border-accent);
+  font-weight: 600;
+}
+
+.composer-mention-anchor {
+  position: relative;
+}
+
+.composer-mention-list {
+  position: absolute;
+  z-index: 30;
+  left: 0;
+  right: 0;
+  top: calc(100% + var(--space-2xs));
+  max-height: 16rem;
+  overflow-y: auto;
+  margin: 0;
+  padding: var(--space-2xs);
+  list-style: none;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-input);
+  background: var(--surface-panel, var(--surface-input));
+  box-shadow: var(--shadow-dropdown);
+}
+
+.composer-mention-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  width: 100%;
+  padding: var(--space-2xs) var(--space-xs);
+  border: none;
+  border-radius: var(--radius-input);
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.composer-mention-option-active,
+.composer-mention-option:hover {
+  background: var(--surface-active);
+}
+
+.composer-mention-option-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.composer-mention-option-label {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer-mention-option-pubkey {
+  font-size: var(--text-caption);
+  color: var(--muted-foreground-soft);
+}
+
+.ui-hover-card-content.mention-hover-card {
+  width: 18rem;
+  max-width: calc(100vw - 2rem);
+  padding: var(--space-sm);
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.mention-hover-card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.mention-hover-card-identity {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.mention-hover-card-label {
+  font-weight: 600;
+}
+
+.mention-hover-card-name,
+.mention-hover-card-pubkey {
+  font-size: var(--text-caption);
+  color: var(--muted-foreground-soft);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mention-hover-card-about {
+  margin: 0;
+  font-size: var(--text-body);
+  color: var(--foreground);
+}
+
 .post-card-targeted {
   border-color: var(--border-accent);
   background: color-mix(in srgb, var(--surface-active) 88%, var(--surface-panel-muted));


### PR DESCRIPTION
@
## 概要
[issue #303](https://github.com/KingYoSun/kukuri/issues/303)（「`@` でフォローユーザーをサジェストする機能が無い」）を解消します。投稿コンポーザーで `@` を起点としたユーザー補完を提供し、選択したユーザーをメンションとして挿入。投稿表示時にはメンションをチップ化し、ホバーでユーザー情報カードを表示します。

## 仕様
- `@`サジェストは**投稿コンポーザーのみ**に適用。
- 候補は**フォロー中ユーザー＋既知ユーザー**（pubkeyで重複排除・自分を除外、フォロー優先）。
- 選択時、内部トークン **`@[表示名](pubkey)`** を本文へ挿入（表示は`@表示名`、pubkey埋め込みで確実に逆引き）。
- **Hover Card** はサジェスト各行と投稿中メンションの両方で表示（アイコン・display_name・name・pubkey・about先頭50字）。

## 主な変更
- `useMentionAutocomplete` フック＋ `ComposerPanel` 統合（フォーカスを奪わない絶対配置 listbox、↑↓/Enter/Tab/Escape 対応）
- `internalLinks.ts`: `@[label](pubkey)` トークンのパース/生成、`parseSmartText` への `mention` セグメント統合
- `hover-card.tsx`（`@radix-ui/react-hover-card` 追加）＋ `MentionHoverCard`
- `SmartReferenceText` / `PostCard` でメンションをチップ描画（未解決時はプレーンテキストにフォールバック）
- view model に候補生成とメンション逆引きを中央集約、コンポーザー開時にフォロー一覧を best-effort 取得
- i18n（en/ja/zh-CN）

## テスト
- typecheck / lint / 全テスト（247件）グリーン
- 追加: パーサ単体、コンポーザー補完の挙動、メンション描画

ブラウザ実機確認は Tauri バックエンドが必要なため、挙動はコンポーネントテストで担保しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@