### PR TITLE
fix: third-party notices のソートをオーディナル化しCI差異を解消

### DIFF
--- a/docs/THIRD_PARTY_NOTICES.md
+++ b/docs/THIRD_PARTY_NOTICES.md
@@ -36,18 +36,18 @@ Total packages: 632
 | anstyle-query | 1.1.5 | MIT OR Apache-2.0 | https://crates.io/crates/anstyle-query |
 | anstyle-wincon | 3.0.11 | MIT OR Apache-2.0 | https://crates.io/crates/anstyle-wincon |
 | anyhow | 1.0.102 | MIT OR Apache-2.0 | https://crates.io/crates/anyhow |
-| arcstr | 1.2.0 | Apache-2.0 OR MIT OR Zlib | https://crates.io/crates/arcstr |
 | arc-swap | 1.9.1 | MIT OR Apache-2.0 | https://crates.io/crates/arc-swap |
+| arcstr | 1.2.0 | Apache-2.0 OR MIT OR Zlib | https://crates.io/crates/arcstr |
 | arrayref | 0.3.9 | BSD-2-Clause | https://crates.io/crates/arrayref |
 | arrayvec | 0.7.6 | MIT OR Apache-2.0 | https://crates.io/crates/arrayvec |
 | asn1-rs | 0.7.2 | MIT OR Apache-2.0 | https://crates.io/crates/asn1-rs |
 | asn1-rs-derive | 0.6.0 | MIT OR Apache-2.0 | https://crates.io/crates/asn1-rs-derive |
 | asn1-rs-impl | 0.2.0 | MIT/Apache-2.0 | https://crates.io/crates/asn1-rs-impl |
-| async_io_stream | 0.3.3 | Unlicense | https://crates.io/crates/async_io_stream |
 | async-channel | 2.5.0 | Apache-2.0 OR MIT | https://crates.io/crates/async-channel |
 | async-compat | 0.2.5 | Apache-2.0 OR MIT | https://crates.io/crates/async-compat |
 | async-lock | 3.4.2 | Apache-2.0 OR MIT | https://crates.io/crates/async-lock |
 | async-trait | 0.1.89 | MIT OR Apache-2.0 | https://crates.io/crates/async-trait |
+| async_io_stream | 0.3.3 | Unlicense | https://crates.io/crates/async_io_stream |
 | atoi | 2.0.0 | MIT | https://crates.io/crates/atoi |
 | atomic-polyfill | 1.0.3 | MIT OR Apache-2.0 | https://crates.io/crates/atomic-polyfill |
 | atomic-waker | 1.1.2 | Apache-2.0 OR MIT | https://crates.io/crates/atomic-waker |
@@ -65,22 +65,22 @@ Total packages: 632
 | base64ct | 1.8.3 | Apache-2.0 OR MIT | https://crates.io/crates/base64ct |
 | bech32 | 0.11.1 | MIT | https://crates.io/crates/bech32 |
 | binary-merge | 0.1.2 | MIT OR Apache-2.0 | https://crates.io/crates/binary-merge |
-| bitcoin_hashes | 0.14.100 | CC0-1.0 | https://crates.io/crates/bitcoin_hashes |
-| bitcoin-io | 0.1.100 | CC0-1.0 | https://crates.io/crates/bitcoin-io |
-| bitflags | 2.11.1 | MIT OR Apache-2.0 | https://crates.io/crates/bitflags |
 | bit-vec | 0.9.1 | Apache-2.0 OR MIT | https://crates.io/crates/bit-vec |
+| bitcoin-io | 0.1.100 | CC0-1.0 | https://crates.io/crates/bitcoin-io |
+| bitcoin_hashes | 0.14.100 | CC0-1.0 | https://crates.io/crates/bitcoin_hashes |
+| bitflags | 2.11.1 | MIT OR Apache-2.0 | https://crates.io/crates/bitflags |
 | blake3 | 1.8.5 | CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception | https://crates.io/crates/blake3 |
-| block2 | 0.6.2 | MIT | https://crates.io/crates/block2 |
 | block-buffer | 0.10.4 | MIT OR Apache-2.0 | https://crates.io/crates/block-buffer |
 | block-buffer | 0.12.0 | MIT OR Apache-2.0 | https://crates.io/crates/block-buffer |
+| block2 | 0.6.2 | MIT | https://crates.io/crates/block2 |
 | bumpalo | 3.20.3 | MIT OR Apache-2.0 | https://crates.io/crates/bumpalo |
 | bytemuck | 1.25.0 | Zlib OR Apache-2.0 OR MIT | https://crates.io/crates/bytemuck |
 | byteorder | 1.5.0 | Unlicense OR MIT | https://crates.io/crates/byteorder |
 | byteorder-lite | 0.1.0 | Unlicense OR MIT | https://crates.io/crates/byteorder-lite |
 | bytes | 1.11.1 | MIT | https://crates.io/crates/bytes |
 | cc | 1.2.62 | MIT OR Apache-2.0 | https://crates.io/crates/cc |
-| cfg_aliases | 0.2.1 | MIT | https://crates.io/crates/cfg_aliases |
 | cfg-if | 1.0.4 | MIT OR Apache-2.0 | https://crates.io/crates/cfg-if |
+| cfg_aliases | 0.2.1 | MIT | https://crates.io/crates/cfg_aliases |
 | chacha20 | 0.10.0 | MIT OR Apache-2.0 | https://crates.io/crates/chacha20 |
 | chacha20 | 0.9.1 | Apache-2.0 OR MIT | https://crates.io/crates/chacha20 |
 | chacha20poly1305 | 0.10.1 | Apache-2.0 OR MIT | https://crates.io/crates/chacha20poly1305 |
@@ -97,9 +97,9 @@ Total packages: 632
 | colorchoice | 1.0.5 | MIT OR Apache-2.0 | https://crates.io/crates/colorchoice |
 | combine | 4.6.7 | MIT | https://crates.io/crates/combine |
 | concurrent-queue | 2.5.0 | Apache-2.0 OR MIT | https://crates.io/crates/concurrent-queue |
-| constant_time_eq | 0.4.2 | CC0-1.0 OR MIT-0 OR Apache-2.0 | https://crates.io/crates/constant_time_eq |
 | const-oid | 0.10.2 | Apache-2.0 OR MIT | https://crates.io/crates/const-oid |
 | const-oid | 0.9.6 | Apache-2.0 OR MIT | https://crates.io/crates/const-oid |
+| constant_time_eq | 0.4.2 | CC0-1.0 OR MIT-0 OR Apache-2.0 | https://crates.io/crates/constant_time_eq |
 | convert_case | 0.10.0 | MIT | https://crates.io/crates/convert_case |
 | cordyceps | 0.3.4 | MIT | https://crates.io/crates/cordyceps |
 | core-foundation | 0.10.1 | MIT OR Apache-2.0 | https://crates.io/crates/core-foundation |
@@ -108,8 +108,8 @@ Total packages: 632
 | cpufeatures | 0.2.17 | MIT OR Apache-2.0 | https://crates.io/crates/cpufeatures |
 | cpufeatures | 0.3.0 | MIT OR Apache-2.0 | https://crates.io/crates/cpufeatures |
 | crc | 3.4.0 | MIT OR Apache-2.0 | https://crates.io/crates/crc |
-| crc32fast | 1.5.0 | MIT OR Apache-2.0 | https://crates.io/crates/crc32fast |
 | crc-catalog | 2.5.0 | MIT OR Apache-2.0 | https://crates.io/crates/crc-catalog |
+| crc32fast | 1.5.0 | MIT OR Apache-2.0 | https://crates.io/crates/crc32fast |
 | critical-section | 1.2.0 | MIT OR Apache-2.0 | https://crates.io/crates/critical-section |
 | crossbeam-channel | 0.5.15 | MIT OR Apache-2.0 | https://crates.io/crates/crossbeam-channel |
 | crossbeam-epoch | 0.9.18 | MIT OR Apache-2.0 | https://crates.io/crates/crossbeam-epoch |
@@ -132,13 +132,13 @@ Total packages: 632
 | dbus-secret-service | 4.1.0 | MIT OR Apache-2.0 | https://crates.io/crates/dbus-secret-service |
 | der | 0.7.10 | Apache-2.0 OR MIT | https://crates.io/crates/der |
 | der | 0.8.0 | Apache-2.0 OR MIT | https://crates.io/crates/der |
+| der-parser | 10.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/der-parser |
 | deranged | 0.5.8 | MIT OR Apache-2.0 | https://crates.io/crates/deranged |
 | derive_builder | 0.20.2 | MIT OR Apache-2.0 | https://crates.io/crates/derive_builder |
 | derive_builder_core | 0.20.2 | MIT OR Apache-2.0 | https://crates.io/crates/derive_builder_core |
 | derive_builder_macro | 0.20.2 | MIT OR Apache-2.0 | https://crates.io/crates/derive_builder_macro |
 | derive_more | 2.1.1 | MIT | https://crates.io/crates/derive_more |
 | derive_more-impl | 2.1.1 | MIT | https://crates.io/crates/derive_more-impl |
-| der-parser | 10.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/der-parser |
 | diatomic-waker | 0.2.3 | MIT OR Apache-2.0 | https://crates.io/crates/diatomic-waker |
 | digest | 0.10.7 | MIT OR Apache-2.0 | https://crates.io/crates/digest |
 | digest | 0.11.3 | MIT OR Apache-2.0 | https://crates.io/crates/digest |
@@ -215,9 +215,9 @@ Total packages: 632
 | hmac | 0.12.1 | MIT OR Apache-2.0 | https://crates.io/crates/hmac |
 | home | 0.5.12 | MIT OR Apache-2.0 | https://crates.io/crates/home |
 | http | 1.4.1 | MIT OR Apache-2.0 | https://crates.io/crates/http |
-| httparse | 1.10.1 | MIT OR Apache-2.0 | https://crates.io/crates/httparse |
 | http-body | 1.0.1 | MIT | https://crates.io/crates/http-body |
 | http-body-util | 0.1.3 | MIT | https://crates.io/crates/http-body-util |
+| httparse | 1.10.1 | MIT OR Apache-2.0 | https://crates.io/crates/httparse |
 | httpdate | 1.0.3 | MIT OR Apache-2.0 | https://crates.io/crates/httpdate |
 | hybrid-array | 0.4.12 | MIT OR Apache-2.0 | https://crates.io/crates/hybrid-array |
 | hyper | 1.10.0 | MIT | https://crates.io/crates/hyper |
@@ -267,8 +267,8 @@ Total packages: 632
 | jni-sys | 0.4.1 | MIT OR Apache-2.0 | https://crates.io/crates/jni-sys |
 | jni-sys-macros | 0.4.1 | MIT OR Apache-2.0 | https://crates.io/crates/jni-sys-macros |
 | jobserver | 0.1.34 | MIT OR Apache-2.0 | https://crates.io/crates/jobserver |
-| jsonwebtoken | 10.4.0 | MIT | https://crates.io/crates/jsonwebtoken |
 | js-sys | 0.3.99 | MIT OR Apache-2.0 | https://crates.io/crates/js-sys |
+| jsonwebtoken | 10.4.0 | MIT | https://crates.io/crates/jsonwebtoken |
 | keyring | 3.6.3 | MIT OR Apache-2.0 | https://crates.io/crates/keyring |
 | lazy_static | 1.5.0 | MIT OR Apache-2.0 | https://crates.io/crates/lazy_static |
 | leb128fmt | 0.1.0 | MIT OR Apache-2.0 | https://crates.io/crates/leb128fmt |
@@ -318,15 +318,15 @@ Total packages: 632
 | noq-udp | 1.0.0-rc.1 | MIT OR Apache-2.0 | https://crates.io/crates/noq-udp |
 | ntimestamp | 1.0.0 | MIT | https://crates.io/crates/ntimestamp |
 | nu-ansi-term | 0.50.3 | MIT | https://crates.io/crates/nu-ansi-term |
-| num_enum | 0.7.6 | BSD-3-Clause OR MIT OR Apache-2.0 | https://crates.io/crates/num_enum |
-| num_enum_derive | 0.7.6 | BSD-3-Clause OR MIT OR Apache-2.0 | https://crates.io/crates/num_enum_derive |
-| num_threads | 0.1.7 | MIT OR Apache-2.0 | https://crates.io/crates/num_threads |
 | num-bigint | 0.4.6 | MIT OR Apache-2.0 | https://crates.io/crates/num-bigint |
 | num-bigint-dig | 0.8.6 | MIT/Apache-2.0 | https://crates.io/crates/num-bigint-dig |
 | num-conv | 0.2.2 | MIT OR Apache-2.0 | https://crates.io/crates/num-conv |
 | num-integer | 0.1.46 | MIT OR Apache-2.0 | https://crates.io/crates/num-integer |
 | num-iter | 0.1.45 | MIT OR Apache-2.0 | https://crates.io/crates/num-iter |
 | num-traits | 0.2.19 | MIT OR Apache-2.0 | https://crates.io/crates/num-traits |
+| num_enum | 0.7.6 | BSD-3-Clause OR MIT OR Apache-2.0 | https://crates.io/crates/num_enum |
+| num_enum_derive | 0.7.6 | BSD-3-Clause OR MIT OR Apache-2.0 | https://crates.io/crates/num_enum_derive |
+| num_threads | 0.1.7 | MIT OR Apache-2.0 | https://crates.io/crates/num_threads |
 | objc2 | 0.6.4 | MIT | https://crates.io/crates/objc2 |
 | objc2-core-foundation | 0.3.2 | Zlib OR Apache-2.0 OR MIT | https://crates.io/crates/objc2-core-foundation |
 | objc2-core-wlan | 0.3.2 | Zlib OR Apache-2.0 OR MIT | https://crates.io/crates/objc2-core-wlan |
@@ -373,11 +373,11 @@ Total packages: 632
 | ppv-lite86 | 0.2.21 | MIT OR Apache-2.0 | https://crates.io/crates/ppv-lite86 |
 | prefix-trie | 0.8.4 | MIT OR Apache-2.0 | https://crates.io/crates/prefix-trie |
 | prettyplease | 0.2.37 | MIT OR Apache-2.0 | https://crates.io/crates/prettyplease |
-| proc-macro2 | 1.0.106 | MIT OR Apache-2.0 | https://crates.io/crates/proc-macro2 |
 | proc-macro-crate | 3.5.0 | MIT OR Apache-2.0 | https://crates.io/crates/proc-macro-crate |
 | proc-macro-error | 0.4.12 | MIT OR Apache-2.0 | https://crates.io/crates/proc-macro-error |
 | proc-macro-error-attr | 0.4.12 | MIT OR Apache-2.0 | https://crates.io/crates/proc-macro-error-attr |
 | proc-macro-hack | 0.5.20+deprecated | MIT OR Apache-2.0 | https://crates.io/crates/proc-macro-hack |
+| proc-macro2 | 1.0.106 | MIT OR Apache-2.0 | https://crates.io/crates/proc-macro2 |
 | pxfm | 0.1.29 | BSD-3-Clause OR Apache-2.0 | https://crates.io/crates/pxfm |
 | quick-error | 2.0.1 | MIT/Apache-2.0 | https://crates.io/crates/quick-error |
 | quick-xml | 0.39.4 | MIT | https://crates.io/crates/quick-xml |
@@ -385,6 +385,8 @@ Total packages: 632
 | quinn-proto | 0.11.14 | MIT OR Apache-2.0 | https://crates.io/crates/quinn-proto |
 | quinn-udp | 0.5.14 | MIT OR Apache-2.0 | https://crates.io/crates/quinn-udp |
 | quote | 1.0.45 | MIT OR Apache-2.0 | https://crates.io/crates/quote |
+| r-efi | 5.3.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later | https://crates.io/crates/r-efi |
+| r-efi | 6.0.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later | https://crates.io/crates/r-efi |
 | rand | 0.10.1 | MIT OR Apache-2.0 | https://crates.io/crates/rand |
 | rand | 0.8.6 | MIT OR Apache-2.0 | https://crates.io/crates/rand |
 | rand | 0.9.4 | MIT OR Apache-2.0 | https://crates.io/crates/rand |
@@ -402,8 +404,6 @@ Total packages: 632
 | redox_syscall | 0.8.0 | MIT | https://crates.io/crates/redox_syscall |
 | ref-cast | 1.0.25 | MIT OR Apache-2.0 | https://crates.io/crates/ref-cast |
 | ref-cast-impl | 1.0.25 | MIT OR Apache-2.0 | https://crates.io/crates/ref-cast-impl |
-| r-efi | 5.3.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later | https://crates.io/crates/r-efi |
-| r-efi | 6.0.0 | MIT OR Apache-2.0 OR LGPL-2.1-or-later | https://crates.io/crates/r-efi |
 | reflink-copy | 0.1.29 | MIT/Apache-2.0 | https://crates.io/crates/reflink-copy |
 | regex-automata | 0.4.14 | MIT OR Apache-2.0 | https://crates.io/crates/regex-automata |
 | regex-syntax | 0.8.10 | MIT OR Apache-2.0 | https://crates.io/crates/regex-syntax |
@@ -414,8 +414,8 @@ Total packages: 632
 | resolv-conf | 0.7.6 | MIT OR Apache-2.0 | https://crates.io/crates/resolv-conf |
 | ring | 0.17.14 | Apache-2.0 AND ISC | https://crates.io/crates/ring |
 | rsa | 0.9.10 | MIT OR Apache-2.0 | https://crates.io/crates/rsa |
-| rustc_version | 0.4.1 | MIT OR Apache-2.0 | https://crates.io/crates/rustc_version |
 | rustc-hash | 2.1.2 | Apache-2.0 OR MIT | https://crates.io/crates/rustc-hash |
+| rustc_version | 0.4.1 | MIT OR Apache-2.0 | https://crates.io/crates/rustc_version |
 | rusticata-macros | 4.1.0 | MIT/Apache-2.0 | https://crates.io/crates/rusticata-macros |
 | rustix | 1.1.4 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://crates.io/crates/rustix |
 | rustls | 0.23.40 | Apache-2.0 OR ISC OR MIT | https://crates.io/crates/rustls |
@@ -442,6 +442,7 @@ Total packages: 632
 | semver | 1.0.28 | MIT OR Apache-2.0 | https://crates.io/crates/semver |
 | send_wrapper | 0.6.0 | MIT/Apache-2.0 | https://crates.io/crates/send_wrapper |
 | serde | 1.0.228 | MIT OR Apache-2.0 | https://crates.io/crates/serde |
+| serde-error | 0.1.3 | MIT | https://crates.io/crates/serde-error |
 | serde_bencode | 0.2.4 | MIT | https://crates.io/crates/serde_bencode |
 | serde_bytes | 0.11.19 | MIT OR Apache-2.0 | https://crates.io/crates/serde_bytes |
 | serde_core | 1.0.228 | MIT OR Apache-2.0 | https://crates.io/crates/serde_core |
@@ -452,7 +453,6 @@ Total packages: 632
 | serde_urlencoded | 0.7.1 | MIT/Apache-2.0 | https://crates.io/crates/serde_urlencoded |
 | serde_yaml | 0.9.34+deprecated | MIT OR Apache-2.0 | https://crates.io/crates/serde_yaml |
 | serdect | 0.4.3 | Apache-2.0 OR MIT | https://crates.io/crates/serdect |
-| serde-error | 0.1.3 | MIT | https://crates.io/crates/serde-error |
 | sha1 | 0.10.6 | MIT OR Apache-2.0 | https://crates.io/crates/sha1 |
 | sha1 | 0.11.0 | MIT OR Apache-2.0 | https://crates.io/crates/sha1 |
 | sha1_smol | 1.0.1 | BSD-3-Clause | https://crates.io/crates/sha1_smol |
@@ -463,12 +463,12 @@ Total packages: 632
 | signal-hook-registry | 1.4.8 | MIT OR Apache-2.0 | https://crates.io/crates/signal-hook-registry |
 | signature | 2.2.0 | Apache-2.0 OR MIT | https://crates.io/crates/signature |
 | signature | 3.0.0 | Apache-2.0 OR MIT | https://crates.io/crates/signature |
-| simd_cesu8 | 1.1.1 | Apache-2.0 OR MIT | https://crates.io/crates/simd_cesu8 |
 | simd-adler32 | 0.3.9 | MIT | https://crates.io/crates/simd-adler32 |
+| simd_cesu8 | 1.1.1 | Apache-2.0 OR MIT | https://crates.io/crates/simd_cesu8 |
 | simdutf8 | 0.1.5 | MIT OR Apache-2.0 | https://crates.io/crates/simdutf8 |
-| simple_asn1 | 0.6.4 | ISC | https://crates.io/crates/simple_asn1 |
 | simple-dns | 0.11.3 | MIT | https://crates.io/crates/simple-dns |
 | simple-dns | 0.9.3 | MIT | https://crates.io/crates/simple-dns |
+| simple_asn1 | 0.6.4 | ISC | https://crates.io/crates/simple_asn1 |
 | siphasher | 1.0.3 | MIT/Apache-2.0 | https://crates.io/crates/siphasher |
 | slab | 0.4.12 | MIT | https://crates.io/crates/slab |
 | smallvec | 1.15.1 | MIT OR Apache-2.0 | https://crates.io/crates/smallvec |
@@ -494,8 +494,8 @@ Total packages: 632
 | subtle | 2.6.1 | BSD-3-Clause | https://crates.io/crates/subtle |
 | syn | 1.0.109 | MIT OR Apache-2.0 | https://crates.io/crates/syn |
 | syn | 2.0.117 | MIT OR Apache-2.0 | https://crates.io/crates/syn |
-| sync_wrapper | 1.0.2 | Apache-2.0 | https://crates.io/crates/sync_wrapper |
 | syn-mid | 0.5.4 | Apache-2.0 OR MIT | https://crates.io/crates/syn-mid |
+| sync_wrapper | 1.0.2 | Apache-2.0 | https://crates.io/crates/sync_wrapper |
 | synstructure | 0.13.2 | MIT | https://crates.io/crates/synstructure |
 | system-configuration | 0.7.0 | MIT OR Apache-2.0 | https://crates.io/crates/system-configuration |
 | system-configuration-sys | 0.6.0 | MIT OR Apache-2.0 | https://crates.io/crates/system-configuration-sys |
@@ -568,13 +568,13 @@ Total packages: 632
 | wasm-bindgen-shared | 0.2.122 | MIT OR Apache-2.0 | https://crates.io/crates/wasm-bindgen-shared |
 | wasm-encoder | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://crates.io/crates/wasm-encoder |
 | wasm-metadata | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://crates.io/crates/wasm-metadata |
-| wasmparser | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://crates.io/crates/wasmparser |
 | wasm-streams | 0.5.0 | MIT OR Apache-2.0 | https://crates.io/crates/wasm-streams |
+| wasmparser | 0.244.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://crates.io/crates/wasmparser |
+| web-sys | 0.3.99 | MIT OR Apache-2.0 | https://crates.io/crates/web-sys |
+| web-time | 1.1.0 | MIT OR Apache-2.0 | https://crates.io/crates/web-time |
 | webpki-root-certs | 1.0.7 | CDLA-Permissive-2.0 | https://crates.io/crates/webpki-root-certs |
 | webpki-roots | 0.26.11 | CDLA-Permissive-2.0 | https://crates.io/crates/webpki-roots |
 | webpki-roots | 1.0.7 | CDLA-Permissive-2.0 | https://crates.io/crates/webpki-roots |
-| web-sys | 0.3.99 | MIT OR Apache-2.0 | https://crates.io/crates/web-sys |
-| web-time | 1.1.0 | MIT OR Apache-2.0 | https://crates.io/crates/web-time |
 | weezl | 0.1.12 | MIT OR Apache-2.0 | https://crates.io/crates/weezl |
 | whoami | 1.6.1 | Apache-2.0 OR BSL-1.0 OR MIT | https://crates.io/crates/whoami |
 | widestring | 1.2.1 | MIT OR Apache-2.0 | https://crates.io/crates/widestring |
@@ -583,6 +583,24 @@ Total packages: 632
 | winapi-util | 0.1.11 | Unlicense OR MIT | https://crates.io/crates/winapi-util |
 | winapi-x86_64-pc-windows-gnu | 0.4.0 | MIT/Apache-2.0 | https://crates.io/crates/winapi-x86_64-pc-windows-gnu |
 | windows | 0.62.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows |
+| windows-collections | 0.3.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-collections |
+| windows-core | 0.62.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-core |
+| windows-future | 0.3.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-future |
+| windows-implement | 0.60.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-implement |
+| windows-interface | 0.59.3 | MIT OR Apache-2.0 | https://crates.io/crates/windows-interface |
+| windows-link | 0.2.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-link |
+| windows-numerics | 0.3.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-numerics |
+| windows-registry | 0.6.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-registry |
+| windows-result | 0.4.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-result |
+| windows-strings | 0.5.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-strings |
+| windows-sys | 0.48.0 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
+| windows-sys | 0.52.0 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
+| windows-sys | 0.60.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
+| windows-sys | 0.61.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
+| windows-targets | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows-targets |
+| windows-targets | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows-targets |
+| windows-targets | 0.53.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows-targets |
+| windows-threading | 0.2.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-threading |
 | windows_aarch64_gnullvm | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_gnullvm |
 | windows_aarch64_gnullvm | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_gnullvm |
 | windows_aarch64_gnullvm | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_gnullvm |
@@ -606,24 +624,6 @@ Total packages: 632
 | windows_x86_64_msvc | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
 | windows_x86_64_msvc | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
 | windows_x86_64_msvc | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
-| windows-collections | 0.3.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-collections |
-| windows-core | 0.62.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-core |
-| windows-future | 0.3.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-future |
-| windows-implement | 0.60.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-implement |
-| windows-interface | 0.59.3 | MIT OR Apache-2.0 | https://crates.io/crates/windows-interface |
-| windows-link | 0.2.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-link |
-| windows-numerics | 0.3.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-numerics |
-| windows-registry | 0.6.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-registry |
-| windows-result | 0.4.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-result |
-| windows-strings | 0.5.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-strings |
-| windows-sys | 0.48.0 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
-| windows-sys | 0.52.0 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
-| windows-sys | 0.60.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
-| windows-sys | 0.61.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
-| windows-targets | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows-targets |
-| windows-targets | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows-targets |
-| windows-targets | 0.53.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows-targets |
-| windows-threading | 0.2.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-threading |
 | winnow | 1.0.3 | MIT | https://crates.io/crates/winnow |
 | wit-bindgen | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://crates.io/crates/wit-bindgen |
 | wit-bindgen | 0.57.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://crates.io/crates/wit-bindgen |
@@ -771,8 +771,8 @@ Total packages: 158
 | i18next-browser-languagedetector | 8.2.1 | MIT | https://github.com/i18next/i18next-browser-languageDetector |
 | ieee754 | 1.2.1 | BSD-3-Clause | https://github.com/feross/ieee754#readme |
 | immediate | 3.0.6 | MIT | https://github.com/calvinmetcalf/immediate#readme |
-| isexe | 2.0.0 | ISC | https://github.com/isaacs/isexe#readme |
 | is-promise | 2.2.2 | MIT | https://github.com/then/is-promise#readme |
+| isexe | 2.0.0 | ISC | https://github.com/isaacs/isexe#readme |
 | its-fine | 2.0.0 | MIT | https://github.com/pmndrs/its-fine |
 | lie | 3.3.0 | MIT | https://github.com/calvinmetcalf/lie#readme |
 | lucide-react | 1.8.0 | ISC | https://lucide.dev |
@@ -796,8 +796,8 @@ Total packages: 158
 | set-cookie-parser | 2.7.2 | MIT | https://github.com/nfriedly/set-cookie-parser |
 | shebang-command | 2.0.0 | MIT | https://github.com/kevva/shebang-command#readme |
 | shebang-regex | 3.0.0 | MIT | https://github.com/sindresorhus/shebang-regex#readme |
-| stats.js | 0.17.0 | MIT | https://github.com/mrdoob/stats.js |
 | stats-gl | 2.4.2 | MIT | https://github.com/RenaudRohlinger/stats-gl |
+| stats.js | 0.17.0 | MIT | https://github.com/mrdoob/stats.js |
 | suspend-react | 0.1.3 | MIT | https://github.com/pmndrs/suspend-react#readme |
 | tailwind-merge | 3.5.0 | MIT | https://github.com/dcastil/tailwind-merge |
 | three | 0.184.0 | MIT | https://threejs.org/ |

--- a/scripts/release/generate-third-party-notices.ps1
+++ b/scripts/release/generate-third-party-notices.ps1
@@ -22,6 +22,39 @@ function Escape-MarkdownCell {
   return ($Value.Trim() -replace "\|", "\|" -replace "`r?`n", " ")
 }
 
+# Sort inventory rows with culture-invariant ordinal comparison and drop
+# duplicates by (Name, Version, License). Sort-Object uses culture-aware
+# collation whose order differs between Windows PowerShell 5.1 and pwsh 7, which
+# made the generated file depend on the host. Ordinal comparison keeps the
+# output identical across platforms so the CI -Check gate is deterministic.
+function Sort-Inventory {
+  param([object[]]$Items)
+
+  $list = [System.Collections.Generic.List[object]]::new()
+  if ($Items) { $list.AddRange([object[]]$Items) }
+
+  $comparison = [System.Comparison[object]] {
+    param($a, $b)
+    $c = [string]::CompareOrdinal([string]$a.Name, [string]$b.Name)
+    if ($c -ne 0) { return $c }
+    $c = [string]::CompareOrdinal([string]$a.Version, [string]$b.Version)
+    if ($c -ne 0) { return $c }
+    return [string]::CompareOrdinal([string]$a.License, [string]$b.License)
+  }
+  $list.Sort($comparison)
+
+  $result = [System.Collections.Generic.List[object]]::new()
+  $previousKey = $null
+  foreach ($item in $list) {
+    $key = "$($item.Name)|$($item.Version)|$($item.License)"
+    if ($key -ne $previousKey) {
+      $result.Add($item)
+      $previousKey = $key
+    }
+  }
+  return , $result.ToArray()
+}
+
 function Get-CargoMetadata {
   if (-not [string]::IsNullOrWhiteSpace($RustMetadataPath)) {
     return Get-Content -LiteralPath $RustMetadataPath -Raw -Encoding UTF8 | ConvertFrom-Json
@@ -62,10 +95,9 @@ function Get-RustInventory {
         License = if ([string]::IsNullOrWhiteSpace($_.license)) { "UNKNOWN" } else { [string]$_.license }
         Source = "https://crates.io/crates/$($_.name)"
       }
-    } |
-    Sort-Object Name, Version, License -Unique
+    }
 
-  return @($packages)
+  return @(Sort-Inventory $packages)
 }
 
 function Get-NpmInventory {
@@ -83,7 +115,7 @@ function Get-NpmInventory {
     }
   }
 
-  return @($packages | Sort-Object Name, Version, License -Unique)
+  return @(Sort-Inventory $packages)
 }
 
 function Add-InventorySection {


### PR DESCRIPTION
## 概要

`v0.1.2-preview.1` のリリースワークフローが `Third-party notices check` で繰り返し失敗していた根本原因を修正します。

## 根本原因

`scripts/release/generate-third-party-notices.ps1` の `Sort-Object Name, Version, License` は **カルチャ依存の照合順**でソートしていました。これにより:

- **Windows PowerShell 5.1**（メンテナのローカル生成）と
- **CI の pwsh 7 (Linux)**（`-Check` での再生成）

で並び順が異なり、コミット済み `THIRD_PARTY_NOTICES.md` と CI 生成物が食い違って `-Check` が失敗していました。

差分はハイフン等を含むパッケージ名の隣接行が1行ずつ入れ替わるもの（例: `arcstr` / `bit-vec` / `block2` / `der-parser` / `proc-macro2` など）。内容（パッケージ集合）は同一で、順序だけの差でした。

## 修正

- ソートを `[string]::CompareOrdinal` ベースの **決定論的オーディナルソート + 重複排除**（`Sort-Inventory` ヘルパー）に変更。プラットフォーム/PSバージョン非依存で同一出力になります。
- `docs/THIRD_PARTY_NOTICES.md` を新しいソートで再生成。

## 検証

- 同一入力に対し **Windows PS5.1 と Linux pwsh7（Docker）で生成結果がバイト一致**することを確認。
- `generate-third-party-notices.ps1 -Check` がローカルで通過。
- `test-generate-third-party-notices.ps1` smoke テスト通過。

これにより以後のリリースで notices ゲートがホスト環境に依存せず安定します。マージ後 `v0.1.2-preview.1` を再タグしてリリースを再実行します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)