### PR TITLE
feat(desktop): content provenance / responsible capability metadata (#358)

### DIFF
--- a/apps/desktop/src/components/core/types.ts
+++ b/apps/desktop/src/components/core/types.ts
@@ -1,6 +1,6 @@
 import type * as React from 'react';
 
-import type { AuthorSocialView, ChannelAudienceKind, PostView } from '@/lib/api';
+import type { AuthorSocialView, ChannelAudienceKind, ContentProvenance, PostView } from '@/lib/api';
 
 export type TopicChannelSummary = {
   channelId: string;
@@ -62,6 +62,9 @@ export type PostMediaView = {
   videoPlaybackSrc?: string | null;
   videoUnsupportedOnClient: boolean;
   videoProps?: React.VideoHTMLAttributes<HTMLVideoElement>;
+  // どの source を正本とし、どの community node capability（media_cache 等）経由で
+  // 観測したか。media cache 由来の通報ルーティングに使う。
+  provenance?: ContentProvenance;
 };
 
 export type ReferencedAuthorMeta = {
@@ -107,6 +110,9 @@ export type PostCardView = {
   replyParentAuthor?: ReferencedAuthorMeta | null;
   suppressReplyPreview?: boolean;
   mentionAuthors?: Record<string, MentionAuthorView>;
+  // 正本（通常は author_docs）と、index / moderation / cache 等の観測経路を分離して保持する。
+  // 通報ルーティング（#310）・content details・default node boundary 説明に使う。
+  provenance?: ContentProvenance;
 };
 
 export type ThreadPanelState = {
@@ -136,4 +142,7 @@ export type AuthorDetailView = {
   summary: AuthorRelationshipSummary | null;
   canMessage?: boolean;
   authorError?: string | null;
+  // profile の canonical source は author_docs。community node はあくまで観測経路であり
+  // truth source ではないことを provenance で表す。
+  provenance?: ContentProvenance;
 };

--- a/apps/desktop/src/components/storyFixtures.ts
+++ b/apps/desktop/src/components/storyFixtures.ts
@@ -6,6 +6,7 @@ import type {
   TopicDiagnosticSummary,
 } from '@/components/core/types';
 import type { PrimarySection } from '@/components/shell/types';
+import type { ContentProvenance } from '@/lib/api';
 import i18n from '@/i18n';
 import { formatLocalizedTime } from '@/i18n/format';
 
@@ -83,6 +84,28 @@ const timelineRootPost = {
   my_reactions: [],
 };
 
+// 正本は author docs だが、community index 経由で観測したことを示す provenance 例。
+// truth source ではなく観測経路として community node を表す。
+export const STORY_INDEX_PROVENANCE: ContentProvenance = {
+  canonicalSource: 'author_docs',
+  observedVia: [
+    {
+      nodeBaseUrl: 'https://node.example',
+      capability: 'community_index',
+      nodeRole: 'community-node',
+      manifestVersion: 'v1',
+    },
+  ],
+  responsibleReportTargets: [
+    {
+      nodeBaseUrl: 'https://node.example',
+      capability: 'community_index',
+      reportEndpoint: 'https://node.example/v1/report',
+      abuseContact: 'abuse@node.example',
+    },
+  ],
+};
+
 export function createStoryTimelinePosts(): PostCardView[] {
   return [
     {
@@ -93,6 +116,7 @@ export function createStoryTimelinePosts(): PostCardView[] {
       relationshipLabel: i18n.t('common:relationships.mutual'),
       audienceChipLabel: i18n.t('common:audience.public'),
       threadTargetId: 'timeline-post-1',
+      provenance: STORY_INDEX_PROVENANCE,
       media: {
         objectId: 'timeline-post-1',
         kind: null,

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -1,3 +1,4 @@
 export * from './api/types';
+export * from './api/provenance';
 export { getDesktopStartupStatus } from './api/startupStatus';
 export { runtimeApi } from './api/commands/runtimeApi';

--- a/apps/desktop/src/lib/api/provenance.test.ts
+++ b/apps/desktop/src/lib/api/provenance.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ContentProvenance,
+  type ReportTarget,
+  hasResolvableReportTarget,
+  isProvenanceUnknown,
+  reportTargetContact,
+  resolveReportTargets,
+  summarizeProvenance,
+  unknownProvenance,
+} from './provenance';
+
+const indexTarget: ReportTarget = {
+  nodeBaseUrl: 'https://node.example',
+  capability: 'community_index',
+  reportEndpoint: 'https://node.example/v1/report',
+  abuseContact: 'abuse@node.example',
+};
+
+const knownProvenance: ContentProvenance = {
+  canonicalSource: 'author_docs',
+  observedVia: [
+    {
+      nodeBaseUrl: 'https://node.example',
+      capability: 'community_index',
+      nodeRole: 'community-node',
+      manifestVersion: 'v1',
+    },
+  ],
+  responsibleReportTargets: [indexTarget],
+};
+
+describe('content provenance', () => {
+  it('separates canonical source from observed-via nodes', () => {
+    expect(knownProvenance.canonicalSource).toBe('author_docs');
+    expect(knownProvenance.observedVia[0].capability).toBe('community_index');
+    // 観測経路があっても canonicalSource は author_docs のまま（truth source ではない）。
+    expect(knownProvenance.canonicalSource).not.toBe('community_docs');
+  });
+
+  it('represents unknown provenance', () => {
+    const unknown = unknownProvenance();
+    expect(unknown.canonicalSource).toBe('unknown');
+    expect(unknown.observedVia).toEqual([]);
+    expect(unknown.responsibleReportTargets).toEqual([]);
+    expect(isProvenanceUnknown(unknown)).toBe(true);
+    expect(isProvenanceUnknown(null)).toBe(true);
+    expect(isProvenanceUnknown(undefined)).toBe(true);
+    expect(isProvenanceUnknown(knownProvenance)).toBe(false);
+  });
+
+  it('resolves responsible report targets', () => {
+    expect(resolveReportTargets(knownProvenance)).toEqual([indexTarget]);
+    expect(hasResolvableReportTarget(knownProvenance)).toBe(true);
+  });
+
+  it('never falls back to a default node when provenance is unknown', () => {
+    // unknown / null / undefined はいずれも空配列。default node を合成しない。
+    expect(resolveReportTargets(unknownProvenance())).toEqual([]);
+    expect(resolveReportTargets(null)).toEqual([]);
+    expect(resolveReportTargets(undefined)).toEqual([]);
+    expect(hasResolvableReportTarget(unknownProvenance())).toBe(false);
+  });
+
+  it('does not synthesize a target when observedVia exists but no report target is provided', () => {
+    const observedButNoTarget: ContentProvenance = {
+      canonicalSource: 'community_docs',
+      observedVia: [{ nodeBaseUrl: 'https://node.example', capability: 'community_index' }],
+      responsibleReportTargets: [],
+    };
+    // 観測経路はあるが通報先未解決 → 空配列（default へ向けない）。
+    expect(resolveReportTargets(observedButNoTarget)).toEqual([]);
+    expect(hasResolvableReportTarget(observedButNoTarget)).toBe(false);
+    // ただし observedVia があるため unknown ではない。
+    expect(isProvenanceUnknown(observedButNoTarget)).toBe(false);
+  });
+
+  it('prefers report endpoint then abuse contact for contact resolution', () => {
+    expect(reportTargetContact(indexTarget)).toEqual({
+      kind: 'endpoint',
+      value: 'https://node.example/v1/report',
+    });
+    expect(
+      reportTargetContact({
+        nodeBaseUrl: 'https://n',
+        capability: 'moderation',
+        abuseContact: 'abuse@n',
+      }),
+    ).toEqual({ kind: 'contact', value: 'abuse@n' });
+    expect(
+      reportTargetContact({ nodeBaseUrl: 'https://n', capability: 'moderation' }),
+    ).toEqual({ kind: 'none' });
+  });
+
+  it('summarizes provenance for diagnostics', () => {
+    const summary = summarizeProvenance(knownProvenance);
+    expect(summary.unknown).toBe(false);
+    expect(summary.canonicalSource).toBe('author_docs');
+    expect(summary.observedVia).toHaveLength(1);
+    expect(summary.canReport).toBe(true);
+
+    const unknownSummary = summarizeProvenance(undefined);
+    expect(unknownSummary.unknown).toBe(true);
+    expect(unknownSummary.canReport).toBe(false);
+    expect(unknownSummary.reportTargets).toEqual([]);
+  });
+});

--- a/apps/desktop/src/lib/api/provenance.ts
+++ b/apps/desktop/src/lib/api/provenance.ts
@@ -1,0 +1,159 @@
+// Content provenance and responsible-capability metadata (#358).
+//
+// kukuri では profile / social graph の canonical source は author docs + signed
+// envelope であり、community node は truth source ではない。一方で検索結果・index・
+// moderation label・trust signal・media cache・recommendation は特定 community node の
+// capability に由来し得る。この差分を DTO に載せることで、#310 の分散通報ルーティングや
+// dependency 表示が「どの source を正本とし、どの node capability を経由して観測したか」を
+// 正しく扱える。
+//
+// 重要な不変条件:
+// - `canonicalSource` と `observedVia` は分離する。community node 経由で観測したことは、
+//   その node が content の truth source であることを意味しない。
+// - provenance が不明な場合は `unknown` として表現し、通報先を default node /
+//   kukuri project へ自動 fallback しない（`resolveReportTargets` は空配列を返す）。
+
+/// content の正本（canonical source）。
+///
+/// `community_docs` は community node が保持する docs を指すが、これは observation 経路で
+/// あって profile / social graph の truth source ではない点に注意する。
+export type CanonicalSource =
+  | 'author_docs'
+  | 'community_docs'
+  | 'blob'
+  | 'local_cache'
+  | 'external_bridge'
+  | 'unknown';
+
+/// content を現在の client へ観測・表示させた community node capability。
+export type ObservedViaCapability =
+  | 'bootstrap_assist'
+  | 'relay_assist'
+  | 'community_index'
+  | 'moderation'
+  | 'trust_signal'
+  | 'media_cache'
+  | 'recommendation'
+  | 'bridge';
+
+/// content の観測経路となった community node。truth source ではなく observation 経路。
+export type ObservedViaNode = {
+  nodeBaseUrl: string;
+  capability: ObservedViaCapability;
+  nodeRole?: string;
+  manifestVersion?: string;
+};
+
+/// 通報先となり得る community node capability（#310 と整合）。
+export type ReportTargetCapability =
+  | 'community_index'
+  | 'moderation'
+  | 'trust_signal'
+  | 'media_cache'
+  | 'recommendation'
+  | 'relay_assist'
+  | 'bootstrap_assist';
+
+/// 通報先候補。node manifest（#355/#356）から解決される。
+export type ReportTarget = {
+  nodeBaseUrl: string;
+  nodeId?: string;
+  capability: ReportTargetCapability;
+  reportEndpoint?: string;
+  abuseContact?: string;
+  policyUrl?: string;
+  authorityScope?: string[];
+};
+
+/// content / profile / media / search result / moderation label / recommendation などに
+/// 付与する provenance metadata。
+export type ContentProvenance = {
+  /// 正本の種類。truth source を表す。
+  canonicalSource: CanonicalSource;
+  /// 観測・表示に関与した community node（複数可）。truth source ではない。
+  observedVia: ObservedViaNode[];
+  /// この content に関する責任ある通報先（実際に関与した node の capability に基づく）。
+  responsibleReportTargets: ReportTarget[];
+};
+
+/// provenance を持ち得る DTO を表すユーティリティ型。
+export type WithProvenance<T> = T & { provenance?: ContentProvenance };
+
+/// provenance 不明を表す値。`observedVia` / `responsibleReportTargets` は空。
+export function unknownProvenance(): ContentProvenance {
+  return {
+    canonicalSource: 'unknown',
+    observedVia: [],
+    responsibleReportTargets: [],
+  };
+}
+
+/// provenance が不明かどうか。canonicalSource が unknown かつ観測経路が無い場合に true。
+export function isProvenanceUnknown(provenance: ContentProvenance | null | undefined): boolean {
+  if (!provenance) {
+    return true;
+  }
+  return provenance.canonicalSource === 'unknown' && provenance.observedVia.length === 0;
+}
+
+/// 通報先を解決する。
+///
+/// 返すのは provenance が保持する `responsibleReportTargets` のみ。provenance が不明、または
+/// 通報先が解決できない場合は **空配列** を返し、default node / kukuri project へ fallback
+/// しない。これにより通報の中央集約を構造的に防ぐ（#310）。
+export function resolveReportTargets(
+  provenance: ContentProvenance | null | undefined,
+): ReportTarget[] {
+  if (!provenance) {
+    return [];
+  }
+  return provenance.responsibleReportTargets;
+}
+
+/// 通報先を 1 つでも解決できるか。false の場合、client は local action（block / mute /
+/// local hide）のみを案内し、通報先を default node へ向けない。
+export function hasResolvableReportTarget(
+  provenance: ContentProvenance | null | undefined,
+): boolean {
+  return resolveReportTargets(provenance).length > 0;
+}
+
+/// 通報先への連絡手段。reportEndpoint があれば POST、なければ abuseContact を mailto /
+/// copyable contact として案内する（#310 の初期実装方針）。
+export type ReportContact =
+  | { kind: 'endpoint'; value: string }
+  | { kind: 'contact'; value: string }
+  | { kind: 'none' };
+
+export function reportTargetContact(target: ReportTarget): ReportContact {
+  if (target.reportEndpoint && target.reportEndpoint.trim().length > 0) {
+    return { kind: 'endpoint', value: target.reportEndpoint };
+  }
+  if (target.abuseContact && target.abuseContact.trim().length > 0) {
+    return { kind: 'contact', value: target.abuseContact };
+  }
+  return { kind: 'none' };
+}
+
+/// content details / diagnostics 表示用の provenance サマリ（非ローカライズの構造データ）。
+/// UI 側で i18n する前提で、source / capability は key のまま返す。
+export type ProvenanceSummary = {
+  canonicalSource: CanonicalSource;
+  unknown: boolean;
+  observedVia: ObservedViaNode[];
+  reportTargets: ReportTarget[];
+  canReport: boolean;
+};
+
+export function summarizeProvenance(
+  provenance: ContentProvenance | null | undefined,
+): ProvenanceSummary {
+  const resolved = provenance ?? unknownProvenance();
+  return {
+    canonicalSource: resolved.canonicalSource,
+    unknown: isProvenanceUnknown(provenance),
+    observedVia: resolved.observedVia,
+    reportTargets: resolveReportTargets(provenance),
+    canReport: hasResolvableReportTarget(provenance),
+  };
+}


### PR DESCRIPTION
## 概要

#358 の実装。client DTO に **content provenance / responsible capability metadata** を追加します。kukuri では profile / social graph の canonical source は author docs + signed envelope であり、community node は truth source ではありません。一方で index / moderation / trust signal / media cache / recommendation は特定 community node の capability に由来し得るため、その差分を DTO に載せ、#310 の分散通報ルーティングや dependency 表示に使えるようにします。

## 変更

- **`lib/api/provenance.ts`**（新規）
  - 型: `ContentProvenance` / `CanonicalSource` / `ObservedViaNode` / `ObservedViaCapability` / `ReportTarget` / `WithProvenance<T>`（issue のモデルに準拠）
  - helper: `unknownProvenance` / `isProvenanceUnknown` / `resolveReportTargets` / `hasResolvableReportTarget` / `reportTargetContact` / `summarizeProvenance`
- **canonical source と observed-via を分離**し、community node を truth source と誤解させない命名・doc コメント
- **unknown 時に default node へ fallback しない構造**: `resolveReportTargets` は unknown / null / 通報先未解決のとき**空配列**を返し、default node / kukuri project を合成しない
- `PostCardView` / `AuthorDetailView` / `PostMediaView` に optional `provenance` を付与（`WithProvenance<T>` で汎用適用可能）
- story fixture に provenance 例を追加（mock 更新）

## 受け入れ条件（#358）

- [x] provenance model が定義されている
- [x] canonical source と observed via node が分離されている
- [x] responsible report targets を表現できる
- [x] post / profile / media など主要 DTO に適用（search result / moderation label / recommendation は該当 DTO 追加時に `WithProvenance<T>` で同様に適用可能）
- [x] provenance unknown を表現できる
- [x] unknown の場合に default node へ通報 fallback しない設計
- [x] #310 の report routing がこの metadata を使える（`ReportTarget` + `resolveReportTargets` + `reportTargetContact`）
- [x] UI / mock / tests が更新されている
- [x] community node を content truth source と誤解させない命名

## テスト

- `vitest` provenance helper **7件 pass**（unknown 表現 / no-fallback / endpoint vs abuse contact / summary 等）
- `lib` + `components/core` 回帰 **71件 pass**
- `tsc --noEmit` / `eslint --max-warnings 0` クリーン

## 補足

search result / community listing / moderation label / recommendation candidate の DTO は現状の client にまだ存在しないため、本 PR ではモデルを汎用化（`WithProvenance<T>`）し、既存の content DTO 3種へ適用しました。これらの DTO が追加された時点で同じ型を付与できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ)_