### PR TITLE
feat(desktop): community node 依存度 / capability scope 表示 (#357)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/community_node.rs
+++ b/apps/desktop/src-tauri/src/commands/community_node.rs
@@ -1,6 +1,7 @@
 use kukuri_desktop_runtime::{
-    AcceptCommunityNodeConsentsRequest, CommunityNodeConfig, CommunityNodeNodeStatus,
-    CommunityNodeTargetRequest, CreatePrivateChannelRequest, DiscoveryConfig,
+    AcceptCommunityNodeConsentsRequest, CommunityNodeConfig, CommunityNodeManifestFetch,
+    CommunityNodeNodeStatus, CommunityNodeTargetRequest, CreatePrivateChannelRequest,
+    DiscoveryConfig,
     ExportChannelAccessTokenRequest, ExportFriendOnlyGrantRequest, ExportFriendPlusShareRequest,
     ExportPrivateChannelInviteRequest, FreezePrivateChannelRequest,
     ImportChannelAccessTokenRequest, ImportFriendOnlyGrantRequest, ImportFriendPlusShareRequest,
@@ -350,6 +351,18 @@ pub async fn refresh_community_node_metadata(
     state
         .runtime
         .refresh_community_node_metadata(request)
+        .await
+        .map_err(map_error)
+}
+
+#[tauri::command]
+pub async fn fetch_community_node_manifest(
+    state: tauri::State<'_, DesktopState>,
+    request: CommunityNodeTargetRequest,
+) -> Result<CommunityNodeManifestFetch, String> {
+    state
+        .runtime
+        .fetch_community_node_manifest(request)
         .await
         .map_err(map_error)
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -127,7 +127,8 @@ pub fn run() {
             commands::community_node::clear_community_node_token,
             commands::community_node::get_community_node_consent_status,
             commands::community_node::accept_community_node_consents,
-            commands::community_node::refresh_community_node_metadata
+            commands::community_node::refresh_community_node_metadata,
+            commands::community_node::fetch_community_node_manifest
         ])
         .run(tauri::generate_context!())
         .expect("failed to run kukuri desktop tauri app");

--- a/apps/desktop/src/components/settings/CommunityNodePanel.stories.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.stories.tsx
@@ -32,6 +32,7 @@ function CommunityNodePanelStory({
                 autoApprove: false,
                 saved: false,
                 diagnostics: [],
+                dependency: { diagnostics: [], boundaryNotes: [] },
                 lastError: null,
               },
             ])

--- a/apps/desktop/src/components/settings/CommunityNodePanel.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.tsx
@@ -136,6 +136,21 @@ export function CommunityNodePanel({
               <SettingsDiagnosticList items={node.diagnostics} columns={2} />
             </div>
 
+            <div className='mt-4 space-y-2'>
+              <h5 className='text-sm font-semibold text-foreground'>
+                {t('settings:communityNode.dependency.heading')}
+              </h5>
+              <SettingsDiagnosticList items={node.dependency.diagnostics} columns={2} />
+              {node.dependency.manifestError ? (
+                <Notice tone='destructive'>{node.dependency.manifestError}</Notice>
+              ) : null}
+              {node.dependency.boundaryNotes.map((note) => (
+                <p key={note} className='text-sm text-[var(--muted-foreground)]'>
+                  {note}
+                </p>
+              ))}
+            </div>
+
             <div className='mt-4'>
               <SettingsActionRow>
                 <Button

--- a/apps/desktop/src/components/settings/communityNodeDependency.test.ts
+++ b/apps/desktop/src/components/settings/communityNodeDependency.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { type CommunityNodeManifest } from '@/lib/api';
+import { type CommunityNodeManifestEntry } from '@/shell/store';
+
+import { buildCommunityNodeDependencyView } from './communityNodeDependency';
+
+// i18n を初期化せずに構造を検証するため、key をそのまま返す stub。
+const t = (key: string) => key;
+
+function manifest(overrides: Partial<CommunityNodeManifest> = {}): CommunityNodeManifest {
+  return {
+    node_id: '',
+    node_name: 'node.example',
+    node_role: 'community-node',
+    server_name: 'node.example',
+    manifest_version: 'v1',
+    capability_scope: {
+      available_enabled: ['auth_consent', 'iroh_relay'],
+      planned_enabled: ['moderation'],
+    },
+    authority_scope: {
+      applies_to: ['this_node'],
+      does_not_apply_to: ['user_identity', 'kukuri_network_as_a_whole'],
+    },
+    p2p_boundary: {
+      identity_authority: false,
+      profile_canonical_store: false,
+      social_graph_canonical_store: false,
+      content_truth_source: false,
+      network_wide_authority: false,
+    },
+    abuse_contact: 'abuse@node.example',
+    terms_url: 'https://node.example/terms',
+    privacy_url: 'https://node.example/privacy',
+    moderation_policy_url: 'https://node.example/moderation-policy',
+    ...overrides,
+  };
+}
+
+function values(view: ReturnType<typeof buildCommunityNodeDependencyView>): string[] {
+  return view.diagnostics.map((item) => item.value);
+}
+
+describe('buildCommunityNodeDependencyView', () => {
+  it('shows capability scope, authority scope and role for an ok manifest', () => {
+    const entry: CommunityNodeManifestEntry = { status: 'ok', manifest: manifest() };
+    const view = buildCommunityNodeDependencyView(entry, t);
+
+    const vals = values(view).join('\n');
+    expect(vals).toContain('auth_consent, iroh_relay');
+    expect(vals).toContain('moderation');
+    expect(vals).toContain('this_node');
+    expect(vals).toContain('user_identity, kukuri_network_as_a_whole');
+    // identity が node-owned ではない説明は常に表示。
+    expect(view.boundaryNotes).toContain(
+      'settings:communityNode.dependency.boundary.identityNotOwned'
+    );
+    expect(view.manifestError).toBeNull();
+  });
+
+  it('marks a default onboarding node and adds the not-network-authority note', () => {
+    const entry: CommunityNodeManifestEntry = {
+      status: 'ok',
+      manifest: manifest({ node_role: 'default-onboarding-node' }),
+    };
+    const view = buildCommunityNodeDependencyView(entry, t);
+    expect(values(view)).toContain('settings:communityNode.dependency.origin.default');
+    expect(view.boundaryNotes).toContain(
+      'settings:communityNode.dependency.boundary.defaultNotAuthority'
+    );
+  });
+
+  it('does not add the default-authority note for a user-added community node', () => {
+    const entry: CommunityNodeManifestEntry = {
+      status: 'ok',
+      manifest: manifest({ node_role: 'community-node' }),
+    };
+    const view = buildCommunityNodeDependencyView(entry, t);
+    expect(values(view)).toContain('settings:communityNode.dependency.origin.userAdded');
+    expect(view.boundaryNotes).not.toContain(
+      'settings:communityNode.dependency.boundary.defaultNotAuthority'
+    );
+  });
+
+  it('represents absent manifest without scope rows but keeps boundary note', () => {
+    const view = buildCommunityNodeDependencyView({ status: 'absent' }, t);
+    // manifestStatus 行のみ。capability/authority は出さない。
+    expect(view.diagnostics).toHaveLength(1);
+    expect(view.diagnostics[0].value).toBe('settings:communityNode.dependency.status.absent');
+    expect(view.boundaryNotes).toContain(
+      'settings:communityNode.dependency.boundary.identityNotOwned'
+    );
+  });
+
+  it('surfaces fetch errors and never falls back to a default node', () => {
+    const view = buildCommunityNodeDependencyView(
+      { status: 'error', error: 'boom' },
+      t
+    );
+    expect(view.manifestError).toBe('boom');
+    expect(view.diagnostics[0].tone).toBe('danger');
+  });
+
+  it('treats a missing entry as loading', () => {
+    const view = buildCommunityNodeDependencyView(undefined, t);
+    expect(view.diagnostics[0].value).toBe('settings:communityNode.dependency.status.loading');
+  });
+});

--- a/apps/desktop/src/components/settings/communityNodeDependency.ts
+++ b/apps/desktop/src/components/settings/communityNodeDependency.ts
@@ -1,0 +1,89 @@
+import { type CommunityNodeManifestEntry } from '@/shell/store';
+
+import { type CommunityNodeDependencyView } from './types';
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+const DEFAULT_ONBOARDING_NODE_ROLE = 'default-onboarding-node';
+
+function joinedOrNone(values: string[], t: Translate): string {
+  return values.length > 0 ? values.join(', ') : t('common:fallbacks.none');
+}
+
+/// manifest fetch 状態 (#356) から、settings 表示用の依存度 view を組み立てる。
+///
+/// - capability scope / authority scope / node role を行として表示する。
+/// - identity / profile / social graph が node-owned ではないこと、default node が
+///   network-wide authority ではないことを常に説明する（manifest が無くても表示）。
+/// - manifest fetch 失敗時はエラーを表示し、default node へ fallback しない。
+export function buildCommunityNodeDependencyView(
+  entry: CommunityNodeManifestEntry | undefined,
+  t: Translate
+): CommunityNodeDependencyView {
+  const status = entry?.status ?? 'loading';
+  const diagnostics: CommunityNodeDependencyView['diagnostics'] = [
+    {
+      label: t('settings:communityNode.dependency.diagnostics.manifestStatus'),
+      value: t(`settings:communityNode.dependency.status.${status}`),
+      tone: status === 'error' ? 'danger' : 'default',
+    },
+  ];
+
+  // identity / profile / social graph は node-owned ではない。常に説明する。
+  const boundaryNotes = [t('settings:communityNode.dependency.boundary.identityNotOwned')];
+
+  if (entry?.status === 'ok') {
+    const manifest = entry.manifest;
+    const isDefaultNode = manifest.node_role === DEFAULT_ONBOARDING_NODE_ROLE;
+
+    diagnostics.push(
+      {
+        label: t('settings:communityNode.dependency.diagnostics.origin'),
+        value: isDefaultNode
+          ? t('settings:communityNode.dependency.origin.default')
+          : t('settings:communityNode.dependency.origin.userAdded'),
+      },
+      {
+        label: t('settings:communityNode.dependency.diagnostics.role'),
+        value: manifest.node_role || t('common:fallbacks.none'),
+        monospace: true,
+      },
+      {
+        label: t('settings:communityNode.dependency.diagnostics.manifestVersion'),
+        value: manifest.manifest_version || t('common:fallbacks.none'),
+        monospace: true,
+      },
+      {
+        label: t('settings:communityNode.dependency.diagnostics.capabilityAvailable'),
+        value: joinedOrNone(manifest.capability_scope.available_enabled, t),
+        monospace: true,
+      },
+      {
+        label: t('settings:communityNode.dependency.diagnostics.capabilityPlanned'),
+        value: joinedOrNone(manifest.capability_scope.planned_enabled, t),
+        monospace: true,
+      },
+      {
+        label: t('settings:communityNode.dependency.diagnostics.authorityAppliesTo'),
+        value: joinedOrNone(manifest.authority_scope.applies_to, t),
+        monospace: true,
+      },
+      {
+        label: t('settings:communityNode.dependency.diagnostics.authorityDoesNotApplyTo'),
+        value: joinedOrNone(manifest.authority_scope.does_not_apply_to, t),
+        monospace: true,
+      }
+    );
+
+    // default node であっても network-wide authority ではないことを明記する。
+    if (isDefaultNode) {
+      boundaryNotes.push(t('settings:communityNode.dependency.boundary.defaultNotAuthority'));
+    }
+  }
+
+  return {
+    diagnostics,
+    boundaryNotes,
+    manifestError: entry?.status === 'error' ? entry.error : null,
+  };
+}

--- a/apps/desktop/src/components/settings/fixtures.ts
+++ b/apps/desktop/src/components/settings/fixtures.ts
@@ -4,8 +4,12 @@ import type {
   ConnectivityPanelView,
   DiscoveryPanelView,
 } from './types';
+import { buildCommunityNodeDependencyView } from './communityNodeDependency';
 import i18n from '@/i18n';
 import { formatLocalizedTime, getResolvedLocale } from '@/i18n/format';
+
+const fixtureTranslate = (key: string, options?: Record<string, unknown>): string =>
+  i18n.t(key, options);
 
 export function createAppearancePanelFixture(): AppearancePanelView {
   return {
@@ -173,6 +177,43 @@ export function createCommunityNodePanelFixture(): CommunityNodePanelView {
             value: i18n.t('common:fallbacks.none'),
           },
         ],
+        dependency: buildCommunityNodeDependencyView(
+          {
+            status: 'ok',
+            manifest: {
+              node_id: '',
+              node_name: 'api.kukuri.app',
+              node_role: 'default-onboarding-node',
+              server_name: 'api.kukuri.app',
+              manifest_version: 'v1',
+              capability_scope: {
+                available_enabled: ['auth_consent', 'bootstrap_assist', 'iroh_relay'],
+                planned_enabled: ['community_index', 'moderation'],
+              },
+              authority_scope: {
+                applies_to: ['this_node'],
+                does_not_apply_to: [
+                  'kukuri_network_as_a_whole',
+                  'user_identity',
+                  'user_profile_canonical_source',
+                  'user_social_graph_canonical_source',
+                ],
+              },
+              p2p_boundary: {
+                identity_authority: false,
+                profile_canonical_store: false,
+                social_graph_canonical_store: false,
+                content_truth_source: false,
+                network_wide_authority: false,
+              },
+              abuse_contact: 'abuse@api.kukuri.app',
+              terms_url: 'https://api.kukuri.app/terms',
+              privacy_url: 'https://api.kukuri.app/privacy',
+              moderation_policy_url: 'https://api.kukuri.app/moderation-policy',
+            },
+          },
+          fixtureTranslate
+        ),
         lastError: null,
       },
       {
@@ -211,6 +252,7 @@ export function createCommunityNodePanelFixture(): CommunityNodePanelView {
             tone: 'danger',
           },
         ],
+        dependency: buildCommunityNodeDependencyView({ status: 'absent' }, fixtureTranslate),
         lastError: i18n.t('common:errors.failedToRefreshCommunityNode'),
       },
     ],

--- a/apps/desktop/src/components/settings/types.ts
+++ b/apps/desktop/src/components/settings/types.ts
@@ -54,12 +54,23 @@ export type DiscoveryPanelView = {
   envLocked: boolean;
 };
 
+// public manifest (#356) 由来の依存度 / capability scope / authority scope 表示。
+export type CommunityNodeDependencyView = {
+  // role / origin / manifest status / capability scope / authority scope を行として表示する。
+  diagnostics: SettingsDiagnosticItemView[];
+  // identity / profile / social graph が node-owned ではない等、常に表示する責任境界の説明。
+  boundaryNotes: string[];
+  // manifest fetch が失敗した場合のエラー（client は default node へ fallback しない）。
+  manifestError?: string | null;
+};
+
 export type CommunityNodeEntryView = {
   id: string;
   baseUrl: string;
   autoApprove: boolean;
   saved: boolean;
   diagnostics: SettingsDiagnosticItemView[];
+  dependency: CommunityNodeDependencyView;
   lastError?: string | null;
 };
 

--- a/apps/desktop/src/components/shell/SettingsDrawer.stories.tsx
+++ b/apps/desktop/src/components/shell/SettingsDrawer.stories.tsx
@@ -90,6 +90,7 @@ function SettingsDrawerStory({ initialSection = 'connectivity' }: { initialSecti
                 autoApprove: false,
                 saved: false,
                 diagnostics: [],
+                dependency: { diagnostics: [], boundaryNotes: [] },
                 lastError: null,
               },
             ])

--- a/apps/desktop/src/i18n/locales/en/settings.json
+++ b/apps/desktop/src/i18n/locales/en/settings.json
@@ -30,6 +30,33 @@
       "clearToken": "Clear Token",
       "saveNodes": "Save Nodes"
     },
+    "dependency": {
+      "heading": "Dependency & scope",
+      "diagnostics": {
+        "manifestStatus": "Manifest status",
+        "origin": "Type",
+        "role": "Node role",
+        "manifestVersion": "Manifest version",
+        "capabilityAvailable": "Available capabilities",
+        "capabilityPlanned": "Planned capabilities",
+        "authorityAppliesTo": "Authority scope",
+        "authorityDoesNotApplyTo": "Outside authority scope"
+      },
+      "origin": {
+        "default": "Default onboarding node",
+        "userAdded": "User-added node"
+      },
+      "status": {
+        "loading": "Loading…",
+        "ok": "Loaded",
+        "absent": "This node does not publish a manifest",
+        "error": "Could not fetch the manifest"
+      },
+      "boundary": {
+        "identityNotOwned": "Your identity, profile, and social graph are not owned by this node. The node only provides supporting capabilities for the P2P network.",
+        "defaultNotAuthority": "Even as a default node, it is not the operator or authority for the whole network."
+      }
+    },
     "autoApproveLabel": "Auto-approve consent for this node",
     "baseUrlLabel": "Base URL",
     "baseUrlsHint": "One HTTPS base URL per line.",

--- a/apps/desktop/src/i18n/locales/ja/settings.json
+++ b/apps/desktop/src/i18n/locales/ja/settings.json
@@ -30,6 +30,33 @@
       "clearToken": "トークンをクリア",
       "saveNodes": "ノードを保存"
     },
+    "dependency": {
+      "heading": "依存とスコープ",
+      "diagnostics": {
+        "manifestStatus": "マニフェスト状態",
+        "origin": "種別",
+        "role": "ノードロール",
+        "manifestVersion": "マニフェストバージョン",
+        "capabilityAvailable": "提供中の capability",
+        "capabilityPlanned": "計画中の capability",
+        "authorityAppliesTo": "責任範囲",
+        "authorityDoesNotApplyTo": "責任範囲外"
+      },
+      "origin": {
+        "default": "オンボーディング用デフォルトノード",
+        "userAdded": "ユーザー追加ノード"
+      },
+      "status": {
+        "loading": "取得中…",
+        "ok": "取得済み",
+        "absent": "このノードはマニフェストを公開していません",
+        "error": "マニフェストを取得できませんでした"
+      },
+      "boundary": {
+        "identityNotOwned": "あなたの identity・プロフィール・ソーシャルグラフはこのノードに所有されません。ノードは P2P ネットワークの補助機能を提供するだけです。",
+        "defaultNotAuthority": "デフォルトノードであっても、ネットワーク全体の運営者・権限者ではありません。"
+      }
+    },
     "autoApproveLabel": "このノードの consent を自動承認する",
     "baseUrlLabel": "ベース URL",
     "baseUrlsHint": "HTTPS の base URL を 1 行に 1 つ入力します。",

--- a/apps/desktop/src/i18n/locales/zh-CN/settings.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/settings.json
@@ -29,6 +29,33 @@
       "clearToken": "清除令牌",
       "saveNodes": "保存节点"
     },
+    "dependency": {
+      "heading": "依赖与范围",
+      "diagnostics": {
+        "manifestStatus": "清单状态",
+        "origin": "类型",
+        "role": "节点角色",
+        "manifestVersion": "清单版本",
+        "capabilityAvailable": "已提供的能力",
+        "capabilityPlanned": "计划中的能力",
+        "authorityAppliesTo": "职责范围",
+        "authorityDoesNotApplyTo": "职责范围之外"
+      },
+      "origin": {
+        "default": "默认引导节点",
+        "userAdded": "用户添加的节点"
+      },
+      "status": {
+        "loading": "加载中…",
+        "ok": "已加载",
+        "absent": "该节点未发布清单",
+        "error": "无法获取清单"
+      },
+      "boundary": {
+        "identityNotOwned": "您的身份、个人资料和社交图谱不归该节点所有。该节点仅为 P2P 网络提供辅助能力。",
+        "defaultNotAuthority": "即使是默认节点，也不是整个网络的运营者或权限方。"
+      }
+    },
     "baseUrlsHint": "每行一个 HTTPS 基础 URL。",
     "baseUrlsLabel": "基础 URL",
     "baseUrlsPlaceholder": "https://community.example.com",

--- a/apps/desktop/src/lib/api/commands/runtimeApi.ts
+++ b/apps/desktop/src/lib/api/commands/runtimeApi.ts
@@ -6,6 +6,7 @@ import type {
   ChannelAccessTokenExport,
   ChannelAccessTokenPreview,
   CommunityNodeConfig,
+  CommunityNodeManifestFetch,
   CommunityNodeNodeStatus,
   CustomReactionAssetView,
   DesktopApi,
@@ -818,6 +819,16 @@ export const runtimeApi: DesktopApi = {
       return window.__KUKURI_DESKTOP__.refreshCommunityNodeMetadata(baseUrl);
     }
     return invokeDesktop<CommunityNodeNodeStatus>('refresh_community_node_metadata', {
+      request: {
+        base_url: baseUrl,
+      },
+    });
+  },
+  fetchCommunityNodeManifest: async (baseUrl) => {
+    if (window.__KUKURI_DESKTOP__) {
+      return window.__KUKURI_DESKTOP__.fetchCommunityNodeManifest(baseUrl);
+    }
+    return invokeDesktop<CommunityNodeManifestFetch>('fetch_community_node_manifest', {
       request: {
         base_url: baseUrl,
       },

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -438,6 +438,50 @@ export type CommunityNodeConfigInput = {
   auto_approve: boolean;
 };
 
+// community node manifest (#355/#356) の client 側表現。public manifest endpoint から取得し、
+// dependency 表示 (#357) に使う。snake_case は Rust 由来の JSON 形状に合わせる。
+export type CommunityNodeCapabilityScope = {
+  available_enabled: string[];
+  planned_enabled: string[];
+};
+
+export type CommunityNodeAuthorityScope = {
+  applies_to: string[];
+  does_not_apply_to: string[];
+};
+
+export type CommunityNodeP2pBoundary = {
+  identity_authority: boolean;
+  profile_canonical_store: boolean;
+  social_graph_canonical_store: boolean;
+  content_truth_source: boolean;
+  network_wide_authority: boolean;
+};
+
+export type CommunityNodeManifest = {
+  node_id: string;
+  node_name: string;
+  node_role: string;
+  server_name: string;
+  manifest_version: string;
+  capability_scope: CommunityNodeCapabilityScope;
+  authority_scope: CommunityNodeAuthorityScope;
+  p2p_boundary: CommunityNodeP2pBoundary;
+  abuse_contact: string;
+  terms_url: string;
+  privacy_url: string;
+  moderation_policy_url: string;
+};
+
+// manifest fetch 状態。'ok' は取得成功、'absent' は node が未公開 (404)。
+// 'error' は fetch 失敗、'loading' は取得中（client 側で付与）。
+export type CommunityNodeManifestFetchStatus = 'ok' | 'absent';
+
+export type CommunityNodeManifestFetch = {
+  status: CommunityNodeManifestFetchStatus;
+  manifest?: CommunityNodeManifest | null;
+};
+
 export type TopicSyncStatus = {
   topic: string;
   joined: boolean;
@@ -842,6 +886,7 @@ export interface DesktopApi {
     policySlugs: string[]
   ): Promise<CommunityNodeNodeStatus>;
   refreshCommunityNodeMetadata(baseUrl: string): Promise<CommunityNodeNodeStatus>;
+  fetchCommunityNodeManifest(baseUrl: string): Promise<CommunityNodeManifestFetch>;
   importPeerTicket(ticket: string): Promise<void>;
   setDiscoverySeeds(seedEntries: string[]): Promise<DiscoveryConfig>;
   unsubscribeTopic(topic: string): Promise<void>;

--- a/apps/desktop/src/mocks/desktopApiMock.ts
+++ b/apps/desktop/src/mocks/desktopApiMock.ts
@@ -1431,6 +1431,42 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       };
       return communityNodeStatuses.find((status) => status.base_url === baseUrl)!;
     },
+    async fetchCommunityNodeManifest(baseUrl) {
+      return {
+        status: 'ok',
+        manifest: {
+          node_id: '',
+          node_name: baseUrl,
+          node_role: 'community-node',
+          server_name: baseUrl,
+          manifest_version: 'v1',
+          capability_scope: {
+            available_enabled: ['auth_consent', 'bootstrap_assist', 'iroh_relay'],
+            planned_enabled: ['community_index', 'moderation'],
+          },
+          authority_scope: {
+            applies_to: ['this_node'],
+            does_not_apply_to: [
+              'kukuri_network_as_a_whole',
+              'user_identity',
+              'user_profile_canonical_source',
+              'user_social_graph_canonical_source',
+            ],
+          },
+          p2p_boundary: {
+            identity_authority: false,
+            profile_canonical_store: false,
+            social_graph_canonical_store: false,
+            content_truth_source: false,
+            network_wide_authority: false,
+          },
+          abuse_contact: `abuse@${baseUrl.replace(/^https?:\/\//, '')}`,
+          terms_url: `${baseUrl}/terms`,
+          privacy_url: `${baseUrl}/privacy`,
+          moderation_policy_url: `${baseUrl}/moderation-policy`,
+        },
+      };
+    },
     async importPeerTicket() {},
     async setDiscoverySeeds(seedEntries) {
       discoveryConfig = {

--- a/apps/desktop/src/shell/store.ts
+++ b/apps/desktop/src/shell/store.ts
@@ -20,6 +20,7 @@ import {
   type BookmarkedPostView,
   type ChannelRef,
   type CommunityNodeConfig,
+  type CommunityNodeManifest,
   type CommunityNodeNodeStatus,
   type CreateAttachmentInput,
   type CustomReactionAssetView,
@@ -75,6 +76,13 @@ export type CommunityNodeDraftNode = {
   auto_approve: boolean;
 };
 
+// public manifest endpoint (#356) からの取得状態。base_url ごとに保持する。
+export type CommunityNodeManifestEntry =
+  | { status: 'loading' }
+  | { status: 'ok'; manifest: CommunityNodeManifest }
+  | { status: 'absent' }
+  | { status: 'error'; error: string };
+
 export type DesktopShellState = {
   trackedTopics: string[];
   activeTopic: string;
@@ -112,6 +120,7 @@ export type DesktopShellState = {
   discoveryError: string | null;
   communityNodeConfig: CommunityNodeConfig;
   communityNodeStatuses: CommunityNodeNodeStatus[];
+  communityNodeManifests: Record<string, CommunityNodeManifestEntry>;
   communityNodeInput: CommunityNodeDraftNode[];
   communityNodeEditorDirty: boolean;
   communityNodeError: string | null;
@@ -397,6 +406,7 @@ export function createInitialShellState(): DesktopShellState {
     discoveryError: null,
     communityNodeConfig: DEFAULT_COMMUNITY_NODE_CONFIG,
     communityNodeStatuses: [],
+    communityNodeManifests: {},
     communityNodeInput: [],
     communityNodeEditorDirty: false,
     communityNodeError: null,

--- a/apps/desktop/src/shell/useDesktopShellData.ts
+++ b/apps/desktop/src/shell/useDesktopShellData.ts
@@ -135,6 +135,7 @@ export function useDesktopShellData({
   const setDiscoveryError = useDesktopShellFieldSetter('discoveryError');
   const setCommunityNodeConfig = useDesktopShellFieldSetter('communityNodeConfig');
   const setCommunityNodeStatuses = useDesktopShellFieldSetter('communityNodeStatuses');
+  const setCommunityNodeManifests = useDesktopShellFieldSetter('communityNodeManifests');
   const setCommunityNodeInput = useDesktopShellFieldSetter('communityNodeInput');
   const setCommunityNodeError = useDesktopShellFieldSetter('communityNodeError');
   const setMediaObjectUrls = useDesktopShellFieldSetter('mediaObjectUrls');
@@ -914,6 +915,44 @@ export function useDesktopShellData({
                   );
                   setCommunityNodeError(null);
                 });
+                // public manifest endpoint (#356) から dependency 情報を best-effort 取得する。
+                const baseUrls = config.nodes
+                  .map((node) => node.base_url)
+                  .filter((baseUrl) => baseUrl.trim().length > 0);
+                if (baseUrls.length > 0) {
+                  setCommunityNodeManifests((current) => {
+                    const next = { ...current };
+                    for (const baseUrl of baseUrls) {
+                      next[baseUrl] = { status: 'loading' };
+                    }
+                    return next;
+                  });
+                  for (const baseUrl of baseUrls) {
+                    void api
+                      .fetchCommunityNodeManifest(baseUrl)
+                      .then((result) => {
+                        setCommunityNodeManifests((current) => ({
+                          ...current,
+                          [baseUrl]:
+                            result.status === 'ok' && result.manifest
+                              ? { status: 'ok', manifest: result.manifest }
+                              : { status: 'absent' },
+                        }));
+                      })
+                      .catch((error) => {
+                        setCommunityNodeManifests((current) => ({
+                          ...current,
+                          [baseUrl]: {
+                            status: 'error',
+                            error: messageFromError(
+                              error,
+                              translate('common:errors.failedToLoadSettings')
+                            ),
+                          },
+                        }));
+                      });
+                  }
+                }
               })
               .catch((error) => {
                 setCommunityNodeError(
@@ -950,6 +989,7 @@ export function useDesktopShellData({
       setCommunityNodeConfig,
       setCommunityNodeError,
       setCommunityNodeInput,
+      setCommunityNodeManifests,
       setCommunityNodeStatuses,
       setDirectMessages,
       setDirectMessageError,

--- a/apps/desktop/src/shell/useDesktopShellViewModels.ts
+++ b/apps/desktop/src/shell/useDesktopShellViewModels.ts
@@ -14,6 +14,7 @@ import type {
   ThreadPanelState,
   TopicDiagnosticSummary,
 } from '@/components/core/types';
+import { buildCommunityNodeDependencyView } from '@/components/settings/communityNodeDependency';
 import type {
   AppearancePanelView,
   CommunityNodePanelView,
@@ -199,6 +200,7 @@ export function useDesktopShellViewModels({
     communityNodeConfig,
     communityNodeError,
     communityNodeInput,
+    communityNodeManifests,
     communityNodeEditorDirty,
     reactionPanelState,
     ownedReactionAssets,
@@ -1015,6 +1017,10 @@ export function useDesktopShellViewModels({
               tone: status?.last_error ? 'danger' : 'default',
             },
           ],
+          dependency: buildCommunityNodeDependencyView(
+            communityNodeManifests[node.base_url],
+            t
+          ),
           lastError: status?.last_error ?? null,
         };
       }),
@@ -1024,6 +1030,7 @@ export function useDesktopShellViewModels({
       communityNodeEditorDirty,
       communityNodeError,
       communityNodeInput,
+      communityNodeManifests,
       communityNodeStatusByBaseUrl,
       t,
     ]

--- a/crates/desktop-runtime/src/community_node/manifest_support.rs
+++ b/crates/desktop-runtime/src/community_node/manifest_support.rs
@@ -154,7 +154,10 @@ mod tests {
         let manifest: CommunityNodeManifest = serde_json::from_str(SAMPLE_MANIFEST).unwrap();
         assert_eq!(manifest.node_role, "default-onboarding-node");
         assert_eq!(manifest.capability_scope.available_enabled.len(), 2);
-        assert_eq!(manifest.capability_scope.planned_enabled, vec!["moderation"]);
+        assert_eq!(
+            manifest.capability_scope.planned_enabled,
+            vec!["moderation"]
+        );
         assert!(
             manifest
                 .authority_scope

--- a/crates/desktop-runtime/src/community_node/manifest_support.rs
+++ b/crates/desktop-runtime/src/community_node/manifest_support.rs
@@ -1,0 +1,187 @@
+use super::*;
+
+/// community node manifest（#355/#356）の client 側 slim 表現。
+///
+/// dependency 表示に必要なフィールドのみを保持する。未知フィールドは無視し、欠落は
+/// default で補う（manifest schema が拡張されても client が壊れない）。
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommunityNodeManifest {
+    #[serde(default)]
+    pub node_id: String,
+    #[serde(default)]
+    pub node_name: String,
+    #[serde(default)]
+    pub node_role: String,
+    #[serde(default)]
+    pub server_name: String,
+    #[serde(default)]
+    pub manifest_version: String,
+    #[serde(default)]
+    pub capability_scope: CommunityNodeCapabilityScope,
+    #[serde(default)]
+    pub authority_scope: CommunityNodeAuthorityScope,
+    #[serde(default)]
+    pub p2p_boundary: CommunityNodeP2pBoundary,
+    #[serde(default)]
+    pub abuse_contact: String,
+    #[serde(default)]
+    pub terms_url: String,
+    #[serde(default)]
+    pub privacy_url: String,
+    #[serde(default)]
+    pub moderation_policy_url: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommunityNodeCapabilityScope {
+    #[serde(default)]
+    pub available_enabled: Vec<String>,
+    #[serde(default)]
+    pub planned_enabled: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommunityNodeAuthorityScope {
+    #[serde(default)]
+    pub applies_to: Vec<String>,
+    #[serde(default)]
+    pub does_not_apply_to: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommunityNodeP2pBoundary {
+    #[serde(default)]
+    pub identity_authority: bool,
+    #[serde(default)]
+    pub profile_canonical_store: bool,
+    #[serde(default)]
+    pub social_graph_canonical_store: bool,
+    #[serde(default)]
+    pub content_truth_source: bool,
+    #[serde(default)]
+    pub network_wide_authority: bool,
+}
+
+/// manifest fetch の結果状態。error は command の Err として返すため含めない。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommunityNodeManifestFetchStatus {
+    /// manifest を取得・解析できた。
+    Ok,
+    /// node が manifest を公開していない（404）。client は default node へ fallback しない。
+    Absent,
+}
+
+/// manifest fetch の結果。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommunityNodeManifestFetch {
+    pub status: CommunityNodeManifestFetchStatus,
+    #[serde(default)]
+    pub manifest: Option<CommunityNodeManifest>,
+}
+
+impl DesktopRuntime {
+    /// public manifest endpoint (#356) から unauthenticated に manifest を取得する。
+    ///
+    /// - 200: 解析して `Ok` 状態で返す
+    /// - 404: node が manifest 未公開。`Absent` 状態で返す（default node へ fallback しない）
+    /// - その他/通信失敗: `Err`（呼び出し側は error として表示する）
+    pub(crate) async fn request_community_node_manifest(
+        &self,
+        base_url: &str,
+    ) -> Result<CommunityNodeManifestFetch> {
+        let base_url = normalize_http_url(base_url)?;
+        let client = community_node_http_client()?;
+        let url = format!("{}/v1/node/manifest", base_url);
+        let response = client
+            .get(url)
+            .send()
+            .await
+            .context("failed to fetch community node manifest")?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(CommunityNodeManifestFetch {
+                status: CommunityNodeManifestFetchStatus::Absent,
+                manifest: None,
+            });
+        }
+        let response = response
+            .error_for_status()
+            .context("community node manifest request failed")?;
+        let manifest = response
+            .json::<CommunityNodeManifest>()
+            .await
+            .context("failed to decode community node manifest")?;
+        Ok(CommunityNodeManifestFetch {
+            status: CommunityNodeManifestFetchStatus::Ok,
+            manifest: Some(manifest),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // #356 の server-manifest.json と同形の JSON が client slim 型へ解析できることを確認する。
+    const SAMPLE_MANIFEST: &str = r#"{
+        "node_id": "",
+        "node_name": "example-kukuri.net",
+        "node_role": "default-onboarding-node",
+        "server_name": "example-kukuri.net",
+        "manifest_version": "v1",
+        "extra_unknown_field": "ignored",
+        "capability_scope": {
+            "available_enabled": ["auth_consent", "iroh_relay"],
+            "planned_enabled": ["moderation"]
+        },
+        "authority_scope": {
+            "applies_to": ["this_node"],
+            "does_not_apply_to": ["user_identity", "kukuri_network_as_a_whole"]
+        },
+        "p2p_boundary": {
+            "identity_authority": false,
+            "profile_canonical_store": false,
+            "social_graph_canonical_store": false,
+            "content_truth_source": false,
+            "network_wide_authority": false
+        },
+        "abuse_contact": "abuse@example-kukuri.net",
+        "terms_url": "https://example-kukuri.net/terms"
+    }"#;
+
+    #[test]
+    fn parses_manifest_and_ignores_unknown_fields() {
+        let manifest: CommunityNodeManifest = serde_json::from_str(SAMPLE_MANIFEST).unwrap();
+        assert_eq!(manifest.node_role, "default-onboarding-node");
+        assert_eq!(manifest.capability_scope.available_enabled.len(), 2);
+        assert_eq!(manifest.capability_scope.planned_enabled, vec!["moderation"]);
+        assert!(
+            manifest
+                .authority_scope
+                .does_not_apply_to
+                .contains(&"user_identity".to_string())
+        );
+        assert!(!manifest.p2p_boundary.network_wide_authority);
+        assert_eq!(manifest.abuse_contact, "abuse@example-kukuri.net");
+    }
+
+    #[test]
+    fn defaults_fill_missing_fields() {
+        // 最小 JSON でも default で補完され壊れない。
+        let manifest: CommunityNodeManifest = serde_json::from_str("{}").unwrap();
+        assert_eq!(manifest.node_role, "");
+        assert!(manifest.capability_scope.available_enabled.is_empty());
+        assert!(!manifest.p2p_boundary.identity_authority);
+    }
+
+    #[test]
+    fn fetch_result_serializes_with_snake_case_status() {
+        let fetch = CommunityNodeManifestFetch {
+            status: CommunityNodeManifestFetchStatus::Absent,
+            manifest: None,
+        };
+        let json = serde_json::to_value(&fetch).unwrap();
+        assert_eq!(json["status"], "absent");
+        assert!(json["manifest"].is_null());
+    }
+}

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -21,6 +21,7 @@ use crate::runtime::DesktopRuntime;
 
 mod config_support;
 mod http_client_support;
+mod manifest_support;
 mod reconnect_support;
 mod requests_support;
 mod session_runtime_support;
@@ -29,6 +30,10 @@ mod token_storage_support;
 
 pub(crate) use config_support::*;
 pub(crate) use http_client_support::*;
+pub use manifest_support::{
+    CommunityNodeAuthorityScope, CommunityNodeCapabilityScope, CommunityNodeManifest,
+    CommunityNodeManifestFetch, CommunityNodeManifestFetchStatus, CommunityNodeP2pBoundary,
+};
 pub(crate) use token_storage_support::*;
 
 pub(crate) const COMMUNITY_NODE_TOKEN_PURPOSE: &str = "community-node-token";

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -11,8 +11,10 @@ mod stack;
 mod tests;
 
 pub use community_node::{
-    AcceptCommunityNodeConsentsRequest, CommunityNodeAuthState, CommunityNodeConfig,
-    CommunityNodeNodeConfig, CommunityNodeNodeStatus, CommunityNodeSessionPhase,
+    AcceptCommunityNodeConsentsRequest, CommunityNodeAuthState, CommunityNodeAuthorityScope,
+    CommunityNodeCapabilityScope, CommunityNodeConfig, CommunityNodeManifest,
+    CommunityNodeManifestFetch, CommunityNodeManifestFetchStatus, CommunityNodeNodeConfig,
+    CommunityNodeNodeStatus, CommunityNodeP2pBoundary, CommunityNodeSessionPhase,
     CommunityNodeTargetRequest, SetCommunityNodeConfigNode, SetCommunityNodeConfigRequest,
 };
 pub use discovery::{DiscoveryConfig, SetDiscoverySeedsRequest};

--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -317,6 +317,16 @@ impl DesktopRuntime {
         self.community_node_status(refreshed, None, None).await
     }
 
+    /// public manifest endpoint (#356) から node manifest を取得する。
+    /// dependency 表示（#357）のため client が unauthenticated に呼ぶ。
+    pub async fn fetch_community_node_manifest(
+        &self,
+        request: CommunityNodeTargetRequest,
+    ) -> Result<CommunityNodeManifestFetch> {
+        self.request_community_node_manifest(request.base_url.as_str())
+            .await
+    }
+
     pub async fn reapply_community_node_connectivity(&self) -> Result<()> {
         self.force_rebuild_runtime_connectivity_assist().await?;
         self.force_apply_effective_seed_peers().await?;

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -34,12 +34,11 @@ use crate::community_node::{
     AcceptCommunityNodeConsentsRequest, COMMUNITY_NODE_TOKEN_PURPOSE, CommunityNodeConfig,
     CommunityNodeManifestFetch, CommunityNodeNodeConfig, CommunityNodeNodeStatus,
     CommunityNodeReconnectState, CommunityNodeSessionPhase, CommunityNodeTargetRequest,
-    SetCommunityNodeConfigRequest,
-    community_node_seed_peers, default_preview_community_node_config,
-    effective_seed_peer_apply_state, load_community_node_config_from_file,
-    load_community_node_token, normalize_community_node_config,
-    relay_config_from_community_node_config, runtime_connectivity_assist_state,
-    save_community_node_config,
+    SetCommunityNodeConfigRequest, community_node_seed_peers,
+    default_preview_community_node_config, effective_seed_peer_apply_state,
+    load_community_node_config_from_file, load_community_node_token,
+    normalize_community_node_config, relay_config_from_community_node_config,
+    runtime_connectivity_assist_state, save_community_node_config,
 };
 use crate::discovery::{
     DiscoveryConfig, SetDiscoverySeedsRequest, parse_seed_entries,

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -32,8 +32,9 @@ use crate::attachments::{
 };
 use crate::community_node::{
     AcceptCommunityNodeConsentsRequest, COMMUNITY_NODE_TOKEN_PURPOSE, CommunityNodeConfig,
-    CommunityNodeNodeConfig, CommunityNodeNodeStatus, CommunityNodeReconnectState,
-    CommunityNodeSessionPhase, CommunityNodeTargetRequest, SetCommunityNodeConfigRequest,
+    CommunityNodeManifestFetch, CommunityNodeNodeConfig, CommunityNodeNodeStatus,
+    CommunityNodeReconnectState, CommunityNodeSessionPhase, CommunityNodeTargetRequest,
+    SetCommunityNodeConfigRequest,
     community_node_seed_peers, default_preview_community_node_config,
     effective_seed_peer_apply_state, load_community_node_config_from_file,
     load_community_node_token, normalize_community_node_config,


### PR DESCRIPTION
## 概要

#357 の実装。client settings に、接続中 community node の **依存度 / capability scope / authority scope / P2P boundary** を表示します。#356 の public manifest endpoint を実際に **fetch** して表示まで通しました（fetch 配線を含む方針で実装）。

## 変更（クロススタック）

### Rust (desktop-runtime)
- `community_node/manifest_support.rs`: `CommunityNodeManifest` slim 型（未知フィールド無視・欠落は default）と fetch（`200`=ok / `404`=absent / その他=error）。manifest 解析テスト3件
- runtime API `fetch_community_node_manifest` + Tauri command を追加・登録

### Frontend (apps/desktop)
- `CommunityNodeManifest` / `CommunityNodeManifestFetch` 型、`DesktopApi.fetchCommunityNodeManifest`、invoke 配線、mock 実装
- store に `communityNodeManifests` slice を追加し、settings の community-node セクション表示時に saved nodes の manifest を best-effort 取得（loading/ok/absent/error）
- `buildCommunityNodeDependencyView`: capability scope / authority scope / node role を行表示。**identity / profile / social graph が node-owned ではないこと**、**default node が network-wide authority ではないこと**を常に説明。manifest fetch failure 時はエラー表示し **default node へ fallback しない**
- `CommunityNodePanel` に依存表示セクション、i18n ja/en/zh-CN、fixtures / stories 更新

## 受け入れ条件（#357）

- [x] connected community nodes が表示される（既存 + dependency セクション）
- [x] node role / default vs user-added / auth / consent / manifest status 表示
- [x] manifest から capability scope 表示
- [x] authority scope / P2P boundary metadata 表示
- [x] identity / profile / social graph が node-owned ではないことを明示
- [x] default node が network-wide authority ではないことを明示
- [x] manifest fetch failure 時の表示がある（default へ fallback しない）
- [x] UI text が個人運営や分散運用を discourage する表現になっていない
- [x] DTO / mock / i18n / tests が更新されている

## テスト

- Rust: `cargo check --workspace` ✅ / `manifest_support` 3件 ✅ / desktop-runtime `community_node` 35件 ✅（リグレッションなし）
- Frontend: `tsc --noEmit` ✅ / `eslint --max-warnings 0` ✅ / `vitest` 170件 ✅（依存ビルダー6件含む）/ i18n parity ✅

## 注記

`apps/desktop/src-tauri` の最終コンパイルは GTK/webkit system 依存が当実行環境で取得不可（apt 404）のため検証できず、CI に委ねます。src-tauri の変更は既存コマンドと同型の機械的追加（import 1 + command fn 1 + 登録 1 行）で、`cargo check --workspace` が desktop-runtime の runtime API シグネチャ・型エクスポートを検証済みです。

## follow-up

これで #310（分散通報ルーティング）の前提（#355/#356/#357/#358）が揃いました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ)_