### PR TITLE
docs: README を最新の実装状況に更新

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -57,25 +57,33 @@ preview 更新では identity、local DB、Iroh data、Community Node 設定、p
 - connectivity は static-peer、seeded DHT discovery、community-node assist が担います。
 - durability は offline 利用、restart 復元、late join backfill を前提に設計します。
 - community-node は bootstrap、auth、control plane、connectivity assist を担うもので、ユーザーコンテンツの canonical store ではありません。
+- moderation event / safety advisory は optional な trust input であり、network-wide command ではありません。適用方法は各 client が判断します。
 - Nostr 互換は identity、envelope 形状、一部 tag に限った subset であり、kukuri の内部同期モデルは kukuri 固有です。
 
 ## 現在動いている範囲
 
 - desktop target: Linux / Windows
-- connectivity: static-peer、seeded DHT discovery、community-node connectivity/auth
+- connectivity: static-peer、seeded DHT discovery、community-node connectivity/auth、topic/channel ごとの gossip 接続トグル
 - topic timeline: public post、reply/thread、image 添付、video 添付
+- topic discovery: topic 一覧の search / filter / sort
+- post interaction: reaction / custom reaction、repost、quote repost
 - social graph v1: public profile、follow/unfollow、`mutual`、`friend of friend` 表示
+- local social management: post bookmark library、local author mute
 - private channel audience v1: `invite_only`、`friend_only`、`friend_plus` と epoch-aware lifecycle
 - pairwise DM v1: 1on1、mutual 限定、offline 可、local transcript/delete、image/video attachment
+- local notification inbox v1: mention、reply、repost、quote repost、DM、follow 通知
+- OS 通知 / tray 常駐: ユーザー許可制、click-to-open、background OS 通知。local notification inbox とは独立
+- builder preview リリース面: in-app updater、`Settings -> Release`、秘匿情報除去済み診断レポート、feedback 導線
+- safety / operations: content provenance と capability scope 表示、community node 宛ての分散通報ルーティング、community-node 運営者向け文書生成
 - `docs + blobs` から復元できる live session / game room state
 
-現在のスコープは [foundation progress](./docs/progress/2026-03-10-foundation.md) と [docs/adr/](./docs/adr/) 配下の accepted ADR を正とします。
+現在のスコープは [foundation progress](./docs/progress/2026-03-10-foundation.md)、[release readiness plan](./docs/progress/2026-06-11-release-readiness-execution-plan.md)、[docs/adr/](./docs/adr/) 配下の accepted ADR を正とします。
 
 ## 今後の方向性
 
 - 検索やサジェストは、core sync plane に必須で埋め込むのではなく、optional な specialized service として扱えるようにする方針です。
 - gateway / bridge 層によって、選択的な import/export や ecosystem interoperability を持てる余地を残します。
-- trust、moderation、policy assist は community-node の周辺で拡張しうる一方、canonical content store にはしません。
+- trust、moderation、policy assist は community-node の周辺で拡張しうる一方、canonical content store にはしません。分散通報ルーティングと運営者向け文書はその最初の一歩です。
 - これらは longer-term direction / optional ecosystem services であり、現行 workspace ですべて出荷済みという意味ではありません。
 
 ## コントリビューター向け
@@ -83,16 +91,25 @@ preview 更新では identity、local DB、Iroh data、Community Node 設定、p
 - 新規実装・修正は root workspace を対象にします。
 - 現在の truth は主に次です。
   - [docs/progress/2026-03-10-foundation.md](./docs/progress/2026-03-10-foundation.md)
+  - [docs/progress/2026-06-11-release-readiness-execution-plan.md](./docs/progress/2026-06-11-release-readiness-execution-plan.md)
   - [docs/README.md](./docs/README.md)
   - [docs/runbooks/dev.md](./docs/runbooks/dev.md)
+  - [CHANGELOG.md](./CHANGELOG.md)
   - [harness/scenarios/](./harness/scenarios/)
 - protocol / product の主要参照は次です。
   - [docs/adr/0010-kukuri-protocol-v1-boundary-definition.md](./docs/adr/0010-kukuri-protocol-v1-boundary-definition.md)
   - [docs/adr/0011-kukuri-protocol-v1-draft.md](./docs/adr/0011-kukuri-protocol-v1-draft.md)
   - [docs/adr/0012-topic-first_progressive_community_filtering_draft.md](./docs/adr/0012-topic-first_progressive_community_filtering_draft.md)
   - [docs/adr/0013-social-graph-foundation-draft.md](./docs/adr/0013-social-graph-foundation-draft.md)
+  - [docs/adr/0016-repost-data-classification.md](./docs/adr/0016-repost-data-classification.md)
+  - [docs/adr/0017-reaction-data-classification.md](./docs/adr/0017-reaction-data-classification.md)
   - [docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md](./docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md)
   - [docs/adr/0020-pairwise-dm-v1.md](./docs/adr/0020-pairwise-dm-v1.md)
+  - [docs/adr/0023-local-notification-inbox-v1.md](./docs/adr/0023-local-notification-inbox-v1.md)
+- community-node の責任境界 / trust 境界は次です。
+  - [docs/architecture/p2p-first-community-node-responsibility-boundary.md](./docs/architecture/p2p-first-community-node-responsibility-boundary.md)
+  - [docs/architecture/moderation-event-trust-semantics.md](./docs/architecture/moderation-event-trust-semantics.md)
+  - [docs/architecture/default-community-node-dependency-reduction.md](./docs/architecture/default-community-node-dependency-reduction.md)
 
 ### 作業入口
 
@@ -101,7 +118,7 @@ cargo xtask doctor
 cargo xtask check
 cargo xtask test
 cargo xtask e2e-smoke
-cargo xtask release-check v0.1.0-preview.1
+cargo xtask release-check v0.1.2-preview.1
 
 cd apps/desktop
 npx pnpm@10.16.1 install

--- a/README.md
+++ b/README.md
@@ -57,25 +57,33 @@ Preview updates are expected to preserve identity, local DB state, Iroh data, Co
 - Connectivity comes from static-peer links, seeded DHT discovery, and community-node assist.
 - Durability is designed around offline use, restart recovery, and late join backfill.
 - Community nodes are bootstrap, auth, control-plane, and connectivity-assist components, not the canonical store for user content.
+- Moderation events and safety advisories are an optional trust input, not a network-wide command; each client decides how to apply them.
 - Nostr compatibility is a limited subset for identity, envelope shape, and some tags; kukuri's internal sync model is its own.
 
 ## What Works Today
 
 - Desktop targets: Linux and Windows.
-- Connectivity: static-peer, seeded DHT discovery, and community-node connectivity/auth.
+- Connectivity: static-peer, seeded DHT discovery, and community-node connectivity/auth, with per-topic/channel gossip toggles.
 - Topic timeline flow: public posts, reply/thread, image attachments, and video attachments.
+- Topic discovery: topic-list search, filter, and sort.
+- Post interaction: reactions and custom reactions, repost, and quote repost.
 - Social graph v1: public profiles, follow/unfollow, `mutual`, and `friend of friend` display.
+- Local social management: post bookmark library and local author mute.
 - Private channel audience v1: `invite_only`, `friend_only`, and `friend_plus` with epoch-aware lifecycle.
 - Pairwise DM v1: 1:1, mutual-only, offline-capable, local transcript/delete, and image/video attachments.
+- Local notification inbox v1: mentions, replies, reposts, quote reposts, DMs, and follow notifications.
+- OS notifications and tray residency: user-permission-gated, with click-to-open and background OS notifications, kept independent of the local notification inbox.
+- Builder preview release plane: in-app updater, `Settings -> Release`, sanitized diagnostics report, and feedback flow.
+- Safety/operations: content provenance and capability-scope display, distributed report routing to community nodes, and community-node operator docs generation.
 - Live session and game room state that recover from `docs + blobs`.
 
-Current scope is defined by [foundation progress](./docs/progress/2026-03-10-foundation.md) and the accepted ADRs under [docs/adr/](./docs/adr/).
+Current scope is defined by [foundation progress](./docs/progress/2026-03-10-foundation.md), the [release readiness plan](./docs/progress/2026-06-11-release-readiness-execution-plan.md), and the accepted ADRs under [docs/adr/](./docs/adr/).
 
 ## Longer-Term Direction
 
 - Search and suggestion can be provided by optional specialized services instead of becoming required parts of the core sync plane.
 - Gateway and bridge layers can provide selective import/export and ecosystem interoperability.
-- Trust, moderation, and policy-assist functions can grow around community nodes without turning them into the canonical content store.
+- Trust, moderation, and policy-assist functions can grow around community nodes without turning them into the canonical content store. Distributed report routing and operator docs are an initial step in this direction.
 - These are planned directions and optional ecosystem services, not a statement that they are all shipped in the current workspace.
 
 ## For Contributors
@@ -83,16 +91,25 @@ Current scope is defined by [foundation progress](./docs/progress/2026-03-10-fou
 - New work targets the root workspace.
 - Current sources of truth:
   - [docs/progress/2026-03-10-foundation.md](./docs/progress/2026-03-10-foundation.md)
+  - [docs/progress/2026-06-11-release-readiness-execution-plan.md](./docs/progress/2026-06-11-release-readiness-execution-plan.md)
   - [docs/README.md](./docs/README.md)
   - [docs/runbooks/dev.md](./docs/runbooks/dev.md)
+  - [CHANGELOG.md](./CHANGELOG.md)
   - [harness/scenarios/](./harness/scenarios/)
 - Key protocol and product references:
   - [docs/adr/0010-kukuri-protocol-v1-boundary-definition.md](./docs/adr/0010-kukuri-protocol-v1-boundary-definition.md)
   - [docs/adr/0011-kukuri-protocol-v1-draft.md](./docs/adr/0011-kukuri-protocol-v1-draft.md)
   - [docs/adr/0012-topic-first_progressive_community_filtering_draft.md](./docs/adr/0012-topic-first_progressive_community_filtering_draft.md)
   - [docs/adr/0013-social-graph-foundation-draft.md](./docs/adr/0013-social-graph-foundation-draft.md)
+  - [docs/adr/0016-repost-data-classification.md](./docs/adr/0016-repost-data-classification.md)
+  - [docs/adr/0017-reaction-data-classification.md](./docs/adr/0017-reaction-data-classification.md)
   - [docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md](./docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md)
   - [docs/adr/0020-pairwise-dm-v1.md](./docs/adr/0020-pairwise-dm-v1.md)
+  - [docs/adr/0023-local-notification-inbox-v1.md](./docs/adr/0023-local-notification-inbox-v1.md)
+- Community-node responsibility and trust boundaries:
+  - [docs/architecture/p2p-first-community-node-responsibility-boundary.md](./docs/architecture/p2p-first-community-node-responsibility-boundary.md)
+  - [docs/architecture/moderation-event-trust-semantics.md](./docs/architecture/moderation-event-trust-semantics.md)
+  - [docs/architecture/default-community-node-dependency-reduction.md](./docs/architecture/default-community-node-dependency-reduction.md)
 
 ### Entry Points
 
@@ -101,7 +118,7 @@ cargo xtask doctor
 cargo xtask check
 cargo xtask test
 cargo xtask e2e-smoke
-cargo xtask release-check v0.1.0-preview.1
+cargo xtask release-check v0.1.2-preview.1
 
 cd apps/desktop
 npx pnpm@10.16.1 install


### PR DESCRIPTION
## 概要

`README.md` / `README.ja.md` を現行の実装状況に合わせて更新しました。foundation 以降に出荷された機能や、community-node まわりの責任境界ドキュメントが README に反映されていなかったため、`docs/progress/2026-06-11-release-readiness-execution-plan.md`、`CHANGELOG.md`、accepted ADR、`docs/architecture/` を確認して追記しています。

## 主な変更

- **What Works Today / 現在動いている範囲** に以下を追加:
  - reaction / custom reaction、repost、quote repost
  - topic 一覧の search / filter / sort、topic/channel ごとの gossip 接続トグル
  - post bookmark library、local author mute
  - local notification inbox v1（mention/reply/repost/quote repost/DM/follow）
  - OS 通知 / tray 常駐（許可制・click-to-open・background OS 通知、inbox とは独立）
  - builder preview リリース面（in-app updater、`Settings -> Release`、診断レポート）
  - content provenance / capability scope 表示、分散通報ルーティング、operator docs 生成
- **Core Concepts / 重要な設計原則** に moderation event / safety advisory は optional な trust input である旨を追加。
- **Longer-Term Direction / 今後の方向性** の trust/moderation 行に、通報ルーティング・operator docs が最初の一歩である旨を追記。
- **For Contributors / コントリビューター向け** の参照リンクを更新:
  - release readiness plan、`CHANGELOG.md`、ADR 0016/0017/0023、`docs/architecture/` 3 本を追加。
- `cargo xtask release-check` の例タグを現行 preview `v0.1.2-preview.1` に更新。

## 検証

- ドキュメントのみの変更。リンク先のファイルが存在することを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0199dwKteeM3ttXqLm9k7Rb7)_