### PR TITLE
feat(notification): バックグラウンドOS通知とトレイ常駐 (#304)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3800,6 +3800,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-winrt-notification",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,11 +18,12 @@ kukuri-core = { path = "../../../crates/core" }
 kukuri-desktop-runtime = { path = "../../../crates/desktop-runtime" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-tauri = { version = "2.10.3", features = [] }
+tauri = { version = "2.10.3", features = ["tray-icon"] }
 tauri-plugin-deep-link = "2.0.0"
 tauri-plugin-notification = "2.3.3"
 tauri-plugin-single-instance = { version = "2.0.0", features = ["deep-link"] }
 tauri-plugin-updater = "2.10.1"
+tokio = { version = "1", features = ["time"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 

--- a/apps/desktop/src-tauri/src/commands/background_notifications.rs
+++ b/apps/desktop/src-tauri/src/commands/background_notifications.rs
@@ -1,0 +1,443 @@
+//! Backend-driven OS notification dispatch.
+//!
+//! Issue #304: kukuri needs to keep working in the background. The P2P runtime
+//! already persists notification records regardless of window state, but OS
+//! toasts used to be fired only by the React frontend — which means no toast
+//! appears once the window is hidden to the tray (and historically not even
+//! when a section other than "notifications" was open).
+//!
+//! This module owns notification dispatch on the Rust side: a background task
+//! polls the runtime for new notifications and shows OS toasts through the same
+//! platform code the manual `show_os_notification` command uses. The frontend
+//! only mirrors the user's settings down to us via `set_os_notification_settings`.
+
+use std::{path::PathBuf, sync::Mutex, time::Duration};
+
+use kukuri_app_api::{NotificationKind, NotificationView};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+use tracing::{debug, warn};
+
+use crate::{commands::os_notification::show_platform_notification, state::DesktopState};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(15);
+
+/// User-facing OS notification preferences. Mirrors the `OsNotificationSettings`
+/// type the frontend persists in `localStorage` (camelCase keys on the wire).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OsNotificationSettings {
+    pub enabled: bool,
+    pub direct_messages: bool,
+    pub mentions_and_replies: bool,
+    pub follows_and_reposts: bool,
+    pub quiet_mode: bool,
+    pub preview_body: bool,
+}
+
+impl Default for OsNotificationSettings {
+    fn default() -> Self {
+        // Keep these defaults in sync with DEFAULT_OS_NOTIFICATION_SETTINGS in
+        // apps/desktop/src/lib/releaseReadiness.ts.
+        Self {
+            enabled: false,
+            direct_messages: true,
+            mentions_and_replies: true,
+            follows_and_reposts: false,
+            quiet_mode: false,
+            preview_body: false,
+        }
+    }
+}
+
+/// High-water mark over `received_at` plus the ids that share that timestamp,
+/// so we never re-toast a notification we've already dispatched while keeping
+/// memory bounded (notifications are returned newest-first and unbounded).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DispatchCursor {
+    last_received_at: i64,
+    ids_at_last: Vec<String>,
+}
+
+/// Shared, persisted state for the background dispatcher. Managed by Tauri so the
+/// `set_os_notification_settings` command and the poll loop can both reach it.
+pub struct OsNotificationBackground {
+    settings: Mutex<OsNotificationSettings>,
+    settings_path: PathBuf,
+    cursor: Mutex<DispatchCursor>,
+    cursor_path: PathBuf,
+    /// `true` until the first successful poll establishes a baseline. Prevents the
+    /// existing notification backlog from bursting as toasts on first launch.
+    baseline_pending: Mutex<bool>,
+    /// Cached local author pubkey, used to suppress toasts for our own actions.
+    local_pubkey: Mutex<String>,
+}
+
+impl OsNotificationBackground {
+    pub fn new(app: &AppHandle) -> Self {
+        let dir = app
+            .path()
+            .app_data_dir()
+            .unwrap_or_else(|_| PathBuf::from("."));
+        let settings_path = dir.join("os-notification-settings.json");
+        let cursor_path = dir.join("os-notification-cursor.json");
+
+        let settings = read_json(&settings_path).unwrap_or_default();
+        let cursor_existed = cursor_path.exists();
+        let cursor = read_json(&cursor_path).unwrap_or_default();
+
+        Self {
+            settings: Mutex::new(settings),
+            settings_path,
+            cursor: Mutex::new(cursor),
+            cursor_path,
+            baseline_pending: Mutex::new(!cursor_existed),
+            local_pubkey: Mutex::new(String::new()),
+        }
+    }
+
+    fn settings_snapshot(&self) -> OsNotificationSettings {
+        self.settings.lock().expect("settings lock poisoned").clone()
+    }
+
+    fn replace_settings(&self, next: OsNotificationSettings) {
+        if let Ok(mut guard) = self.settings.lock() {
+            *guard = next.clone();
+        }
+        if let Err(error) = write_json(&self.settings_path, &next) {
+            warn!(%error, "failed to persist OS notification settings");
+        }
+    }
+}
+
+/// Push the latest settings from the frontend down to the background dispatcher.
+#[tauri::command]
+pub fn set_os_notification_settings(
+    state: tauri::State<'_, OsNotificationBackground>,
+    settings: OsNotificationSettings,
+) {
+    state.replace_settings(settings);
+}
+
+/// Start the background poll loop. Call once after the runtime is ready.
+pub fn spawn(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+            if let Err(error) = poll_once(&app).await {
+                debug!(%error, "background notification poll skipped");
+            }
+        }
+    });
+}
+
+async fn poll_once(app: &AppHandle) -> anyhow::Result<()> {
+    let Some(state) = app.try_state::<DesktopState>() else {
+        // Runtime failed to initialize; nothing to dispatch.
+        return Ok(());
+    };
+    let background = app.state::<OsNotificationBackground>();
+
+    let notifications = state.runtime.list_notifications().await?;
+    let local_pubkey = resolve_local_pubkey(&state, &background).await;
+    let settings = background.settings_snapshot();
+
+    let next_cursor = compute_cursor(&notifications);
+
+    // First successful poll only records a baseline so the existing backlog does
+    // not surface as a burst of toasts.
+    if std::mem::replace(
+        &mut *background.baseline_pending.lock().expect("baseline lock poisoned"),
+        false,
+    ) {
+        store_cursor(&background, next_cursor);
+        return Ok(());
+    }
+
+    let previous = background.cursor.lock().expect("cursor lock poisoned").clone();
+    let to_dispatch: Vec<&NotificationView> = notifications
+        .iter()
+        .filter(|notification| is_new(notification, &previous))
+        .filter(|notification| should_send(notification, &settings, &local_pubkey))
+        .collect();
+
+    for notification in &to_dispatch {
+        let title = notification_title(&notification.kind).to_string();
+        let body = notification_body(
+            &notification.kind,
+            notification.preview_text.as_deref(),
+            settings.preview_body,
+        );
+        if let Err(error) = show_platform_notification(
+            app.clone(),
+            notification.notification_id.clone(),
+            title,
+            body,
+            settings.quiet_mode,
+        ) {
+            warn!(%error, "failed to show background OS notification");
+        }
+    }
+
+    store_cursor(&background, next_cursor);
+    Ok(())
+}
+
+async fn resolve_local_pubkey(
+    state: &DesktopState,
+    background: &OsNotificationBackground,
+) -> String {
+    {
+        let cached = background.local_pubkey.lock().expect("pubkey lock poisoned");
+        if !cached.is_empty() {
+            return cached.clone();
+        }
+    }
+    let resolved = state
+        .runtime
+        .get_sync_status()
+        .await
+        .map(|status| status.local_author_pubkey)
+        .unwrap_or_default();
+    if !resolved.is_empty() {
+        *background.local_pubkey.lock().expect("pubkey lock poisoned") = resolved.clone();
+    }
+    resolved
+}
+
+fn store_cursor(background: &OsNotificationBackground, cursor: DispatchCursor) {
+    if let Ok(mut guard) = background.cursor.lock() {
+        *guard = cursor.clone();
+    }
+    if let Err(error) = write_json(&background.cursor_path, &cursor) {
+        warn!(%error, "failed to persist OS notification cursor");
+    }
+}
+
+/// A notification is new when it is strictly newer than the cursor, or shares the
+/// cursor's timestamp but was not already handled at that timestamp.
+fn is_new(notification: &NotificationView, cursor: &DispatchCursor) -> bool {
+    if notification.received_at > cursor.last_received_at {
+        return true;
+    }
+    if notification.received_at == cursor.last_received_at {
+        return !cursor
+            .ids_at_last
+            .iter()
+            .any(|id| id == &notification.notification_id);
+    }
+    false
+}
+
+/// Recompute the cursor from the full (newest-first) notification list.
+fn compute_cursor(notifications: &[NotificationView]) -> DispatchCursor {
+    let last_received_at = notifications
+        .iter()
+        .map(|notification| notification.received_at)
+        .max()
+        .unwrap_or(0);
+    let ids_at_last = notifications
+        .iter()
+        .filter(|notification| notification.received_at == last_received_at)
+        .map(|notification| notification.notification_id.clone())
+        .collect();
+    DispatchCursor {
+        last_received_at,
+        ids_at_last,
+    }
+}
+
+/// Whether an OS toast should be shown for this notification. Mirrors
+/// `shouldSendOsNotification` in apps/desktop/src/lib/releaseReadiness.ts.
+fn should_send(
+    notification: &NotificationView,
+    settings: &OsNotificationSettings,
+    local_author_pubkey: &str,
+) -> bool {
+    if !settings.enabled || settings.quiet_mode || notification.read_at.is_some() {
+        return false;
+    }
+    if notification.actor_pubkey == local_author_pubkey {
+        return false;
+    }
+    match notification.kind {
+        NotificationKind::DirectMessage => settings.direct_messages,
+        NotificationKind::Mention | NotificationKind::Reply => settings.mentions_and_replies,
+        NotificationKind::Followed | NotificationKind::Repost | NotificationKind::QuoteRepost => {
+            settings.follows_and_reposts
+        }
+    }
+}
+
+/// Mirrors `notificationTitle` in apps/desktop/src/lib/releaseReadiness.ts.
+fn notification_title(kind: &NotificationKind) -> &'static str {
+    match kind {
+        NotificationKind::DirectMessage => "Direct message",
+        NotificationKind::Mention => "Mention",
+        NotificationKind::Reply => "Reply",
+        NotificationKind::Followed => "New follower",
+        NotificationKind::QuoteRepost => "Quote repost",
+        NotificationKind::Repost => "Repost",
+    }
+}
+
+/// Mirrors `notificationBody` in apps/desktop/src/lib/releaseReadiness.ts.
+fn notification_body(
+    kind: &NotificationKind,
+    preview_text: Option<&str>,
+    preview_body: bool,
+) -> Option<String> {
+    if !preview_body {
+        return Some(
+            if matches!(kind, NotificationKind::DirectMessage) {
+                "Open kukuri to read this message."
+            } else {
+                "Open kukuri to view this activity."
+            }
+            .to_string(),
+        );
+    }
+    preview_text.map(|text| text.to_string())
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &PathBuf) -> Option<T> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn write_json<T: Serialize>(path: &PathBuf, value: &T) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let bytes = serde_json::to_vec(value)?;
+    std::fs::write(path, bytes)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn notification(
+        id: &str,
+        kind: NotificationKind,
+        received_at: i64,
+        read_at: Option<i64>,
+        actor: &str,
+        preview: Option<&str>,
+    ) -> NotificationView {
+        NotificationView {
+            notification_id: id.to_string(),
+            kind,
+            actor_pubkey: actor.to_string(),
+            actor_name: None,
+            actor_display_name: None,
+            actor_picture: None,
+            actor_picture_asset: None,
+            source_envelope_id: None,
+            source_replica_id: None,
+            topic_id: None,
+            channel_id: None,
+            object_id: None,
+            thread_root_object_id: None,
+            dm_id: None,
+            message_id: None,
+            preview_text: preview.map(|value| value.to_string()),
+            created_at: received_at,
+            received_at,
+            read_at,
+        }
+    }
+
+    fn enabled_settings() -> OsNotificationSettings {
+        OsNotificationSettings {
+            enabled: true,
+            direct_messages: true,
+            mentions_and_replies: true,
+            follows_and_reposts: true,
+            quiet_mode: false,
+            preview_body: false,
+        }
+    }
+
+    #[test]
+    fn should_send_respects_enabled_and_quiet_and_read() {
+        let dm = notification("a", NotificationKind::DirectMessage, 10, None, "actor", None);
+        assert!(should_send(&dm, &enabled_settings(), "me"));
+
+        let mut disabled = enabled_settings();
+        disabled.enabled = false;
+        assert!(!should_send(&dm, &disabled, "me"));
+
+        let mut quiet = enabled_settings();
+        quiet.quiet_mode = true;
+        assert!(!should_send(&dm, &quiet, "me"));
+
+        let read = notification("a", NotificationKind::DirectMessage, 10, Some(11), "actor", None);
+        assert!(!should_send(&read, &enabled_settings(), "me"));
+    }
+
+    #[test]
+    fn should_send_suppresses_self_actions() {
+        let mine = notification("a", NotificationKind::Mention, 10, None, "me", None);
+        assert!(!should_send(&mine, &enabled_settings(), "me"));
+    }
+
+    #[test]
+    fn should_send_honors_per_kind_toggles() {
+        let mut settings = enabled_settings();
+        settings.direct_messages = false;
+        settings.mentions_and_replies = false;
+        settings.follows_and_reposts = false;
+
+        let dm = notification("a", NotificationKind::DirectMessage, 10, None, "x", None);
+        let mention = notification("b", NotificationKind::Mention, 10, None, "x", None);
+        let repost = notification("c", NotificationKind::Repost, 10, None, "x", None);
+        assert!(!should_send(&dm, &settings, "me"));
+        assert!(!should_send(&mention, &settings, "me"));
+        assert!(!should_send(&repost, &settings, "me"));
+
+        settings.mentions_and_replies = true;
+        assert!(should_send(&mention, &settings, "me"));
+    }
+
+    #[test]
+    fn body_uses_preview_only_when_enabled() {
+        assert_eq!(
+            notification_body(&NotificationKind::DirectMessage, Some("hi"), false).as_deref(),
+            Some("Open kukuri to read this message.")
+        );
+        assert_eq!(
+            notification_body(&NotificationKind::Mention, Some("hi"), false).as_deref(),
+            Some("Open kukuri to view this activity.")
+        );
+        assert_eq!(
+            notification_body(&NotificationKind::Mention, Some("hi"), true).as_deref(),
+            Some("hi")
+        );
+        assert_eq!(notification_body(&NotificationKind::Mention, None, true), None);
+    }
+
+    #[test]
+    fn cursor_detects_only_new_notifications() {
+        // Newest-first, like the runtime returns.
+        let first = vec![
+            notification("n2", NotificationKind::Mention, 20, None, "x", None),
+            notification("n1", NotificationKind::Mention, 10, None, "x", None),
+        ];
+        let cursor = compute_cursor(&first);
+        assert_eq!(cursor.last_received_at, 20);
+        assert_eq!(cursor.ids_at_last, vec!["n2".to_string()]);
+
+        // Nothing new against its own cursor.
+        assert!(!is_new(&first[0], &cursor));
+        assert!(!is_new(&first[1], &cursor));
+
+        // A strictly newer item is new; a second item at the same timestamp is new.
+        let n3 = notification("n3", NotificationKind::Mention, 30, None, "x", None);
+        let n2b = notification("n2b", NotificationKind::Mention, 20, None, "x", None);
+        assert!(is_new(&n3, &cursor));
+        assert!(is_new(&n2b, &cursor));
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod background_notifications;
 pub mod community_node;
 pub mod direct_messages;
 pub mod live_game;

--- a/apps/desktop/src-tauri/src/commands/os_notification.rs
+++ b/apps/desktop/src-tauri/src/commands/os_notification.rs
@@ -40,7 +40,7 @@ pub fn show_os_notification(
 }
 
 #[cfg(windows)]
-fn show_platform_notification(
+pub(crate) fn show_platform_notification(
     app: AppHandle,
     id: String,
     title: String,
@@ -70,7 +70,7 @@ fn show_platform_notification(
 }
 
 #[cfg(target_os = "linux")]
-fn show_platform_notification(
+pub(crate) fn show_platform_notification(
     app: AppHandle,
     id: String,
     title: String,
@@ -103,7 +103,7 @@ fn show_platform_notification(
 }
 
 #[cfg(target_os = "macos")]
-fn show_platform_notification(
+pub(crate) fn show_platform_notification(
     _app: AppHandle,
     _id: String,
     title: String,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,13 +3,61 @@ mod state;
 mod tracing;
 
 use ::tracing::{error, info};
-use tauri::Manager;
+use tauri::{
+    AppHandle, Manager, WindowEvent,
+    menu::{Menu, MenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+};
 use tauri_plugin_deep_link::DeepLinkExt;
 
 use crate::{
+    commands::background_notifications::OsNotificationBackground,
     state::{DesktopStartupState, build_desktop_state, resolve_db_path},
     tracing::init_tracing,
 };
+
+/// Bring the main window back from the tray.
+fn show_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+/// Build the system tray so kukuri stays resident after the window is closed
+/// (issue #304). Closing the window hides it; the app keeps syncing in the
+/// background and only exits via the tray "Quit" entry.
+fn build_tray(app: &AppHandle) -> tauri::Result<()> {
+    let open_item = MenuItem::with_id(app, "open", "Open kukuri", true, None::<&str>)?;
+    let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&open_item, &quit_item])?;
+
+    let mut builder = TrayIconBuilder::with_id("main")
+        .tooltip("kukuri")
+        .menu(&menu)
+        .show_menu_on_left_click(false)
+        .on_menu_event(|app, event| match event.id.as_ref() {
+            "open" => show_main_window(app),
+            "quit" => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                show_main_window(tray.app_handle());
+            }
+        });
+    if let Some(icon) = app.default_window_icon() {
+        builder = builder.icon(icon.clone());
+    }
+    builder.build(app)?;
+    Ok(())
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -19,8 +67,11 @@ pub fn run() {
 
     #[cfg(desktop)]
     {
-        builder = builder.plugin(tauri_plugin_single_instance::init(|_app, argv, _cwd| {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             info!(?argv, "received kukuri desktop single-instance activation");
+            // The app may be resident in the tray with its window hidden
+            // (issue #304); a re-launch should bring it back to the front.
+            show_main_window(app);
         }));
     }
 
@@ -28,6 +79,15 @@ pub fn run() {
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
+        .on_window_event(|window, event| {
+            // Issue #304: closing the window keeps kukuri running in the
+            // background (tray) instead of exiting. Only the tray "Quit" entry
+            // terminates the process.
+            if let WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                let _ = window.hide();
+            }
+        })
         .setup(|app| {
             let startup_state = match build_desktop_state(app.handle()) {
                 Ok(state) => {
@@ -42,6 +102,11 @@ pub fn run() {
                 }
             };
             app.manage(startup_state);
+            app.manage(OsNotificationBackground::new(app.handle()));
+            if let Err(error) = build_tray(app.handle()) {
+                error!(%error, "failed to build system tray");
+            }
+            commands::background_notifications::spawn(app.handle().clone());
             #[cfg(any(windows, target_os = "linux"))]
             app.deep_link().register_all()?;
             Ok(())
@@ -130,7 +195,8 @@ pub fn run() {
             commands::community_node::refresh_community_node_metadata,
             commands::community_node::fetch_community_node_manifest,
             commands::community_node::submit_community_node_report,
-            commands::os_notification::show_os_notification
+            commands::os_notification::show_os_notification,
+            commands::background_notifications::set_os_notification_settings
         ])
         .run(tauri::generate_context!())
         .expect("failed to run kukuri desktop tauri app");

--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -420,7 +420,7 @@ export function DesktopShellPage({
   } = viewModels;
   const notificationBadgeLabel =
     notificationStatus.unread_count > 99 ? '99+' : formatCount(notificationStatus.unread_count);
-  useOsNotificationBridge(notifications, syncStatus.local_author_pubkey);
+  useOsNotificationBridge();
   useOsNotificationActivation(notifications, handleOpenNotification);
   const notificationItems = useMemo(
     () =>

--- a/apps/desktop/src/shell/useOsNotificationBridge.ts
+++ b/apps/desktop/src/shell/useOsNotificationBridge.ts
@@ -1,79 +1,32 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 
-import type { NotificationView } from '@/lib/api';
 import {
   isTauriRuntime,
   loadOsNotificationSettings,
-  notificationBody,
-  notificationTitle,
   OS_NOTIFICATION_SETTINGS_STORAGE_KEY,
-  readSeenOsNotificationIds,
-  shouldSendOsNotification,
-  writeSeenOsNotificationIds,
 } from '@/lib/releaseReadiness';
 
-export function useOsNotificationBridge(
-  notifications: NotificationView[],
-  localAuthorPubkey: string
-): void {
-  const seenNotificationIdsRef = useRef<Set<string>>(readSeenOsNotificationIds());
-
-  useEffect(() => {
-    const handleSettingsChange = () => {
-      seenNotificationIdsRef.current = readSeenOsNotificationIds();
-    };
-    window.addEventListener(OS_NOTIFICATION_SETTINGS_STORAGE_KEY, handleSettingsChange);
-    return () => {
-      window.removeEventListener(OS_NOTIFICATION_SETTINGS_STORAGE_KEY, handleSettingsChange);
-    };
-  }, []);
-
+// OS notification dispatch now lives in the Rust backend (issue #304) so toasts
+// fire even while the window is hidden to the tray and regardless of which
+// section is open. The frontend's only job here is to mirror the user's
+// settings down to the backend dispatcher whenever they change.
+export function useOsNotificationBridge(): void {
   useEffect(() => {
     if (!isTauriRuntime()) {
       return;
     }
-    const settings = loadOsNotificationSettings();
-    const unseen = notifications.filter(
-      (notification) =>
-        !seenNotificationIdsRef.current.has(notification.notification_id) &&
-        shouldSendOsNotification(notification, settings, localAuthorPubkey)
-    );
-    if (unseen.length === 0) {
-      return;
-    }
-
-    let cancelled = false;
-    // Route through the custom `show_os_notification` command. The
-    // `@tauri-apps/plugin-notification` JS helpers go through the WebView2 Web
-    // Notification API, which does not produce real Windows toasts and reports a
-    // volatile permission state (see issue #313). The plugin's desktop backend
-    // also never reports toast click/activation events back to the app, so we
-    // own the toast here to wire up click-to-open (see useOsNotificationActivation).
-    void (async () => {
-      for (const notification of unseen) {
-        if (cancelled) {
-          break;
-        }
-        try {
-          await invoke('show_os_notification', {
-            id: notification.notification_id,
-            title: notificationTitle(notification),
-            body: notificationBody(notification, settings),
-            silent: settings.quietMode,
-          });
-          seenNotificationIdsRef.current.add(notification.notification_id);
-        } catch {
-          // best effort OS notification
-        }
-      }
-      if (!cancelled) {
-        writeSeenOsNotificationIds(seenNotificationIdsRef.current);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
+    const syncSettings = () => {
+      void invoke('set_os_notification_settings', {
+        settings: loadOsNotificationSettings(),
+      }).catch(() => {
+        // best effort settings sync
+      });
     };
-  }, [localAuthorPubkey, notifications]);
+    syncSettings();
+    window.addEventListener(OS_NOTIFICATION_SETTINGS_STORAGE_KEY, syncSettings);
+    return () => {
+      window.removeEventListener(OS_NOTIFICATION_SETTINGS_STORAGE_KEY, syncSettings);
+    };
+  }, []);
 }

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -11,5 +11,6 @@ mod sync;
 mod timeline;
 mod views;
 
+pub use kukuri_store::NotificationKind;
 pub use service::AppService;
 pub use views::*;


### PR DESCRIPTION
## 概要

[#304](https://github.com/KingYoSun/kukuri/issues/304)「バックグラウンド動作」対応。ウィンドウを閉じてもアプリをトレイに常駐させ、**バックエンド主導**でOS通知を発火するようにした。

これまで OS通知の発火は React フロント駆動で、ウィンドウが閉じる/隠れると発火せず、さらに「通知タブを開いている時しかトーストが出ない」既存の弱点もあった。本PRでディスパッチを Rust 側へ移し、webview の状態に依存せず常時発火するようにする。

## 変更点

### バックグラウンド常駐
- システムトレイ（`Open kukuri` / `Quit`、左クリックで復帰）を追加
- ウィンドウの × を `CloseRequested` で横取りして `hide()`。終了はトレイ `Quit` のみ
- single-instance 再起動時に隠れたウィンドウを前面復帰
- `tauri` に `tray-icon` フィーチャ、`tokio`(time) を追加

### バックエンド主導のOS通知ディスパッチ
- 新規 `background_notifications.rs`: 15秒間隔で `list_notifications()` をポーリングし、既存のプラットフォーム別トースト(`show_platform_notification`)で発火
  - `received_at` 高水位カーソル＋同時刻ID集合で重複発火を防止（メモリ有界）
  - 初回起動はバックログ一括発火を避けるためベースラインのみ記録
  - 設定/カーソルを `app_data_dir` に JSON 永続化。`set_os_notification_settings` コマンドでフロントから同期
  - フィルタ/タイトル/本文ロジックは TS 実装を Rust に移植（単体テスト付き）
- `show_platform_notification` を `pub(crate)` 化、`NotificationKind` を app-api から re-export

### フロントエンド
- `useOsNotificationBridge`: トースト発火ループを廃止し設定同期のみに（通知タブ以外で出ない弱点も解消）

## 検証

- ✅ `pnpm typecheck` / `pnpm lint` / `pnpm test`（302件）
- ✅ `cargo check`（app-api / tauri クレート）
- ✅ `cargo test`（新モジュール5件）

> トレイ常駐・実OSトーストはネイティブ Tauri ランタイム依存のため自動検証は対象外。`pnpm tauri dev` で「× → トレイ常駐 / 通知受信 → トースト → クリックで該当投稿へ」を手動確認推奨。

## 補足
- 通知は受信から最大15秒で発火（バッテリー考慮、`POLL_INTERVAL` で調整可）
- 起動中に受け取れなかった通知は次回起動時の同期で発火（キャッチアップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)