### PR TITLE
feat(cn-operator): manifest 型付き共有スキーマ + authority scope/P2P境界 (#355)

### DIFF
--- a/crates/cn-operator/src/config.rs
+++ b/crates/cn-operator/src/config.rs
@@ -8,6 +8,7 @@ use anyhow::{Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::capability::{Availability, Capability};
+use crate::manifest::{AuthorityScopeOverride, NodeRole};
 use crate::profile::Profile;
 
 /// `operator-config.yaml` の生表現。
@@ -82,12 +83,16 @@ fn default_moderation_logs_days() -> u32 {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ManifestConfig {
-    /// node role。未指定なら有効 capability から推定する。
+    /// node role。未指定なら profile / 有効 capability から推定する。
     #[serde(default)]
-    pub node_role: Option<String>,
+    pub node_role: Option<NodeRole>,
     /// manifest / policy version。決定論的出力のため config 由来とする。
     #[serde(default = "default_manifest_version")]
     pub manifest_version: String,
+    /// authority scope を operator が明示的に拡張・上書きするための設定。
+    /// 未指定なら applies_to は有効 capability から導出し、does_not_apply_to は安全な default を使う。
+    #[serde(default)]
+    pub authority_scope: AuthorityScopeOverride,
 }
 
 fn default_manifest_version() -> String {

--- a/crates/cn-operator/src/docs.rs
+++ b/crates/cn-operator/src/docs.rs
@@ -11,7 +11,7 @@ use std::fmt::Write as _;
 
 use crate::capability::{Availability, Capability, ExternalDestination};
 use crate::config::ResolvedConfig;
-use crate::manifest::render_manifest;
+use crate::manifest::{build_manifest, render_manifest};
 
 /// すべての生成文書に付す共通の注記。
 const LEGAL_DISCLAIMER: &str = "> 注記: この文書は operator config から自動生成された下書きであり、法的助言ではありません。\n\
@@ -131,6 +131,41 @@ fn gen_network_diagram(config: &ResolvedConfig) -> String {
              経由し得ます。届出要否は構成と所在地に依存するため、別途確認してください。\n"
         );
     }
+
+    // manifest の authority scope / P2P boundary を文書へ反映する。
+    let manifest = build_manifest(config);
+    let _ = writeln!(s, "## node role と責任境界 (authority scope)\n");
+    let _ = writeln!(
+        s,
+        "- node role: `{}`",
+        serde_json::to_value(manifest.node_role)
+            .ok()
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| "community-node".to_string())
+    );
+    let _ = writeln!(s, "\n本ノードが責任を負う範囲 (applies_to):\n");
+    for item in &manifest.authority_scope.applies_to {
+        let _ = writeln!(s, "- `{item}`");
+    }
+    let _ = writeln!(s, "\n本ノードが責任を負わない範囲 (does_not_apply_to):\n");
+    for item in &manifest.authority_scope.does_not_apply_to {
+        let _ = writeln!(s, "- `{item}`");
+    }
+    let _ = writeln!(s, "\n## P2P boundary\n");
+    let _ = writeln!(
+        s,
+        "本ノードは以下のいずれの権威も持ちません（kukuri の P2P-first 設計の不変条件）。\n"
+    );
+    let _ = writeln!(s, "- identity authority: false");
+    let _ = writeln!(s, "- profile canonical store: false");
+    let _ = writeln!(s, "- social graph canonical store: false");
+    let _ = writeln!(s, "- content truth source: false");
+    let _ = writeln!(s, "- network-wide authority: false\n");
+    let _ = writeln!(
+        s,
+        "詳細は `server-manifest.json` の `authority_scope` / `p2p_boundary` を参照してください。\n"
+    );
+
     s.push_str(&planned_section(config));
     s
 }

--- a/crates/cn-operator/src/lib.rs
+++ b/crates/cn-operator/src/lib.rs
@@ -26,7 +26,11 @@ pub use config::{
 };
 pub use docs::{GeneratedFile, generate_all};
 pub use drift::{DriftReport, check_drift};
-pub use manifest::{build_manifest, render_manifest};
+pub use manifest::{
+    AuthorityScope, AuthorityScopeOverride, Capabilities, CapabilityScope, CommunityNodeManifest,
+    ManifestFeatures, ManifestRetention, NodeRole, P2pBoundary, build_manifest, manifest_value,
+    render_manifest,
+};
 pub use profile::Profile;
 
 /// `operator init` が出力するサンプル config。
@@ -59,6 +63,12 @@ retention:
 
 manifest:
   manifest_version: v1
+  # node_role 未指定なら有効 capability から推定する（既定: community-node）。
+  # default onboarding node の場合は明示する:
+  #   node_role: default-onboarding-node
+  # authority_scope:
+  #   additional_applies_to: []        # 導出された applies_to に追加する項目
+  #   does_not_apply_to: null          # 未指定なら安全な default を使う
 
 # community_index / moderation / community_local_trust / report_endpoint は
 # 現行実装では未提供（計画中）。spec として記述することを明示的に承認する。

--- a/crates/cn-operator/src/manifest.rs
+++ b/crates/cn-operator/src/manifest.rs
@@ -1,54 +1,227 @@
-//! operator config から `server-manifest.json` を決定論的に生成する。
+//! community node manifest の型付き共有スキーマ (#355)。
 //!
-//! manifest は #355 の authority scope / P2P boundary / capability scope を先取りした
-//! schema を持ち、client の dependency 表示 / report routing / consent UI から利用できる。
+//! `server-manifest.json` を単なる JSON 値ではなく型付き struct として定義する。これにより:
+//! - operator config (#352) から決定論的に生成できる
+//! - public manifest endpoint (#356) が同じ型を共有できる
+//! - client が dependency 表示 / report routing / consent UI で型安全に扱える
 //!
-//! Phase A / Phase B の分離はここでも保たれる。capability scope は
-//! `available_enabled`（運用中）と `planned_enabled`（計画中・未提供）を分けて宣言する。
+//! authority scope / P2P boundary は `docs/architecture/p2p-first-community-node-responsibility-boundary.md`
+//! の責任境界を machine-readable に表現する。community node を home server / central operator と
+//! 誤解させないため、p2p_boundary は identity / profile / social graph / network-wide authority を
+//! すべて false として宣言する（これは kukuri の P2P-first 設計の不変条件であり、operator は変更できない）。
+//!
+//! Phase A / Phase B の分離も保持する。`capability_scope` は `available_enabled`（運用中）と
+//! `planned_enabled`（計画中・未提供）を分けて宣言する。
 
-use serde_json::{Value, json};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::capability::{Availability, Capability};
 use crate::config::ResolvedConfig;
 
-/// node role を推定する（config 指定があればそれを優先）。
-fn node_role(config: &ResolvedConfig) -> String {
-    if let Some(role) = config
-        .raw
-        .manifest
-        .node_role
-        .clone()
-        .filter(|r| !r.trim().is_empty())
-    {
-        return role;
+/// community node の役割。
+///
+/// `default-onboarding-node` と `community-node`（third-party）を区別できることが重要。
+/// default-onboarding-node は onboarding infrastructure であり network-wide authority ではない。
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NodeRole {
+    DefaultOnboardingNode,
+    /// 複数 capability を持つ一般的なノードの既定 role。
+    #[default]
+    CommunityNode,
+    RelayAssist,
+    IndexNode,
+    ModerationNode,
+    TrustSignalNode,
+}
+
+impl NodeRole {
+    /// 明示指定がない場合に有効 capability から role を推定する。
+    ///
+    /// 複数 capability を持つノードは一般的なため、既定は `community-node`。
+    /// 単一目的に強く寄っている場合のみ専用 role を推定する。
+    fn infer(config: &ResolvedConfig) -> NodeRole {
+        let index = config.enabled(Capability::CommunityIndex);
+        let moderation = config.enabled(Capability::Moderation);
+        let trust = config.enabled(Capability::CommunityLocalTrust);
+        let relay = config.enabled(Capability::IrohRelay)
+            || config.enabled(Capability::TrafficRelayFallback);
+
+        // 単一目的への強い寄りを優先して推定する。
+        match (index, moderation, trust, relay) {
+            (true, false, false, false) => NodeRole::IndexNode,
+            (false, true, false, false) => NodeRole::ModerationNode,
+            (false, false, true, false) => NodeRole::TrustSignalNode,
+            (false, false, false, true) => NodeRole::RelayAssist,
+            _ => NodeRole::CommunityNode,
+        }
     }
-    "community-node".to_string()
+
+    fn resolve(config: &ResolvedConfig) -> NodeRole {
+        config
+            .raw
+            .manifest
+            .node_role
+            .unwrap_or_else(|| NodeRole::infer(config))
+    }
+}
+
+/// authority scope を operator が拡張・上書きするための設定。
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorityScopeOverride {
+    /// 有効 capability から導出した applies_to に追加する項目。
+    #[serde(default)]
+    pub additional_applies_to: Vec<String>,
+    /// does_not_apply_to を上書きする。未指定なら安全な default を使う。
+    #[serde(default)]
+    pub does_not_apply_to: Option<Vec<String>>,
+}
+
+/// 安全な default の does_not_apply_to。
+fn default_does_not_apply_to() -> Vec<String> {
+    [
+        "kukuri_network_as_a_whole",
+        "third_party_nodes",
+        "user_identity",
+        "user_profile_canonical_source",
+        "user_social_graph_canonical_source",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+/// 各 capability の有効・無効。client が capability scope を型安全に扱えるようにする。
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct Capabilities {
+    pub auth_consent: bool,
+    pub bootstrap_assist: bool,
+    pub topic_rendezvous: bool,
+    pub iroh_relay: bool,
+    pub traffic_relay_fallback: bool,
+    pub blob_cache: bool,
+    pub private_message_storage: bool,
+    pub analytics: bool,
+    pub crash_report: bool,
+    pub cloudflare_proxy: bool,
+    pub push_notification: bool,
+    pub community_index: bool,
+    pub moderation: bool,
+    pub community_local_trust: bool,
+    pub report_endpoint: bool,
+}
+
+impl Capabilities {
+    fn from_config(config: &ResolvedConfig) -> Self {
+        Self {
+            auth_consent: config.enabled(Capability::AuthConsent),
+            bootstrap_assist: config.enabled(Capability::BootstrapAssist),
+            topic_rendezvous: config.enabled(Capability::TopicRendezvous),
+            iroh_relay: config.enabled(Capability::IrohRelay),
+            traffic_relay_fallback: config.enabled(Capability::TrafficRelayFallback),
+            blob_cache: config.enabled(Capability::BlobCache),
+            private_message_storage: config.enabled(Capability::PrivateMessageStorage),
+            analytics: config.enabled(Capability::Analytics),
+            crash_report: config.enabled(Capability::CrashReport),
+            cloudflare_proxy: config.enabled(Capability::CloudflareProxy),
+            push_notification: config.enabled(Capability::PushNotification),
+            community_index: config.enabled(Capability::CommunityIndex),
+            moderation: config.enabled(Capability::Moderation),
+            community_local_trust: config.enabled(Capability::CommunityLocalTrust),
+            report_endpoint: config.enabled(Capability::ReportEndpoint),
+        }
+    }
+}
+
+/// Phase A / Phase B を分離した capability scope。
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct CapabilityScope {
+    /// 有効かつ提供中（Phase A）の capability キー。
+    pub available_enabled: Vec<String>,
+    /// 有効だが計画中・未提供（Phase B）の capability キー。
+    pub planned_enabled: Vec<String>,
+}
+
+/// authority scope。node が責任を主張する範囲と、しない範囲。
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct AuthorityScope {
+    pub applies_to: Vec<String>,
+    pub does_not_apply_to: Vec<String>,
+}
+
+/// P2P boundary metadata。
+///
+/// kukuri の P2P-first 不変条件として、community node は user identity / profile /
+/// social graph / content truth source / network-wide authority のいずれの権威も持たない
+/// （すべて false）。`Default` がこの不変条件を表現する。
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct P2pBoundary {
+    pub identity_authority: bool,
+    pub profile_canonical_store: bool,
+    pub social_graph_canonical_store: bool,
+    pub content_truth_source: bool,
+    pub network_wide_authority: bool,
+}
+
+/// 互換のための features サマリ（#352 例と整合）。
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct ManifestFeatures {
+    pub community_index: bool,
+    pub moderation: bool,
+    /// "community-local" または "none"。
+    pub trust_score: String,
+    pub iroh_relay: bool,
+    /// "dedicated" または "none"。
+    pub iroh_relay_mode: String,
+    pub traffic_relay_fallback: bool,
+    pub private_message_storage: bool,
+    pub blob_cache: bool,
+}
+
+/// retention サマリ。
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct ManifestRetention {
+    pub connection_logs_days: u32,
+    pub moderation_logs_days: u32,
+}
+
+/// community node manifest（`server-manifest.json` の型付き表現）。
+///
+/// フィールド宣言順がそのまま JSON の出力順となり、決定論的。
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct CommunityNodeManifest {
+    pub node_id: String,
+    pub node_name: String,
+    pub node_role: NodeRole,
+    pub server_name: String,
+    pub operator_name: String,
+    pub operator_country: String,
+    pub cloud_provider: String,
+    pub region: String,
+    pub contact: String,
+    pub abuse_contact: String,
+    pub terms_url: String,
+    pub privacy_url: String,
+    pub external_transmission_url: String,
+    pub moderation_policy_url: String,
+    pub abuse_policy_url: String,
+    pub manifest_version: String,
+    pub capabilities: Capabilities,
+    pub capability_scope: CapabilityScope,
+    pub authority_scope: AuthorityScope,
+    pub p2p_boundary: P2pBoundary,
+    pub features: ManifestFeatures,
+    pub retention: ManifestRetention,
 }
 
 fn capability_keys(caps: &[Capability]) -> Vec<String> {
     caps.iter().map(|c| c.key().to_string()).collect()
 }
 
-/// `server-manifest.json` の値を構築する。
-///
-/// serde_json の Map は既定でキー順ソートされるため、出力は決定論的。
-pub fn build_manifest(config: &ResolvedConfig) -> Value {
-    let server = &config.raw.server;
-
-    let available_enabled: Vec<Capability> = config
-        .enabled_capabilities()
-        .into_iter()
-        .filter(|c| c.availability() == Availability::Available)
-        .collect();
-    let planned_enabled = config.enabled_planned_capabilities();
-
-    // capabilities マップ: 全 capability の有効・無効。
-    let mut capabilities = serde_json::Map::new();
-    for cap in Capability::ALL {
-        capabilities.insert(cap.key().to_string(), Value::Bool(config.enabled(cap)));
-    }
-
-    // authority scope: applies_to は実際に有効な capability から導出する。
+/// authority scope を有効 capability + operator override から構築する。
+fn build_authority_scope(config: &ResolvedConfig) -> AuthorityScope {
     let mut applies_to = vec!["this_node".to_string()];
     if config.enabled(Capability::CommunityIndex) {
         applies_to.push("communities_indexed_by_this_node".to_string());
@@ -63,76 +236,105 @@ pub fn build_manifest(config: &ResolvedConfig) -> Value {
         applies_to.push("media_cached_by_this_node".to_string());
     }
 
+    // operator が明示した追加項目を重複なく足す。
+    for extra in &config.raw.manifest.authority_scope.additional_applies_to {
+        if !applies_to.contains(extra) {
+            applies_to.push(extra.clone());
+        }
+    }
+
+    let does_not_apply_to = config
+        .raw
+        .manifest
+        .authority_scope
+        .does_not_apply_to
+        .clone()
+        .unwrap_or_else(default_does_not_apply_to);
+
+    AuthorityScope {
+        applies_to,
+        does_not_apply_to,
+    }
+}
+
+/// operator config から typed manifest を構築する。
+pub fn build_manifest(config: &ResolvedConfig) -> CommunityNodeManifest {
+    let server = &config.raw.server;
+
+    let available_enabled: Vec<Capability> = config
+        .enabled_capabilities()
+        .into_iter()
+        .filter(|c| c.availability() == Availability::Available)
+        .collect();
+    let planned_enabled = config.enabled_planned_capabilities();
+
     let iroh_relay_mode = if config.enabled(Capability::IrohRelay) {
         "dedicated"
     } else {
         "none"
-    };
+    }
+    .to_string();
 
-    json!({
-        "node_id": server.node_id.clone().unwrap_or_default(),
-        "node_name": server.node_name.clone().unwrap_or_else(|| server.domain.clone()),
-        "node_role": node_role(config),
-        "server_name": server.domain,
-        "operator_name": server.operator_name,
-        "operator_country": server.country,
-        "cloud_provider": server.cloud_provider.clone().unwrap_or_default(),
-        "region": server.region.clone().unwrap_or_default(),
-        "contact": config.contact(),
-        "abuse_contact": config.contact(),
-        "terms_url": config.policy_url("terms"),
-        "privacy_url": config.policy_url("privacy"),
-        "external_transmission_url": config.policy_url("external-transmission"),
-        "moderation_policy_url": config.policy_url("moderation-policy"),
-        "abuse_policy_url": config.policy_url("abuse-policy"),
-        "manifest_version": config.raw.manifest.manifest_version,
-        "capabilities": Value::Object(capabilities),
-        "capability_scope": {
-            "available_enabled": capability_keys(&available_enabled),
-            "planned_enabled": capability_keys(&planned_enabled),
+    let trust_score = if config.enabled(Capability::CommunityLocalTrust) {
+        "community-local"
+    } else {
+        "none"
+    }
+    .to_string();
+
+    CommunityNodeManifest {
+        node_id: server.node_id.clone().unwrap_or_default(),
+        node_name: server
+            .node_name
+            .clone()
+            .unwrap_or_else(|| server.domain.clone()),
+        node_role: NodeRole::resolve(config),
+        server_name: server.domain.clone(),
+        operator_name: server.operator_name.clone(),
+        operator_country: server.country.clone(),
+        cloud_provider: server.cloud_provider.clone().unwrap_or_default(),
+        region: server.region.clone().unwrap_or_default(),
+        contact: config.contact(),
+        abuse_contact: config.contact(),
+        terms_url: config.policy_url("terms"),
+        privacy_url: config.policy_url("privacy"),
+        external_transmission_url: config.policy_url("external-transmission"),
+        moderation_policy_url: config.policy_url("moderation-policy"),
+        abuse_policy_url: config.policy_url("abuse-policy"),
+        manifest_version: config.raw.manifest.manifest_version.clone(),
+        capabilities: Capabilities::from_config(config),
+        capability_scope: CapabilityScope {
+            available_enabled: capability_keys(&available_enabled),
+            planned_enabled: capability_keys(&planned_enabled),
         },
-        "authority_scope": {
-            "applies_to": applies_to,
-            "does_not_apply_to": [
-                "kukuri_network_as_a_whole",
-                "third_party_nodes",
-                "user_identity",
-                "user_profile_canonical_source",
-                "user_social_graph_canonical_source",
-            ],
+        authority_scope: build_authority_scope(config),
+        p2p_boundary: P2pBoundary::default(),
+        features: ManifestFeatures {
+            community_index: config.enabled(Capability::CommunityIndex),
+            moderation: config.enabled(Capability::Moderation),
+            trust_score,
+            iroh_relay: config.enabled(Capability::IrohRelay),
+            iroh_relay_mode,
+            traffic_relay_fallback: config.enabled(Capability::TrafficRelayFallback),
+            private_message_storage: config.enabled(Capability::PrivateMessageStorage),
+            blob_cache: config.enabled(Capability::BlobCache),
         },
-        "p2p_boundary": {
-            "identity_authority": false,
-            "profile_canonical_store": false,
-            "social_graph_canonical_store": false,
-            "content_truth_source": false,
-            "network_wide_authority": false,
+        retention: ManifestRetention {
+            connection_logs_days: config.raw.retention.connection_logs_days,
+            moderation_logs_days: config.raw.retention.moderation_logs_days,
         },
-        "features": {
-            "community_index": config.enabled(Capability::CommunityIndex),
-            "moderation": config.enabled(Capability::Moderation),
-            "trust_score": if config.enabled(Capability::CommunityLocalTrust) {
-                "community-local"
-            } else {
-                "none"
-            },
-            "iroh_relay": config.enabled(Capability::IrohRelay),
-            "iroh_relay_mode": iroh_relay_mode,
-            "traffic_relay_fallback": config.enabled(Capability::TrafficRelayFallback),
-            "private_message_storage": config.enabled(Capability::PrivateMessageStorage),
-            "blob_cache": config.enabled(Capability::BlobCache),
-        },
-        "retention": {
-            "connection_logs_days": config.raw.retention.connection_logs_days,
-            "moderation_logs_days": config.raw.retention.moderation_logs_days,
-        },
-    })
+    }
+}
+
+/// manifest を `serde_json::Value` として得る。
+pub fn manifest_value(config: &ResolvedConfig) -> Value {
+    serde_json::to_value(build_manifest(config)).expect("manifest to value")
 }
 
 /// manifest を改行終端の pretty JSON 文字列にする。
 pub fn render_manifest(config: &ResolvedConfig) -> String {
-    let value = build_manifest(config);
-    let mut out = serde_json::to_string_pretty(&value).expect("manifest serialization");
+    let manifest = build_manifest(config);
+    let mut out = serde_json::to_string_pretty(&manifest).expect("manifest serialization");
     out.push('\n');
     out
 }

--- a/crates/cn-operator/tests/generate.rs
+++ b/crates/cn-operator/tests/generate.rs
@@ -1,6 +1,6 @@
 use kukuri_cn_operator::{
-    Capability, SAMPLE_CONFIG, build_manifest, check_drift, generate_all, load_and_validate,
-    parse_config, resolve_and_validate,
+    Capability, NodeRole, SAMPLE_CONFIG, build_manifest, check_drift, generate_all,
+    load_and_validate, manifest_value, parse_config, resolve_and_validate,
 };
 
 fn base_config(extra_features: &str, ack: bool) -> String {
@@ -96,7 +96,7 @@ fn missing_required_fields_fail() {
 #[test]
 fn manifest_has_authority_scope_and_p2p_boundary() {
     let resolved = load_and_validate(SAMPLE_CONFIG).unwrap();
-    let m = build_manifest(&resolved);
+    let m = manifest_value(&resolved);
 
     // P2P boundary は identity / profile / social graph / network authority を false 宣言。
     let boundary = &m["p2p_boundary"];
@@ -246,4 +246,130 @@ fn parse_then_resolve_roundtrip() {
     assert_eq!(cfg.server.country, "JP");
     let resolved = resolve_and_validate(cfg).unwrap();
     assert!(resolved.enabled(Capability::CloudflareProxy));
+}
+
+// --- #355: manifest authority scope / P2P boundary / node role ---
+
+#[test]
+fn typed_manifest_roundtrips_through_json() {
+    let resolved = load_and_validate(SAMPLE_CONFIG).unwrap();
+    let manifest = build_manifest(&resolved);
+    let json = serde_json::to_string(&manifest).unwrap();
+    let back: kukuri_cn_operator::CommunityNodeManifest = serde_json::from_str(&json).unwrap();
+    // capabilities が型付きで往復できる。
+    assert_eq!(
+        back.capabilities.iroh_relay,
+        manifest.capabilities.iroh_relay
+    );
+    assert_eq!(back.node_role, manifest.node_role);
+}
+
+#[test]
+fn node_role_defaults_to_community_node() {
+    let yaml = base_config("  iroh_relay: true\n  community_index: true\n", true);
+    let resolved = load_and_validate(&yaml).unwrap();
+    // 複数 capability を持つため community-node に推定される。
+    assert_eq!(build_manifest(&resolved).node_role, NodeRole::CommunityNode);
+}
+
+#[test]
+fn node_role_infers_relay_assist_for_relay_only() {
+    let yaml = "server:\n  domain: d.net\n  operator_name: Op\n  country: JP\n\
+                features:\n  iroh_relay: true\n";
+    let resolved = load_and_validate(yaml).unwrap();
+    assert_eq!(build_manifest(&resolved).node_role, NodeRole::RelayAssist);
+}
+
+#[test]
+fn explicit_node_role_is_respected() {
+    let yaml = "server:\n  domain: d.net\n  operator_name: Op\n  country: JP\n\
+                manifest:\n  node_role: default-onboarding-node\n";
+    let resolved = load_and_validate(yaml).unwrap();
+    assert_eq!(
+        build_manifest(&resolved).node_role,
+        NodeRole::DefaultOnboardingNode
+    );
+}
+
+#[test]
+fn default_onboarding_node_distinguished_from_community_node() {
+    let onboarding = "server:\n  domain: d.net\n  operator_name: Op\n  country: JP\n\
+                      manifest:\n  node_role: default-onboarding-node\n";
+    let community = "server:\n  domain: d.net\n  operator_name: Op\n  country: JP\n\
+                     manifest:\n  node_role: community-node\n";
+    let a = build_manifest(&load_and_validate(onboarding).unwrap()).node_role;
+    let b = build_manifest(&load_and_validate(community).unwrap()).node_role;
+    assert_ne!(a, b);
+    assert_eq!(a, NodeRole::DefaultOnboardingNode);
+}
+
+#[test]
+fn authority_scope_applies_to_derives_from_capabilities() {
+    let yaml = base_config("  community_index: true\n", true);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let m = build_manifest(&resolved);
+    assert!(
+        m.authority_scope
+            .applies_to
+            .contains(&"this_node".to_string())
+    );
+    assert!(
+        m.authority_scope
+            .applies_to
+            .contains(&"communities_indexed_by_this_node".to_string())
+    );
+}
+
+#[test]
+fn operator_can_extend_applies_to() {
+    let yaml = "server:\n  domain: d.net\n  operator_name: Op\n  country: JP\n\
+                manifest:\n  authority_scope:\n    additional_applies_to:\n      - custom_scope\n";
+    let resolved = load_and_validate(yaml).unwrap();
+    let m = build_manifest(&resolved);
+    assert!(
+        m.authority_scope
+            .applies_to
+            .contains(&"custom_scope".to_string())
+    );
+}
+
+#[test]
+fn does_not_apply_to_has_safe_default() {
+    let yaml = "server:\n  domain: d.net\n  operator_name: Op\n  country: JP\n";
+    let resolved = load_and_validate(yaml).unwrap();
+    let m = build_manifest(&resolved);
+    for expected in [
+        "kukuri_network_as_a_whole",
+        "user_identity",
+        "user_profile_canonical_source",
+        "user_social_graph_canonical_source",
+        "third_party_nodes",
+    ] {
+        assert!(
+            m.authority_scope
+                .does_not_apply_to
+                .contains(&expected.to_string()),
+            "missing {expected}"
+        );
+    }
+}
+
+#[test]
+fn p2p_boundary_is_all_false_invariant() {
+    let resolved = load_and_validate(SAMPLE_CONFIG).unwrap();
+    let b = build_manifest(&resolved).p2p_boundary;
+    assert!(!b.identity_authority);
+    assert!(!b.profile_canonical_store);
+    assert!(!b.social_graph_canonical_store);
+    assert!(!b.content_truth_source);
+    assert!(!b.network_wide_authority);
+}
+
+#[test]
+fn generated_docs_reflect_authority_scope() {
+    let resolved = load_and_validate(SAMPLE_CONFIG).unwrap();
+    let diagram = doc(&generate_all(&resolved), "network-diagram.md");
+    assert!(diagram.contains("authority scope"));
+    assert!(diagram.contains("does_not_apply_to"));
+    assert!(diagram.contains("network-wide authority: false"));
 }

--- a/docs/runbooks/community-node-operator-docs.md
+++ b/docs/runbooks/community-node-operator-docs.md
@@ -64,7 +64,7 @@ cargo run -p kukuri-cn-operator --bin cn-operator -- generate-docs \
 
 ```text
 dist/operator-docs/
-  server-manifest.json          # #355 の authority scope / P2P boundary / capability scope を含む
+  server-manifest.json          # #355: 型付き manifest schema（下記参照）
   network-diagram.md
   telecom-notification-draft.md
   service-description-draft.md
@@ -79,6 +79,34 @@ dist/operator-docs/
 
 各文書には「法的助言ではない」旨の注記が含まれる。最終判断は運営者自身および総合通信局・
 専門家への確認が必要。
+
+## server-manifest.json（#355）
+
+`server-manifest.json` は型付きの共有スキーマ（`kukuri_cn_operator::CommunityNodeManifest`）として
+定義される。public manifest endpoint (#356) や client（dependency 表示 / report routing /
+consent UI）が同じ型を共有して扱えるようにするためのもの。主な構造:
+
+- `node_role`: `default-onboarding-node` / `community-node` / `relay-assist` / `index-node` /
+  `moderation-node` / `trust-signal-node`。未指定なら有効 capability から推定（既定 `community-node`）。
+  default onboarding node は明示することで third-party community node と区別できる。
+- `capabilities`: 全 capability の有効・無効。
+- `capability_scope`: `available_enabled`（Phase A）/ `planned_enabled`（Phase B）を分離。
+- `authority_scope`: `applies_to`（有効 capability から導出 + operator が `additional_applies_to`
+  で拡張可能）/ `does_not_apply_to`（安全な default。operator が上書き可能）。
+- `p2p_boundary`: identity / profile / social graph / content truth source / network-wide
+  authority をすべて `false` 宣言。これは kukuri の P2P-first 設計の不変条件であり、operator は
+  変更できない（community node を home server / central operator と誤解させないため）。
+
+config からの設定例:
+
+```yaml
+manifest:
+  node_role: default-onboarding-node
+  authority_scope:
+    additional_applies_to:
+      - custom_scope
+    does_not_apply_to: null   # 未指定なら安全な default
+```
 
 ## 決定論性と CI
 


### PR DESCRIPTION
## 概要

#355 の実装。#352 で先取りしていた `server-manifest.json` を、**型付きの共有スキーマ** `CommunityNodeManifest`（`kukuri_cn_operator`）として正式に切り出し、authority scope / P2P boundary / capability scope を machine-readable に表現します。これにより public manifest endpoint (#356) や client が同じ型を共有し、dependency 表示 / report routing / consent UI で型安全に扱えます。

## 主な変更

- **`NodeRole` enum** を追加: `default-onboarding-node` / `community-node` / `relay-assist` / `index-node` / `moderation-node` / `trust-signal-node`。未指定なら有効 capability から推定（既定 `community-node`、単一目的ノードは専用 role）。**default onboarding node を third-party community node と区別できる**。
- **`authority_scope`**: `applies_to` は有効 capability から導出し、operator が `additional_applies_to` で拡張可能。`does_not_apply_to` は安全な default（`user_identity` / `user_profile_canonical_source` / `user_social_graph_canonical_source` / `kukuri_network_as_a_whole` / `third_party_nodes`）を持ち、operator が上書き可能。
- **`p2p_boundary`**: identity / profile / social graph / content truth source / network-wide authority をすべて `false` 宣言。これは kukuri の P2P-first 設計の**不変条件**であり operator は変更できない（home server / central operator と誤解させないため）。
- **`capability_scope`**: Phase A (`available_enabled`) / Phase B (`planned_enabled`) を分離（#352 から継続）。
- 型付き struct のフィールド宣言順で**決定論的**に出力。
- `network-diagram.md` に node role / authority scope / P2P boundary を反映（生成docsへの反映）。
- config に `manifest.node_role` / `manifest.authority_scope` を追加。runbook も更新。

## 受け入れ条件（#355）

- [x] manifest schema に authority scope
- [x] manifest schema に P2P boundary metadata
- [x] manifest schema に capability scope
- [x] identity / profile / social graph / network-wide authority を false 宣言できる
- [x] default-onboarding-node と third-party community-node を区別できる
- [x] #352 operator config から生成できる
- [x] generated docs に manifest の authority scope が反映される
- [x] client が dependency 表示・report routing に使える構造（型付き struct + serde 往復テスト）
- [x] community node を home server / central operator と誤解させない命名・不変条件

## テスト

`cargo test -p kukuri-cn-operator` → **28件 pass**（#355向けに NodeRole 推定/明示、authority scope 導出/拡張、does_not_apply_to default、p2p_boundary 不変、型付きJSON往復、docs反映 など10件追加）。clippy (`-D warnings`) / fmt クリーン。

## follow-up

- #356 (public manifest endpoint) — この `CommunityNodeManifest` 型を endpoint response として共有し、#352 の生成 manifest との schema drift を型共有で防ぐ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ)_