### PR TITLE
feat(cn-operator): コミュニティノード運営者向け文書生成CLI (#352)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,6 +2948,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kukuri-cn-operator"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+]
+
+[[package]]
 name = "kukuri-cn-user-api"
 version = "0.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/cn-user-api",
     "crates/cn-iroh-relay",
     "crates/cn-cli",
+    "crates/cn-operator",
 ]
 exclude = [
     "apps/desktop/src-tauri",

--- a/crates/cn-operator/Cargo.toml
+++ b/crates/cn-operator/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "kukuri-cn-operator"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "kukuri_cn_operator"
+path = "src/lib.rs"
+
+[[bin]]
+name = "cn-operator"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/cn-operator/src/capability.rs
+++ b/crates/cn-operator/src/capability.rs
@@ -1,0 +1,361 @@
+//! community node の capability モデル。
+//!
+//! #352 の operator docs generator は、各機能を boolean トグルとしてだけでなく、
+//! 説明責任・外部送信・保持影響を持つ capability として扱う。
+//!
+//! ここで重要なのは `Availability` による Phase A / Phase B の分離である。
+//!
+//! - `Availability::Available` (Phase A): 現行の community node 実装が実際に提供できる、
+//!   またはデプロイ構成として確定できる capability。生成文書では「運用中」として開示してよい。
+//! - `Availability::Planned` (Phase B): 現行実装に存在しない capability（index / moderation /
+//!   trust signal / report endpoint など）。config 上は宣言できるが、生成文書では
+//!   「計画中・この配布物では未提供」として扱い、運用中の外部送信・データ取扱い開示には載せない。
+//!
+//! これは `docs/architecture/p2p-first-community-node-responsibility-boundary.md` の
+//! 「node manifest が宣言した capability / authority scope が責任範囲の上限」という方針に従い、
+//! 「宣言」と「実際に実行可能」を分離して、実体のない開示を生成しないためのガードである。
+
+use std::fmt;
+
+/// capability が現行配布物で実行可能か（Phase A）、設計のみ（Phase B）か。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Availability {
+    /// Phase A: 現行実装またはデプロイ構成として提供可能。運用中として開示してよい。
+    Available,
+    /// Phase B: 設計・spec のみ。生成文書では「計画中・未提供」として扱う。
+    Planned,
+}
+
+impl Availability {
+    pub fn is_planned(self) -> bool {
+        matches!(self, Availability::Planned)
+    }
+
+    /// 文書中の日本語ラベル。
+    pub fn label_ja(self) -> &'static str {
+        match self {
+            Availability::Available => "提供中",
+            Availability::Planned => "計画中（この配布物では未提供）",
+        }
+    }
+}
+
+/// community node が提供し得る capability。
+///
+/// `ALL` の並び順が生成文書・manifest の決定論的な出力順序になる。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Capability {
+    // --- Phase A: 現行実装 / デプロイ構成 ---
+    AuthConsent,
+    BootstrapAssist,
+    TopicRendezvous,
+    IrohRelay,
+    TrafficRelayFallback,
+    BlobCache,
+    PrivateMessageStorage,
+    Analytics,
+    CrashReport,
+    CloudflareProxy,
+    PushNotification,
+    // --- Phase B: 未実装（spec のみ） ---
+    CommunityIndex,
+    Moderation,
+    CommunityLocalTrust,
+    ReportEndpoint,
+}
+
+impl Capability {
+    /// 決定論的な出力順序を与える全 capability。
+    pub const ALL: [Capability; 15] = [
+        Capability::AuthConsent,
+        Capability::BootstrapAssist,
+        Capability::TopicRendezvous,
+        Capability::IrohRelay,
+        Capability::TrafficRelayFallback,
+        Capability::BlobCache,
+        Capability::PrivateMessageStorage,
+        Capability::Analytics,
+        Capability::CrashReport,
+        Capability::CloudflareProxy,
+        Capability::PushNotification,
+        Capability::CommunityIndex,
+        Capability::Moderation,
+        Capability::CommunityLocalTrust,
+        Capability::ReportEndpoint,
+    ];
+
+    /// config / manifest の snake_case キー。
+    pub fn key(self) -> &'static str {
+        match self {
+            Capability::AuthConsent => "auth_consent",
+            Capability::BootstrapAssist => "bootstrap_assist",
+            Capability::TopicRendezvous => "topic_rendezvous",
+            Capability::IrohRelay => "iroh_relay",
+            Capability::TrafficRelayFallback => "traffic_relay_fallback",
+            Capability::BlobCache => "blob_cache",
+            Capability::PrivateMessageStorage => "private_message_storage",
+            Capability::Analytics => "analytics",
+            Capability::CrashReport => "crash_report",
+            Capability::CloudflareProxy => "cloudflare_proxy",
+            Capability::PushNotification => "push_notification",
+            Capability::CommunityIndex => "community_index",
+            Capability::Moderation => "moderation",
+            Capability::CommunityLocalTrust => "community_local_trust",
+            Capability::ReportEndpoint => "report_endpoint",
+        }
+    }
+
+    pub fn availability(self) -> Availability {
+        match self {
+            Capability::CommunityIndex
+            | Capability::Moderation
+            | Capability::CommunityLocalTrust
+            | Capability::ReportEndpoint => Availability::Planned,
+            _ => Availability::Available,
+        }
+    }
+
+    pub fn display_name(self) -> &'static str {
+        self.meta().display_name
+    }
+
+    /// 文書生成用の静的メタデータ。
+    pub fn meta(self) -> CapabilityMeta {
+        match self {
+            Capability::AuthConsent => CapabilityMeta {
+                capability: self,
+                display_name: "認証・同意 (auth / consent)",
+                handled_data: "ユーザー公開鍵、署名付き認証エンベロープ、同意ステータス、JWT 発行記録",
+                purpose: "community node の補助機能を利用する client の認証と、利用規約・ポリシーへの同意取得",
+                retention_impact: "認証チャレンジは短期 TTL、同意レコードは撤回まで保持",
+                external_transmission: None,
+                telecom_note: "認証はノード自身が処理する。回線設備の設置を伴わない。",
+                privacy_note: "公開鍵と同意状態を扱う。IP アドレス・接続ログの扱いは接続ログ保持期間に従う。",
+                terms_note: "本ノードの補助機能利用には認証と同意が必要である旨を記載する。",
+            },
+            Capability::BootstrapAssist => CapabilityMeta {
+                capability: self,
+                display_name: "ブートストラップ補助 (bootstrap assist)",
+                handled_data: "ピアの接続ヒント（node id / addr hint）、一時的な登録エントリ",
+                purpose: "新規 client が P2P network へ最初に到達するための seed peer 情報の提供",
+                retention_impact: "ピア登録は短期 TTL で失効する ephemeral state",
+                external_transmission: None,
+                telecom_note: "接続ヒントの中継のみ。実データの伝送経路を恒久的に保持しない。",
+                privacy_note: "一時的な接続情報を扱う。長期保存はしない。",
+                terms_note: "P2P 接続を補助する目的であり、通信内容を保持しない旨を記載する。",
+            },
+            Capability::TopicRendezvous => CapabilityMeta {
+                capability: self,
+                display_name: "トピックランデブー (topic rendezvous)",
+                handled_data: "topic ごとの presence 情報（node id / 接続ヒント）、TTL 付き ephemeral state",
+                purpose: "同一 topic を購読する client 同士の Relay Supported P2P 接続成立を補助する",
+                retention_impact: "presence は KV 上の TTL 付き ephemeral state で短期失効する",
+                external_transmission: None,
+                telecom_note: "presence の一時的な突き合わせのみ。実データ伝送の恒久経路を持たない。",
+                privacy_note: "どの topic に接続中かの一時情報を扱う。長期保存はしない。",
+                terms_note: "topic 接続の補助であり、投稿内容を保持しない旨を記載する。",
+            },
+            Capability::IrohRelay => CapabilityMeta {
+                capability: self,
+                display_name: "iroh relay 補助 (iroh relay assist)",
+                handled_data: "NAT traversal / hole punching のためのシグナリング、暗号化済みパケットの中継",
+                purpose: "Direct P2P が成立しない場合の hole punching / endpoint assist",
+                retention_impact: "中継は経路上の一時処理であり、内容を恒久保存しない",
+                external_transmission: Some(ExternalDestination::DedicatedIrohRelay),
+                telecom_note: "iroh relay は単なる signaling ではなく、NAT 越えのために暗号化済み traffic の中継が発生し得る。届出要否は構成と所在地に依存するため事前確認が必要。",
+                privacy_note: "中継時に接続元の IP アドレスを観測し得る。接続ログ保持期間に従って扱う。",
+                terms_note: "relay 経由の接続補助が行われ得る旨を記載する。",
+            },
+            Capability::TrafficRelayFallback => CapabilityMeta {
+                capability: self,
+                display_name: "トラフィック relay フォールバック (traffic relay fallback)",
+                handled_data: "Direct P2P / Relay Supported P2P が成立しない場合の暗号化済み実データ通信",
+                purpose: "他のすべての経路が成立しない場合に限り、暗号化済み traffic を relay 経由で疎通させる",
+                retention_impact: "中継のみで内容は恒久保存しない。接続メタデータは接続ログ保持期間に従う",
+                external_transmission: Some(ExternalDestination::PublicRelay),
+                telecom_note: "暗号化済みであっても traffic relay fallback は実データの伝送経路となり得る。signaling only と混同せず、届出要否を事前確認する。",
+                privacy_note: "fallback 時に接続元 IP アドレスやタイミングメタデータを観測し得る。",
+                terms_note: "最終手段として暗号化済み通信が relay 経由になり得る旨を記載する。",
+            },
+            Capability::BlobCache => CapabilityMeta {
+                capability: self,
+                display_name: "blob / 添付キャッシュ (blob cache)",
+                handled_data: "添付メディアの一時キャッシュ、blob の content address (CID)",
+                purpose: "添付メディアの配信補助・可用性向上のための一時キャッシュ",
+                retention_impact: "キャッシュは一時保持であり、community node は blob 本体を恒久保存しない方針",
+                external_transmission: Some(ExternalDestination::ObjectStorage),
+                telecom_note: "メディア配信補助。恒久保存を行わない方針を明記する。",
+                privacy_note: "添付メディアを一時的に扱う。保持期間と削除方針を明記する。",
+                terms_note: "添付メディアが一時的にキャッシュされ得る旨を記載する。",
+            },
+            Capability::PrivateMessageStorage => CapabilityMeta {
+                capability: self,
+                display_name: "プライベートメッセージ保管 (private message storage)",
+                handled_data: "暗号化されたプライベートメッセージの保管データ",
+                purpose: "オフライン配送のためのプライベートメッセージの一時保管",
+                retention_impact: "保管期間はノードの設定に従う。既定では無効。",
+                external_transmission: None,
+                telecom_note: "メッセージ保管はノード内処理。回線設備の設置を伴わない。",
+                privacy_note: "プライベートメッセージを扱うため、保持期間・暗号化・アクセス制御を明記する。",
+                terms_note: "プライベートメッセージが一時保管され得る旨と暗号化方針を記載する。",
+            },
+            Capability::Analytics => CapabilityMeta {
+                capability: self,
+                display_name: "アナリティクス (analytics)",
+                handled_data: "利用状況の統計データ、イベントログ",
+                purpose: "サービス改善のための利用状況分析",
+                retention_impact: "分析プロバイダのポリシーに従う。既定では無効。",
+                external_transmission: Some(ExternalDestination::AnalyticsProvider),
+                telecom_note: "分析目的のデータ送信が発生し得る。",
+                privacy_note: "利用状況データを第三者の分析プロバイダへ送信し得る旨を明記する。",
+                terms_note: "アナリティクス目的のデータ収集が行われ得る旨を記載する。",
+            },
+            Capability::CrashReport => CapabilityMeta {
+                capability: self,
+                display_name: "クラッシュレポート (crash reporting)",
+                handled_data: "クラッシュ時の診断データ、スタックトレース",
+                purpose: "不具合の検出と修正のためのクラッシュ情報収集",
+                retention_impact: "クラッシュレポートプロバイダのポリシーに従う。既定では無効。",
+                external_transmission: Some(ExternalDestination::CrashReportProvider),
+                telecom_note: "診断目的のデータ送信が発生し得る。",
+                privacy_note: "クラッシュ診断データを第三者プロバイダへ送信し得る旨を明記する。",
+                terms_note: "クラッシュレポートが送信され得る旨を記載する。",
+            },
+            Capability::CloudflareProxy => CapabilityMeta {
+                capability: self,
+                display_name: "Cloudflare プロキシ / CDN / WAF",
+                handled_data: "HTTP リクエスト・レスポンス、接続元 IP アドレス（Cloudflare 経由）",
+                purpose: "リバースプロキシ・CDN・WAF による配信補助と保護",
+                retention_impact: "Cloudflare のログ・キャッシュポリシーに従う",
+                external_transmission: Some(ExternalDestination::Cloudflare),
+                telecom_note: "通信が Cloudflare を経由する。所在地・データ越境の観点を確認する。",
+                privacy_note: "リクエストと接続元 IP が Cloudflare を経由する旨を外部送信として明記する。",
+                terms_note: "通信が Cloudflare を経由し得る旨を記載する。",
+            },
+            Capability::PushNotification => CapabilityMeta {
+                capability: self,
+                display_name: "プッシュ通知 (push notification)",
+                handled_data: "デバイストークン、通知ペイロード",
+                purpose: "OS プッシュ通知の配信",
+                retention_impact: "デバイストークンは登録解除まで保持。通知ペイロードは配送後保持しない方針",
+                external_transmission: Some(ExternalDestination::PushProvider),
+                telecom_note: "プッシュ通知プロバイダ経由の送信が発生する。",
+                privacy_note: "デバイストークンと通知内容をプッシュプロバイダへ送信する旨を明記する。",
+                terms_note: "プッシュ通知のためにデバイストークンを扱う旨を記載する。",
+            },
+            Capability::CommunityIndex => CapabilityMeta {
+                capability: self,
+                display_name: "コミュニティインデックス (community index)",
+                handled_data: "（計画）index 対象 content のメタデータ、検索インデックス",
+                purpose: "（計画）community node が関与した content の検索・発見の補助",
+                retention_impact: "（計画）index 保持方針はノード設定に従う",
+                external_transmission: None,
+                telecom_note: "（計画）index はノードの authority scope 内に限定される。",
+                privacy_note: "（計画）index 対象と保持方針を実装時に明記する。",
+                terms_note: "（計画）本ノードが index した content の範囲についてのみ責任を負う旨を記載する。",
+            },
+            Capability::Moderation => CapabilityMeta {
+                capability: self,
+                display_name: "モデレーション (moderation)",
+                handled_data: "（計画）moderation verdict、署名付き moderation event",
+                purpose: "（計画）ノードの index / discovery / recommendation からの critical safety risk の排除",
+                retention_impact: "（計画）moderation ログ保持期間に従う",
+                external_transmission: None,
+                telecom_note: "（計画）moderation はノードの authority scope 内に限定される。",
+                privacy_note: "（計画）moderation 対象データの扱いを実装時に明記する。",
+                terms_note: "（計画）moderation event は本ノードの authority scope 内でのみ意味を持つ旨を記載する。",
+            },
+            Capability::CommunityLocalTrust => CapabilityMeta {
+                capability: self,
+                display_name: "コミュニティローカル trust signal (community-local trust)",
+                handled_data: "（計画）根拠付き risk signal / trust signal",
+                purpose: "（計画）ノードの authority scope 内での trust / relation signal の発行",
+                retention_impact: "（計画）signal の失効ポリシーに従う",
+                external_transmission: None,
+                telecom_note: "（計画）trust signal はノードの authority scope 内に限定される。",
+                privacy_note: "（計画）signal 対象データの扱いを実装時に明記する。",
+                terms_note: "（計画）trust signal は network-wide command ではなく optional trust input である旨を記載する。",
+            },
+            Capability::ReportEndpoint => CapabilityMeta {
+                capability: self,
+                display_name: "通報エンドポイント (report endpoint)",
+                handled_data: "（計画）通報内容、通報者の連絡先（任意）",
+                purpose: "（計画）本ノードが関与した対象に対する通報の受付",
+                retention_impact: "（計画）通報データ保持期間に従う",
+                external_transmission: None,
+                telecom_note: "（計画）通報受付はノードの authority scope 内に限定される。",
+                privacy_note: "（計画）通報データの扱いを実装時に明記する。",
+                terms_note: "（計画）通報は本ノードが関与した対象に限定され、中央通報窓口ではない旨を記載する。",
+            },
+        }
+    }
+}
+
+impl fmt::Display for Capability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.key())
+    }
+}
+
+/// 文書生成に使う capability の静的メタデータ。
+#[derive(Clone, Copy, Debug)]
+pub struct CapabilityMeta {
+    pub capability: Capability,
+    pub display_name: &'static str,
+    pub handled_data: &'static str,
+    pub purpose: &'static str,
+    pub retention_impact: &'static str,
+    pub external_transmission: Option<ExternalDestination>,
+    pub telecom_note: &'static str,
+    pub privacy_note: &'static str,
+    pub terms_note: &'static str,
+}
+
+/// 外部送信表示で列挙し得る送信先。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ExternalDestination {
+    CommunityServer,
+    DedicatedIrohRelay,
+    PublicRelay,
+    Cloudflare,
+    ObjectStorage,
+    PushProvider,
+    AnalyticsProvider,
+    CrashReportProvider,
+}
+
+impl ExternalDestination {
+    pub fn display_name(self) -> &'static str {
+        match self {
+            ExternalDestination::CommunityServer => "コミュニティサーバー本体",
+            ExternalDestination::DedicatedIrohRelay => "専用 iroh relay",
+            ExternalDestination::PublicRelay => "n0.computer 等のパブリック relay",
+            ExternalDestination::Cloudflare => "Cloudflare (プロキシ / CDN / WAF)",
+            ExternalDestination::ObjectStorage => "オブジェクトストレージ",
+            ExternalDestination::PushProvider => "プッシュ通知プロバイダ",
+            ExternalDestination::AnalyticsProvider => "アナリティクスプロバイダ",
+            ExternalDestination::CrashReportProvider => "クラッシュレポートプロバイダ",
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            ExternalDestination::CommunityServer => {
+                "client からの接続を受け、補助機能を提供する本ノード。"
+            }
+            ExternalDestination::DedicatedIrohRelay => {
+                "NAT traversal / hole punching を補助する専用 relay。暗号化済み traffic の中継が発生し得る。"
+            }
+            ExternalDestination::PublicRelay => {
+                "他経路が成立しない場合の fallback として、暗号化済み traffic が経由し得るパブリック relay。"
+            }
+            ExternalDestination::Cloudflare => {
+                "リバースプロキシ / CDN / WAF。HTTP リクエストと接続元 IP が経由する。"
+            }
+            ExternalDestination::ObjectStorage => "添付メディアの一時キャッシュ配信先。",
+            ExternalDestination::PushProvider => "デバイストークンと通知内容の送信先。",
+            ExternalDestination::AnalyticsProvider => "利用状況データの送信先。",
+            ExternalDestination::CrashReportProvider => "クラッシュ診断データの送信先。",
+        }
+    }
+}

--- a/crates/cn-operator/src/config.rs
+++ b/crates/cn-operator/src/config.rs
@@ -1,0 +1,234 @@
+//! operator config (`operator-config.yaml`) の schema と検証。
+//!
+//! このファイルは CLI と server manifest / 生成文書の単一の入力元である。
+
+use std::collections::BTreeMap;
+
+use anyhow::{Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::capability::{Availability, Capability};
+use crate::profile::Profile;
+
+/// `operator-config.yaml` の生表現。
+///
+/// `features` は未指定キーを許容し、profile の既定値で補完する。
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OperatorConfig {
+    pub server: ServerConfig,
+    #[serde(default)]
+    pub profile: Option<Profile>,
+    #[serde(default)]
+    pub features: BTreeMap<String, bool>,
+    #[serde(default)]
+    pub retention: RetentionConfig,
+    #[serde(default)]
+    pub manifest: ManifestConfig,
+    /// Phase B（未実装 / 計画中）capability を有効化することを明示的に承認する。
+    ///
+    /// これが false のまま Planned capability を有効化すると検証で失敗する。
+    /// 実体のない「運用中」開示を生成しないためのガード。
+    #[serde(default)]
+    pub acknowledge_planned_capabilities: bool,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ServerConfig {
+    pub domain: String,
+    pub operator_name: String,
+    /// ISO 3166-1 alpha-2（例: JP）。
+    pub country: String,
+    #[serde(default)]
+    pub cloud_provider: Option<String>,
+    #[serde(default)]
+    pub region: Option<String>,
+    /// abuse / 問い合わせ連絡先。未指定なら domain から導出する。
+    #[serde(default)]
+    pub contact: Option<String>,
+    #[serde(default)]
+    pub node_id: Option<String>,
+    #[serde(default)]
+    pub node_name: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RetentionConfig {
+    #[serde(default = "default_connection_logs_days")]
+    pub connection_logs_days: u32,
+    #[serde(default = "default_moderation_logs_days")]
+    pub moderation_logs_days: u32,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            connection_logs_days: default_connection_logs_days(),
+            moderation_logs_days: default_moderation_logs_days(),
+        }
+    }
+}
+
+fn default_connection_logs_days() -> u32 {
+    30
+}
+
+fn default_moderation_logs_days() -> u32 {
+    180
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ManifestConfig {
+    /// node role。未指定なら有効 capability から推定する。
+    #[serde(default)]
+    pub node_role: Option<String>,
+    /// manifest / policy version。決定論的出力のため config 由来とする。
+    #[serde(default = "default_manifest_version")]
+    pub manifest_version: String,
+}
+
+fn default_manifest_version() -> String {
+    "v1".to_string()
+}
+
+/// profile / features を解決し検証済みの設定。
+#[derive(Clone, Debug)]
+pub struct ResolvedConfig {
+    pub raw: OperatorConfig,
+    /// capability ごとの有効・無効（全 capability を網羅）。
+    enabled: BTreeMap<Capability, bool>,
+}
+
+impl ResolvedConfig {
+    pub fn enabled(&self, capability: Capability) -> bool {
+        self.enabled.get(&capability).copied().unwrap_or(false)
+    }
+
+    /// `Capability::ALL` の順序で有効な capability を返す。
+    pub fn enabled_capabilities(&self) -> Vec<Capability> {
+        Capability::ALL
+            .iter()
+            .copied()
+            .filter(|cap| self.enabled(*cap))
+            .collect()
+    }
+
+    /// `Capability::ALL` の順序で無効な capability を返す。
+    pub fn disabled_capabilities(&self) -> Vec<Capability> {
+        Capability::ALL
+            .iter()
+            .copied()
+            .filter(|cap| !self.enabled(*cap))
+            .collect()
+    }
+
+    /// 有効かつ Phase B（計画中）の capability。
+    pub fn enabled_planned_capabilities(&self) -> Vec<Capability> {
+        self.enabled_capabilities()
+            .into_iter()
+            .filter(|cap| cap.availability().is_planned())
+            .collect()
+    }
+
+    pub fn contact(&self) -> String {
+        self.raw
+            .server
+            .contact
+            .clone()
+            .filter(|c| !c.trim().is_empty())
+            .unwrap_or_else(|| format!("abuse@{}", self.raw.server.domain))
+    }
+
+    pub fn policy_url(&self, path: &str) -> String {
+        format!("https://{}/{}", self.raw.server.domain, path)
+    }
+}
+
+/// YAML 文字列をパースする。
+pub fn parse_config(yaml: &str) -> Result<OperatorConfig> {
+    let config: OperatorConfig = serde_yaml::from_str(yaml)
+        .map_err(|e| anyhow!("operator-config.yaml のパースに失敗しました: {e}"))?;
+    Ok(config)
+}
+
+/// profile と features を解決し、必須項目・Phase B 承認を検証する。
+pub fn resolve_and_validate(config: OperatorConfig) -> Result<ResolvedConfig> {
+    // 必須フィールド。
+    if config.server.domain.trim().is_empty() {
+        bail!("server.domain は必須です");
+    }
+    if config.server.operator_name.trim().is_empty() {
+        bail!("server.operator_name は必須です");
+    }
+    if config.server.country.trim().len() != 2 {
+        bail!("server.country は ISO 3166-1 alpha-2（2文字、例: JP）で指定してください");
+    }
+
+    // 未知の feature キーを拒否する（typo によるサイレントな無効化を防ぐ）。
+    let known: BTreeMap<&str, Capability> = Capability::ALL.iter().map(|c| (c.key(), *c)).collect();
+    for key in config.features.keys() {
+        if !known.contains_key(key.as_str()) {
+            bail!(
+                "features に未知のキー `{key}` があります。指定可能: {}",
+                Capability::ALL
+                    .iter()
+                    .map(|c| c.key())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+    }
+
+    // profile 既定値 -> features 上書き の順で解決する。
+    let profile_defaults = config
+        .profile
+        .map(|p| p.feature_defaults())
+        .unwrap_or_default();
+
+    let mut enabled: BTreeMap<Capability, bool> = BTreeMap::new();
+    for cap in Capability::ALL {
+        // auth_consent は baseline として常に有効。
+        let baseline = matches!(cap, Capability::AuthConsent);
+        let from_profile = profile_defaults.get(&cap).copied().unwrap_or(baseline);
+        let value = config
+            .features
+            .get(cap.key())
+            .copied()
+            .unwrap_or(from_profile);
+        enabled.insert(cap, value || baseline);
+    }
+
+    let resolved = ResolvedConfig {
+        raw: config,
+        enabled,
+    };
+
+    // Phase B capability の承認ガード。
+    let planned = resolved.enabled_planned_capabilities();
+    if !planned.is_empty() && !resolved.raw.acknowledge_planned_capabilities {
+        let names = planned
+            .iter()
+            .map(|c| c.key())
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!(
+            "計画中（未実装）の capability が有効化されています: {names}\n\
+             これらは現行の community node 実装では提供されません。\n\
+             運用中であるかのような開示文書の生成を防ぐため、\n\
+             config に `acknowledge_planned_capabilities: true` を設定して\n\
+             「spec として記述する」ことを明示的に承認してください。\n\
+             承認した場合でも、生成文書ではこれらは「{}」として扱われます。",
+            Availability::Planned.label_ja()
+        );
+    }
+
+    Ok(resolved)
+}
+
+/// パースと解決・検証をまとめて行う。
+pub fn load_and_validate(yaml: &str) -> Result<ResolvedConfig> {
+    resolve_and_validate(parse_config(yaml)?)
+}

--- a/crates/cn-operator/src/docs.rs
+++ b/crates/cn-operator/src/docs.rs
@@ -1,0 +1,492 @@
+//! operator config から運営者向け文書群を決定論的に生成する。
+//!
+//! 出力は wall-clock 非依存（version は config 由来）であり、同じ config からは同じ出力が得られる。
+//!
+//! Phase A / Phase B の分離:
+//! - 運用中の開示（外部送信表示・データ取扱い）は Available かつ有効な capability のみに基づく。
+//! - Planned（計画中・未提供）capability は、各文書で明示的に「計画中」として分離して記述し、
+//!   運用中であるかのような開示には含めない。
+
+use std::fmt::Write as _;
+
+use crate::capability::{Availability, Capability, ExternalDestination};
+use crate::config::ResolvedConfig;
+use crate::manifest::render_manifest;
+
+/// すべての生成文書に付す共通の注記。
+const LEGAL_DISCLAIMER: &str = "> 注記: この文書は operator config から自動生成された下書きであり、法的助言ではありません。\n\
+> 最終的な内容・適法性の判断は、運営者自身および必要に応じて総合通信局・弁護士等の専門家への確認が必要です。";
+
+const MANIFEST_FILE: &str = "server-manifest.json";
+
+/// 生成された 1 ファイル。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GeneratedFile {
+    pub filename: String,
+    pub content: String,
+}
+
+/// 有効かつ Available な capability。
+fn available_enabled(config: &ResolvedConfig) -> Vec<Capability> {
+    config
+        .enabled_capabilities()
+        .into_iter()
+        .filter(|c| c.availability() == Availability::Available)
+        .collect()
+}
+
+/// 有効かつ Planned な capability。
+fn planned_enabled(config: &ResolvedConfig) -> Vec<Capability> {
+    config.enabled_planned_capabilities()
+}
+
+/// 有効な Available capability に基づく外部送信先（重複排除、Capability::ALL 順）。
+fn external_destinations(config: &ResolvedConfig) -> Vec<ExternalDestination> {
+    let mut dests = vec![ExternalDestination::CommunityServer];
+    for cap in available_enabled(config) {
+        if let Some(dest) = cap.meta().external_transmission
+            && !dests.contains(&dest)
+        {
+            dests.push(dest);
+        }
+    }
+    dests
+}
+
+/// 文書ヘッダ（タイトル + 運営者情報 + 注記）。
+fn header(config: &ResolvedConfig, title: &str) -> String {
+    let s = &config.raw.server;
+    format!(
+        "# {title}\n\n\
+         - 運営者: {operator}\n\
+         - サーバー: {domain}\n\
+         - 所在国: {country}\n\
+         - manifest version: {version}\n\n\
+         {disclaimer}\n",
+        title = title,
+        operator = s.operator_name,
+        domain = s.domain,
+        country = s.country,
+        version = config.raw.manifest.manifest_version,
+        disclaimer = LEGAL_DISCLAIMER,
+    )
+}
+
+/// 計画中 capability があれば、それを明示する共通セクション。
+fn planned_section(config: &ResolvedConfig) -> String {
+    let planned = planned_enabled(config);
+    if planned.is_empty() {
+        return String::new();
+    }
+    let mut s = String::new();
+    let _ = writeln!(s, "\n## 計画中（この配布物では未提供）の capability\n");
+    let _ = writeln!(
+        s,
+        "以下の capability は config 上で宣言されていますが、現行の community node 実装では提供されていません。"
+    );
+    let _ = writeln!(
+        s,
+        "そのため、本文書では「運用中の機能」としては扱わず、将来提供する予定の設計（spec）として記載します。\n"
+    );
+    for cap in planned {
+        let m = cap.meta();
+        let _ = writeln!(
+            s,
+            "- **{}**（{}）: {}",
+            m.display_name,
+            Availability::Planned.label_ja(),
+            m.purpose
+        );
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// 各文書ジェネレータ
+// ---------------------------------------------------------------------------
+
+fn gen_network_diagram(config: &ResolvedConfig) -> String {
+    let mut s = header(config, "ネットワーク構成説明");
+    let _ = writeln!(s, "\n## 通信経路の基本優先度\n");
+    let _ = writeln!(
+        s,
+        "kukuri の基本通信優先度は `Direct P2P -> Relay Supported P2P -> Relay Fallback` です。\
+         community node はこの経路を補助する層であり、ユーザーの所属先（home server）ではありません。\n"
+    );
+    let _ = writeln!(s, "## 有効な接続補助 capability\n");
+    let _ = writeln!(s, "```text");
+    let _ = writeln!(s, "client");
+    let _ = writeln!(s, "  |");
+    for cap in available_enabled(config) {
+        let _ = writeln!(s, "  +-- {} ({})", cap.meta().display_name, cap.key());
+    }
+    let _ = writeln!(s, "```\n");
+
+    if config.enabled(Capability::IrohRelay) || config.enabled(Capability::TrafficRelayFallback) {
+        let _ = writeln!(s, "## relay に関する補足\n");
+        let _ = writeln!(
+            s,
+            "iroh relay / traffic relay fallback が有効です。これらは単なる signaling ではなく、\
+             Direct / Relay Supported P2P が成立しない場合に、暗号化済みであっても実 traffic が relay を\
+             経由し得ます。届出要否は構成と所在地に依存するため、別途確認してください。\n"
+        );
+    }
+    s.push_str(&planned_section(config));
+    s
+}
+
+fn gen_telecom_notification(config: &ResolvedConfig) -> String {
+    let mut s = header(config, "電気通信事業 届出補助資料（役務説明ドラフト）");
+    let _ = writeln!(s, "\n## 前提\n");
+    let _ = writeln!(
+        s,
+        "この資料は、クラウド / VPS 利用・回線非設置を前提とした説明ドラフトです。\
+         自宅サーバー構成や回線設置を伴う構成は advanced であり、個別確認が必要です。\n"
+    );
+    let _ = writeln!(s, "## 役務の概要\n");
+    let _ = writeln!(
+        s,
+        "本サービスは、P2P network の補助層として動作する community node です。\
+         ユーザーの identity / profile / social graph を所有せず、以下の補助機能を提供します。\n"
+    );
+    for cap in available_enabled(config) {
+        let m = cap.meta();
+        let _ = writeln!(s, "- {}: {}", m.display_name, m.telecom_note);
+    }
+    let _ = writeln!(s, "\n## relay に関する注意\n");
+    if config.enabled(Capability::IrohRelay) || config.enabled(Capability::TrafficRelayFallback) {
+        let _ = writeln!(
+            s,
+            "iroh relay / traffic relay fallback が有効なため、暗号化済み traffic の中継が発生し得ます。\
+             これを signaling only と混同せず、役務区分・届出要否を総合通信局・専門家に事前確認してください。"
+        );
+    } else {
+        let _ = writeln!(
+            s,
+            "relay 系 capability は無効です。実 traffic の中継は前提としていません。\
+             ただし届出要否は最終的に運営者自身で確認してください。"
+        );
+    }
+    let _ = writeln!(s, "\n## 構成情報\n");
+    let _ = writeln!(
+        s,
+        "- クラウド / インフラ: {}",
+        config
+            .raw
+            .server
+            .cloud_provider
+            .clone()
+            .unwrap_or_else(|| "未指定".to_string())
+    );
+    let _ = writeln!(
+        s,
+        "- リージョン: {}",
+        config
+            .raw
+            .server
+            .region
+            .clone()
+            .unwrap_or_else(|| "未指定".to_string())
+    );
+    s.push_str(&planned_section(config));
+    s
+}
+
+fn gen_service_description(config: &ResolvedConfig) -> String {
+    let mut s = header(config, "サービス説明ドラフト");
+    let _ = writeln!(s, "\n## 提供する補助機能（運用中）\n");
+    for cap in available_enabled(config) {
+        let m = cap.meta();
+        let _ = writeln!(s, "### {}\n", m.display_name);
+        let _ = writeln!(s, "- 目的: {}", m.purpose);
+        let _ = writeln!(s, "- 取扱いデータ: {}", m.handled_data);
+        let _ = writeln!(s, "- 保持への影響: {}\n", m.retention_impact);
+    }
+    s.push_str(&planned_section(config));
+    s
+}
+
+fn gen_terms(config: &ResolvedConfig) -> String {
+    let mut s = header(config, "利用規約（ドラフト）");
+    let _ = writeln!(s, "\n## 第1条（本ノードの位置づけ）\n");
+    let _ = writeln!(
+        s,
+        "本 community node は P2P network の補助層であり、ユーザーの identity / profile / social graph を\
+         所有しません。本ノードの停止・変更によってもこれらは失われません。\n"
+    );
+    let _ = writeln!(s, "## 第2条（禁止事項）\n");
+    let _ = writeln!(s, "- 法令に違反する目的での利用");
+    let _ = writeln!(s, "- 他者の権利を侵害する行為");
+    let _ = writeln!(s, "- 本ノードの補助機能の妨害\n");
+    let _ = writeln!(s, "## 第3条（免責）\n");
+    let _ = writeln!(
+        s,
+        "運営者は、本ノードが関与した補助機能の範囲でのみ責任を負い、kukuri network 全体・他ノードの\
+         活動については責任を負いません。\n"
+    );
+    let _ = writeln!(s, "## 第4条（capability 別の取扱い）\n");
+    for cap in available_enabled(config) {
+        let m = cap.meta();
+        let _ = writeln!(s, "- {}: {}", m.display_name, m.terms_note);
+    }
+    s.push_str(&planned_section(config));
+    s
+}
+
+fn gen_privacy(config: &ResolvedConfig) -> String {
+    let mut s = header(config, "プライバシーポリシー（ドラフト）");
+    let _ = writeln!(s, "\n## 取得・取扱いするデータ（運用中の capability）\n");
+    for cap in available_enabled(config) {
+        let m = cap.meta();
+        let _ = writeln!(s, "### {}\n", m.display_name);
+        let _ = writeln!(s, "- 取扱いデータ: {}", m.handled_data);
+        let _ = writeln!(s, "- 取扱いの説明: {}\n", m.privacy_note);
+    }
+    let _ = writeln!(s, "## 接続ログ・保持期間\n");
+    let _ = writeln!(
+        s,
+        "- 接続ログ保持期間: {} 日",
+        config.raw.retention.connection_logs_days
+    );
+    let _ = writeln!(
+        s,
+        "- モデレーションログ保持期間: {} 日\n",
+        config.raw.retention.moderation_logs_days
+    );
+    let _ = writeln!(s, "## 外部送信\n");
+    let _ = writeln!(
+        s,
+        "外部送信の詳細は `external-transmission-notice.md` を参照してください。\n"
+    );
+    s.push_str(&planned_section(config));
+    s
+}
+
+fn gen_external_transmission(config: &ResolvedConfig) -> String {
+    let mut s = header(config, "外部送信表示");
+    let _ = writeln!(s, "\n## 現在の外部送信先（有効な機能に基づく）\n");
+    let _ = writeln!(
+        s,
+        "以下は、現在有効な機能の構成に基づいて発生し得る外部送信先です。\n"
+    );
+    for dest in external_destinations(config) {
+        let _ = writeln!(s, "### {}\n", dest.display_name());
+        let _ = writeln!(s, "{}\n", dest.description());
+    }
+
+    // 無効化により送信されないものを明示（analytics: false 等の検証可能性）。
+    let mut not_sent: Vec<ExternalDestination> = Vec::new();
+    let active = external_destinations(config);
+    for dest in [
+        ExternalDestination::Cloudflare,
+        ExternalDestination::ObjectStorage,
+        ExternalDestination::PushProvider,
+        ExternalDestination::AnalyticsProvider,
+        ExternalDestination::CrashReportProvider,
+        ExternalDestination::DedicatedIrohRelay,
+        ExternalDestination::PublicRelay,
+    ] {
+        if !active.contains(&dest) {
+            not_sent.push(dest);
+        }
+    }
+    if !not_sent.is_empty() {
+        let _ = writeln!(s, "## 送信していない外部送信先（無効な機能）\n");
+        for dest in not_sent {
+            let _ = writeln!(
+                s,
+                "- {}: 該当機能が無効のため送信しません。",
+                dest.display_name()
+            );
+        }
+        s.push('\n');
+    }
+    s.push_str(&planned_section(config));
+    s
+}
+
+fn gen_abuse_policy(config: &ResolvedConfig) -> String {
+    let mut s = header(config, "Abuse ポリシー（ドラフト）");
+    let _ = writeln!(s, "\n## 連絡先\n");
+    let _ = writeln!(s, "- abuse 連絡先: {}\n", config.contact());
+    let _ = writeln!(s, "## 対応範囲\n");
+    let _ = writeln!(
+        s,
+        "本ノードは、本ノードが実際に関与した補助機能（index / moderation / cache / relay 等のうち有効なもの）の\
+         範囲でのみ abuse 対応を行います。kukuri network 全体の中央通報窓口ではありません。\n"
+    );
+    if config.enabled(Capability::ReportEndpoint) {
+        let _ = writeln!(
+            s,
+            "（計画中）通報エンドポイントは未実装です。実装までは上記連絡先を窓口とします。\n"
+        );
+    }
+    s.push_str(&planned_section(config));
+    s
+}
+
+fn gen_moderation_policy(config: &ResolvedConfig) -> String {
+    let mut s = header(config, "モデレーションポリシー（ドラフト）");
+    let _ = writeln!(s, "\n## authority scope\n");
+    let _ = writeln!(
+        s,
+        "本ノードの moderation / trust signal は、本ノードの authority scope 内でのみ意味を持ちます。\
+         これらは network-wide command ではなく、他ノード・client が任意に採用し得る optional trust input です。\n"
+    );
+    if config.enabled(Capability::Moderation) || config.enabled(Capability::CommunityLocalTrust) {
+        let _ = writeln!(
+            s,
+            "（計画中）moderation / trust signal は現行実装では未提供です。実装方針は #353 / #362 に従います。\n"
+        );
+    } else {
+        let _ = writeln!(
+            s,
+            "本ノードでは moderation / trust signal を有効化していません。\n"
+        );
+    }
+    let _ = writeln!(s, "## ログ保持\n");
+    let _ = writeln!(
+        s,
+        "- モデレーションログ保持期間: {} 日\n",
+        config.raw.retention.moderation_logs_days
+    );
+    s.push_str(&planned_section(config));
+    s
+}
+
+fn gen_data_retention(config: &ResolvedConfig) -> String {
+    let mut s = header(config, "データ保持ポリシー（ドラフト）");
+    let _ = writeln!(s, "\n## 保持期間\n");
+    let _ = writeln!(
+        s,
+        "- 接続ログ: {} 日",
+        config.raw.retention.connection_logs_days
+    );
+    let _ = writeln!(
+        s,
+        "- モデレーションログ: {} 日\n",
+        config.raw.retention.moderation_logs_days
+    );
+    let _ = writeln!(s, "## capability 別の保持への影響（運用中）\n");
+    for cap in available_enabled(config) {
+        let m = cap.meta();
+        let _ = writeln!(s, "- {}: {}", m.display_name, m.retention_impact);
+    }
+    s.push_str(&planned_section(config));
+    s
+}
+
+fn gen_prior_consultation_email(config: &ResolvedConfig) -> String {
+    let s_cfg = &config.raw.server;
+    let mut s = header(config, "事前相談メールテンプレート");
+    let _ = writeln!(s, "\n## 件名\n");
+    let _ = writeln!(
+        s,
+        "電気通信事業の届出要否に関する事前相談（{}）\n",
+        s_cfg.domain
+    );
+    let _ = writeln!(s, "## 本文（ドラフト）\n");
+    let _ = writeln!(s, "```text");
+    let _ = writeln!(s, "ご担当者様");
+    s.push('\n');
+    let _ = writeln!(
+        s,
+        "{operator} と申します。P2P network の補助層として動作する community node の",
+        operator = s_cfg.operator_name
+    );
+    let _ = writeln!(
+        s,
+        "運営に関し、電気通信事業の届出要否について事前相談させていただきたくご連絡しました。"
+    );
+    s.push('\n');
+    let _ = writeln!(s, "■ サービス概要");
+    let _ = writeln!(s, "- ドメイン: {}", s_cfg.domain);
+    let _ = writeln!(
+        s,
+        "- インフラ: {} / 回線非設置（クラウド / VPS 利用）",
+        s_cfg
+            .cloud_provider
+            .clone()
+            .unwrap_or_else(|| "クラウド".to_string())
+    );
+    let _ = writeln!(
+        s,
+        "- 役割: ユーザーの identity / profile / social graph を所有しない補助ノード"
+    );
+    s.push('\n');
+    let _ = writeln!(s, "■ 有効な補助機能");
+    for cap in available_enabled(config) {
+        let _ = writeln!(s, "- {}", cap.meta().display_name);
+    }
+    if config.enabled(Capability::IrohRelay) || config.enabled(Capability::TrafficRelayFallback) {
+        s.push('\n');
+        let _ = writeln!(s, "■ relay について");
+        let _ = writeln!(
+            s,
+            "暗号化済み traffic の relay 中継が発生し得ます（signaling only ではありません）。"
+        );
+    }
+    s.push('\n');
+    let _ = writeln!(
+        s,
+        "上記構成における届出要否についてご教示いただけますと幸いです。"
+    );
+    let _ = writeln!(s, "```\n");
+    s
+}
+
+// ---------------------------------------------------------------------------
+// 集約
+// ---------------------------------------------------------------------------
+
+/// すべての生成文書を filename 昇順で返す。
+pub fn generate_all(config: &ResolvedConfig) -> Vec<GeneratedFile> {
+    let mut files = vec![
+        GeneratedFile {
+            filename: MANIFEST_FILE.to_string(),
+            content: render_manifest(config),
+        },
+        GeneratedFile {
+            filename: "network-diagram.md".to_string(),
+            content: gen_network_diagram(config),
+        },
+        GeneratedFile {
+            filename: "telecom-notification-draft.md".to_string(),
+            content: gen_telecom_notification(config),
+        },
+        GeneratedFile {
+            filename: "service-description-draft.md".to_string(),
+            content: gen_service_description(config),
+        },
+        GeneratedFile {
+            filename: "terms.md".to_string(),
+            content: gen_terms(config),
+        },
+        GeneratedFile {
+            filename: "privacy-policy.md".to_string(),
+            content: gen_privacy(config),
+        },
+        GeneratedFile {
+            filename: "external-transmission-notice.md".to_string(),
+            content: gen_external_transmission(config),
+        },
+        GeneratedFile {
+            filename: "abuse-policy.md".to_string(),
+            content: gen_abuse_policy(config),
+        },
+        GeneratedFile {
+            filename: "moderation-policy.md".to_string(),
+            content: gen_moderation_policy(config),
+        },
+        GeneratedFile {
+            filename: "data-retention-policy.md".to_string(),
+            content: gen_data_retention(config),
+        },
+        GeneratedFile {
+            filename: "prior-consultation-email.md".to_string(),
+            content: gen_prior_consultation_email(config),
+        },
+    ];
+    files.sort_by(|a, b| a.filename.cmp(&b.filename));
+    files
+}

--- a/crates/cn-operator/src/drift.rs
+++ b/crates/cn-operator/src/drift.rs
@@ -1,0 +1,85 @@
+//! 生成済み文書と現在の config から再生成した結果の drift 検出。
+//!
+//! `check-disclosures` は、config から文書を再生成し、出力ディレクトリの内容と比較する。
+//! 差分があれば non-zero exit する想定。
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::config::ResolvedConfig;
+use crate::docs::generate_all;
+
+/// drift の検出結果。
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DriftReport {
+    /// 内容が一致しないファイル。
+    pub changed: Vec<String>,
+    /// 出力ディレクトリに存在しない（未生成の）ファイル。
+    pub missing: Vec<String>,
+    /// 出力ディレクトリにあるが生成対象でない余分なファイル。
+    pub unexpected: Vec<String>,
+}
+
+impl DriftReport {
+    pub fn is_clean(&self) -> bool {
+        self.changed.is_empty() && self.missing.is_empty() && self.unexpected.is_empty()
+    }
+
+    /// 人間可読なサマリ。
+    pub fn summary(&self) -> String {
+        if self.is_clean() {
+            return "生成文書は config と一致しています（drift なし）。".to_string();
+        }
+        let mut s = String::new();
+        if !self.missing.is_empty() {
+            s.push_str(&format!("未生成: {}\n", self.missing.join(", ")));
+        }
+        if !self.changed.is_empty() {
+            s.push_str(&format!("差分あり: {}\n", self.changed.join(", ")));
+        }
+        if !self.unexpected.is_empty() {
+            s.push_str(&format!("余分なファイル: {}\n", self.unexpected.join(", ")));
+        }
+        s.push_str("`generate-docs` で再生成してください。");
+        s
+    }
+}
+
+/// config から再生成した内容と `dir` 配下の内容を比較する。
+pub fn check_drift(config: &ResolvedConfig, dir: &Path) -> Result<DriftReport> {
+    let expected = generate_all(config);
+    let mut report = DriftReport::default();
+
+    let mut expected_names: Vec<String> = Vec::new();
+    for file in &expected {
+        expected_names.push(file.filename.clone());
+        let path = dir.join(&file.filename);
+        match fs::read_to_string(&path) {
+            Ok(actual) => {
+                if actual != file.content {
+                    report.changed.push(file.filename.clone());
+                }
+            }
+            Err(_) => report.missing.push(file.filename.clone()),
+        }
+    }
+
+    // 余分なファイル（生成対象でない既知拡張子）の検出。
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let name = entry.file_name().to_string_lossy().to_string();
+            let is_target = name.ends_with(".md") || name.ends_with(".json");
+            if is_target && !expected_names.contains(&name) {
+                report.unexpected.push(name);
+            }
+        }
+    }
+
+    report.changed.sort();
+    report.missing.sort();
+    report.unexpected.sort();
+    Ok(report)
+}

--- a/crates/cn-operator/src/lib.rs
+++ b/crates/cn-operator/src/lib.rs
@@ -1,0 +1,66 @@
+//! kukuri community node operator docs generator (#352)。
+//!
+//! operator config (`operator-config.yaml`) を単一の入力元として、運営者向けの
+//! 利用規約・プライバシーポリシー・外部送信表示・電気通信届出補助資料・server manifest を
+//! 決定論的に生成する。
+//!
+//! Phase A / Phase B の分離:
+//! - Phase A (`Availability::Available`): 現行 community node 実装 / デプロイ構成として
+//!   提供できる capability。生成文書で「運用中」として開示してよい。
+//! - Phase B (`Availability::Planned`): 未実装の capability（index / moderation / trust /
+//!   report endpoint）。config で宣言できるが、生成文書では「計画中・未提供」として扱い、
+//!   運用中の外部送信・データ取扱い開示には含めない。`acknowledge_planned_capabilities`
+//!   による明示承認がなければ検証で失敗する。
+
+pub mod capability;
+pub mod config;
+pub mod docs;
+pub mod drift;
+pub mod manifest;
+pub mod profile;
+
+pub use capability::{Availability, Capability, CapabilityMeta, ExternalDestination};
+pub use config::{
+    OperatorConfig, ResolvedConfig, RetentionConfig, ServerConfig, load_and_validate, parse_config,
+    resolve_and_validate,
+};
+pub use docs::{GeneratedFile, generate_all};
+pub use drift::{DriftReport, check_drift};
+pub use manifest::{build_manifest, render_manifest};
+pub use profile::Profile;
+
+/// `operator init` が出力するサンプル config。
+pub const SAMPLE_CONFIG: &str = r#"server:
+  domain: example-kukuri.net
+  operator_name: Example Operator
+  country: JP
+  cloud_provider: AWS
+  region: ap-northeast-1
+  contact: abuse@example-kukuri.net
+
+# profile が features の既定値を与える。個別の features キーで上書きできる。
+profile: relay-enabled
+
+features:
+  community_index: true
+  moderation: true
+  community_local_trust: true
+  iroh_relay: true
+  traffic_relay_fallback: true
+  private_message_storage: false
+  blob_cache: false
+  analytics: false
+  crash_report: false
+  cloudflare_proxy: true
+
+retention:
+  connection_logs_days: 30
+  moderation_logs_days: 180
+
+manifest:
+  manifest_version: v1
+
+# community_index / moderation / community_local_trust / report_endpoint は
+# 現行実装では未提供（計画中）。spec として記述することを明示的に承認する。
+acknowledge_planned_capabilities: true
+"#;

--- a/crates/cn-operator/src/main.rs
+++ b/crates/cn-operator/src/main.rs
@@ -1,0 +1,140 @@
+//! `cn-operator` CLI。operator config から運営者向け文書を生成・検証する。
+//!
+//! サブコマンド:
+//! - `init`            : サンプル operator-config.yaml を出力する
+//! - `validate-config` : config を検証する（Phase B 承認ガードを含む）
+//! - `generate-docs`   : 文書群を出力ディレクトリへ生成する
+//! - `check-disclosures`: config から再生成した結果と既存生成物の drift を検出する
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+
+use kukuri_cn_operator::{
+    Availability, SAMPLE_CONFIG, check_drift, generate_all, load_and_validate,
+};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "cn-operator",
+    about = "kukuri community node operator docs generator"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// サンプル operator-config.yaml を出力する。
+    Init {
+        /// 出力先（既定: 標準出力）。
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+    /// operator config を検証する。
+    ValidateConfig {
+        #[arg(long, default_value = "operator-config.yaml")]
+        config: PathBuf,
+    },
+    /// 運営者向け文書群を生成する。
+    GenerateDocs {
+        #[arg(long, default_value = "operator-config.yaml")]
+        config: PathBuf,
+        #[arg(long, default_value = "dist/operator-docs")]
+        out_dir: PathBuf,
+    },
+    /// config から再生成した結果と既存生成物の drift を検出する。
+    CheckDisclosures {
+        #[arg(long, default_value = "operator-config.yaml")]
+        config: PathBuf,
+        #[arg(long, default_value = "dist/operator-docs")]
+        out_dir: PathBuf,
+    },
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(code) => code,
+        Err(err) => {
+            eprintln!("error: {err:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<ExitCode> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Init { out } => {
+            match out {
+                Some(path) => {
+                    fs::write(&path, SAMPLE_CONFIG).with_context(|| {
+                        format!("{} への書き込みに失敗しました", path.display())
+                    })?;
+                    println!("サンプル config を {} に出力しました", path.display());
+                }
+                None => print!("{SAMPLE_CONFIG}"),
+            }
+            Ok(ExitCode::SUCCESS)
+        }
+        Command::ValidateConfig { config } => {
+            let resolved = load_config(&config)?;
+            println!("config は有効です: {}", config.display());
+            print_planned_warning(&resolved);
+            Ok(ExitCode::SUCCESS)
+        }
+        Command::GenerateDocs { config, out_dir } => {
+            let resolved = load_config(&config)?;
+            fs::create_dir_all(&out_dir)
+                .with_context(|| format!("{} の作成に失敗しました", out_dir.display()))?;
+            let files = generate_all(&resolved);
+            for file in &files {
+                let path = out_dir.join(&file.filename);
+                fs::write(&path, &file.content)
+                    .with_context(|| format!("{} の書き込みに失敗しました", path.display()))?;
+            }
+            println!(
+                "{} 個の文書を {} に生成しました",
+                files.len(),
+                out_dir.display()
+            );
+            print_planned_warning(&resolved);
+            Ok(ExitCode::SUCCESS)
+        }
+        Command::CheckDisclosures { config, out_dir } => {
+            let resolved = load_config(&config)?;
+            let report = check_drift(&resolved, &out_dir)?;
+            println!("{}", report.summary());
+            if report.is_clean() {
+                Ok(ExitCode::SUCCESS)
+            } else {
+                Ok(ExitCode::FAILURE)
+            }
+        }
+    }
+}
+
+fn load_config(path: &PathBuf) -> Result<kukuri_cn_operator::ResolvedConfig> {
+    let yaml = fs::read_to_string(path)
+        .with_context(|| format!("{} の読み込みに失敗しました", path.display()))?;
+    load_and_validate(&yaml)
+}
+
+fn print_planned_warning(resolved: &kukuri_cn_operator::ResolvedConfig) {
+    let planned = resolved.enabled_planned_capabilities();
+    if !planned.is_empty() {
+        let names = planned
+            .iter()
+            .map(|c| c.key())
+            .collect::<Vec<_>>()
+            .join(", ");
+        eprintln!(
+            "注意: 計画中（未実装）capability が有効です: {names}（{}として扱われます）",
+            Availability::Planned.label_ja()
+        );
+    }
+}

--- a/crates/cn-operator/src/manifest.rs
+++ b/crates/cn-operator/src/manifest.rs
@@ -1,0 +1,138 @@
+//! operator config から `server-manifest.json` を決定論的に生成する。
+//!
+//! manifest は #355 の authority scope / P2P boundary / capability scope を先取りした
+//! schema を持ち、client の dependency 表示 / report routing / consent UI から利用できる。
+//!
+//! Phase A / Phase B の分離はここでも保たれる。capability scope は
+//! `available_enabled`（運用中）と `planned_enabled`（計画中・未提供）を分けて宣言する。
+
+use serde_json::{Value, json};
+
+use crate::capability::{Availability, Capability};
+use crate::config::ResolvedConfig;
+
+/// node role を推定する（config 指定があればそれを優先）。
+fn node_role(config: &ResolvedConfig) -> String {
+    if let Some(role) = config
+        .raw
+        .manifest
+        .node_role
+        .clone()
+        .filter(|r| !r.trim().is_empty())
+    {
+        return role;
+    }
+    "community-node".to_string()
+}
+
+fn capability_keys(caps: &[Capability]) -> Vec<String> {
+    caps.iter().map(|c| c.key().to_string()).collect()
+}
+
+/// `server-manifest.json` の値を構築する。
+///
+/// serde_json の Map は既定でキー順ソートされるため、出力は決定論的。
+pub fn build_manifest(config: &ResolvedConfig) -> Value {
+    let server = &config.raw.server;
+
+    let available_enabled: Vec<Capability> = config
+        .enabled_capabilities()
+        .into_iter()
+        .filter(|c| c.availability() == Availability::Available)
+        .collect();
+    let planned_enabled = config.enabled_planned_capabilities();
+
+    // capabilities マップ: 全 capability の有効・無効。
+    let mut capabilities = serde_json::Map::new();
+    for cap in Capability::ALL {
+        capabilities.insert(cap.key().to_string(), Value::Bool(config.enabled(cap)));
+    }
+
+    // authority scope: applies_to は実際に有効な capability から導出する。
+    let mut applies_to = vec!["this_node".to_string()];
+    if config.enabled(Capability::CommunityIndex) {
+        applies_to.push("communities_indexed_by_this_node".to_string());
+    }
+    if config.enabled(Capability::Moderation) {
+        applies_to.push("moderation_events_issued_by_this_node".to_string());
+    }
+    if config.enabled(Capability::CommunityLocalTrust) {
+        applies_to.push("trust_signals_issued_by_this_node".to_string());
+    }
+    if config.enabled(Capability::BlobCache) {
+        applies_to.push("media_cached_by_this_node".to_string());
+    }
+
+    let iroh_relay_mode = if config.enabled(Capability::IrohRelay) {
+        "dedicated"
+    } else {
+        "none"
+    };
+
+    json!({
+        "node_id": server.node_id.clone().unwrap_or_default(),
+        "node_name": server.node_name.clone().unwrap_or_else(|| server.domain.clone()),
+        "node_role": node_role(config),
+        "server_name": server.domain,
+        "operator_name": server.operator_name,
+        "operator_country": server.country,
+        "cloud_provider": server.cloud_provider.clone().unwrap_or_default(),
+        "region": server.region.clone().unwrap_or_default(),
+        "contact": config.contact(),
+        "abuse_contact": config.contact(),
+        "terms_url": config.policy_url("terms"),
+        "privacy_url": config.policy_url("privacy"),
+        "external_transmission_url": config.policy_url("external-transmission"),
+        "moderation_policy_url": config.policy_url("moderation-policy"),
+        "abuse_policy_url": config.policy_url("abuse-policy"),
+        "manifest_version": config.raw.manifest.manifest_version,
+        "capabilities": Value::Object(capabilities),
+        "capability_scope": {
+            "available_enabled": capability_keys(&available_enabled),
+            "planned_enabled": capability_keys(&planned_enabled),
+        },
+        "authority_scope": {
+            "applies_to": applies_to,
+            "does_not_apply_to": [
+                "kukuri_network_as_a_whole",
+                "third_party_nodes",
+                "user_identity",
+                "user_profile_canonical_source",
+                "user_social_graph_canonical_source",
+            ],
+        },
+        "p2p_boundary": {
+            "identity_authority": false,
+            "profile_canonical_store": false,
+            "social_graph_canonical_store": false,
+            "content_truth_source": false,
+            "network_wide_authority": false,
+        },
+        "features": {
+            "community_index": config.enabled(Capability::CommunityIndex),
+            "moderation": config.enabled(Capability::Moderation),
+            "trust_score": if config.enabled(Capability::CommunityLocalTrust) {
+                "community-local"
+            } else {
+                "none"
+            },
+            "iroh_relay": config.enabled(Capability::IrohRelay),
+            "iroh_relay_mode": iroh_relay_mode,
+            "traffic_relay_fallback": config.enabled(Capability::TrafficRelayFallback),
+            "private_message_storage": config.enabled(Capability::PrivateMessageStorage),
+            "blob_cache": config.enabled(Capability::BlobCache),
+        },
+        "retention": {
+            "connection_logs_days": config.raw.retention.connection_logs_days,
+            "moderation_logs_days": config.raw.retention.moderation_logs_days,
+        },
+    })
+}
+
+/// manifest を改行終端の pretty JSON 文字列にする。
+pub fn render_manifest(config: &ResolvedConfig) -> String {
+    let value = build_manifest(config);
+    let mut out = serde_json::to_string_pretty(&value).expect("manifest serialization");
+    out.push('\n');
+    out
+}

--- a/crates/cn-operator/src/profile.rs
+++ b/crates/cn-operator/src/profile.rs
@@ -1,0 +1,85 @@
+//! operator profile。profile は features の既定値を与える。
+//!
+//! 個々の `features` キーが profile の既定値を上書きできる。
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::capability::Capability;
+
+/// 初期実装で定義する operator profile。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Profile {
+    /// community index / moderation / community-local trust（いずれも計画中）。
+    /// private message storage / blob cache / analytics / crash report は無効。
+    Minimal,
+    /// minimal + 専用 iroh relay + 暗号化済み traffic fallback 開示。
+    RelayEnabled,
+    /// relay-enabled + blob cache + 通知 + 任意の analytics / crash report。
+    FullService,
+}
+
+impl Profile {
+    pub fn key(self) -> &'static str {
+        match self {
+            Profile::Minimal => "minimal",
+            Profile::RelayEnabled => "relay-enabled",
+            Profile::FullService => "full-service",
+        }
+    }
+
+    /// この profile における capability の既定有効値。
+    ///
+    /// 明示されない capability は false（auth_consent は config 側で baseline 有効）。
+    pub fn feature_defaults(self) -> BTreeMap<Capability, bool> {
+        let mut map = BTreeMap::new();
+        let mut set = |cap: Capability, on: bool| {
+            map.insert(cap, on);
+        };
+
+        // 全 profile 共通: 接続補助の基盤。
+        set(Capability::AuthConsent, true);
+        set(Capability::BootstrapAssist, true);
+        set(Capability::TopicRendezvous, true);
+
+        match self {
+            Profile::Minimal => {
+                set(Capability::CommunityIndex, true);
+                set(Capability::Moderation, true);
+                set(Capability::CommunityLocalTrust, true);
+                set(Capability::PrivateMessageStorage, false);
+                set(Capability::BlobCache, false);
+                set(Capability::Analytics, false);
+                set(Capability::CrashReport, false);
+            }
+            Profile::RelayEnabled => {
+                set(Capability::CommunityIndex, true);
+                set(Capability::Moderation, true);
+                set(Capability::CommunityLocalTrust, true);
+                set(Capability::IrohRelay, true);
+                set(Capability::TrafficRelayFallback, true);
+                set(Capability::PrivateMessageStorage, false);
+                set(Capability::BlobCache, false);
+                set(Capability::Analytics, false);
+                set(Capability::CrashReport, false);
+            }
+            Profile::FullService => {
+                set(Capability::CommunityIndex, true);
+                set(Capability::Moderation, true);
+                set(Capability::CommunityLocalTrust, true);
+                set(Capability::IrohRelay, true);
+                set(Capability::TrafficRelayFallback, true);
+                set(Capability::BlobCache, true);
+                set(Capability::PushNotification, true);
+                set(Capability::ReportEndpoint, true);
+                // analytics / crash report は任意。既定は無効のまま運用者が選ぶ。
+                set(Capability::Analytics, false);
+                set(Capability::CrashReport, false);
+            }
+        }
+
+        map
+    }
+}

--- a/crates/cn-operator/tests/generate.rs
+++ b/crates/cn-operator/tests/generate.rs
@@ -1,0 +1,249 @@
+use kukuri_cn_operator::{
+    Capability, SAMPLE_CONFIG, build_manifest, check_drift, generate_all, load_and_validate,
+    parse_config, resolve_and_validate,
+};
+
+fn base_config(extra_features: &str, ack: bool) -> String {
+    format!(
+        "server:\n\
+         \x20 domain: example-kukuri.net\n\
+         \x20 operator_name: Example Operator\n\
+         \x20 country: JP\n\
+         \x20 cloud_provider: AWS\n\
+         \x20 region: ap-northeast-1\n\
+         features:\n{extra_features}\
+         retention:\n\
+         \x20 connection_logs_days: 30\n\
+         \x20 moderation_logs_days: 180\n\
+         acknowledge_planned_capabilities: {ack}\n"
+    )
+}
+
+#[test]
+fn sample_config_is_valid() {
+    let resolved = load_and_validate(SAMPLE_CONFIG).expect("sample config must validate");
+    assert!(resolved.enabled(Capability::IrohRelay));
+    assert!(
+        resolved.enabled(Capability::AuthConsent),
+        "auth_consent is baseline"
+    );
+}
+
+#[test]
+fn profiles_are_defined() {
+    for key in ["minimal", "relay-enabled", "full-service"] {
+        let yaml = format!(
+            "server:\n  domain: d.net\n  operator_name: Op\n  country: JP\n\
+             profile: {key}\nacknowledge_planned_capabilities: true\n"
+        );
+        let resolved = load_and_validate(&yaml).expect("profile config validates");
+        assert!(resolved.enabled(Capability::BootstrapAssist));
+    }
+}
+
+#[test]
+fn relay_enabled_profile_turns_on_relay() {
+    let yaml = "server:\n  domain: d.net\n  operator_name: Op\n  country: JP\n\
+                profile: relay-enabled\nacknowledge_planned_capabilities: true\n";
+    let resolved = load_and_validate(yaml).unwrap();
+    assert!(resolved.enabled(Capability::IrohRelay));
+    assert!(resolved.enabled(Capability::TrafficRelayFallback));
+}
+
+#[test]
+fn explicit_feature_overrides_profile() {
+    let yaml = "server:\n  domain: d.net\n  operator_name: Op\n  country: JP\n\
+                profile: relay-enabled\nfeatures:\n  iroh_relay: false\n\
+                acknowledge_planned_capabilities: true\n";
+    let resolved = load_and_validate(yaml).unwrap();
+    assert!(!resolved.enabled(Capability::IrohRelay));
+}
+
+#[test]
+fn planned_capability_without_ack_fails() {
+    let yaml = base_config("  moderation: true\n", false);
+    let err = load_and_validate(&yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("acknowledge_planned_capabilities"),
+        "error should explain the Phase B ack guard: {err}"
+    );
+}
+
+#[test]
+fn planned_capability_with_ack_validates() {
+    let yaml = base_config("  moderation: true\n", true);
+    let resolved = load_and_validate(&yaml).unwrap();
+    assert!(resolved.enabled(Capability::Moderation));
+    assert_eq!(
+        resolved.enabled_planned_capabilities(),
+        vec![Capability::Moderation]
+    );
+}
+
+#[test]
+fn unknown_feature_key_is_rejected() {
+    let yaml = base_config("  not_a_real_feature: true\n", true);
+    let err = load_and_validate(&yaml).unwrap_err();
+    assert!(err.to_string().contains("未知のキー"), "got: {err}");
+}
+
+#[test]
+fn missing_required_fields_fail() {
+    let yaml = "server:\n  domain: \"\"\n  operator_name: Op\n  country: JP\n";
+    assert!(load_and_validate(yaml).is_err());
+}
+
+#[test]
+fn manifest_has_authority_scope_and_p2p_boundary() {
+    let resolved = load_and_validate(SAMPLE_CONFIG).unwrap();
+    let m = build_manifest(&resolved);
+
+    // P2P boundary は identity / profile / social graph / network authority を false 宣言。
+    let boundary = &m["p2p_boundary"];
+    assert_eq!(boundary["identity_authority"], false);
+    assert_eq!(boundary["profile_canonical_store"], false);
+    assert_eq!(boundary["social_graph_canonical_store"], false);
+    assert_eq!(boundary["content_truth_source"], false);
+    assert_eq!(boundary["network_wide_authority"], false);
+
+    // authority scope の does_not_apply_to に user identity 等が含まれる。
+    let does_not = m["authority_scope"]["does_not_apply_to"]
+        .as_array()
+        .unwrap();
+    assert!(does_not.iter().any(|v| v == "user_identity"));
+    assert!(does_not.iter().any(|v| v == "kukuri_network_as_a_whole"));
+
+    // capability_scope は available と planned を分離する。
+    let scope = &m["capability_scope"];
+    assert!(scope["available_enabled"].is_array());
+    assert!(scope["planned_enabled"].is_array());
+    let planned = scope["planned_enabled"].as_array().unwrap();
+    assert!(planned.iter().any(|v| v == "moderation"));
+}
+
+#[test]
+fn all_expected_docs_are_generated() {
+    let resolved = load_and_validate(SAMPLE_CONFIG).unwrap();
+    let files = generate_all(&resolved);
+    let names: Vec<&str> = files.iter().map(|f| f.filename.as_str()).collect();
+    for expected in [
+        "server-manifest.json",
+        "network-diagram.md",
+        "telecom-notification-draft.md",
+        "service-description-draft.md",
+        "terms.md",
+        "privacy-policy.md",
+        "external-transmission-notice.md",
+        "abuse-policy.md",
+        "moderation-policy.md",
+        "data-retention-policy.md",
+        "prior-consultation-email.md",
+    ] {
+        assert!(names.contains(&expected), "missing {expected}");
+    }
+}
+
+#[test]
+fn generated_docs_contain_legal_disclaimer() {
+    let resolved = load_and_validate(SAMPLE_CONFIG).unwrap();
+    for file in generate_all(&resolved) {
+        if file.filename.ends_with(".md") {
+            assert!(
+                file.content.contains("法的助言ではありません"),
+                "{} should contain legal disclaimer",
+                file.filename
+            );
+        }
+    }
+}
+
+fn doc(files: &[kukuri_cn_operator::GeneratedFile], name: &str) -> String {
+    files
+        .iter()
+        .find(|f| f.filename == name)
+        .unwrap_or_else(|| panic!("missing {name}"))
+        .content
+        .clone()
+}
+
+#[test]
+fn relay_enabled_explains_encrypted_traffic_fallback() {
+    let yaml = base_config("  iroh_relay: true\n  traffic_relay_fallback: true\n", true);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let files = generate_all(&resolved);
+    let telecom = doc(&files, "telecom-notification-draft.md");
+    assert!(telecom.contains("暗号化済み"));
+    let ext = doc(&files, "external-transmission-notice.md");
+    assert!(ext.contains("relay"));
+}
+
+#[test]
+fn analytics_disabled_omits_analytics_destination() {
+    let yaml = base_config("  analytics: false\n", true);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let ext = doc(&generate_all(&resolved), "external-transmission-notice.md");
+    // 「現在の外部送信先」セクションにアナリティクスが運用中として出ないこと。
+    let active_section = ext.split("送信していない").next().unwrap();
+    assert!(!active_section.contains("### アナリティクスプロバイダ"));
+    // 無効として明示はされる。
+    assert!(ext.contains("アナリティクスプロバイダ: 該当機能が無効"));
+}
+
+#[test]
+fn cloudflare_enabled_emits_external_transmission() {
+    let yaml = base_config("  cloudflare_proxy: true\n", true);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let ext = doc(&generate_all(&resolved), "external-transmission-notice.md");
+    let active_section = ext.split("送信していない").next().unwrap();
+    assert!(active_section.contains("Cloudflare"));
+}
+
+#[test]
+fn planned_capability_marked_as_planned_not_operating() {
+    let yaml = base_config("  moderation: true\n", true);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let svc = doc(&generate_all(&resolved), "service-description-draft.md");
+    assert!(svc.contains("計画中（この配布物では未提供）"));
+    // moderation は「運用中の補助機能」セクションに出ない（capability が Planned のため）。
+    let operating_section = svc.split("計画中").next().unwrap();
+    assert!(!operating_section.contains("### モデレーション"));
+}
+
+#[test]
+fn output_is_deterministic() {
+    let resolved = load_and_validate(SAMPLE_CONFIG).unwrap();
+    let first = generate_all(&resolved);
+    let second = generate_all(&resolved);
+    assert_eq!(first, second);
+}
+
+#[test]
+fn drift_check_detects_changes_and_clean() {
+    let resolved = load_and_validate(SAMPLE_CONFIG).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+
+    // 生成前は missing。
+    let report = check_drift(&resolved, dir.path()).unwrap();
+    assert!(!report.is_clean());
+    assert!(!report.missing.is_empty());
+
+    // 生成後は clean。
+    for file in generate_all(&resolved) {
+        std::fs::write(dir.path().join(&file.filename), &file.content).unwrap();
+    }
+    let report = check_drift(&resolved, dir.path()).unwrap();
+    assert!(report.is_clean(), "{}", report.summary());
+
+    // 改変すると changed 検出。
+    std::fs::write(dir.path().join("terms.md"), "tampered").unwrap();
+    let report = check_drift(&resolved, dir.path()).unwrap();
+    assert!(report.changed.contains(&"terms.md".to_string()));
+}
+
+#[test]
+fn parse_then_resolve_roundtrip() {
+    let cfg = parse_config(SAMPLE_CONFIG).unwrap();
+    assert_eq!(cfg.server.country, "JP");
+    let resolved = resolve_and_validate(cfg).unwrap();
+    assert!(resolved.enabled(Capability::CloudflareProxy));
+}

--- a/docs/runbooks/community-node-operator-docs.md
+++ b/docs/runbooks/community-node-operator-docs.md
@@ -1,0 +1,93 @@
+# Community Node Operator Docs Generator (`cn-operator`)
+
+最終更新日: 2026-06-19
+
+## 目的
+
+community node 運営者が `operator-config.yaml` を単一の入力元として、有効化した機能に対応した
+運営者向け文書群（利用規約 / プライバシーポリシー / 外部送信表示 / 電気通信届出補助資料 /
+ネットワーク構成説明 / server manifest）を**決定論的に**生成できるようにする。
+
+これは #352 の実装であり、`docs/architecture/p2p-first-community-node-responsibility-boundary.md`
+の責任境界を共通前提とする。community node を中央 SNS 運営者にするためのものではなく、
+P2P network の補助層を個人・小規模グループでも説明可能に運用できるようにするためのもの。
+
+## Phase A / Phase B（宣言と実行可能の分離）
+
+`cn-operator` は各機能を capability として扱い、`availability` を持たせている。
+
+- **Phase A (`Available`)**: 現行 community node 実装（auth / consent / bootstrap / topic
+  rendezvous / iroh relay）またはデプロイ構成（Cloudflare / analytics / crash report /
+  blob cache / private message storage / push）として提供できる capability。
+  生成文書では「運用中」として開示してよい。
+- **Phase B (`Planned`)**: 現行実装に存在しない capability（`community_index` / `moderation` /
+  `community_local_trust` / `report_endpoint`）。config で宣言できるが、生成文書では
+  「計画中（この配布物では未提供）」として扱い、運用中の外部送信・データ取扱い開示には載せない。
+
+Phase B capability を有効化するには、config に `acknowledge_planned_capabilities: true` を
+明示する必要がある。これがないと検証で失敗する。実体のない「運用中」開示を生成しないためのガード。
+
+## サブコマンド
+
+```bash
+# サンプル config を出力
+cn-operator init --out operator-config.yaml
+
+# config を検証（Phase B 承認ガードを含む）
+cn-operator validate-config --config operator-config.yaml
+
+# 文書群を生成
+cn-operator generate-docs --config operator-config.yaml --out-dir dist/operator-docs
+
+# 生成済み文書と config の drift を検出（差分があれば non-zero exit）
+cn-operator check-disclosures --config operator-config.yaml --out-dir dist/operator-docs
+```
+
+cargo から直接実行する場合:
+
+```bash
+cargo run -p kukuri-cn-operator --bin cn-operator -- generate-docs \
+  --config operator-config.yaml --out-dir dist/operator-docs
+```
+
+## profile
+
+`profile` は features の既定値を与え、個別の `features` キーで上書きできる。
+
+- `minimal`: index / moderation / community-local trust（いずれも計画中）。relay / cache /
+  analytics / crash report は無効。
+- `relay-enabled`: minimal + 専用 iroh relay + 暗号化済み traffic fallback 開示。
+- `full-service`: relay-enabled + blob cache + push 通知 + report endpoint。analytics /
+  crash report は任意（既定無効）。
+
+## 生成される文書
+
+```text
+dist/operator-docs/
+  server-manifest.json          # #355 の authority scope / P2P boundary / capability scope を含む
+  network-diagram.md
+  telecom-notification-draft.md
+  service-description-draft.md
+  terms.md
+  privacy-policy.md
+  external-transmission-notice.md
+  abuse-policy.md
+  moderation-policy.md
+  data-retention-policy.md
+  prior-consultation-email.md
+```
+
+各文書には「法的助言ではない」旨の注記が含まれる。最終判断は運営者自身および総合通信局・
+専門家への確認が必要。
+
+## 決定論性と CI
+
+出力は wall-clock に依存せず、version は config 由来（`manifest.manifest_version`）。
+同じ config からは同じ出力が得られる。CI では `check-disclosures` で生成済み文書と config の
+drift を検出できる。
+
+## 関連
+
+- #352（本実装）, #355（manifest authority scope）, #356（public manifest endpoint）,
+  #359（capability 別リスクガイド）
+- `docs/architecture/p2p-first-community-node-responsibility-boundary.md`

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,11 +6,12 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
-const CN_PACKAGES: [&str; 4] = [
+const CN_PACKAGES: [&str; 5] = [
     "kukuri-cn-core",
     "kukuri-cn-user-api",
     "kukuri-cn-iroh-relay",
     "kukuri-cn-cli",
+    "kukuri-cn-operator",
 ];
 const SERIAL_RUST_PACKAGE: &str = "kukuri-harness";
 const TAURI_CHECK_TARGET_DIR: &str = "target/desktop-tauri-check";


### PR DESCRIPTION
## 概要

#352 の実装。`operator-config.yaml` を単一の入力元として、運営者向け文書群を決定論的に生成する `cn-operator` CLI（新規 crate `crates/cn-operator`）を追加します。

着手にあたり「index/moderation/trust の本実装が #352 の前提か」を検討した結果、**不要**（むしろ #352 が capability の契約を先に固定する方が #355→#356→#310 / #353 の design-first 方針に合致する）と判断し、issue を **Phase A / Phase B に分けて**実装しました。

## Phase A / Phase B（宣言と実行可能の分離）

各機能を `availability` を持つ capability として扱います。

- **Phase A (`Available`)**: 現行 community node 実装（auth / consent / bootstrap / topic rendezvous / iroh relay）またはデプロイ構成（Cloudflare / analytics / crash report / blob cache / private message storage / push）。生成文書で「運用中」として開示。
- **Phase B (`Planned`)**: 未実装の `community_index` / `moderation` / `community_local_trust` / `report_endpoint`。config で宣言できるが「計画中（この配布物では未提供）」として扱い、運用中の外部送信・データ取扱い開示には**載せない**。`acknowledge_planned_capabilities: true` の明示承認がないと検証で失敗（実体のない開示生成を防ぐガード）。

現状確認: `crates/cn-core` には index/moderation/trust モジュールが存在せず、#353 コメントの「relay 中心の early phase」と一致します。

## サブコマンド

- `cn-operator init` — サンプル config 出力
- `cn-operator validate-config` — 検証（Phase B 承認ガード含む）
- `cn-operator generate-docs` — 文書群生成
- `cn-operator check-disclosures` — config と生成物の drift 検出（差分で non-zero exit）

## 生成物

`server-manifest.json`（#355 を先取りし authority scope / P2P boundary / capability scope を含む）, `terms.md`, `privacy-policy.md`, `external-transmission-notice.md`, `telecom-notification-draft.md`, `service-description-draft.md`, `network-diagram.md`, `abuse-policy.md`, `moderation-policy.md`, `data-retention-policy.md`, `prior-consultation-email.md`

## 受け入れ条件（#352）

- [x] `operator-config.yaml` schema 定義
- [x] `minimal` / `relay-enabled` / `full-service` profile
- [x] config validation
- [x] `server-manifest.json` 生成
- [x] terms / privacy / external-transmission / telecom / network-diagram / prior-consultation 生成
- [x] `iroh_relay`/`traffic_relay_fallback` 有効時に暗号化済み traffic fallback を文書へ反映
- [x] `analytics: false` で analytics 送信先を出さない
- [x] `cloudflare_proxy: true` で Cloudflare 外部送信表示を生成
- [x] 決定論的出力（wall-clock 非依存、version は config 由来）
- [x] drift 検出（`check-disclosures`）
- [x] 「法的助言ではない」注記を全 md に付与

## テスト

`cargo test -p kukuri-cn-operator` → 18 件 pass、clippy / fmt クリーン。

注: ワークスペース全体の `cargo check` はこの環境に `libdbus-sys`（system dbus）が無いため別 crate のビルドスクリプトで失敗しますが、本 crate は dbus 非依存でビルド・テスト・lint すべて通過します。

## 関連 / follow-up

- #355 (manifest authority scope) — schema を本 PR が先取り。endpoint/型共有は後続。
- #356 (public manifest endpoint), #359 (capability 別リスクガイド `capability-risk-and-practices.md`), #310 (report routing)
- 前提: `docs/architecture/p2p-first-community-node-responsibility-boundary.md`（#354, close 済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ)_