### PR TITLE
feat(cn-user-api): public manifest endpoint (#356)

### DIFF
--- a/.env.community-node.example
+++ b/.env.community-node.example
@@ -25,6 +25,12 @@ CN_BASE_URL=http://127.0.0.1:18080
 CN_PUBLIC_BASE_URL=http://127.0.0.1:18080
 COMMUNITY_NODE_CONNECTIVITY_URLS=http://127.0.0.1:13340
 
+# public manifest endpoint (#356) を有効化する場合、operator-config.yaml のパスを指定する。
+# 設定すると GET /.well-known/kukuri/community-node.json と GET /v1/node/manifest が
+# unauthenticated で manifest を返す。未設定なら両 endpoint は 404。
+# 不正な config を指すと起動時に失敗する（設定ミスを黙って無視しない）。
+# COMMUNITY_NODE_OPERATOR_CONFIG=/etc/kukuri/operator-config.yaml
+
 CN_USER_API_HOST_BIND_IP=127.0.0.1
 CN_USER_API_PORT=18080
 CN_IROH_RELAY_HTTP_HOST_BIND_IP=127.0.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,6 +2967,7 @@ dependencies = [
  "axum",
  "chrono",
  "kukuri-cn-core",
+ "kukuri-cn-operator",
  "kukuri-core",
  "redis",
  "reqwest 0.13.4",

--- a/crates/cn-user-api/Cargo.toml
+++ b/crates/cn-user-api/Cargo.toml
@@ -22,6 +22,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 kukuri-cn-core = { path = "../cn-core" }
+kukuri-cn-operator = { path = "../cn-operator" }
 
 [dev-dependencies]
 kukuri-core = { path = "../core" }

--- a/crates/cn-user-api/src/lib.rs
+++ b/crates/cn-user-api/src/lib.rs
@@ -1,8 +1,11 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use axum::extract::State;
-use axum::http::HeaderMap;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use kukuri_cn_core::{
@@ -17,6 +20,7 @@ use kukuri_cn_core::{
     require_bearer_identity, require_bearer_pubkey, require_consents,
     verify_auth_envelope_and_issue_token,
 };
+use kukuri_cn_operator::{CommunityNodeManifest, build_manifest, load_and_validate};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sqlx::postgres::PgPool;
@@ -32,6 +36,15 @@ pub struct UserApiState {
     rendezvous_store: TopicRendezvousStore,
     jwt_config: JwtConfig,
     self_node: CommunityNodeBootstrapNode,
+    /// 公開する manifest（operator config が設定されている場合のみ）。
+    manifest: Option<Arc<CommunityNodeManifest>>,
+}
+
+/// public manifest endpoint 用の最小 state。DB を必要としないため、
+/// manifest 単独でテスト・配信できる。
+#[derive(Clone)]
+struct ManifestState {
+    manifest: Option<Arc<CommunityNodeManifest>>,
 }
 
 #[derive(Clone, Debug)]
@@ -44,6 +57,9 @@ pub struct UserApiConfig {
     pub public_base_url: String,
     pub connectivity_urls: Vec<String>,
     pub jwt_config: JwtConfig,
+    /// 公開 manifest を生成する operator-config.yaml のパス。
+    /// 未設定なら manifest endpoint は 404 を返す（client は別 node / 直接 P2P へ fallback）。
+    pub operator_config_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -105,6 +121,10 @@ impl UserApiConfig {
         )?;
         let connectivity_urls =
             normalize_http_url_list(parse_csv_env("COMMUNITY_NODE_CONNECTIVITY_URLS"))?;
+        let operator_config_path = std::env::var("COMMUNITY_NODE_OPERATOR_CONFIG")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .map(PathBuf::from);
         Ok(Self {
             bind_addr,
             database_url,
@@ -114,6 +134,7 @@ impl UserApiConfig {
             public_base_url,
             connectivity_urls,
             jwt_config: JwtConfig::from_env()?,
+            operator_config_path,
         })
     }
 }
@@ -226,6 +247,7 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
         config.rendezvous_redis_url.as_str(),
         config.rendezvous_key_prefix.as_str(),
     )?;
+    let manifest = load_manifest(config.operator_config_path.as_deref())?;
     Ok(UserApiState {
         pool,
         rendezvous_store,
@@ -238,11 +260,28 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
                 Vec::new(),
             )?,
         },
+        manifest,
     })
 }
 
+/// operator config から公開 manifest を構築する。
+///
+/// config が指定されているのに読込・検証に失敗した場合は起動を失敗させる
+/// （運営者の設定ミスを黙って無視せず、明示的に止める）。
+fn load_manifest(path: Option<&std::path::Path>) -> Result<Option<Arc<CommunityNodeManifest>>> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    let yaml = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read operator config at {}", path.display()))?;
+    let resolved = load_and_validate(&yaml)
+        .with_context(|| format!("invalid operator config at {}", path.display()))?;
+    Ok(Some(Arc::new(build_manifest(&resolved))))
+}
+
 pub fn app_router(state: UserApiState) -> Router {
-    Router::new()
+    let manifest = manifest_routes(state.manifest.clone());
+    let api = Router::new()
         .route("/healthz", get(healthz))
         .route("/v1/auth/challenge", post(auth_challenge))
         .route("/v1/auth/verify", post(auth_verify))
@@ -254,8 +293,46 @@ pub fn app_router(state: UserApiState) -> Router {
             "/v1/rendezvous/topics/heartbeat",
             post(topic_rendezvous_heartbeat),
         )
-        .layer(TraceLayer::new_for_http())
-        .with_state(state)
+        .with_state(state);
+    api.merge(manifest).layer(TraceLayer::new_for_http())
+}
+
+/// 公開 manifest endpoint。unauthenticated で取得できる。
+///
+/// `GET /.well-known/kukuri/community-node.json` と `GET /v1/node/manifest` の
+/// 両方を同じ handler で提供する。manifest 単独でテスト・配信できるよう、DB を
+/// 必要としない最小 state を持つ独立 router にしている。
+pub fn manifest_routes(manifest: Option<Arc<CommunityNodeManifest>>) -> Router {
+    Router::new()
+        .route(
+            "/.well-known/kukuri/community-node.json",
+            get(node_manifest),
+        )
+        .route("/v1/node/manifest", get(node_manifest))
+        .with_state(ManifestState { manifest })
+}
+
+/// public manifest を返す。設定されていなければ 404（client は別経路へ fallback）。
+async fn node_manifest(State(state): State<ManifestState>) -> Response {
+    match state.manifest {
+        Some(manifest) => {
+            let mut response = Json(manifest.as_ref()).into_response();
+            // client が安全に cache できるようにする（private secret は含まれない）。
+            response.headers_mut().insert(
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=300"),
+            );
+            response
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "error": "manifest_not_configured",
+                "message": "this community node does not publish a manifest"
+            })),
+        )
+            .into_response(),
+    }
 }
 
 pub async fn run_from_env() -> Result<()> {

--- a/crates/cn-user-api/tests/contract.rs
+++ b/crates/cn-user-api/tests/contract.rs
@@ -43,6 +43,7 @@ impl TestServer {
             public_base_url: base_url.clone(),
             connectivity_urls: vec!["http://127.0.0.1:13340".to_string()],
             jwt_config: JwtConfig::new("kukuri-cn-tests", "test-secret", 3600),
+            operator_config_path: None,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-user-api/tests/manifest.rs
+++ b/crates/cn-user-api/tests/manifest.rs
@@ -1,0 +1,108 @@
+//! public manifest endpoint (#356) の contract test。
+//!
+//! manifest endpoint は DB を必要としないため、`manifest_routes` を単独でサーブして検証する。
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use kukuri_cn_operator::{build_manifest, load_and_validate};
+use kukuri_cn_user_api::manifest_routes;
+use reqwest::{Client, StatusCode};
+
+async fn spawn_manifest_server(
+    yaml: Option<&str>,
+) -> Result<(String, tokio::task::JoinHandle<()>)> {
+    let manifest = match yaml {
+        Some(yaml) => {
+            let resolved = load_and_validate(yaml).context("config must validate")?;
+            Some(Arc::new(build_manifest(&resolved)))
+        }
+        None => None,
+    };
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("bind manifest test listener")?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://{addr}");
+    let app = manifest_routes(manifest);
+    let task = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .expect("manifest server");
+    });
+    Ok((base_url, task))
+}
+
+const SAMPLE_YAML: &str = r#"server:
+  domain: example-kukuri.net
+  operator_name: Example Operator
+  country: JP
+profile: relay-enabled
+features:
+  cloudflare_proxy: true
+acknowledge_planned_capabilities: true
+"#;
+
+#[tokio::test]
+async fn manifest_endpoint_serves_unauthenticated_json() -> Result<()> {
+    let (base_url, task) = spawn_manifest_server(Some(SAMPLE_YAML)).await?;
+    let client = Client::new();
+
+    for path in [
+        "/.well-known/kukuri/community-node.json",
+        "/v1/node/manifest",
+    ] {
+        let resp = client.get(format!("{base_url}{path}")).send().await?;
+        assert_eq!(resp.status(), StatusCode::OK, "path {path}");
+
+        // client が cache できる。
+        let cache_control = resp
+            .headers()
+            .get(reqwest::header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(cache_control.contains("max-age"), "cache header on {path}");
+
+        let body: serde_json::Value = resp.json().await?;
+        // authority scope / P2P boundary / capability scope を含む。
+        assert_eq!(body["p2p_boundary"]["network_wide_authority"], false);
+        assert!(
+            body["authority_scope"]["does_not_apply_to"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|v| v == "user_identity")
+        );
+        assert!(body["capability_scope"]["available_enabled"].is_array());
+        // policy URLs / abuse contact を含む。
+        assert_eq!(body["terms_url"], "https://example-kukuri.net/terms");
+        assert!(body["abuse_contact"].as_str().unwrap().contains("@"));
+        // private secret を含まない。
+        assert!(body.get("jwt_secret").is_none());
+        assert!(body.get("database_url").is_none());
+    }
+
+    task.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn manifest_endpoint_returns_404_when_not_configured() -> Result<()> {
+    let (base_url, task) = spawn_manifest_server(None).await?;
+    let client = Client::new();
+    let resp = client
+        .get(format!("{base_url}/v1/node/manifest"))
+        .send()
+        .await?;
+    // 設定されていない場合は 404。client は default node へ fallback せず別経路を使う。
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body: serde_json::Value = resp.json().await?;
+    assert_eq!(body["error"], "manifest_not_configured");
+    task.abort();
+    Ok(())
+}

--- a/crates/harness/src/runtime.rs
+++ b/crates/harness/src/runtime.rs
@@ -100,6 +100,7 @@ impl CommunityNodeStack {
             public_base_url: base_url.clone(),
             connectivity_urls: vec![iroh_relay_url.clone()],
             jwt_config: JwtConfig::new("kukuri-cn-harness", "test-secret", 3600),
+            operator_config_path: None,
         })
         .await
         .context("failed to build community-node user-api state")?;

--- a/docs/runbooks/community-node-operator-docs.md
+++ b/docs/runbooks/community-node-operator-docs.md
@@ -108,6 +108,27 @@ manifest:
     does_not_apply_to: null   # 未指定なら安全な default
 ```
 
+## public manifest endpoint（#356）
+
+稼働中の community node (`cn-user-api`) は、生成した manifest を unauthenticated な
+public endpoint から配信できる。`COMMUNITY_NODE_OPERATOR_CONFIG` に `operator-config.yaml`
+のパスを設定すると、起動時に config を読み込み・検証して `CommunityNodeManifest` を構築し、
+以下で配信する。
+
+```text
+GET /.well-known/kukuri/community-node.json
+GET /v1/node/manifest
+```
+
+- unauthenticated で取得できる。`cn-operator` と同じ生成ロジック・型を共有するため、
+  生成文書の `server-manifest.json` と endpoint response の schema drift が起きない。
+- `Cache-Control: public, max-age=300` を付与し、client が cache できる。
+- private secret / provider credential は含まれない（manifest は operator config 由来で
+  秘密情報を持たない）。
+- `COMMUNITY_NODE_OPERATOR_CONFIG` 未設定なら両 endpoint は `404`（`{"error":"manifest_not_configured"}`）。
+  この場合 client は default node / kukuri project へ fallback せず、別 node または直接 P2P 経路を使う。
+- config を指しているのに読込・検証に失敗した場合は起動時に失敗する（設定ミスを黙って無視しない）。
+
 ## 決定論性と CI
 
 出力は wall-clock に依存せず、version は config 由来（`manifest.manifest_version`）。


### PR DESCRIPTION
## 概要

#356 の実装。稼働中の community node (`cn-user-api`) が自身の manifest を **unauthenticated な public endpoint** から配信できるようにします。「config ファイル読込方式」で実装しました。

## エンドポイント

```text
GET /.well-known/kukuri/community-node.json
GET /v1/node/manifest
```

`COMMUNITY_NODE_OPERATOR_CONFIG` に `operator-config.yaml` のパスを設定すると、起動時に #352 の `load_and_validate` + #355 の `build_manifest` で `CommunityNodeManifest` を構築して配信します。

## 設計ポイント

- **schema drift を構造的に排除**: endpoint は `cn-operator` の生成文書 (`server-manifest.json`) と**同じ型・同じ生成ロジック**を共有するため、両者がずれません（#356受け入れ条件「同じ type を共有」を直接満たす）。
- **unauthenticated** で取得可能。`Cache-Control: public, max-age=300` を付与し client が cache できる。
- **private secret / provider credential を含まない**（manifest は operator config 由来で秘密情報を持たない）。テストで `jwt_secret` / `database_url` が含まれないことを確認。
- **未設定なら 404** (`{"error":"manifest_not_configured"}`)。この場合 client は default node / kukuri project へ fallback せず、別 node または直接 P2P 経路を使う（#354 の責任境界と整合）。
- config を指すのに読込・検証失敗時は**起動を失敗**させる（設定ミスを黙って無視しない）。
- manifest 配信を **DB 非依存の `manifest_routes` として独立**させ、`app_router` に merge。これにより DB なしの contract test が可能。

## 受け入れ条件（#356）

- [x] public manifest endpoint が定義されている
- [x] unauthenticated で取得できる
- [x] capability scope / authority scope / P2P boundary metadata を含む（#355 の型）
- [x] report endpoint / abuse contact / policy URLs を含む
- [x] private secret / provider credential を含まない
- [x] client が fetch / cache できる（Cache-Control）
- [x] manifest fetch failure 時の client fallback が定義されている（404 → 別経路、default へ fallback しない）
- [x] endpoint contract test がある（2件、DB非依存）
- [x] #352 の生成 manifest と endpoint response が同じ type を共有

## テスト

`cargo test -p kukuri-cn-user-api --test manifest` → **2件 pass**（200/JSON+認証不要+Cache-Control+authority scope/p2p boundary/policy URL検証、未設定時404）。clippy / fmt クリーン。既存 contract.rs の `UserApiConfig` リテラルに `operator_config_path: None` を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ)_