### PR TITLE
feat(notification): OS通知クリックで対象投稿を開く

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3790,6 +3790,7 @@ dependencies = [
  "kukuri-app-api",
  "kukuri-core",
  "kukuri-desktop-runtime",
+ "notify-rust",
  "serde",
  "serde_json",
  "tauri",
@@ -3798,6 +3799,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-winrt-notification",
  "tracing",
  "tracing-subscriber",
 ]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -25,3 +25,9 @@ tauri-plugin-single-instance = { version = "2.0.0", features = ["deep-link"] }
 tauri-plugin-updater = "2.10.1"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+
+[target.'cfg(windows)'.dependencies]
+tauri-winrt-notification = "0.7"
+
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+notify-rust = "4"

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod community_node;
 pub mod direct_messages;
 pub mod live_game;
+pub mod os_notification;
 pub mod posts;
 pub mod profile;
 pub mod reactions;

--- a/apps/desktop/src-tauri/src/commands/os_notification.rs
+++ b/apps/desktop/src-tauri/src/commands/os_notification.rs
@@ -1,0 +1,126 @@
+use tauri::{AppHandle, Emitter, Manager};
+
+/// Event payload emitted to the frontend when an OS toast is clicked.
+#[derive(Clone, serde::Serialize)]
+struct ActivationPayload {
+    notification_id: String,
+}
+
+/// Bring the main window forward and tell the frontend which notification was
+/// activated. The frontend resolves the id back to a notification and opens the
+/// target post via the existing in-app handler.
+fn activate_main_window(app: &AppHandle, notification_id: String) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+    let _ = app.emit(
+        "os-notification://activated",
+        ActivationPayload { notification_id },
+    );
+}
+
+/// Show an OS toast for an incoming notification. On platforms that support it,
+/// clicking the toast focuses the window and emits `os-notification://activated`
+/// so the frontend can open the related post.
+///
+/// This replaces the direct `plugin:notification|notify` invocation because the
+/// `tauri-plugin-notification` desktop backend never reports click/activation
+/// events back to the app (those are mobile-only).
+#[tauri::command]
+pub fn show_os_notification(
+    app: AppHandle,
+    id: String,
+    title: String,
+    body: Option<String>,
+    silent: bool,
+) -> Result<(), String> {
+    show_platform_notification(app, id, title, body, silent)
+}
+
+#[cfg(windows)]
+fn show_platform_notification(
+    app: AppHandle,
+    id: String,
+    title: String,
+    body: Option<String>,
+    silent: bool,
+) -> Result<(), String> {
+    use tauri_winrt_notification::{Sound, Toast};
+
+    // Use the same AUMID as the existing plugin path (the bundle identifier) so
+    // the toast renders under the registered app identity.
+    let app_id = app.config().identifier.clone();
+    let mut toast = Toast::new(&app_id).title(&title);
+    if let Some(body) = body.as_deref() {
+        toast = toast.text1(body);
+    }
+    toast = toast.sound(if silent { None } else { Some(Sound::Default) });
+
+    // The activation closure must be `Send + 'static`, so it owns a cloned
+    // `AppHandle` and the notification id captured for this single toast.
+    let activate_app = app.clone();
+    toast = toast.on_activated(move |_action| {
+        activate_main_window(&activate_app, id.clone());
+        Ok(())
+    });
+
+    toast.show().map_err(|error| error.to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn show_platform_notification(
+    app: AppHandle,
+    id: String,
+    title: String,
+    body: Option<String>,
+    _silent: bool,
+) -> Result<(), String> {
+    use notify_rust::Notification;
+
+    let mut notification = Notification::new();
+    notification.summary(&title);
+    if let Some(body) = body.as_deref() {
+        notification.body(body);
+    }
+    // "default" fires when the notification body itself is clicked.
+    notification.action("default", "Open");
+
+    let handle = notification.show().map_err(|error| error.to_string())?;
+
+    // `wait_for_action` blocks until the notification is actioned or closed, so
+    // run it off the command thread.
+    let activate_app = app.clone();
+    std::thread::spawn(move || {
+        handle.wait_for_action(|action| {
+            if action == "default" {
+                activate_main_window(&activate_app, id);
+            }
+        });
+    });
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn show_platform_notification(
+    _app: AppHandle,
+    _id: String,
+    title: String,
+    body: Option<String>,
+    _silent: bool,
+) -> Result<(), String> {
+    use notify_rust::Notification;
+
+    // notify-rust routes through mac-notification-sys on macOS, whose action
+    // callbacks require a signed application bundle. For now we only display the
+    // toast; click-through activation can be added later via the UserNotifications
+    // framework (UNUserNotificationCenter).
+    let mut notification = Notification::new();
+    notification.summary(&title);
+    if let Some(body) = body.as_deref() {
+        notification.body(body);
+    }
+    notification.show().map_err(|error| error.to_string())?;
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -129,7 +129,8 @@ pub fn run() {
             commands::community_node::accept_community_node_consents,
             commands::community_node::refresh_community_node_metadata,
             commands::community_node::fetch_community_node_manifest,
-            commands::community_node::submit_community_node_report
+            commands::community_node::submit_community_node_report,
+            commands::os_notification::show_os_notification
         ])
         .run(tauri::generate_context!())
         .expect("failed to run kukuri desktop tauri app");

--- a/apps/desktop/src/lib/releaseReadiness.ts
+++ b/apps/desktop/src/lib/releaseReadiness.ts
@@ -130,14 +130,6 @@ export function notificationBody(
   return notification.preview_text ?? undefined;
 }
 
-export function nextOsNotificationId(notificationId: string): number {
-  let hash = 0;
-  for (let index = 0; index < notificationId.length; index += 1) {
-    hash = (hash * 31 + notificationId.charCodeAt(index)) >>> 0;
-  }
-  return hash & 0x7fffffff;
-}
-
 export function readSeenOsNotificationIds(): Set<string> {
   if (typeof window === 'undefined') {
     return new Set();

--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -53,6 +53,7 @@ import { useDesktopShellData } from '@/shell/useDesktopShellData';
 import { useDesktopShellRouting } from '@/shell/useDesktopShellRouting';
 import { useDesktopShellActions } from '@/shell/useDesktopShellActions';
 import { useOsNotificationBridge } from '@/shell/useOsNotificationBridge';
+import { useOsNotificationActivation } from '@/shell/useOsNotificationActivation';
 import { selectUpdateAvailable, useAppUpdateStore } from '@/shell/useAppUpdateStore';
 import { useDesktopShellViewModels } from '@/shell/useDesktopShellViewModels';
 import {
@@ -420,6 +421,7 @@ export function DesktopShellPage({
   const notificationBadgeLabel =
     notificationStatus.unread_count > 99 ? '99+' : formatCount(notificationStatus.unread_count);
   useOsNotificationBridge(notifications, syncStatus.local_author_pubkey);
+  useOsNotificationActivation(notifications, handleOpenNotification);
   const notificationItems = useMemo(
     () =>
       notifications.map((notification) => {

--- a/apps/desktop/src/shell/useOsNotificationActivation.test.ts
+++ b/apps/desktop/src/shell/useOsNotificationActivation.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { NotificationView } from '@/lib/api';
+
+const listenMock = vi.fn();
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
+}));
+
+import { useOsNotificationActivation } from './useOsNotificationActivation';
+
+type EventCallback = (event: { payload: { notification_id: string } }) => void;
+
+function notification(overrides: Partial<NotificationView> = {}): NotificationView {
+  return {
+    notification_id: 'notif-1',
+    kind: 'reply',
+    actor_pubkey: 'actor-pubkey',
+    created_at: 0,
+    received_at: 0,
+    ...overrides,
+  } as NotificationView;
+}
+
+describe('useOsNotificationActivation', () => {
+  beforeEach(() => {
+    listenMock.mockReset();
+    listenMock.mockResolvedValue(() => undefined);
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+  });
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+  });
+
+  test('does not subscribe outside the Tauri runtime', () => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    renderHook(() => useOsNotificationActivation([notification()], vi.fn()));
+    expect(listenMock).not.toHaveBeenCalled();
+  });
+
+  test('opens the matching notification when activated', async () => {
+    let capturedCallback: EventCallback | undefined;
+    listenMock.mockImplementation(async (_event: string, cb: EventCallback) => {
+      capturedCallback = cb;
+      return () => undefined;
+    });
+    const onActivate = vi.fn();
+    const target = notification({ notification_id: 'notif-2' });
+
+    renderHook(() =>
+      useOsNotificationActivation([notification(), target], onActivate)
+    );
+
+    // Wait for the async listen() registration to resolve.
+    await vi.waitFor(() => expect(capturedCallback).toBeDefined());
+
+    capturedCallback?.({ payload: { notification_id: 'notif-2' } });
+    expect(onActivate).toHaveBeenCalledWith(target);
+  });
+
+  test('ignores activation for an unknown notification id', async () => {
+    let capturedCallback: EventCallback | undefined;
+    listenMock.mockImplementation(async (_event: string, cb: EventCallback) => {
+      capturedCallback = cb;
+      return () => undefined;
+    });
+    const onActivate = vi.fn();
+
+    renderHook(() => useOsNotificationActivation([notification()], onActivate));
+    await vi.waitFor(() => expect(capturedCallback).toBeDefined());
+
+    capturedCallback?.({ payload: { notification_id: 'missing' } });
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/shell/useOsNotificationActivation.ts
+++ b/apps/desktop/src/shell/useOsNotificationActivation.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+import type { NotificationView } from '@/lib/api';
+import { isTauriRuntime } from '@/lib/releaseReadiness';
+
+type ActivationPayload = {
+  notification_id: string;
+};
+
+/**
+ * Listens for OS toast clicks emitted by the `show_os_notification` Rust command
+ * and opens the related notification target via the existing in-app handler.
+ *
+ * The Rust side already focuses the window; here we just resolve the activated
+ * id back to a notification and reuse `handleOpenNotification`.
+ */
+export function useOsNotificationActivation(
+  notifications: NotificationView[],
+  onActivate: (notification: NotificationView) => void
+): void {
+  const notificationsRef = useRef<NotificationView[]>(notifications);
+  const onActivateRef = useRef(onActivate);
+
+  useEffect(() => {
+    notificationsRef.current = notifications;
+  }, [notifications]);
+
+  useEffect(() => {
+    onActivateRef.current = onActivate;
+  }, [onActivate]);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    let unlisten: UnlistenFn | undefined;
+    let cancelled = false;
+
+    void (async () => {
+      const dispose = await listen<ActivationPayload>('os-notification://activated', (event) => {
+        const notificationId = event.payload?.notification_id;
+        if (!notificationId) {
+          return;
+        }
+        const notification = notificationsRef.current.find(
+          (candidate) => candidate.notification_id === notificationId
+        );
+        if (notification) {
+          onActivateRef.current(notification);
+        }
+      });
+      if (cancelled) {
+        dispose();
+        return;
+      }
+      unlisten = dispose;
+    })();
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+}

--- a/apps/desktop/src/shell/useOsNotificationBridge.ts
+++ b/apps/desktop/src/shell/useOsNotificationBridge.ts
@@ -5,7 +5,6 @@ import type { NotificationView } from '@/lib/api';
 import {
   isTauriRuntime,
   loadOsNotificationSettings,
-  nextOsNotificationId,
   notificationBody,
   notificationTitle,
   OS_NOTIFICATION_SETTINGS_STORAGE_KEY,
@@ -45,24 +44,23 @@ export function useOsNotificationBridge(
     }
 
     let cancelled = false;
-    // Route through the Tauri backend `notify` command directly. The
+    // Route through the custom `show_os_notification` command. The
     // `@tauri-apps/plugin-notification` JS helpers go through the WebView2 Web
     // Notification API, which does not produce real Windows toasts and reports a
-    // volatile permission state (see issue #313). The Rust backend grants
-    // permission unconditionally on desktop and emits a proper OS toast.
+    // volatile permission state (see issue #313). The plugin's desktop backend
+    // also never reports toast click/activation events back to the app, so we
+    // own the toast here to wire up click-to-open (see useOsNotificationActivation).
     void (async () => {
       for (const notification of unseen) {
         if (cancelled) {
           break;
         }
         try {
-          await invoke('plugin:notification|notify', {
-            options: {
-              id: nextOsNotificationId(notification.notification_id),
-              title: notificationTitle(notification),
-              body: notificationBody(notification, settings),
-              silent: settings.quietMode,
-            },
+          await invoke('show_os_notification', {
+            id: notification.notification_id,
+            title: notificationTitle(notification),
+            body: notificationBody(notification, settings),
+            silent: settings.quietMode,
           });
           seenNotificationIdsRef.current.add(notification.notification_id);
         } catch {


### PR DESCRIPTION
## 背景・目的

OS通知（reply / mention / repost / quote_repost / followed / direct_message）のトーストをクリックしても**何も起きない**問題を解消する。

調査の結果、`tauri-plugin-notification` 2.3.3 の**デスクトップ実装はクリック/アクションイベントを一切発火しない**ことが判明（`actionPerformed` はモバイル専用、`desktop.rs` の `show()` は notify-rust への撃ちっぱなし）。一方、アプリ内通知パネルのクリックは既存 `handleOpenNotification` が種別ごとに正しく遷移処理している。

**目標: OSトーストのクリックでウィンドウを前面化し、通知対象の投稿（DM/フォローは対応画面）を開く。**

## アプローチ

`plugin:notification|notify` の呼び出しを自前コマンド `show_os_notification` に置き換え。各トースト呼び出しで `notification_id` をクロージャに捕捉し、クリック時に Tauri イベント `os-notification://activated` を emit + メインウィンドウ前面化。frontend は新フックで購読し、**既存の `handleOpenNotification` を再利用**して遷移する（新規の遷移ロジックは書かない）。

`tauri-plugin-notification` は権限 API（ReleasePanel が使用）のため残置し、`notify` の呼び出しのみ置き換え。

## 変更点

### Rust
- **新規** `commands/os_notification.rs` — `show_os_notification` コマンド
  - **Windows**: `tauri-winrt-notification` の `on_activated` で完全対応
  - **Linux**: notify-rust の `default` アクション + `wait_for_action` で完全対応
  - **macOS**: 表示のみ（署名バンドル必須のため activation は将来 UserNotifications で対応）
- `Cargo.toml` にプラットフォーム別依存追加（lock 解決済み・DL不要）、`mod.rs`/`lib.rs` に登録

### Frontend
- `useOsNotificationBridge.ts` — invoke 先を `show_os_notification` に差し替え（生の `notification_id` を渡す）
- **新規** `useOsNotificationActivation.ts` — activation イベント購読 → id 照合 → `handleOpenNotification`
- `DesktopShellPage.tsx` でフック配線、未使用化した `nextOsNotificationId` を削除

## スコープ

- **アプリ起動中のクリックのみ対応**（cold-start 起動は AUMID/COM activator 登録が必要なため対象外）
- capability 変更不要（`core:default` でイベント購読・カスタムコマンド許可済み）

## 検証

- ✅ `pnpm typecheck` / `pnpm lint`
- ✅ `cargo check`（Windows ターゲットで cfg 分岐コンパイル成功）
- ✅ vitest: 新フックテスト3件 + DesktopShellPage 122件 + releaseReadiness 5件 すべて合格
- ⏳ 実機の手動E2E（別アカウントから reply → トースト → クリック → 対象スレッドが開く）はビルド・第2アカウントが必要なため未実施。Windows の activation は AUMID 登録済みのインストール済みビルドで最も確実に動作する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)