### PR TITLE
feat(cn-operator): capability 別リスクと推奨対応ガイドを生成 (#359)

### DIFF
--- a/crates/cn-operator/src/capability_risk.rs
+++ b/crates/cn-operator/src/capability_risk.rs
@@ -1,0 +1,254 @@
+//! capability 別のリスクと推奨対応（#359）。
+//!
+//! この内容は「個人・小規模運営を discourage する」ためのものではない。各 capability の性質を
+//! 理解し、限定された責任範囲で現実的に運用するための実践的なガイドとして提供する。
+//!
+//! `capability.rs` の `meta()`（display_name / handled_data / purpose / retention_impact）を
+//! 補完する形で、user expectation / authority scope / responsibility boundary / risks /
+//! recommended practices / small-scale tips / how to reduce を定義する。
+
+use crate::capability::Capability;
+
+/// capability を運用する際のリスクと推奨対応。
+pub struct CapabilityRiskPractices {
+    /// この capability が user に生じさせる期待。
+    pub user_expectation: &'static str,
+    /// authority scope（この capability で node が責任を主張する範囲）。
+    pub authority_scope: &'static str,
+    /// responsibility boundary（引き受けない範囲）。
+    pub responsibility_boundary: &'static str,
+    /// 想定されるリスク（法務 / 運用 / プライバシー / safety）。
+    pub risks: &'static [&'static str],
+    /// 推奨対応。
+    pub recommended_practices: &'static [&'static str],
+    /// 個人・小規模運営のための実践 tips。
+    pub small_scale_tips: &'static str,
+    /// scope を狭める / 無効化する方法。
+    pub how_to_reduce: &'static str,
+}
+
+impl Capability {
+    /// 文書生成用の capability 別リスク・推奨対応（#359）。
+    pub fn risk_practices(self) -> CapabilityRiskPractices {
+        match self {
+            Capability::AuthConsent => CapabilityRiskPractices {
+                user_expectation: "補助機能を使う際に認証・同意が必要であり、同意状態が記録されること。",
+                authority_scope: "本ノードの補助機能に対する認証・同意の管理のみ。",
+                responsibility_boundary: "user identity そのものの所有・認証の canonical source ではない（鍵が canonical）。",
+                risks: &[
+                    "公開鍵・同意レコードの取り扱い（個人情報該当性は運用次第）。",
+                    "認証ログ・IP の保持期間が長すぎるとプライバシー負荷になる。",
+                ],
+                recommended_practices: &[
+                    "認証チャレンジは短期 TTL で失効させる。",
+                    "同意レコードは撤回可能にし、撤回時に確実に反映する。",
+                    "接続ログ保持期間をポリシーに明記し最小化する。",
+                ],
+                small_scale_tips: "既定の短期 TTL と最小ログで十分。独自の identity DB を作らない。",
+                how_to_reduce: "baseline 機能のため無効化はできないが、ログ保持期間を最小化することで負荷を下げられる。",
+            },
+            Capability::BootstrapAssist => CapabilityRiskPractices {
+                user_expectation: "新規 client が最初の peer に到達できること。",
+                authority_scope: "本ノードが提供する seed peer 情報の範囲のみ。",
+                responsibility_boundary: "到達後の P2P 通信内容・相手 peer の振る舞いには責任を持たない。",
+                risks: &[
+                    "登録された peer 接続ヒントの一時的な取り扱い。",
+                    "悪意ある peer 情報の混入（登録元の検証が弱い場合）。",
+                ],
+                recommended_practices: &[
+                    "ピア登録は短期 TTL の ephemeral state とし長期保存しない。",
+                    "登録は認証済み client に限定する。",
+                ],
+                small_scale_tips: "ephemeral state のみ扱うため運用負荷は低い。TTL を既定のまま使う。",
+                how_to_reduce: "`features.bootstrap_assist: false` で無効化できる（onboarding 補助が外れる点に注意）。",
+            },
+            Capability::TopicRendezvous => CapabilityRiskPractices {
+                user_expectation: "同じ topic の相手と接続を成立できること。",
+                authority_scope: "topic presence の一時的な突き合わせのみ。",
+                responsibility_boundary: "topic 内の投稿内容・モデレーションには責任を持たない（rendezvous は presence のみ）。",
+                risks: &["どの topic に接続中かという presence 情報の一時的な扱い。"],
+                recommended_practices: &[
+                    "presence は TTL 付き ephemeral state とし短期失効させる。",
+                    "presence の長期ログを残さない。",
+                ],
+                small_scale_tips: "KV の TTL に任せれば運用は軽い。presence を分析目的に転用しない。",
+                how_to_reduce: "`features.topic_rendezvous: false` で無効化できる。",
+            },
+            Capability::IrohRelay => CapabilityRiskPractices {
+                user_expectation: "Direct P2P が成立しないときも接続が成立すること。",
+                authority_scope: "暗号化済みパケットの中継・hole punching 補助の範囲のみ。",
+                responsibility_boundary: "中継するトラフィックの内容は復号できず、内容に責任を持たない。",
+                risks: &[
+                    "帯域・転送量の負荷（高トラフィック capability）。",
+                    "電気通信事業の届出該当性の検討が必要になり得る（暗号化済み traffic relay fallback を伴う場合）。",
+                    "relay 経由の通信量増加に伴うコスト。",
+                ],
+                recommended_practices: &[
+                    "relay は dedicated mode で運用し、帯域・転送量を監視する。",
+                    "暗号化済み traffic fallback が起こり得る旨を外部送信表示・利用規約に明記する（生成文書が自動で含める）。",
+                    "転送量上限・レート制限を設ける。",
+                ],
+                small_scale_tips: "個人運営では転送量課金に注意。必要なら relay を無効化し signaling 補助のみに寄せる構成も検討する。",
+                how_to_reduce: "`features.iroh_relay: false` で無効化できる。`traffic_relay_fallback` も併せて見直す。",
+            },
+            Capability::TrafficRelayFallback => CapabilityRiskPractices {
+                user_expectation: "直接接続も relay hole punching も失敗したときの最終手段で接続できること。",
+                authority_scope: "暗号化済みトラフィックの fallback 中継の範囲のみ。",
+                responsibility_boundary: "中継内容は復号できず、内容には責任を持たない。",
+                risks: &[
+                    "最も帯域負荷が高くなり得る経路。",
+                    "暗号化済みとはいえ通信の中継を行うため、電気通信事業の届出該当性の検討が必要になり得る。",
+                ],
+                recommended_practices: &[
+                    "転送量を監視し上限・レート制限を設ける。",
+                    "fallback が起こり得る旨を生成文書（外部送信表示 / 電気通信届出補助）で開示する。",
+                ],
+                small_scale_tips: "コストが読みにくいため、個人運営では上限設定を必須にする。",
+                how_to_reduce: "`features.traffic_relay_fallback: false` で無効化できる。",
+            },
+            Capability::BlobCache => CapabilityRiskPractices {
+                user_expectation: "メディア・添付が高速に取得できること。",
+                authority_scope: "本ノードが cache した blob の範囲のみ。",
+                responsibility_boundary: "blob 本体の恒久保存・truth source ではない（原本は P2P / author 側）。",
+                risks: &[
+                    "違法・有害コンテンツ（CSAM 含む）を一時的に保持・配信してしまうリスク。",
+                    "ストレージ容量・転送量の負荷。",
+                ],
+                recommended_practices: &[
+                    "index / 配信前に safety scan を行う（#353 の fail-closed 方針）。",
+                    "cache は短期で失効させ、blob 本体を恒久保存しない。",
+                    "scan 失敗時は配信しない（fail-closed）。",
+                ],
+                small_scale_tips: "CSAM リスクを避けるため、safety provider を用意できないうちは blob cache を有効化しない選択も現実的。",
+                how_to_reduce: "`features.blob_cache: false` で無効化できる。原本配信に任せる。",
+            },
+            Capability::PrivateMessageStorage => CapabilityRiskPractices {
+                user_expectation: "オフライン時の DM が後で受け取れること。",
+                authority_scope: "本ノードが保管する暗号化メッセージの範囲のみ。",
+                responsibility_boundary: "メッセージ内容は復号できず、会話の当事者・内容に責任を持たない。",
+                risks: &[
+                    "暗号化済みとはいえメッセージを保管するため、保持期間・削除要求の取り扱いが論点になる。",
+                    "ストレージ負荷。",
+                ],
+                recommended_practices: &[
+                    "保管は暗号化済みのまま行い、復号鍵を持たない。",
+                    "保持期間を明示し、配送後・期限後に削除する。",
+                ],
+                small_scale_tips: "保管を持たない（store-and-forward を無効化する）構成が最も負荷・リスクが低い。",
+                how_to_reduce: "`features.private_message_storage: false` で無効化できる。",
+            },
+            Capability::Analytics => CapabilityRiskPractices {
+                user_expectation: "（有効時）利用統計が収集され得ること。",
+                authority_scope: "本ノードが収集する利用統計の範囲のみ。",
+                responsibility_boundary: "個々の user の identity / 投稿内容の所有者ではない。",
+                risks: &[
+                    "外部 analytics provider への送信が発生し、プライバシー開示が必要になる。",
+                    "収集範囲が広いとプライバシー負荷が増す。",
+                ],
+                recommended_practices: &[
+                    "外部送信先と収集項目を privacy policy / 外部送信表示に明記する（生成文書が自動反映）。",
+                    "収集を最小化し、可能なら無効のまま運用する。",
+                ],
+                small_scale_tips: "既定の無効のままで全く問題ない。必要になってから最小範囲で有効化する。",
+                how_to_reduce: "`features.analytics: false`（既定）で無効。無効時は外部送信表示にも現れない。",
+            },
+            Capability::CrashReport => CapabilityRiskPractices {
+                user_expectation: "（有効時）クラッシュ情報が送信され得ること。",
+                authority_scope: "本ノードが収集するクラッシュ情報の範囲のみ。",
+                responsibility_boundary: "user identity / 投稿内容の所有者ではない。",
+                risks: &[
+                    "外部 crash provider への送信が発生する。",
+                    "クラッシュデータに意図せず個人情報が含まれ得る。",
+                ],
+                recommended_practices: &[
+                    "送信先と項目を privacy policy / 外部送信表示に明記する。",
+                    "PII を含めないようスクラブする。",
+                ],
+                small_scale_tips: "既定の無効のままで問題ない。",
+                how_to_reduce: "`features.crash_report: false`（既定）で無効。",
+            },
+            Capability::CloudflareProxy => CapabilityRiskPractices {
+                user_expectation: "（有効時）CDN / WAF 経由で接続が保護・高速化されること。",
+                authority_scope: "本ノードのエッジ保護・配信の範囲のみ。",
+                responsibility_boundary: "Cloudflare の処理に対する責任を kukuri network 全体に拡張しない。",
+                risks: &["Cloudflare への外部送信（IP・リクエスト情報）が発生し、開示が必要。"],
+                recommended_practices: &[
+                    "Cloudflare 経由の外部送信を外部送信表示に明記する（生成文書が自動反映）。",
+                ],
+                small_scale_tips: "DDoS 対策として有用。使う場合は外部送信表示の自動生成に任せる。",
+                how_to_reduce: "`features.cloudflare_proxy: false` で無効化できる。",
+            },
+            Capability::PushNotification => CapabilityRiskPractices {
+                user_expectation: "（有効時）通知が push されること。",
+                authority_scope: "本ノードが扱う通知配信の範囲のみ。",
+                responsibility_boundary: "通知の元になる投稿内容の truth source ではない。",
+                risks: &["push provider への外部送信（device token 等）が発生する。"],
+                recommended_practices: &[
+                    "device token の取り扱い・保持期間を明示する。",
+                    "外部 provider への送信を開示する。",
+                ],
+                small_scale_tips: "ローカル通知で足りる範囲なら push provider を持たない選択もできる。",
+                how_to_reduce: "`features.push_notification: false` で無効化できる。",
+            },
+            Capability::CommunityIndex => CapabilityRiskPractices {
+                user_expectation: "本ノードの検索・発見結果が提供されること。",
+                authority_scope: "本ノードが index した対象の範囲のみ（communities_indexed_by_this_node）。",
+                responsibility_boundary: "kukuri network 全体の content truth source ではない。他ノードの index に責任を持たない。",
+                risks: &[
+                    "違法・有害コンテンツ（CSAM 含む）を index・配信してしまうリスク。",
+                    "index 対象の選定・除外に伴う運用・法務負荷。",
+                ],
+                recommended_practices: &[
+                    "index 前に safety scan を行い、scan 前 / scan 失敗 / critical verdict を index しない（#353 fail-closed）。",
+                    "index 除外を signed moderation event として説明・監査可能にする。",
+                ],
+                small_scale_tips: "safety provider を用意できるまで有効化しない判断も妥当（現状 Phase B / 未提供）。",
+                how_to_reduce: "`features.community_index: false`（既定）で無効化できる。",
+            },
+            Capability::Moderation => CapabilityRiskPractices {
+                user_expectation: "本ノードの moderation 判断・ラベルが提供されること。",
+                authority_scope: "本ノードが発行した moderation event の範囲のみ（issuer node の authority scope 内）。",
+                responsibility_boundary: "network-wide moderation authority ではない。moderation event は optional trust input（#362）。",
+                risks: &[
+                    "誤検知・過剰除外による表現への影響。",
+                    "CSAM 等 critical safety の取り扱いに伴う法務・心理的負荷。",
+                ],
+                recommended_practices: &[
+                    "known CSAM / suspected unknown CSAM / 一般モデレーションを分離する（#353）。",
+                    "moderation event を署名し、visibility（local/subscribed/public）を適切に設定する（#362）。",
+                    "suspected unknown は local visibility を基本とする。",
+                ],
+                small_scale_tips: "人力レビュー依存を避け、provider / mock 経由の自動判定を前提にする（#353）。",
+                how_to_reduce: "`features.moderation: false`（既定）で無効化できる。",
+            },
+            Capability::CommunityLocalTrust => CapabilityRiskPractices {
+                user_expectation: "本ノードの trust / risk signal が参照できること。",
+                authority_scope: "本ノードが発行した trust signal の範囲のみ。",
+                responsibility_boundary: "network-wide な信頼権威ではない。trust signal は optional trust input（#362）。",
+                risks: &["断定ラベル化による誤った信頼判断の誘発。"],
+                recommended_practices: &[
+                    "断定ラベルではなく根拠つき risk signal（basis / confidence / severity）として扱う。",
+                    "visibility を適切に設定し、誤検知を public に拡散しない。",
+                ],
+                small_scale_tips: "local-first で運用し、subscribed/public への昇格は慎重に行う。",
+                how_to_reduce: "`features.community_local_trust: false`（既定）で無効化できる。",
+            },
+            Capability::ReportEndpoint => CapabilityRiskPractices {
+                user_expectation: "本ノードに対して通報を送れること。",
+                authority_scope: "本ノードが関与した対象への通報受付の範囲のみ（中央通報窓口ではない）。",
+                responsibility_boundary: "kukuri network 全体・他ノードが関与した対象の通報窓口ではない（#310）。",
+                risks: &[
+                    "通報内容・通報者連絡先の取り扱い。",
+                    "通報を受け付ける以上、最低限のトリアージ運用が必要になる。",
+                ],
+                recommended_practices: &[
+                    "reporter の identity / social graph を保持せず、明示入力された連絡先のみ任意保存する（#370 実装）。",
+                    "受信通報を `cn-cli reports` で確認し、保持期間ポリシーに従う。",
+                    "critical safety 区分は evidence を再配布せず内容で説明する。",
+                ],
+                small_scale_tips: "完全な ticketing system は不要。`cn-cli reports list/show` で確認できれば十分。",
+                how_to_reduce: "`features.report_endpoint: false` で無効化できる。無効時は abuse contact が窓口になる。",
+            },
+        }
+    }
+}

--- a/crates/cn-operator/src/docs.rs
+++ b/crates/cn-operator/src/docs.rs
@@ -472,6 +472,81 @@ fn gen_prior_consultation_email(config: &ResolvedConfig) -> String {
     s
 }
 
+/// capability 別リスクと推奨対応ガイド（#359）。
+///
+/// 個人・小規模運営を discourage しない。各 capability の性質・責任範囲・リスク・推奨対応を
+/// 示し、限定された責任範囲で現実的に運用できるようにする。有効 capability を実践ガイドとして、
+/// 無効 capability を「引き受けていない責務」として記述する。
+fn gen_capability_risk_and_practices(config: &ResolvedConfig) -> String {
+    let mut s = header(config, "Capability 別リスクと推奨対応ガイド（ドラフト）");
+
+    let _ = writeln!(
+        s,
+        "\nkukuri は、コミュニティ基盤の運営を企業だけが担うものとは考えない。\
+         このガイドは、個人・小規模グループが各 capability の性質を理解し、\
+         限定された責任範囲で現実的に運用するための実践的なガイドである。\n"
+    );
+    let _ = writeln!(
+        s,
+        "各 capability は authority scope（責任を主張する範囲）と responsibility boundary\
+         （引き受けない範囲）を持つ。これらは `docs/architecture/p2p-first-community-node-responsibility-boundary.md`\
+         の責任境界と整合する。\n"
+    );
+
+    let _ = writeln!(s, "## 有効化している capability\n");
+    let enabled = config.enabled_capabilities();
+    for cap in &enabled {
+        write_capability_risk_section(&mut s, *cap);
+    }
+
+    // 無効 capability は「引き受けていない責務」として一覧する。
+    let disabled = config.disabled_capabilities();
+    if !disabled.is_empty() {
+        let _ = writeln!(s, "## 引き受けていない責務（無効な capability）\n");
+        let _ = writeln!(
+            s,
+            "以下の capability は無効であり、本ノードはこれらに関する責務を引き受けていない。\n"
+        );
+        for cap in disabled {
+            let m = cap.meta();
+            let _ = writeln!(s, "- **{}**: {}", m.display_name, m.purpose);
+        }
+        s.push('\n');
+    }
+
+    s
+}
+
+/// 1 capability 分のリスク・推奨対応セクションを書き出す。
+fn write_capability_risk_section(s: &mut String, cap: Capability) {
+    let m = cap.meta();
+    let rp = cap.risk_practices();
+    let availability = match cap.availability() {
+        Availability::Available => "提供中（Phase A）",
+        Availability::Planned => "計画中・未提供（Phase B）",
+    };
+
+    let _ = writeln!(s, "### {}（{}）\n", m.display_name, availability);
+    let _ = writeln!(s, "- 機能: {}", m.purpose);
+    let _ = writeln!(s, "- 取り扱うデータ: {}", m.handled_data);
+    let _ = writeln!(s, "- user の期待: {}", rp.user_expectation);
+    let _ = writeln!(s, "- authority scope: {}", rp.authority_scope);
+    let _ = writeln!(s, "- 引き受けない範囲: {}", rp.responsibility_boundary);
+    let _ = writeln!(s, "- 保持への影響: {}", m.retention_impact);
+
+    let _ = writeln!(s, "- 想定リスク:");
+    for risk in rp.risks {
+        let _ = writeln!(s, "  - {risk}");
+    }
+    let _ = writeln!(s, "- 推奨対応:");
+    for practice in rp.recommended_practices {
+        let _ = writeln!(s, "  - {practice}");
+    }
+    let _ = writeln!(s, "- 小規模運営の tips: {}", rp.small_scale_tips);
+    let _ = writeln!(s, "- scope を狭める / 無効化: {}", rp.how_to_reduce);
+    s.push('\n');
+}
+
 // ---------------------------------------------------------------------------
 // 集約
 // ---------------------------------------------------------------------------
@@ -522,6 +597,10 @@ pub fn generate_all(config: &ResolvedConfig) -> Vec<GeneratedFile> {
         GeneratedFile {
             filename: "prior-consultation-email.md".to_string(),
             content: gen_prior_consultation_email(config),
+        },
+        GeneratedFile {
+            filename: "capability-risk-and-practices.md".to_string(),
+            content: gen_capability_risk_and_practices(config),
         },
     ];
     files.sort_by(|a, b| a.filename.cmp(&b.filename));

--- a/crates/cn-operator/src/lib.rs
+++ b/crates/cn-operator/src/lib.rs
@@ -13,6 +13,7 @@
 //!   による明示承認がなければ検証で失敗する。
 
 pub mod capability;
+pub mod capability_risk;
 pub mod config;
 pub mod docs;
 pub mod drift;
@@ -20,6 +21,7 @@ pub mod manifest;
 pub mod profile;
 
 pub use capability::{Availability, Capability, CapabilityMeta, ExternalDestination};
+pub use capability_risk::CapabilityRiskPractices;
 pub use config::{
     OperatorConfig, ResolvedConfig, RetentionConfig, ServerConfig, load_and_validate, parse_config,
     resolve_and_validate,

--- a/crates/cn-operator/tests/generate.rs
+++ b/crates/cn-operator/tests/generate.rs
@@ -170,9 +170,35 @@ fn all_expected_docs_are_generated() {
         "moderation-policy.md",
         "data-retention-policy.md",
         "prior-consultation-email.md",
+        "capability-risk-and-practices.md",
     ] {
         assert!(names.contains(&expected), "missing {expected}");
     }
+}
+
+#[test]
+fn capability_risk_guide_covers_enabled_and_disabled() {
+    // #359: enabled capability は実践ガイドとして、disabled capability は
+    // 「引き受けていない責務」として記述される。個人運営を discourage しない。
+    let yaml = base_config("  report_endpoint: true\n  analytics: false\n", true);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let guide = doc(&generate_all(&resolved), "capability-risk-and-practices.md");
+
+    // discourage しないトーンの明示。
+    assert!(guide.contains("企業だけが担うものとは考えない"));
+    // セクション構造。
+    assert!(guide.contains("## 有効化している capability"));
+    assert!(guide.contains("## 引き受けていない責務（無効な capability）"));
+    // 有効化した report_endpoint の実践記述。
+    assert!(guide.contains("通報エンドポイント"));
+    assert!(guide.contains("authority scope:"));
+    assert!(guide.contains("推奨対応:"));
+    assert!(guide.contains("scope を狭める / 無効化:"));
+    // 無効化した analytics は「引き受けていない責務」側に出る。
+    let disabled_section = guide.split("引き受けていない責務").nth(1).unwrap();
+    assert!(disabled_section.contains("アナリティクス"));
+    // 法的免責が含まれる（header 経由）。
+    assert!(guide.contains("法的助言ではありません"));
 }
 
 #[test]


### PR DESCRIPTION
## 概要

#359 を実装。#352 の operator docs generator に `capability-risk-and-practices.md` を追加する。個人・小規模運営を discourage せず、各 capability の性質・責任範囲・リスク・推奨対応を示す。

closes #359

## 変更点
- **`crates/cn-operator/src/capability_risk.rs`**（新規）: capability ごとに `user_expectation` / `authority_scope` / `responsibility_boundary` / `risks` / `recommended_practices` / `small_scale_tips` / `how_to_reduce` を定義（全 15 capability）。`capability.rs` の `meta()`（display_name / handled_data / purpose / retention_impact）を補完。
- **`docs.rs`**: `gen_capability_risk_and_practices` を追加し `generate_all` に組み込む → `check-disclosures`（drift check）に自動で含まれる。有効 capability は実践ガイド、無効 capability は「引き受けていない責務」として記述。header 経由で法的免責も付与。
- **トーン**: 「kukuri は、コミュニティ基盤の運営を企業だけが担うものとは考えない。…」を明記し、discourage しない。

## 受け入れ条件
- `capability-risk-and-practices.md` が生成される ✓
- enabled capability ごとに risk / recommended practices が生成される ✓
- disabled capability を「引き受けていない責務」として説明 ✓
- discourage するトーンになっていない ✓ /「非推奨」ではなく「リスクと推奨対応」中心 ✓
- media cache / index / moderation / report endpoint / relay fallback など高負荷 capability の実践的備え ✓
- authority scope / P2P boundary と整合 ✓
- generated docs の drift check に含まれる ✓

## 検証
`cargo test -p kukuri-cn-operator` 31 passed（新規ガイドの生成・enabled/disabled 記述・トーン・法的免責を検証）、`cargo fmt --check` clean、clippy（--tests）clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014k9stb4ox8NHoax5DhePyQ)_