### PR TITLE
chore(security): 監査ベースの community-node ハードニングとユーザー入力検証

### DIFF
--- a/.env.community-node.example
+++ b/.env.community-node.example
@@ -11,6 +11,16 @@ COMMUNITY_NODE_JWT_ISSUER=kukuri-cn
 COMMUNITY_NODE_JWT_SECRET=dev-jwt-change-me-32-bytes-minimum
 COMMUNITY_NODE_JWT_TTL_SECONDS=86400
 
+# cn-user-api per-client HTTP rate limit. Enabled by default here; the binary itself
+# defaults to disabled. per_second is the sustained rate, burst the short-term allowance.
+# Set TRUST_FORWARDED_FOR=true ONLY behind a trusted reverse proxy (e.g. the Caddy edge
+# below) so each real client is limited individually instead of sharing the proxy IP.
+# Leave it false when cn-user-api is directly exposed, since X-Forwarded-For is spoofable.
+COMMUNITY_NODE_RATE_LIMIT_ENABLED=true
+COMMUNITY_NODE_RATE_LIMIT_PER_SECOND=10
+COMMUNITY_NODE_RATE_LIMIT_BURST=30
+COMMUNITY_NODE_RATE_LIMIT_TRUST_FORWARDED_FOR=false
+
 CN_BASE_URL=http://127.0.0.1:18080
 CN_PUBLIC_BASE_URL=http://127.0.0.1:18080
 COMMUNITY_NODE_CONNECTIVITY_URLS=http://127.0.0.1:13340

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -699,7 +699,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1445,6 +1445,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1580,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1720,6 +1736,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1801,17 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1840,7 +1890,7 @@ dependencies = [
  "jni",
  "rand 0.10.1",
  "rustls",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -1862,7 +1912,7 @@ dependencies = [
  "prefix-trie",
  "rand 0.10.1",
  "ring",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
@@ -1890,7 +1940,7 @@ dependencies = [
  "rustls",
  "smallvec",
  "system-configuration",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -2013,6 +2063,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2457,7 +2520,7 @@ dependencies = [
  "serde-error",
  "strum",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2704,7 +2767,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -2901,6 +2964,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3188,7 +3252,7 @@ dependencies = [
  "serde_bencode",
  "serde_bytes",
  "sha1_smol",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -3445,7 +3509,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3508,6 +3572,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "noq"
 version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3522,7 +3598,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3552,7 +3628,7 @@ dependencies = [
  "rustls-platform-verifier",
  "slab",
  "sorted-index-buffer",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3955,7 +4031,7 @@ dependencies = [
  "serde",
  "sha1_smol",
  "simple-dns 0.9.3",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -4229,6 +4305,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,7 +4348,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -4279,7 +4370,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4416,6 +4507,15 @@ dependencies = [
  "ref-cast",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -4727,7 +4827,7 @@ checksum = "8bb47c2a50fdfdaf95b0ac8b12620fc327da1fd4adbb30d0c56d866b005873ff"
 dependencies = [
  "rustls-cert-read",
  "rustls-pki-types",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -4750,7 +4850,7 @@ dependencies = [
  "reloadable-state",
  "rustls",
  "rustls-cert-read",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5194,7 +5294,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -5262,6 +5362,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5323,7 +5432,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5407,7 +5516,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -5445,7 +5554,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -5470,7 +5579,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -5620,11 +5729,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5763,7 +5892,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-rustls",
@@ -5884,6 +6013,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5891,9 +6049,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5929,6 +6090,23 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tonic",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"
@@ -6011,7 +6189,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1 0.10.6",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6887,7 +7065,7 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "windows",
  "windows-core",
 ]
@@ -6911,7 +7089,7 @@ dependencies = [
  "pharos",
  "rustc_version",
  "send_wrapper",
- "thiserror",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -6931,7 +7109,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,6 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tempfile = "3.27.0"
 pkarr = { version = "=5.0.2", default-features = false, features = ["relays", "dht"] }
 tower-http = { version = "0.6.8", features = ["trace"] }
+tower_governor = "0.8.0"
 url = "2.5.8"
 uuid = { version = "1.23.1", features = ["serde", "v4"] }

--- a/crates/app-api/src/service/timeline_runtime_support.rs
+++ b/crates/app-api/src/service/timeline_runtime_support.rs
@@ -929,11 +929,42 @@ impl AppService {
     }
 }
 
+/// Upper bounds (in Unicode scalar values) for user-authored text that gets signed
+/// into envelopes and replicated to other peers. They bound the gossip/docs payload
+/// size and keep a single client from flooding the topic with oversized objects.
+pub(crate) const MAX_POST_CONTENT_CHARS: usize = 10_000;
+pub(crate) const MAX_REPOST_COMMENTARY_CHARS: usize = 2_000;
+pub(crate) const MAX_PROFILE_NAME_CHARS: usize = 64;
+pub(crate) const MAX_PROFILE_DISPLAY_NAME_CHARS: usize = 128;
+pub(crate) const MAX_PROFILE_ABOUT_CHARS: usize = 2_000;
+
 pub(crate) fn normalize_optional_text(value: Option<String>) -> Option<String> {
     value.and_then(|value| {
         let trimmed = value.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_string())
     })
+}
+
+/// Reject user text whose character count exceeds `max_chars`. Counting `chars()`
+/// keeps the limit user-facing (it matches what a person types) while still bounding
+/// the byte payload, since a scalar value is at most 4 bytes.
+pub(crate) fn ensure_text_within_limit(field: &str, value: &str, max_chars: usize) -> Result<()> {
+    let count = value.chars().count();
+    if count > max_chars {
+        anyhow::bail!("{field} must be at most {max_chars} characters (got {count})");
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_optional_text_within_limit(
+    field: &str,
+    value: Option<&str>,
+    max_chars: usize,
+) -> Result<()> {
+    match value {
+        Some(value) => ensure_text_within_limit(field, value, max_chars),
+        None => Ok(()),
+    }
 }
 
 pub(crate) fn profile_asset_view_from_ref(

--- a/crates/app-api/src/social.rs
+++ b/crates/app-api/src/social.rs
@@ -35,6 +35,22 @@ impl AppService {
 
     pub async fn set_my_profile(&self, input: ProfileInput) -> Result<Profile> {
         let author_pubkey = Pubkey::from(self.current_author_pubkey());
+        // Normalize and length-check the text fields before any blob upload so invalid
+        // input fails fast without persisting a side effect.
+        let name = normalize_optional_text(input.name);
+        let display_name = normalize_optional_text(input.display_name);
+        let about = normalize_optional_text(input.about);
+        ensure_optional_text_within_limit("profile name", name.as_deref(), MAX_PROFILE_NAME_CHARS)?;
+        ensure_optional_text_within_limit(
+            "profile display name",
+            display_name.as_deref(),
+            MAX_PROFILE_DISPLAY_NAME_CHARS,
+        )?;
+        ensure_optional_text_within_limit(
+            "profile about",
+            about.as_deref(),
+            MAX_PROFILE_ABOUT_CHARS,
+        )?;
         let current_profile = self.get_my_profile().await?;
         let picture = if input.clear_picture || input.picture_upload.is_some() {
             normalize_optional_text(input.picture)
@@ -61,9 +77,9 @@ impl AppService {
             self.keys.as_ref(),
             &KukuriProfileEnvelopeContentV1 {
                 author_pubkey: author_pubkey.clone(),
-                name: normalize_optional_text(input.name),
-                display_name: normalize_optional_text(input.display_name),
-                about: normalize_optional_text(input.about),
+                name,
+                display_name,
+                about,
                 picture,
                 picture_asset,
             },

--- a/crates/app-api/src/tests/timeline/profile.rs
+++ b/crates/app-api/src/tests/timeline/profile.rs
@@ -373,7 +373,12 @@ async fn create_repost_rejects_commentary_over_limit() {
 
     let oversized = "a".repeat(crate::service::MAX_REPOST_COMMENTARY_CHARS + 1);
     let error = app
-        .create_repost(topic, topic, source_object_id.as_str(), Some(oversized.as_str()))
+        .create_repost(
+            topic,
+            topic,
+            source_object_id.as_str(),
+            Some(oversized.as_str()),
+        )
         .await
         .expect_err("repost commentary over the limit should be rejected");
     assert!(

--- a/crates/app-api/src/tests/timeline/profile.rs
+++ b/crates/app-api/src/tests/timeline/profile.rs
@@ -342,6 +342,84 @@ async fn create_same_topic_repost_persists_repost_object_and_profile_repost_doc(
 }
 
 #[tokio::test]
+async fn create_post_rejects_content_over_limit() {
+    let (app, _store, _docs_sync, _blob_service) = local_app_with_memory_services();
+    let topic = "kukuri:topic:post-length";
+
+    let oversized = "a".repeat(crate::service::MAX_POST_CONTENT_CHARS + 1);
+    let error = app
+        .create_post(topic, oversized.as_str(), None)
+        .await
+        .expect_err("post content over the limit should be rejected");
+    assert!(
+        error.to_string().contains("post content"),
+        "unexpected error: {error}"
+    );
+
+    let at_limit = "a".repeat(crate::service::MAX_POST_CONTENT_CHARS);
+    app.create_post(topic, at_limit.as_str(), None)
+        .await
+        .expect("post content at the limit should be accepted");
+}
+
+#[tokio::test]
+async fn create_repost_rejects_commentary_over_limit() {
+    let (app, _store, _docs_sync, _blob_service) = local_app_with_memory_services();
+    let topic = "kukuri:topic:repost-length";
+    let source_object_id = app
+        .create_post(topic, "source", None)
+        .await
+        .expect("source post");
+
+    let oversized = "a".repeat(crate::service::MAX_REPOST_COMMENTARY_CHARS + 1);
+    let error = app
+        .create_repost(topic, topic, source_object_id.as_str(), Some(oversized.as_str()))
+        .await
+        .expect_err("repost commentary over the limit should be rejected");
+    assert!(
+        error.to_string().contains("repost commentary"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn set_my_profile_rejects_text_fields_over_limit() {
+    let (app, _store, _docs_sync, _blob_service) = local_app_with_memory_services();
+
+    let error = app
+        .set_my_profile(ProfileInput {
+            name: Some("a".repeat(crate::service::MAX_PROFILE_NAME_CHARS + 1)),
+            display_name: None,
+            about: None,
+            picture: None,
+            picture_upload: None,
+            clear_picture: false,
+        })
+        .await
+        .expect_err("profile name over the limit should be rejected");
+    assert!(
+        error.to_string().contains("profile name"),
+        "unexpected error: {error}"
+    );
+
+    let error = app
+        .set_my_profile(ProfileInput {
+            name: None,
+            display_name: None,
+            about: Some("a".repeat(crate::service::MAX_PROFILE_ABOUT_CHARS + 1)),
+            picture: None,
+            picture_upload: None,
+            clear_picture: false,
+        })
+        .await
+        .expect_err("profile about over the limit should be rejected");
+    assert!(
+        error.to_string().contains("profile about"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
 async fn list_profile_timeline_ignores_profile_post_with_signer_mismatch() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));

--- a/crates/app-api/src/timeline.rs
+++ b/crates/app-api/src/timeline.rs
@@ -87,6 +87,11 @@ impl AppService {
         source_object_id: &str,
         commentary: Option<&str>,
     ) -> Result<String> {
+        ensure_optional_text_within_limit(
+            "repost commentary",
+            commentary,
+            MAX_REPOST_COMMENTARY_CHARS,
+        )?;
         self.ensure_topic_subscription(target_topic_id).await?;
         self.ensure_topic_subscription(source_topic_id).await?;
 
@@ -293,6 +298,7 @@ impl AppService {
         reply_to: Option<&str>,
         attachments: Vec<PendingAttachment>,
     ) -> Result<String> {
+        ensure_text_within_limit("post content", content, MAX_POST_CONTENT_CHARS)?;
         self.ensure_topic_subscription(topic_id).await?;
         let topic = TopicId::new(topic_id);
         let parent = if let Some(reply_to) = reply_to {

--- a/crates/cn-core/src/auth.rs
+++ b/crates/cn-core/src/auth.rs
@@ -40,6 +40,10 @@ pub async fn create_auth_challenge(pool: &PgPool, pubkey: &str) -> Result<AuthCh
     let pubkey = normalize_pubkey(pubkey)?;
     let challenge = uuid::Uuid::new_v4().to_string();
     let expires_at = Utc::now() + Duration::seconds(AUTH_CHALLENGE_TTL_SECONDS);
+    // `/v1/auth/challenge` is unauthenticated, so without opportunistic cleanup the
+    // table would grow without bound under challenge spam. The index on `expires_at`
+    // keeps this DELETE cheap.
+    prune_expired_auth_challenges(pool).await?;
     sqlx::query(
         "INSERT INTO cn_auth.auth_challenges (challenge, pubkey, expires_at)
          VALUES ($1, $2, $3)",
@@ -53,6 +57,19 @@ pub async fn create_auth_challenge(pool: &PgPool, pubkey: &str) -> Result<AuthCh
         challenge,
         expires_at: expires_at.timestamp(),
     })
+}
+
+pub(crate) async fn prune_expired_auth_challenges<'e, E>(executor: E) -> Result<()>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    sqlx::query(
+        "DELETE FROM cn_auth.auth_challenges
+         WHERE expires_at <= NOW()",
+    )
+    .execute(executor)
+    .await?;
+    Ok(())
 }
 
 pub async fn verify_auth_envelope_and_issue_token(

--- a/crates/cn-core/src/config.rs
+++ b/crates/cn-core/src/config.rs
@@ -8,6 +8,7 @@ pub const AUTH_ENVELOPE_KIND: &str = "auth";
 pub const AUTH_CHALLENGE_TTL_SECONDS: i64 = 300;
 pub const AUTH_EVENT_MAX_SKEW_SECONDS: i64 = 600;
 pub const DEFAULT_TOKEN_TTL_SECONDS: i64 = 86_400;
+pub const MIN_JWT_SECRET_BYTES: usize = 32;
 pub const BOOTSTRAP_PEER_REGISTRATION_TTL_SECONDS: i64 = 90;
 pub const TOPIC_RENDEZVOUS_TTL_SECONDS: u64 = 45;
 pub const COMMUNITY_NODE_RENDEZVOUS_REDIS_URL_ENV: &str = "COMMUNITY_NODE_RENDEZVOUS_REDIS_URL";
@@ -42,6 +43,7 @@ impl JwtConfig {
             .unwrap_or_else(|| "kukuri-cn".to_string());
         let secret = std::env::var("COMMUNITY_NODE_JWT_SECRET")
             .context("COMMUNITY_NODE_JWT_SECRET is required")?;
+        validate_jwt_secret(secret.as_str())?;
         let ttl_seconds = std::env::var("COMMUNITY_NODE_JWT_TTL_SECONDS")
             .ok()
             .filter(|value| !value.trim().is_empty())
@@ -67,6 +69,28 @@ impl JwtConfig {
     pub(crate) fn decoding_key(&self) -> DecodingKey {
         DecodingKey::from_secret(self.secret.as_bytes())
     }
+}
+
+/// Reject weak or placeholder JWT secrets at startup so a community node never
+/// runs with a brute-forceable or sample signing key.
+pub(crate) fn validate_jwt_secret(secret: &str) -> Result<()> {
+    if secret.len() < MIN_JWT_SECRET_BYTES {
+        bail!(
+            "COMMUNITY_NODE_JWT_SECRET must be at least {MIN_JWT_SECRET_BYTES} bytes; got {}",
+            secret.len()
+        );
+    }
+    const PLACEHOLDER_MARKERS: [&str; 2] = ["change-me", "change_me"];
+    let lowered = secret.to_ascii_lowercase();
+    if PLACEHOLDER_MARKERS
+        .iter()
+        .any(|marker| lowered.contains(marker))
+    {
+        bail!(
+            "COMMUNITY_NODE_JWT_SECRET still contains a placeholder value; set a strong unique secret"
+        );
+    }
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/cn-core/src/tests/config.rs
+++ b/crates/cn-core/src/tests/config.rs
@@ -15,3 +15,29 @@ fn auth_rollout_defaults_to_off() {
     let rollout = crate::AuthRolloutConfig::default();
     assert!(!rollout.requires_auth(chrono::Utc::now().timestamp()));
 }
+
+#[test]
+fn jwt_secret_validation_accepts_strong_secret() {
+    crate::config::validate_jwt_secret("0123456789abcdef0123456789abcdef")
+        .expect("32-byte secret should be accepted");
+}
+
+#[test]
+fn jwt_secret_validation_rejects_short_secret() {
+    let error = crate::config::validate_jwt_secret("too-short-secret")
+        .expect_err("secret shorter than the minimum should be rejected");
+    assert!(
+        error.to_string().contains("at least"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn jwt_secret_validation_rejects_placeholder_value() {
+    let error = crate::config::validate_jwt_secret("dev-jwt-change-me-32-bytes-minimum")
+        .expect_err("placeholder secret should be rejected");
+    assert!(
+        error.to_string().contains("placeholder"),
+        "unexpected error: {error}"
+    );
+}

--- a/crates/cn-user-api/Cargo.toml
+++ b/crates/cn-user-api/Cargo.toml
@@ -17,6 +17,7 @@ serde_json.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
 tower-http.workspace = true
+tower_governor.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true

--- a/crates/cn-user-api/src/lib.rs
+++ b/crates/cn-user-api/src/lib.rs
@@ -20,6 +20,9 @@ use kukuri_cn_core::{
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sqlx::postgres::PgPool;
+use tower_governor::GovernorLayer;
+use tower_governor::governor::GovernorConfigBuilder;
+use tower_governor::key_extractor::SmartIpKeyExtractor;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::EnvFilter;
 
@@ -115,6 +118,100 @@ impl UserApiConfig {
     }
 }
 
+/// Optional per-client rate limit for the public HTTP surface.
+///
+/// Disabled by default in code so unit/contract tests and library embeddings are
+/// never throttled; the shipped `.env.community-node.example` turns it on. Behind a
+/// trusted reverse proxy set `trust_forwarded_for` so each real client is limited
+/// individually instead of sharing the proxy's connection IP. Leave it `false` when
+/// the API is directly exposed, since `X-Forwarded-For` is attacker-controlled there.
+#[derive(Clone, Copy, Debug)]
+pub struct RateLimitConfig {
+    pub enabled: bool,
+    pub per_second: u64,
+    pub burst: u32,
+    pub trust_forwarded_for: bool,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            per_second: 10,
+            burst: 30,
+            trust_forwarded_for: false,
+        }
+    }
+}
+
+impl RateLimitConfig {
+    pub fn from_env() -> Result<Self> {
+        let defaults = Self::default();
+        Ok(Self {
+            enabled: parse_bool_env("COMMUNITY_NODE_RATE_LIMIT_ENABLED", defaults.enabled)?,
+            per_second: parse_u64_env(
+                "COMMUNITY_NODE_RATE_LIMIT_PER_SECOND",
+                defaults.per_second,
+            )?
+            .max(1),
+            burst: parse_u32_env("COMMUNITY_NODE_RATE_LIMIT_BURST", defaults.burst)?.max(1),
+            trust_forwarded_for: parse_bool_env(
+                "COMMUNITY_NODE_RATE_LIMIT_TRUST_FORWARDED_FOR",
+                defaults.trust_forwarded_for,
+            )?,
+        })
+    }
+
+    fn replenish_period_ms(&self) -> u64 {
+        (1_000 / self.per_second.max(1)).max(1)
+    }
+}
+
+/// Apply the rate limit layer to `router` when enabled. Layering returns a plain
+/// `Router` regardless of the key-extractor type, so both branches unify cleanly.
+/// A background task periodically drops idle per-IP buckets so a flood of distinct
+/// source IPs cannot grow the limiter's state without bound; `retain_recent` resolves
+/// through the `Arc`'s deref to the concrete governor limiter, so no governor-internal
+/// type needs to be named here.
+pub fn apply_rate_limit(router: Router, config: &RateLimitConfig) -> Result<Router> {
+    if !config.enabled {
+        return Ok(router);
+    }
+    let period_ms = config.replenish_period_ms();
+    if config.trust_forwarded_for {
+        let governor = GovernorConfigBuilder::default()
+            .per_millisecond(period_ms)
+            .burst_size(config.burst)
+            .key_extractor(SmartIpKeyExtractor)
+            .finish()
+            .context("failed to build rate limit configuration")?;
+        let limiter = governor.limiter().clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                limiter.retain_recent();
+            }
+        });
+        Ok(router.layer(GovernorLayer::new(governor)))
+    } else {
+        let governor = GovernorConfigBuilder::default()
+            .per_millisecond(period_ms)
+            .burst_size(config.burst)
+            .finish()
+            .context("failed to build rate limit configuration")?;
+        let limiter = governor.limiter().clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                limiter.retain_recent();
+            }
+        });
+        Ok(router.layer(GovernorLayer::new(governor)))
+    }
+}
+
 pub async fn build_state(config: &UserApiConfig) -> Result<UserApiState> {
     let pool = connect_postgres(config.database_url.as_str()).await?;
     initialize_database(&pool).await?;
@@ -169,8 +266,17 @@ pub async fn run_from_env() -> Result<()> {
 
     let config = UserApiConfig::from_env()?;
     let bind_addr = config.bind_addr;
+    let rate_limit = RateLimitConfig::from_env()?;
     let state = build_runtime_state(&config).await?;
-    let app = app_router(state);
+    let app = apply_rate_limit(app_router(state), &rate_limit)?;
+    if rate_limit.enabled {
+        tracing::info!(
+            per_second = rate_limit.per_second,
+            burst = rate_limit.burst,
+            trust_forwarded_for = rate_limit.trust_forwarded_for,
+            "community-node user-api rate limit enabled"
+        );
+    }
     let listener = tokio::net::TcpListener::bind(bind_addr)
         .await
         .with_context(|| format!("failed to bind user api at {bind_addr}"))?;
@@ -327,6 +433,39 @@ fn internal_error(error: impl std::fmt::Display) -> ApiError {
         "INTERNAL_ERROR",
         error.to_string(),
     )
+}
+
+fn parse_bool_env(var_name: &str, default: bool) -> Result<bool> {
+    match std::env::var(var_name) {
+        Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
+            "" => Ok(default),
+            "1" | "true" | "yes" | "on" => Ok(true),
+            "0" | "false" | "no" | "off" => Ok(false),
+            other => Err(anyhow::anyhow!("failed to parse {var_name}: `{other}`")),
+        },
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(anyhow::anyhow!("{var_name}: {error}")),
+    }
+}
+
+fn parse_u64_env(var_name: &str, default: u64) -> Result<u64> {
+    match std::env::var(var_name) {
+        Ok(value) if !value.trim().is_empty() => value
+            .trim()
+            .parse::<u64>()
+            .with_context(|| format!("failed to parse {var_name}")),
+        _ => Ok(default),
+    }
+}
+
+fn parse_u32_env(var_name: &str, default: u32) -> Result<u32> {
+    match std::env::var(var_name) {
+        Ok(value) if !value.trim().is_empty() => value
+            .trim()
+            .parse::<u32>()
+            .with_context(|| format!("failed to parse {var_name}")),
+        _ => Ok(default),
+    }
 }
 
 fn parse_csv_env(var_name: &str) -> Vec<String> {

--- a/crates/cn-user-api/src/lib.rs
+++ b/crates/cn-user-api/src/lib.rs
@@ -149,11 +149,8 @@ impl RateLimitConfig {
         let defaults = Self::default();
         Ok(Self {
             enabled: parse_bool_env("COMMUNITY_NODE_RATE_LIMIT_ENABLED", defaults.enabled)?,
-            per_second: parse_u64_env(
-                "COMMUNITY_NODE_RATE_LIMIT_PER_SECOND",
-                defaults.per_second,
-            )?
-            .max(1),
+            per_second: parse_u64_env("COMMUNITY_NODE_RATE_LIMIT_PER_SECOND", defaults.per_second)?
+                .max(1),
             burst: parse_u32_env("COMMUNITY_NODE_RATE_LIMIT_BURST", defaults.burst)?.max(1),
             trust_forwarded_for: parse_bool_env(
                 "COMMUNITY_NODE_RATE_LIMIT_TRUST_FORWARDED_FOR",

--- a/crates/cn-user-api/tests/contract.rs
+++ b/crates/cn-user-api/tests/contract.rs
@@ -707,6 +707,67 @@ async fn topic_rendezvous_keys_do_not_expose_raw_topic_ids() -> Result<()> {
 }
 
 #[tokio::test]
+async fn auth_challenge_prunes_expired_challenges() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server =
+        TestServer::spawn(admin_database_url.as_str(), "cn_user_api_challenge_gc").await?;
+    let client = Client::new();
+    let pool = PgPool::connect(server.database.database_url.as_str()).await?;
+
+    let keys = generate_keys();
+    // Issue a challenge and force it past its expiry without consuming it.
+    let stale = client
+        .post(format!("{}/v1/auth/challenge", server.base_url))
+        .json(&serde_json::json!({ "pubkey": keys.public_key_hex() }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<kukuri_cn_core::AuthChallengeResponse>()
+        .await?;
+    sqlx::query(
+        "UPDATE cn_auth.auth_challenges
+         SET expires_at = NOW() - INTERVAL '1 second'
+         WHERE challenge = $1",
+    )
+    .bind(stale.challenge.as_str())
+    .execute(&pool)
+    .await?;
+
+    let expired_before: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM cn_auth.auth_challenges WHERE expires_at <= NOW()",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(expired_before, 1);
+
+    // A fresh challenge request must opportunistically prune the expired row.
+    client
+        .post(format!("{}/v1/auth/challenge", server.base_url))
+        .json(&serde_json::json!({ "pubkey": generate_keys().public_key_hex() }))
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let expired_after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM cn_auth.auth_challenges WHERE expires_at <= NOW()",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(expired_after, 0);
+    let stale_remaining: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM cn_auth.auth_challenges WHERE challenge = $1")
+            .bind(stale.challenge.as_str())
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(stale_remaining, 0);
+
+    server.shutdown().await
+}
+
+#[tokio::test]
 async fn auth_verify_rejects_capability_url_mismatch() -> Result<()> {
     let Some(admin_database_url) = integration_test_admin_database_url() else {
         eprintln!("skipping cn-user-api integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");

--- a/crates/cn-user-api/tests/contract.rs
+++ b/crates/cn-user-api/tests/contract.rs
@@ -712,8 +712,7 @@ async fn auth_challenge_prunes_expired_challenges() -> Result<()> {
         eprintln!("skipping cn-user-api integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
         return Ok(());
     };
-    let server =
-        TestServer::spawn(admin_database_url.as_str(), "cn_user_api_challenge_gc").await?;
+    let server = TestServer::spawn(admin_database_url.as_str(), "cn_user_api_challenge_gc").await?;
     let client = Client::new();
     let pool = PgPool::connect(server.database.database_url.as_str()).await?;
 

--- a/crates/cn-user-api/tests/rate_limit.rs
+++ b/crates/cn-user-api/tests/rate_limit.rs
@@ -1,0 +1,83 @@
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use axum::Router;
+use axum::routing::get;
+use kukuri_cn_user_api::{RateLimitConfig, apply_rate_limit};
+use reqwest::{Client, StatusCode};
+
+async fn spawn_router(config: RateLimitConfig) -> Result<String> {
+    let app = apply_rate_limit(
+        Router::new().route("/healthz", get(|| async { "ok" })),
+        &config,
+    )?;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .expect("rate limit test server");
+    });
+    Ok(format!("http://{addr}"))
+}
+
+#[tokio::test]
+async fn rate_limit_rejects_requests_beyond_burst() -> Result<()> {
+    let base_url = spawn_router(RateLimitConfig {
+        enabled: true,
+        per_second: 1,
+        burst: 2,
+        trust_forwarded_for: false,
+    })
+    .await?;
+    let client = Client::new();
+
+    let mut statuses = Vec::new();
+    for _ in 0..10 {
+        let status = client
+            .get(format!("{base_url}/healthz"))
+            .send()
+            .await?
+            .status();
+        statuses.push(status);
+    }
+
+    assert!(
+        statuses.contains(&StatusCode::OK),
+        "expected the burst allowance to let some requests through: {statuses:?}"
+    );
+    assert!(
+        statuses.contains(&StatusCode::TOO_MANY_REQUESTS),
+        "expected requests beyond the burst to be rate limited: {statuses:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn rate_limit_disabled_passes_all_requests() -> Result<()> {
+    let base_url = spawn_router(RateLimitConfig {
+        enabled: false,
+        per_second: 1,
+        burst: 1,
+        trust_forwarded_for: false,
+    })
+    .await?;
+    let client = Client::new();
+
+    for _ in 0..10 {
+        let status = client
+            .get(format!("{base_url}/healthz"))
+            .send()
+            .await?
+            .status();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "disabled rate limit must not throttle"
+        );
+    }
+    Ok(())
+}

--- a/docker-compose.community-node.yml
+++ b/docker-compose.community-node.yml
@@ -15,6 +15,7 @@ services:
   cn-postgres:
     image: postgres:17-bookworm
     environment: *cn-postgres-env
+    restart: unless-stopped
     ports:
       - "${CN_POSTGRES_HOST_BIND_IP:-127.0.0.1}:${CN_POSTGRES_PORT:-55432}:5432"
     healthcheck:
@@ -31,6 +32,7 @@ services:
 
   cn-valkey:
     image: valkey/valkey:8-alpine
+    restart: unless-stopped
     ports:
       - "${CN_VALKEY_HOST_BIND_IP:-127.0.0.1}:${CN_VALKEY_PORT:-56379}:6379"
     healthcheck:
@@ -77,6 +79,17 @@ services:
       COMMUNITY_NODE_JWT_ISSUER: ${COMMUNITY_NODE_JWT_ISSUER:-kukuri-cn}
       COMMUNITY_NODE_JWT_SECRET: ${COMMUNITY_NODE_JWT_SECRET:?set COMMUNITY_NODE_JWT_SECRET}
       COMMUNITY_NODE_JWT_TTL_SECONDS: ${COMMUNITY_NODE_JWT_TTL_SECONDS:-86400}
+      COMMUNITY_NODE_RATE_LIMIT_ENABLED: ${COMMUNITY_NODE_RATE_LIMIT_ENABLED:-true}
+      COMMUNITY_NODE_RATE_LIMIT_PER_SECOND: ${COMMUNITY_NODE_RATE_LIMIT_PER_SECOND:-10}
+      COMMUNITY_NODE_RATE_LIMIT_BURST: ${COMMUNITY_NODE_RATE_LIMIT_BURST:-30}
+      COMMUNITY_NODE_RATE_LIMIT_TRUST_FORWARDED_FOR: ${COMMUNITY_NODE_RATE_LIMIT_TRUST_FORWARDED_FOR:-false}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     ports:
       - "${CN_USER_API_HOST_BIND_IP:-127.0.0.1}:${CN_USER_API_PORT:-18080}:8080"
 
@@ -87,6 +100,7 @@ services:
       args:
         TARGET_PACKAGE: kukuri-cn-iroh-relay
         TARGET_BIN: cn-iroh-relay
+    restart: unless-stopped
     environment:
       COMMUNITY_NODE_IROH_RELAY_HTTP_BIND_ADDR: ${CN_IROH_RELAY_HTTP_BIND_ADDR:-0.0.0.0:3340}
       COMMUNITY_NODE_IROH_RELAY_HTTPS_BIND_ADDR: ${CN_IROH_RELAY_HTTPS_BIND_ADDR:-}

--- a/docker/cn/Dockerfile
+++ b/docker/cn/Dockerfile
@@ -17,7 +17,7 @@ FROM debian:bookworm-slim AS runtime
 ARG TARGET_BIN
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN test -n "$TARGET_BIN"

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -63,7 +63,9 @@ docker compose --env-file .env.community-node -f docker-compose.community-node.y
 ## community-node env 標準形
 - `.env.community-node.example` をコピーして `.env.community-node` を作り、compose では `--env-file .env.community-node` を使う
 - secret は `CN_POSTGRES_PASSWORD` と `COMMUNITY_NODE_JWT_SECRET` の 2 つを最低限上書きする
+- `COMMUNITY_NODE_JWT_SECRET` は起動時に検証される。32 byte 未満、または `change-me` を含む placeholder のままだと `cn-user-api` は fail-fast する
 - `COMMUNITY_NODE_JWT_SECRET` を rotate すると既存 bearer token は即時無効化される
+- `cn-user-api` の HTTP レート制限は `COMMUNITY_NODE_RATE_LIMIT_ENABLED`(既定 example では true)、`..._PER_SECOND` / `..._BURST` / `..._TRUST_FORWARDED_FOR` で調整する。Caddy などの信頼できる reverse proxy 配下でのみ `..._TRUST_FORWARDED_FOR=true` にしてクライアント単位で制限する（直公開時は X-Forwarded-For 詐称を避けるため false）
 - `COMMUNITY_NODE_DATABASE_URL` は compose 内では `cn-postgres` 向けに組み立てる。外部 Postgres を使う場合だけ個別に差し替える
 
 ## community-node 公開 manual smoke

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -676,7 +676,7 @@ fn is_ci() -> bool {
 fn cn_compose_envs() -> [(&'static str, &'static str); 2] {
     [
         ("CN_POSTGRES_PASSWORD", "cn_password"),
-        ("COMMUNITY_NODE_JWT_SECRET", "xtask-test-secret"),
+        ("COMMUNITY_NODE_JWT_SECRET", "xtask-test-secret-0123456789abcdef"),
     ]
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -676,7 +676,10 @@ fn is_ci() -> bool {
 fn cn_compose_envs() -> [(&'static str, &'static str); 2] {
     [
         ("CN_POSTGRES_PASSWORD", "cn_password"),
-        ("COMMUNITY_NODE_JWT_SECRET", "xtask-test-secret-0123456789abcdef"),
+        (
+            "COMMUNITY_NODE_JWT_SECRET",
+            "xtask-test-secret-0123456789abcdef",
+        ),
     ]
 }
 


### PR DESCRIPTION
## 概要

[Webサービス公開前チェックリスト (zenn / catnose99)](https://zenn.dev/catnose99/articles/547cbf57e5ad28) を基に、kukuri のクライアント（app-api）とコミュニティノード（cn-*）を監査し、優先度の高い指摘に対応しました。kukuri は Web サービスではありませんが、コミュニティノードの HTTP/サーバ運用とクライアントのユーザー入力に同等の観点が当てはまります。

監査で「対応済み」と確認できた良好な点（参考）: SQL は全てパラメータバインドで SQLi 対策済み、Tauri CSP は厳格、秘密鍵は OS キーリング保管、入力 URL のスキーム制限あり。

## 変更内容

### community-node (cn-*)
- **JWT secret の起動時検証**: `COMMUNITY_NODE_JWT_SECRET` が 32 byte 未満、または `change-me` を含む placeholder のままだと `cn-user-api` が fail-fast。弱い署名鍵での運用を防止。
- **期限切れ `auth_challenges` の掃除**: 無認証の `/v1/auth/challenge` が呼ばれるたびに期限切れ行を prune（既存の `expires_at` インデックスを利用）。無制限 INSERT によるテーブル肥大を解消。
- **HTTP レート制限 (tower_governor)**: cn-user-api に per-client レート制限を追加。env (`COMMUNITY_NODE_RATE_LIMIT_ENABLED` / `_PER_SECOND` / `_BURST` / `_TRUST_FORWARDED_FOR`) で設定可能。**コード既定は無効**（テスト/埋め込みを絞らない）、`.env.community-node.example` は**有効**。信頼できる reverse proxy 配下でのみ `_TRUST_FORWARDED_FOR=true`（直公開時は XFF 詐称を避けて false）。アプリ層適用は本番起動経路のみで、`app_router` の署名は不変。
- **運用ハードニング**: docker-compose の常駐サービスに `restart: unless-stopped`、`cn-user-api` に `/healthz` healthcheck を追加（Dockerfile に `curl` を追加）。

### app-api (client)
- **ユーザー入力の最大長検証**: 投稿本文 (10,000)、リポストコメント (2,000)、プロフィール name (64) / display_name (128) / about (2,000) を文字数（Unicode スカラー値）で上限検証。P2P で署名・複製されるペイロードを bound。検証はサービス層に置き、全クライアント呼び出しに適用。プロフィールはアバターのブロブアップロード前に検証して副作用なく fail-fast。

## テスト
すべて failing-first で再現を確認してから実装しています。

- `cn-core`: JWT secret 検証 3 件（強い秘密 OK / 短すぎ拒否 / placeholder 拒否）
- `cn-user-api`: 期限切れ challenge の prune contract（実 Postgres）、レート制限 2 件（バースト超過で 429 / 無効時は素通し）
- `app-api`: 入力長 3 件（本文・コメント・プロフィール。本文は上限ちょうどで受理する境界も確認）

ローカルで `cargo test -p kukuri-cn-core -p kukuri-app-api`、Postgres/Valkey 起動下の `cargo test -p kukuri-cn-user-api`、変更 crate の `clippy` を実行し全て green。

## 補足 / 未対応
- 採用した文字数上限・レート値は仕様未定義のため妥当な初期値です（DESIGN.md に明示仕様なし）。
- 監査で挙げた残項目（ハンドル名の予約語/形式制限、エラー監視・通知、Valkey 永続化方針、フロントエンドの入力 UI 制限）は本 PR の対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
