### PR TITLE
feat: iroh 1.0 に更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,12 @@ kukuri-tauri/src-tauri/bootstrap_nodes.json
 # kamui
 .kamui/
 
+# kilo code
+.kilo/
+
+# firecrawl
+.firecrawl/
+
 target/
 
 # 各エンジニアのローカル AI エージェント設定（雛形 *.example は commit する）

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,19 +44,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +554,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,12 +914,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -1246,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1887,7 +1880,7 @@ dependencies = [
  "http",
  "idna",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "rand 0.10.1",
  "rustls",
  "thiserror 2.0.18",
@@ -1907,7 +1900,7 @@ dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "once_cell",
  "prefix-trie",
  "rand 0.10.1",
@@ -1930,7 +1923,7 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "moka",
  "ndk-context",
  "once_cell",
@@ -2348,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef865dc2d11a19fe670ff217b68ffc3b511bddf473dc3a3e120090b9f691803"
+checksum = "6435544bb3a5c4e6ff7affaa0c0aa0d1bca45bd700226329d5059d3eb54f9dff"
 dependencies = [
  "axum",
  "backon",
@@ -2386,7 +2379,6 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-webpki",
  "serde",
  "smallvec",
  "strum",
@@ -2397,36 +2389,32 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
+checksum = "c9c95e4459d9bb828a77084277abd308aa2b58a096652b079bddfd6ef2361f53"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "digest 0.11.3",
  "ed25519-dalek",
  "getrandom 0.4.2",
  "n0-error",
  "rand 0.10.1",
  "serde",
- "sha2 0.11.0",
  "url",
  "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
 name = "iroh-blobs"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b492c3b44e08605ad1e7fdc6ef35142543fa1b52166067860199b818e0be7d91"
+checksum = "5be50b0e2d0a9ba65cee4e0dfb708b3704e02ad12bd4c14c6307e94245943126"
 dependencies = [
  "arrayvec",
  "bao-tree",
@@ -2453,7 +2441,7 @@ dependencies = [
  "postcard",
  "rand 0.10.1",
  "range-collections",
- "redb",
+ "redb 4.1.0",
  "ref-cast",
  "reflink-copy",
  "self_cell",
@@ -2465,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+checksum = "754f7e0c1f67938e1d671007264ffef158f14a9f795a7cc219ea68ea09a9d4c9"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -2477,8 +2465,8 @@ dependencies = [
  "n0-error",
  "n0-future",
  "ndk-context",
+ "portable-atomic",
  "rand 0.10.1",
- "reqwest 0.13.4",
  "rustls",
  "simple-dns 0.11.3",
  "strum",
@@ -2489,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-docs"
-version = "0.100.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de285cff6f981bdef3f30b7a199d2fa924c0a7044ee98cb18cf1cc96919a5d9"
+checksum = "8fd1bd5e39d0321a3c4a2bcef9650476c076e2df41a0e84577eca23d6de6c8ab"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2499,7 +2487,6 @@ dependencies = [
  "bytes",
  "cfg_aliases",
  "derive_more",
- "ed25519-dalek",
  "futures-buffered",
  "hex",
  "iroh",
@@ -2514,7 +2501,8 @@ dependencies = [
  "num_enum",
  "postcard",
  "rand 0.10.1",
- "redb",
+ "redb 3.1.3",
+ "redb 4.1.0",
  "self_cell",
  "serde",
  "serde-error",
@@ -2529,16 +2517,14 @@ dependencies = [
 
 [[package]]
 name = "iroh-gossip"
-version = "0.100.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5cada641f84a2ff3d1acbd43e16490cf3b2a4f675e580c5c2caa5d68ee63b5"
+checksum = "4e1dc4b05f73e7a1b9e83b531eb63c3fd671b0af3aeb13b59c546dd7ca747515"
 dependencies = [
  "blake3",
  "bytes",
- "constant_time_eq",
  "data-encoding",
  "derive_more",
- "ed25519-dalek",
  "futures-concurrency",
  "hex",
  "indexmap",
@@ -2571,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-mainline-address-lookup"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c406ca9915461110734901f28e0e093ae713490ca3fe1681df5a60f435d708c"
+checksum = "b1fd07cb8b4af54ccf367fe79516484c544ea3e4b1984cdd2b9aaf3bacaa80f2"
 dependencies = [
  "derive_more",
  "iroh",
@@ -2589,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2612,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2624,11 +2610,10 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70030b9e71c1183bd4f88fbdbebfa1af2a5be549dd6f20a1e8ac3cd0202ee9d"
+checksum = "1c12e48fef252fd04f8e6b6a8802b377baf72548d62ae4838816624cd0e06b79"
 dependencies = [
- "ahash",
  "blake3",
  "bytes",
  "cfg_aliases",
@@ -2684,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-tickets"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d4051ac9825cd834d88377dab71c1d9d483b65e9740029b2d624cc17ac58d"
+checksum = "da53233419ca36bf521ed45683b7748366f9b233032891eefc2d70567a84ac54"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -2698,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c37db3548c6cb18b4d27a6a3ad16a4e6c372c5ff6b2efd680f56db110deebb2"
+checksum = "20e41eb982f15230c55f0a70a74a514360e1f565b07861924fd0e8db172b3d00"
 dependencies = [
  "derive_more",
  "iroh",
@@ -2712,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "irpc"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05799eb70acd04843c327ef939233ccf80f607d30e9ca94857ac7f3d8f18b46"
+checksum = "3623d6ff582b415904b29bbe6ebcb4a4f9a262ccdee05a45fdd003ef0950c386"
 dependencies = [
  "futures-buffered",
  "futures-util",
@@ -2734,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445d81dbc1eed4dab6379bf7f97d12ac28ce8e6f3f7d6660c9f333b7b5d8d03b"
+checksum = "35c254013736de16472140d26904e6ac98e8f3887284dcf4af40f88c77411b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2757,6 +2742,22 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -2764,7 +2765,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -2783,6 +2784,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -3362,9 +3372,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
  "anyhow",
  "n0-error-macros",
@@ -3373,9 +3383,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3405,15 +3415,15 @@ dependencies = [
 
 [[package]]
 name = "n0-mainline"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4015a994f4fc3e3bff900dcea1cb9cbbfc644d0b865fa6704cd2dd7f7ffd47"
+checksum = "d976b09e7ed101cc2571d9423584e3c3eea38afad32fc305c1beae0a4eeadcde"
 dependencies = [
  "crc",
  "dyn-clone",
  "ed25519-dalek",
  "futures-core",
- "lru 0.16.4",
+ "lru 0.18.0",
  "n0-error",
  "noq-udp",
  "rand 0.10.1",
@@ -3427,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
 dependencies = [
  "derive_more",
  "n0-error",
@@ -3456,19 +3466,22 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+checksum = "9d31e7286c21ceaf0ddb1d881964011214555ea0b317cc2eb1a1d68d861386fc"
 dependencies = [
  "block2",
  "dispatch2",
  "dlopen2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core",
  "netlink-packet-route 0.29.0",
  "netlink-sys",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation",
@@ -3501,9 +3514,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags",
  "libc",
@@ -3540,14 +3553,14 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2071e0c2b5b229622c459096b84f1ad51afa150cdeeefdad491ef3704e581d91"
+version = "0.19.0"
+source = "git+https://github.com/n0-computer/net-tools?rev=8b2d36b9be2b44281fdbf58121a9ab6a739919bc#8b2d36b9be2b44281fdbf58121a9ab6a739919bc"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
  "derive_more",
+ "ipnet",
  "js-sys",
  "libc",
  "n0-error",
@@ -3555,7 +3568,7 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-route 0.31.0",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -3598,9 +3611,9 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "noq"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198b99fc085a5db1f7d259edb5ede8311e59f28cdd2687920b4313613d21a73f"
+checksum = "11f0c73794bfde94db01379c46990b9a773993fca2b61a66184ce148b7c7a187"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3620,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab0ac774795ce1e42a7e61266e71f3be8110210630441169ac8dda403dd23f1"
+checksum = "775be06b8d66c2c64db60140bf54dee8410f67b73c81cc1e1e32f11dfdaae501"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -3649,9 +3662,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
+checksum = "cd5a37756f168cf350d68a97c4f0158bdf3c76f10175123941569b09ab51f011"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4154,9 +4167,9 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64959cbabf952c8ffcbaea13745308508f1f825922f4068353f3de08d42cf214"
+checksum = "ccc716c56a0a50f7e4e25f41446419599d47c6197cc5c9858174220e97c272e6"
 dependencies = [
  "base64",
  "bytes",
@@ -4547,6 +4560,15 @@ dependencies = [
 
 [[package]]
 name = "redb"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "redb"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
@@ -4896,7 +4918,7 @@ checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -6613,7 +6635,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6736,6 +6758,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -6768,6 +6799,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6829,6 +6875,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6847,6 +6899,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6862,6 +6920,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6895,6 +6959,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6910,6 +6980,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6931,6 +7007,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6946,6 +7028,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7233,18 +7321,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,16 +40,16 @@ hkdf = "0.12.4"
 hmac = "0.12.1"
 httpdate = "1.0.3"
 image = { version = "0.25.10", default-features = false, features = ["png", "gif", "jpeg", "webp"] }
-iroh = "1.0.0-rc.1"
-iroh-docs = "0.100.0"
-iroh-blobs = "0.102.0"
-iroh-gossip = "0.100.0"
-iroh-mainline-address-lookup = "0.3.0"
-iroh-relay = { version = "1.0.0-rc.1", features = ["server"] }
+iroh = "1.0.0"
+iroh-docs = "0.101.0"
+iroh-blobs = "0.103.0"
+iroh-gossip = "0.101.0"
+iroh-mainline-address-lookup = "0.4.0"
+iroh-relay = { version = "1.0.0", features = ["server"] }
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 keyring = { version = "3.6.3", default-features = false }
 chacha20poly1305 = "0.10.1"
-n0-mainline = "0.4.0"
+n0-mainline = "0.5.0"
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
 redis = { version = "1.2.2", default-features = false, features = ["tokio-comp"] }
 rustls = { version = "0.23.38", default-features = false, features = ["ring", "std"] }
@@ -71,3 +71,6 @@ tower-http = { version = "0.6.8", features = ["trace"] }
 tower_governor = "0.8.0"
 url = "2.5.8"
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
+
+[patch.crates-io]
+netwatch = { git = "https://github.com/n0-computer/net-tools", rev = "8b2d36b9be2b44281fdbf58121a9ab6a739919bc" }

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1219,12 +1219,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -1498,7 +1498,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
 
@@ -1672,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -3121,9 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef865dc2d11a19fe670ff217b68ffc3b511bddf473dc3a3e120090b9f691803"
+checksum = "6435544bb3a5c4e6ff7affaa0c0aa0d1bca45bd700226329d5059d3eb54f9dff"
 dependencies = [
  "backon",
  "blake3",
@@ -3158,7 +3157,6 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-webpki",
  "serde",
  "smallvec",
  "strum",
@@ -3169,36 +3167,32 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
+checksum = "c9c95e4459d9bb828a77084277abd308aa2b58a096652b079bddfd6ef2361f53"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "digest 0.11.3",
  "ed25519-dalek",
  "getrandom 0.4.2",
  "n0-error",
  "rand 0.10.1",
  "serde",
- "sha2 0.11.0",
  "url",
  "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
 name = "iroh-blobs"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b492c3b44e08605ad1e7fdc6ef35142543fa1b52166067860199b818e0be7d91"
+checksum = "5be50b0e2d0a9ba65cee4e0dfb708b3704e02ad12bd4c14c6307e94245943126"
 dependencies = [
  "arrayvec",
  "bao-tree",
@@ -3225,7 +3219,7 @@ dependencies = [
  "postcard",
  "rand 0.10.1",
  "range-collections",
- "redb",
+ "redb 4.1.0",
  "ref-cast",
  "reflink-copy",
  "self_cell",
@@ -3237,9 +3231,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+checksum = "754f7e0c1f67938e1d671007264ffef158f14a9f795a7cc219ea68ea09a9d4c9"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -3249,8 +3243,8 @@ dependencies = [
  "n0-error",
  "n0-future",
  "ndk-context",
+ "portable-atomic",
  "rand 0.10.1",
- "reqwest 0.13.4",
  "rustls",
  "simple-dns 0.11.3",
  "strum",
@@ -3261,9 +3255,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-docs"
-version = "0.100.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de285cff6f981bdef3f30b7a199d2fa924c0a7044ee98cb18cf1cc96919a5d9"
+checksum = "8fd1bd5e39d0321a3c4a2bcef9650476c076e2df41a0e84577eca23d6de6c8ab"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3271,7 +3265,6 @@ dependencies = [
  "bytes",
  "cfg_aliases",
  "derive_more",
- "ed25519-dalek",
  "futures-buffered",
  "hex",
  "iroh",
@@ -3286,7 +3279,8 @@ dependencies = [
  "num_enum",
  "postcard",
  "rand 0.10.1",
- "redb",
+ "redb 3.1.3",
+ "redb 4.1.0",
  "self_cell",
  "serde",
  "serde-error",
@@ -3301,16 +3295,14 @@ dependencies = [
 
 [[package]]
 name = "iroh-gossip"
-version = "0.100.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5cada641f84a2ff3d1acbd43e16490cf3b2a4f675e580c5c2caa5d68ee63b5"
+checksum = "4e1dc4b05f73e7a1b9e83b531eb63c3fd671b0af3aeb13b59c546dd7ca747515"
 dependencies = [
  "blake3",
  "bytes",
- "constant_time_eq",
  "data-encoding",
  "derive_more",
- "ed25519-dalek",
  "futures-concurrency",
  "hex",
  "indexmap 2.14.0",
@@ -3343,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-mainline-address-lookup"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c406ca9915461110734901f28e0e093ae713490ca3fe1681df5a60f435d708c"
+checksum = "b1fd07cb8b4af54ccf367fe79516484c544ea3e4b1984cdd2b9aaf3bacaa80f2"
 dependencies = [
  "derive_more",
  "iroh",
@@ -3361,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
@@ -3376,9 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3388,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70030b9e71c1183bd4f88fbdbebfa1af2a5be549dd6f20a1e8ac3cd0202ee9d"
+checksum = "1c12e48fef252fd04f8e6b6a8802b377baf72548d62ae4838816624cd0e06b79"
 dependencies = [
  "blake3",
  "bytes",
@@ -3434,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-tickets"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d4051ac9825cd834d88377dab71c1d9d483b65e9740029b2d624cc17ac58d"
+checksum = "da53233419ca36bf521ed45683b7748366f9b233032891eefc2d70567a84ac54"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -3448,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c37db3548c6cb18b4d27a6a3ad16a4e6c372c5ff6b2efd680f56db110deebb2"
+checksum = "20e41eb982f15230c55f0a70a74a514360e1f565b07861924fd0e8db172b3d00"
 dependencies = [
  "derive_more",
  "iroh",
@@ -3462,9 +3454,9 @@ dependencies = [
 
 [[package]]
 name = "irpc"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05799eb70acd04843c327ef939233ccf80f607d30e9ca94857ac7f3d8f18b46"
+checksum = "3623d6ff582b415904b29bbe6ebcb4a4f9a262ccdee05a45fdd003ef0950c386"
 dependencies = [
  "futures-buffered",
  "futures-util",
@@ -3484,9 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445d81dbc1eed4dab6379bf7f97d12ac28ce8e6f3f7d6660c9f333b7b5d8d03b"
+checksum = "35c254013736de16472140d26904e6ac98e8f3887284dcf4af40f88c77411b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4203,9 +4195,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
  "anyhow",
  "n0-error-macros",
@@ -4214,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4246,15 +4238,15 @@ dependencies = [
 
 [[package]]
 name = "n0-mainline"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4015a994f4fc3e3bff900dcea1cb9cbbfc644d0b865fa6704cd2dd7f7ffd47"
+checksum = "d976b09e7ed101cc2571d9423584e3c3eea38afad32fc305c1beae0a4eeadcde"
 dependencies = [
  "crc",
  "dyn-clone",
  "ed25519-dalek",
  "futures-core",
- "lru 0.16.4",
+ "lru 0.18.0",
  "n0-error",
  "noq-udp",
  "rand 0.10.1",
@@ -4268,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
 dependencies = [
  "derive_more",
  "n0-error",
@@ -4321,19 +4313,22 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+checksum = "9d31e7286c21ceaf0ddb1d881964011214555ea0b317cc2eb1a1d68d861386fc"
 dependencies = [
  "block2",
  "dispatch2",
  "dlopen2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core",
  "netlink-packet-route 0.29.0",
  "netlink-sys",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation",
@@ -4366,9 +4361,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -4405,14 +4400,14 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2071e0c2b5b229622c459096b84f1ad51afa150cdeeefdad491ef3704e581d91"
+version = "0.19.0"
+source = "git+https://github.com/n0-computer/net-tools?rev=8b2d36b9be2b44281fdbf58121a9ab6a739919bc#8b2d36b9be2b44281fdbf58121a9ab6a739919bc"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
  "derive_more",
+ "ipnet",
  "js-sys",
  "libc",
  "n0-error",
@@ -4420,7 +4415,7 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-route 0.31.0",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -4457,9 +4452,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198b99fc085a5db1f7d259edb5ede8311e59f28cdd2687920b4313613d21a73f"
+checksum = "11f0c73794bfde94db01379c46990b9a773993fca2b61a66184ce148b7c7a187"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4479,9 +4474,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab0ac774795ce1e42a7e61266e71f3be8110210630441169ac8dda403dd23f1"
+checksum = "775be06b8d66c2c64db60140bf54dee8410f67b73c81cc1e1e32f11dfdaae501"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -4508,9 +4503,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
+checksum = "cd5a37756f168cf350d68a97c4f0158bdf3c76f10175123941569b09ab51f011"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5346,9 +5341,9 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64959cbabf952c8ffcbaea13745308508f1f825922f4068353f3de08d42cf214"
+checksum = "ccc716c56a0a50f7e4e25f41446419599d47c6197cc5c9858174220e97c272e6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5776,6 +5771,15 @@ dependencies = [
  "time",
  "x509-parser",
  "yasna",
+]
+
+[[package]]
+name = "redb"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -9653,18 +9657,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -32,3 +32,6 @@ tauri-winrt-notification = "0.7"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 notify-rust = "4"
+
+[patch.crates-io]
+netwatch = { git = "https://github.com/n0-computer/net-tools", rev = "8b2d36b9be2b44281fdbf58121a9ab6a739919bc" }

--- a/crates/docs-sync/src/node.rs
+++ b/crates/docs-sync/src/node.rs
@@ -24,7 +24,7 @@ use tokio::time::timeout;
 use tracing::warn;
 
 #[cfg(test)]
-use iroh::tls::CaRootsConfig;
+use iroh::tls::CaTlsConfig;
 
 const ENDPOINT_SECRET_FILE_NAME: &str = "endpoint-secret.json";
 const DOCS_STORE_FILE_NAME: &str = "docs.redb";
@@ -232,8 +232,7 @@ impl IrohDocsNode {
         )?;
         #[cfg(test)]
         {
-            endpoint_builder =
-                endpoint_builder.ca_roots_config(CaRootsConfig::insecure_skip_verify());
+            endpoint_builder = endpoint_builder.ca_tls_config(CaTlsConfig::insecure_skip_verify());
         }
         if let Some(secret_key) = endpoint_secret {
             endpoint_builder = endpoint_builder.secret_key(secret_key);

--- a/crates/transport/src/iroh/endpoint.rs
+++ b/crates/transport/src/iroh/endpoint.rs
@@ -118,7 +118,7 @@ pub(crate) async fn bind_endpoint_with_options(
     }
     #[cfg(test)]
     {
-        builder = builder.ca_roots_config(CaRootsConfig::insecure_skip_verify());
+        builder = builder.ca_tls_config(CaTlsConfig::insecure_skip_verify());
     }
     builder = apply_bind(builder, bind_addr)?;
     let endpoint = builder

--- a/crates/transport/src/iroh/mod.rs
+++ b/crates/transport/src/iroh/mod.rs
@@ -23,7 +23,7 @@ use iroh::endpoint::{
 use iroh::endpoint_info::EndpointInfo;
 use iroh::protocol::Router;
 #[cfg(test)]
-use iroh::tls::CaRootsConfig;
+use iroh::tls::CaTlsConfig;
 use iroh::{Endpoint, EndpointAddr, EndpointId, RelayConfig, RelayUrl, SecretKey};
 use iroh_gossip::api::{Event as GossipEvent, GossipSender};
 use iroh_gossip::{ALPN as GOSSIP_ALPN, Gossip, TopicId as GossipTopicId};

--- a/crates/transport/src/iroh/tests/relay_connectivity.rs
+++ b/crates/transport/src/iroh/tests/relay_connectivity.rs
@@ -307,6 +307,116 @@ async fn transport_custom_relay_three_clients_multiple_topics_with_stale_addr_hi
     .await;
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn transport_unreachable_home_relay_does_not_starve_concurrent_direct_dials() {
+    let relay_config = TransportRelayConfig {
+        iroh_relay_urls: vec!["https://127.0.0.1:1".to_string()],
+    }
+    .normalized();
+    let config = TransportNetworkConfig::loopback();
+    let (transport_seed, transport_leaf_one, transport_leaf_two) = tokio::try_join!(
+        IrohGossipTransport::bind_with_options(
+            config.clone(),
+            DhtDiscoveryOptions::disabled(),
+            relay_config.clone(),
+        ),
+        IrohGossipTransport::bind_with_options(
+            config.clone(),
+            DhtDiscoveryOptions::disabled(),
+            relay_config.clone(),
+        ),
+        IrohGossipTransport::bind_with_options(
+            config,
+            DhtDiscoveryOptions::disabled(),
+            relay_config,
+        )
+    )
+    .expect("transports");
+
+    let topic = TopicId::new("kukuri:topic:unreachable-relay-concurrent-dial");
+    let ticket_seed = transport_seed
+        .export_ticket()
+        .await
+        .expect("ticket seed")
+        .expect("ticket seed value");
+    let ticket_leaf_one = transport_leaf_one
+        .export_ticket()
+        .await
+        .expect("ticket leaf one")
+        .expect("ticket leaf one value");
+    let ticket_leaf_two = transport_leaf_two
+        .export_ticket()
+        .await
+        .expect("ticket leaf two")
+        .expect("ticket leaf two value");
+
+    let (mut stream_seed, mut stream_leaf_one, mut stream_leaf_two) = tokio::try_join!(
+        transport_seed.subscribe_hints(&topic),
+        transport_leaf_one.subscribe_hints(&topic),
+        transport_leaf_two.subscribe_hints(&topic),
+    )
+    .expect("subscribe hints");
+
+    tokio::try_join!(
+        transport_seed.configure_discovery(
+            DiscoveryMode::StaticPeer,
+            false,
+            vec![
+                seed_peer_from_ticket(&ticket_leaf_one),
+                seed_peer_from_ticket(&ticket_leaf_two),
+            ],
+            Vec::new(),
+        ),
+        transport_leaf_one.configure_discovery(
+            DiscoveryMode::StaticPeer,
+            false,
+            vec![seed_peer_from_ticket(&ticket_seed)],
+            Vec::new(),
+        ),
+        transport_leaf_two.configure_discovery(
+            DiscoveryMode::StaticPeer,
+            false,
+            vec![seed_peer_from_ticket(&ticket_seed)],
+            Vec::new(),
+        ),
+    )
+    .expect("configure unreachable-relay seed peers");
+
+    let join_timeout = initial_topic_join_timeout();
+    wait_for_hint_roundtrip(
+        HintRoundtripParticipant {
+            transport: &transport_seed,
+            stream: &mut stream_seed,
+            expected_source_peer: None,
+        },
+        HintRoundtripParticipant {
+            transport: &transport_leaf_one,
+            stream: &mut stream_leaf_one,
+            expected_source_peer: None,
+        },
+        &topic,
+        join_timeout,
+        "unreachable relay concurrent dial seed-leaf-one",
+    )
+    .await;
+    wait_for_hint_roundtrip(
+        HintRoundtripParticipant {
+            transport: &transport_seed,
+            stream: &mut stream_seed,
+            expected_source_peer: None,
+        },
+        HintRoundtripParticipant {
+            transport: &transport_leaf_two,
+            stream: &mut stream_leaf_two,
+            expected_source_peer: None,
+        },
+        &topic,
+        join_timeout,
+        "unreachable relay concurrent dial seed-leaf-two",
+    )
+    .await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn transport_custom_relay_lookup_connects_unknown_peer_without_dht_publish() {
     let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()

--- a/docs/THIRD_PARTY_NOTICES.md
+++ b/docs/THIRD_PARTY_NOTICES.md
@@ -18,7 +18,7 @@ The first preview targets Windows installer distribution through GitHub Releases
 
 ## Rust crates
 
-Total packages: 632
+Total packages: 658
 
 | Package | Version | License | Source |
 | --- | --- | --- | --- |
@@ -26,7 +26,6 @@ Total packages: 632
 | aead | 0.5.2 | MIT OR Apache-2.0 | https://crates.io/crates/aead |
 | aes | 0.8.4 | MIT OR Apache-2.0 | https://crates.io/crates/aes |
 | aes-gcm | 0.10.3 | Apache-2.0 OR MIT | https://crates.io/crates/aes-gcm |
-| ahash | 0.8.12 | MIT OR Apache-2.0 | https://crates.io/crates/ahash |
 | aho-corasick | 1.1.4 | Unlicense OR MIT | https://crates.io/crates/aho-corasick |
 | allocator-api2 | 0.2.21 | MIT OR Apache-2.0 | https://crates.io/crates/allocator-api2 |
 | android_system_properties | 0.1.5 | MIT/Apache-2.0 | https://crates.io/crates/android_system_properties |
@@ -79,6 +78,7 @@ Total packages: 632
 | byteorder-lite | 0.1.0 | Unlicense OR MIT | https://crates.io/crates/byteorder-lite |
 | bytes | 1.11.1 | MIT | https://crates.io/crates/bytes |
 | cc | 1.2.62 | MIT OR Apache-2.0 | https://crates.io/crates/cc |
+| cesu8 | 1.1.0 | Apache-2.0/MIT | https://crates.io/crates/cesu8 |
 | cfg-if | 1.0.4 | MIT OR Apache-2.0 | https://crates.io/crates/cfg-if |
 | cfg_aliases | 0.2.1 | MIT | https://crates.io/crates/cfg_aliases |
 | chacha20 | 0.10.0 | MIT OR Apache-2.0 | https://crates.io/crates/chacha20 |
@@ -119,7 +119,7 @@ Total packages: 632
 | crypto-common | 0.2.2 | MIT OR Apache-2.0 | https://crates.io/crates/crypto-common |
 | ctr | 0.9.2 | MIT OR Apache-2.0 | https://crates.io/crates/ctr |
 | ctutils | 0.4.2 | Apache-2.0 OR MIT | https://crates.io/crates/ctutils |
-| curve25519-dalek | 5.0.0-pre.6 | BSD-3-Clause | https://crates.io/crates/curve25519-dalek |
+| curve25519-dalek | 5.0.0-rc.0 | BSD-3-Clause | https://crates.io/crates/curve25519-dalek |
 | curve25519-dalek-derive | 0.1.1 | MIT/Apache-2.0 | https://crates.io/crates/curve25519-dalek-derive |
 | darling | 0.20.11 | MIT | https://crates.io/crates/darling |
 | darling_core | 0.20.11 | MIT | https://crates.io/crates/darling_core |
@@ -150,7 +150,7 @@ Total packages: 632
 | dunce | 1.0.5 | CC0-1.0 OR MIT-0 OR Apache-2.0 | https://crates.io/crates/dunce |
 | dyn-clone | 1.0.20 | MIT OR Apache-2.0 | https://crates.io/crates/dyn-clone |
 | ed25519 | 3.0.0 | Apache-2.0 OR MIT | https://crates.io/crates/ed25519 |
-| ed25519-dalek | 3.0.0-pre.7 | BSD-3-Clause | https://crates.io/crates/ed25519-dalek |
+| ed25519-dalek | 3.0.0-rc.0 | BSD-3-Clause | https://crates.io/crates/ed25519-dalek |
 | either | 1.16.0 | MIT OR Apache-2.0 | https://crates.io/crates/either |
 | embedded-io | 0.4.0 | MIT OR Apache-2.0 | https://crates.io/crates/embedded-io |
 | embedded-io | 0.6.1 | MIT OR Apache-2.0 | https://crates.io/crates/embedded-io |
@@ -173,6 +173,7 @@ Total packages: 632
 | foldhash | 0.1.5 | Zlib | https://crates.io/crates/foldhash |
 | foldhash | 0.2.0 | Zlib | https://crates.io/crates/foldhash |
 | form_urlencoded | 1.2.2 | MIT OR Apache-2.0 | https://crates.io/crates/form_urlencoded |
+| forwarded-header-value | 0.1.1 | ISC | https://crates.io/crates/forwarded-header-value |
 | fs_extra | 1.3.0 | MIT | https://crates.io/crates/fs_extra |
 | futures | 0.3.32 | MIT OR Apache-2.0 | https://crates.io/crates/futures |
 | futures-buffered | 0.2.13 | MIT | https://crates.io/crates/futures-buffered |
@@ -186,6 +187,7 @@ Total packages: 632
 | futures-macro | 0.3.32 | MIT OR Apache-2.0 | https://crates.io/crates/futures-macro |
 | futures-sink | 0.3.32 | MIT OR Apache-2.0 | https://crates.io/crates/futures-sink |
 | futures-task | 0.3.32 | MIT OR Apache-2.0 | https://crates.io/crates/futures-task |
+| futures-timer | 3.0.4 | MIT/Apache-2.0 | https://crates.io/crates/futures-timer |
 | futures-util | 0.3.32 | MIT OR Apache-2.0 | https://crates.io/crates/futures-util |
 | genawaiter | 0.99.1 | MIT | https://crates.io/crates/genawaiter |
 | genawaiter-macro | 0.99.1 | MIT/Apache-2.0 | https://crates.io/crates/genawaiter-macro |
@@ -198,10 +200,12 @@ Total packages: 632
 | ghash | 0.5.1 | Apache-2.0 OR MIT | https://crates.io/crates/ghash |
 | gif | 0.14.2 | MIT OR Apache-2.0 | https://crates.io/crates/gif |
 | gloo-timers | 0.3.0 | MIT OR Apache-2.0 | https://crates.io/crates/gloo-timers |
+| governor | 0.10.4 | MIT | https://crates.io/crates/governor |
 | h2 | 0.4.14 | MIT | https://crates.io/crates/h2 |
 | hash32 | 0.2.1 | MIT OR Apache-2.0 | https://crates.io/crates/hash32 |
 | hashbrown | 0.14.5 | MIT OR Apache-2.0 | https://crates.io/crates/hashbrown |
 | hashbrown | 0.15.5 | MIT OR Apache-2.0 | https://crates.io/crates/hashbrown |
+| hashbrown | 0.16.1 | MIT OR Apache-2.0 | https://crates.io/crates/hashbrown |
 | hashbrown | 0.17.1 | MIT OR Apache-2.0 | https://crates.io/crates/hashbrown |
 | hashlink | 0.10.0 | MIT OR Apache-2.0 | https://crates.io/crates/hashlink |
 | heapless | 0.7.17 | MIT OR Apache-2.0 | https://crates.io/crates/heapless |
@@ -222,6 +226,7 @@ Total packages: 632
 | hybrid-array | 0.4.12 | MIT OR Apache-2.0 | https://crates.io/crates/hybrid-array |
 | hyper | 1.10.0 | MIT | https://crates.io/crates/hyper |
 | hyper-rustls | 0.27.9 | Apache-2.0 OR ISC OR MIT | https://crates.io/crates/hyper-rustls |
+| hyper-timeout | 0.5.2 | MIT OR Apache-2.0 | https://crates.io/crates/hyper-timeout |
 | hyper-util | 0.1.20 | MIT | https://crates.io/crates/hyper-util |
 | iana-time-zone | 0.1.65 | MIT OR Apache-2.0 | https://crates.io/crates/iana-time-zone |
 | iana-time-zone-haiku | 0.1.2 | MIT OR Apache-2.0 | https://crates.io/crates/iana-time-zone-haiku |
@@ -245,25 +250,27 @@ Total packages: 632
 | inplace-vec-builder | 0.1.1 | MIT OR Apache-2.0 | https://crates.io/crates/inplace-vec-builder |
 | ipconfig | 0.3.4 | MIT/Apache-2.0 | https://crates.io/crates/ipconfig |
 | ipnet | 2.12.0 | MIT OR Apache-2.0 | https://crates.io/crates/ipnet |
-| iroh | 1.0.0-rc.1 | MIT OR Apache-2.0 | https://crates.io/crates/iroh |
-| iroh-base | 1.0.0-rc.1 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-base |
-| iroh-blobs | 0.102.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-blobs |
-| iroh-dns | 1.0.0-rc.1 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-dns |
-| iroh-docs | 0.100.0 | MIT/Apache-2.0 | https://crates.io/crates/iroh-docs |
-| iroh-gossip | 0.100.0 | MIT/Apache-2.0 | https://crates.io/crates/iroh-gossip |
+| iroh | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh |
+| iroh-base | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-base |
+| iroh-blobs | 0.103.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-blobs |
+| iroh-dns | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-dns |
+| iroh-docs | 0.101.0 | MIT/Apache-2.0 | https://crates.io/crates/iroh-docs |
+| iroh-gossip | 0.101.0 | MIT/Apache-2.0 | https://crates.io/crates/iroh-gossip |
 | iroh-io | 0.6.2 | Apache-2.0 OR MIT | https://crates.io/crates/iroh-io |
-| iroh-mainline-address-lookup | 0.3.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-mainline-address-lookup |
-| iroh-metrics | 1.0.0-rc.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-metrics |
-| iroh-metrics-derive | 1.0.0-rc.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-metrics-derive |
-| iroh-relay | 1.0.0-rc.1 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-relay |
-| iroh-tickets | 1.0.0-rc.1 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-tickets |
-| iroh-util | 0.5.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-util |
-| irpc | 0.16.0 | Apache-2.0/MIT | https://crates.io/crates/irpc |
-| irpc-derive | 0.16.0 | Apache-2.0/MIT | https://crates.io/crates/irpc-derive |
+| iroh-mainline-address-lookup | 0.4.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-mainline-address-lookup |
+| iroh-metrics | 1.0.1 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-metrics |
+| iroh-metrics-derive | 1.0.1 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-metrics-derive |
+| iroh-relay | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-relay |
+| iroh-tickets | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-tickets |
+| iroh-util | 0.6.0 | MIT OR Apache-2.0 | https://crates.io/crates/iroh-util |
+| irpc | 0.17.0 | Apache-2.0/MIT | https://crates.io/crates/irpc |
+| irpc-derive | 0.17.0 | Apache-2.0/MIT | https://crates.io/crates/irpc-derive |
 | is_terminal_polyfill | 1.70.2 | MIT OR Apache-2.0 | https://crates.io/crates/is_terminal_polyfill |
 | itoa | 1.0.18 | MIT OR Apache-2.0 | https://crates.io/crates/itoa |
+| jni | 0.21.1 | MIT/Apache-2.0 | https://crates.io/crates/jni |
 | jni | 0.22.4 | MIT OR Apache-2.0 | https://crates.io/crates/jni |
 | jni-macros | 0.22.4 | MIT OR Apache-2.0 | https://crates.io/crates/jni-macros |
+| jni-sys | 0.3.1 | MIT OR Apache-2.0 | https://crates.io/crates/jni-sys |
 | jni-sys | 0.4.1 | MIT OR Apache-2.0 | https://crates.io/crates/jni-sys |
 | jni-sys-macros | 0.4.1 | MIT OR Apache-2.0 | https://crates.io/crates/jni-sys-macros |
 | jobserver | 0.1.34 | MIT OR Apache-2.0 | https://crates.io/crates/jobserver |
@@ -298,24 +305,26 @@ Total packages: 632
 | mio | 1.2.0 | MIT | https://crates.io/crates/mio |
 | moka | 0.12.15 | (MIT OR Apache-2.0) AND Apache-2.0 | https://crates.io/crates/moka |
 | moxcms | 0.8.1 | BSD-3-Clause OR Apache-2.0 | https://crates.io/crates/moxcms |
-| n0-error | 1.0.0-rc.0 | MIT OR Apache-2.0 | https://crates.io/crates/n0-error |
-| n0-error-macros | 1.0.0-rc.0 | MIT OR Apache-2.0 | https://crates.io/crates/n0-error-macros |
+| n0-error | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/n0-error |
+| n0-error-macros | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/n0-error-macros |
 | n0-future | 0.3.2 | MIT OR Apache-2.0 | https://crates.io/crates/n0-future |
-| n0-mainline | 0.4.0 | MIT OR Apache-2.0 | https://crates.io/crates/n0-mainline |
-| n0-watcher | 1.0.0-rc.0 | MIT OR Apache-2.0 | https://crates.io/crates/n0-watcher |
+| n0-mainline | 0.5.0 | MIT OR Apache-2.0 | https://crates.io/crates/n0-mainline |
+| n0-watcher | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/n0-watcher |
 | ndk-context | 0.1.1 | MIT OR Apache-2.0 | https://crates.io/crates/ndk-context |
 | nested_enum_utils | 0.2.3 | MIT OR Apache-2.0 | https://crates.io/crates/nested_enum_utils |
-| netdev | 0.43.0 | MIT | https://crates.io/crates/netdev |
+| netdev | 0.44.0 | MIT | https://crates.io/crates/netdev |
 | netlink-packet-core | 0.8.1 | MIT | https://crates.io/crates/netlink-packet-core |
 | netlink-packet-route | 0.29.0 | MIT | https://crates.io/crates/netlink-packet-route |
-| netlink-packet-route | 0.30.0 | MIT | https://crates.io/crates/netlink-packet-route |
+| netlink-packet-route | 0.31.0 | MIT | https://crates.io/crates/netlink-packet-route |
 | netlink-proto | 0.12.0 | MIT | https://crates.io/crates/netlink-proto |
 | netlink-sys | 0.8.8 | MIT | https://crates.io/crates/netlink-sys |
-| netwatch | 0.18.0 | MIT OR Apache-2.0 | https://crates.io/crates/netwatch |
+| netwatch | 0.19.0 | MIT OR Apache-2.0 | https://crates.io/crates/netwatch |
 | nom | 7.1.3 | MIT | https://crates.io/crates/nom |
-| noq | 1.0.0-rc.1 | MIT OR Apache-2.0 | https://crates.io/crates/noq |
-| noq-proto | 1.0.0-rc.1 | MIT OR Apache-2.0 | https://crates.io/crates/noq-proto |
-| noq-udp | 1.0.0-rc.1 | MIT OR Apache-2.0 | https://crates.io/crates/noq-udp |
+| nonempty | 0.7.0 | MIT | https://crates.io/crates/nonempty |
+| nonzero_ext | 0.3.0 | Apache-2.0 | https://crates.io/crates/nonzero_ext |
+| noq | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/noq |
+| noq-proto | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/noq-proto |
+| noq-udp | 1.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/noq-udp |
 | ntimestamp | 1.0.0 | MIT | https://crates.io/crates/ntimestamp |
 | nu-ansi-term | 0.50.3 | MIT | https://crates.io/crates/nu-ansi-term |
 | num-bigint | 0.4.6 | MIT OR Apache-2.0 | https://crates.io/crates/num-bigint |
@@ -364,7 +373,7 @@ Total packages: 632
 | poly1305 | 0.8.0 | Apache-2.0 OR MIT | https://crates.io/crates/poly1305 |
 | polyval | 0.6.2 | Apache-2.0 OR MIT | https://crates.io/crates/polyval |
 | portable-atomic | 1.13.1 | Apache-2.0 OR MIT | https://crates.io/crates/portable-atomic |
-| portmapper | 0.18.0 | MIT OR Apache-2.0 | https://crates.io/crates/portmapper |
+| portmapper | 0.19.0 | MIT OR Apache-2.0 | https://crates.io/crates/portmapper |
 | positioned-io | 0.3.5 | MIT | https://crates.io/crates/positioned-io |
 | postcard | 1.1.3 | MIT OR Apache-2.0 | https://crates.io/crates/postcard |
 | postcard-derive | 0.2.2 | MIT OR Apache-2.0 | https://crates.io/crates/postcard-derive |
@@ -379,6 +388,7 @@ Total packages: 632
 | proc-macro-hack | 0.5.20+deprecated | MIT OR Apache-2.0 | https://crates.io/crates/proc-macro-hack |
 | proc-macro2 | 1.0.106 | MIT OR Apache-2.0 | https://crates.io/crates/proc-macro2 |
 | pxfm | 0.1.29 | BSD-3-Clause OR Apache-2.0 | https://crates.io/crates/pxfm |
+| quanta | 0.12.6 | MIT | https://crates.io/crates/quanta |
 | quick-error | 2.0.1 | MIT/Apache-2.0 | https://crates.io/crates/quick-error |
 | quick-xml | 0.39.4 | MIT | https://crates.io/crates/quick-xml |
 | quinn | 0.11.9 | MIT OR Apache-2.0 | https://crates.io/crates/quinn |
@@ -397,7 +407,9 @@ Total packages: 632
 | rand_core | 0.9.5 | MIT OR Apache-2.0 | https://crates.io/crates/rand_core |
 | rand_pcg | 0.10.2 | MIT OR Apache-2.0 | https://crates.io/crates/rand_pcg |
 | range-collections | 0.4.6 | MIT OR Apache-2.0 | https://crates.io/crates/range-collections |
+| raw-cpuid | 11.6.0 | MIT | https://crates.io/crates/raw-cpuid |
 | rcgen | 0.14.8 | MIT OR Apache-2.0 | https://crates.io/crates/rcgen |
+| redb | 3.1.3 | MIT OR Apache-2.0 | https://crates.io/crates/redb |
 | redb | 4.1.0 | MIT OR Apache-2.0 | https://crates.io/crates/redb |
 | redis | 1.2.2 | BSD-3-Clause | https://crates.io/crates/redis |
 | redox_syscall | 0.5.18 | MIT | https://crates.io/crates/redox_syscall |
@@ -477,6 +489,7 @@ Total packages: 632
 | spez | 0.1.2 | BSD-2-Clause | https://crates.io/crates/spez |
 | spin | 0.10.0 | MIT | https://crates.io/crates/spin |
 | spin | 0.9.8 | MIT | https://crates.io/crates/spin |
+| spinning_top | 0.3.0 | MIT/Apache-2.0 | https://crates.io/crates/spinning_top |
 | spki | 0.7.3 | Apache-2.0 OR MIT | https://crates.io/crates/spki |
 | spki | 0.8.0 | Apache-2.0 OR MIT | https://crates.io/crates/spki |
 | sqlx | 0.8.6 | MIT OR Apache-2.0 | https://crates.io/crates/sqlx |
@@ -501,7 +514,9 @@ Total packages: 632
 | system-configuration-sys | 0.6.0 | MIT OR Apache-2.0 | https://crates.io/crates/system-configuration-sys |
 | tagptr | 0.2.0 | MIT/Apache-2.0 | https://crates.io/crates/tagptr |
 | tempfile | 3.27.0 | MIT OR Apache-2.0 | https://crates.io/crates/tempfile |
+| thiserror | 1.0.69 | MIT OR Apache-2.0 | https://crates.io/crates/thiserror |
 | thiserror | 2.0.18 | MIT OR Apache-2.0 | https://crates.io/crates/thiserror |
+| thiserror-impl | 1.0.69 | MIT OR Apache-2.0 | https://crates.io/crates/thiserror-impl |
 | thiserror-impl | 2.0.18 | MIT OR Apache-2.0 | https://crates.io/crates/thiserror-impl |
 | thread_local | 1.1.9 | MIT OR Apache-2.0 | https://crates.io/crates/thread_local |
 | time | 0.3.47 | MIT OR Apache-2.0 | https://crates.io/crates/time |
@@ -523,10 +538,12 @@ Total packages: 632
 | toml_edit | 0.25.12+spec-1.1.0 | MIT OR Apache-2.0 | https://crates.io/crates/toml_edit |
 | toml_parser | 1.1.2+spec-1.1.0 | MIT OR Apache-2.0 | https://crates.io/crates/toml_parser |
 | toml_writer | 1.1.1+spec-1.1.0 | MIT OR Apache-2.0 | https://crates.io/crates/toml_writer |
+| tonic | 0.14.6 | MIT | https://crates.io/crates/tonic |
 | tower | 0.5.3 | MIT | https://crates.io/crates/tower |
 | tower-http | 0.6.11 | MIT | https://crates.io/crates/tower-http |
 | tower-layer | 0.3.3 | MIT | https://crates.io/crates/tower-layer |
 | tower-service | 0.3.3 | MIT | https://crates.io/crates/tower-service |
+| tower_governor | 0.8.0 | MIT OR Apache-2.0 | https://crates.io/crates/tower_governor |
 | tracing | 0.1.44 | MIT | https://crates.io/crates/tracing |
 | tracing-attributes | 0.1.31 | MIT | https://crates.io/crates/tracing-attributes |
 | tracing-core | 0.1.36 | MIT | https://crates.io/crates/tracing-core |
@@ -593,34 +610,43 @@ Total packages: 632
 | windows-registry | 0.6.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-registry |
 | windows-result | 0.4.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-result |
 | windows-strings | 0.5.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-strings |
+| windows-sys | 0.45.0 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
 | windows-sys | 0.48.0 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
 | windows-sys | 0.52.0 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
 | windows-sys | 0.60.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
 | windows-sys | 0.61.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-sys |
+| windows-targets | 0.42.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows-targets |
 | windows-targets | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows-targets |
 | windows-targets | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows-targets |
 | windows-targets | 0.53.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows-targets |
 | windows-threading | 0.2.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows-threading |
+| windows_aarch64_gnullvm | 0.42.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_gnullvm |
 | windows_aarch64_gnullvm | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_gnullvm |
 | windows_aarch64_gnullvm | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_gnullvm |
 | windows_aarch64_gnullvm | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_gnullvm |
+| windows_aarch64_msvc | 0.42.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_msvc |
 | windows_aarch64_msvc | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_msvc |
 | windows_aarch64_msvc | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_msvc |
 | windows_aarch64_msvc | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_aarch64_msvc |
+| windows_i686_gnu | 0.42.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows_i686_gnu |
 | windows_i686_gnu | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows_i686_gnu |
 | windows_i686_gnu | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_i686_gnu |
 | windows_i686_gnu | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_i686_gnu |
 | windows_i686_gnullvm | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_i686_gnullvm |
 | windows_i686_gnullvm | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_i686_gnullvm |
+| windows_i686_msvc | 0.42.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows_i686_msvc |
 | windows_i686_msvc | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows_i686_msvc |
 | windows_i686_msvc | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_i686_msvc |
 | windows_i686_msvc | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_i686_msvc |
+| windows_x86_64_gnu | 0.42.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_gnu |
 | windows_x86_64_gnu | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_gnu |
 | windows_x86_64_gnu | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_gnu |
 | windows_x86_64_gnu | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_gnu |
+| windows_x86_64_gnullvm | 0.42.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_gnullvm |
 | windows_x86_64_gnullvm | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_gnullvm |
 | windows_x86_64_gnullvm | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_gnullvm |
 | windows_x86_64_gnullvm | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_gnullvm |
+| windows_x86_64_msvc | 0.42.2 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
 | windows_x86_64_msvc | 0.48.5 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
 | windows_x86_64_msvc | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
 | windows_x86_64_msvc | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
@@ -646,8 +672,8 @@ Total packages: 632
 | zerocopy-derive | 0.8.49 | BSD-2-Clause OR Apache-2.0 OR MIT | https://crates.io/crates/zerocopy-derive |
 | zerofrom | 0.1.8 | Unicode-3.0 | https://crates.io/crates/zerofrom |
 | zerofrom-derive | 0.1.7 | Unicode-3.0 | https://crates.io/crates/zerofrom-derive |
-| zeroize | 1.8.2 | Apache-2.0 OR MIT | https://crates.io/crates/zeroize |
-| zeroize_derive | 1.4.3 | Apache-2.0 OR MIT | https://crates.io/crates/zeroize_derive |
+| zeroize | 1.9.0 | Apache-2.0 OR MIT | https://crates.io/crates/zeroize |
+| zeroize_derive | 1.5.0 | Apache-2.0 OR MIT | https://crates.io/crates/zeroize_derive |
 | zerotrie | 0.2.4 | Unicode-3.0 | https://crates.io/crates/zerotrie |
 | zerovec | 0.11.6 | Unicode-3.0 | https://crates.io/crates/zerovec |
 | zerovec-derive | 0.11.3 | Unicode-3.0 | https://crates.io/crates/zerovec-derive |

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -126,7 +126,7 @@ curl -fsS https://iroh-relay.kukuri.app/ping
 - relay-only public path でも `Sync Status` / `Tracked Topics` diagnostics は relay-assisted docs/blob peer を含めて `connected` と `peer_count` を出す
 
 ### cn-iroh-relay backpressure guardrail
-- `iroh-relay 1.0.0-rc.1` の per-client send queue depth は upstream で `512` 固定。`cn-iroh-relay` から queue depth は変更できない。
+- `iroh-relay 1.0.0` の per-client send queue depth は upstream で `512` 固定。`cn-iroh-relay` から queue depth は変更できない。
 - `iroh_relay::server::client: failed to handle send packet frame: failed to forward packet: Full` が 3 client 同時起動などで増える場合、まず client 側の topic warmup throttling / coalescing が入った current build で確認する。
 - noisy client の ingress を運用上絞る必要がある場合だけ、`.env.community-node` に `COMMUNITY_NODE_IROH_RELAY_CLIENT_RX_BYTES_PER_SECOND` と任意の `COMMUNITY_NODE_IROH_RELAY_CLIENT_RX_MAX_BURST_BYTES` を設定する。未指定時は従来どおり unlimited。
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -154,6 +154,9 @@ fn rust_test() -> Result<()> {
 }
 
 fn rust_test_with_nextest() -> Result<()> {
+    let stack_env = rust_test_stack_envs();
+    let stack_env_refs = env_refs(&stack_env);
+
     let mut nextest_args = vec![
         "nextest".to_string(),
         "run".to_string(),
@@ -162,12 +165,13 @@ fn rust_test_with_nextest() -> Result<()> {
     nextest_args.extend(cargo_exclude_args(
         &[&CN_PACKAGES[..], &[SERIAL_RUST_PACKAGE]].concat(),
     ));
-    run("cargo", nextest_args, &root_dir())?;
+    run_with_env("cargo", nextest_args, &root_dir(), &stack_env_refs)?;
 
-    run(
+    run_with_env(
         "cargo",
         ["nextest", "run", "-p", SERIAL_RUST_PACKAGE, "-j", "1"],
         &root_dir(),
+        &stack_env_refs,
     )?;
 
     let mut doc_args = vec![
@@ -176,10 +180,14 @@ fn rust_test_with_nextest() -> Result<()> {
         "--doc".to_string(),
     ];
     doc_args.extend(cargo_exclude_args(&CN_PACKAGES));
-    run("cargo", doc_args, &root_dir())
+    run_with_env("cargo", doc_args, &root_dir(), &stack_env_refs)
 }
 
 fn rust_test_with_cargo_test() -> Result<()> {
+    let mut serial_stack_env = rust_test_stack_envs();
+    serial_stack_env.push(("RUST_TEST_THREADS".to_string(), "1".to_string()));
+    let serial_stack_env_refs = env_refs(&serial_stack_env);
+
     let mut regular_test_args = vec![
         "test".to_string(),
         "--workspace".to_string(),
@@ -194,7 +202,7 @@ fn rust_test_with_cargo_test() -> Result<()> {
         "cargo",
         regular_test_args,
         &root_dir(),
-        &[("RUST_TEST_THREADS", "1")],
+        &serial_stack_env_refs,
     )?;
 
     run_with_env(
@@ -208,16 +216,39 @@ fn rust_test_with_cargo_test() -> Result<()> {
             "--tests",
         ],
         &root_dir(),
-        &[("RUST_TEST_THREADS", "1")],
+        &serial_stack_env_refs,
     )?;
 
+    let doc_stack_env = rust_test_stack_envs();
+    let doc_stack_env_refs = env_refs(&doc_stack_env);
     let mut doc_args = vec![
         "test".to_string(),
         "--workspace".to_string(),
         "--doc".to_string(),
     ];
     doc_args.extend(cargo_exclude_args(&CN_PACKAGES));
-    run("cargo", doc_args, &root_dir())
+    run_with_env("cargo", doc_args, &root_dir(), &doc_stack_env_refs)
+}
+
+/// Raise the per-thread stack used while running the Rust test suites.
+///
+/// The async integration tests (notably the desktop-runtime private channel
+/// restore tests that drive several runtimes at once) overflow the default
+/// 2 MiB worker-thread stack under nextest, where the harness `main`
+/// `stack_size` override does not apply. Setting `RUST_MIN_STACK` covers both
+/// nextest and `cargo test`, including each tokio worker thread. Respect an
+/// explicit operator override when one is already present.
+fn rust_test_stack_envs() -> Vec<(String, String)> {
+    if std::env::var_os("RUST_MIN_STACK").is_some() {
+        return Vec::new();
+    }
+    vec![("RUST_MIN_STACK".to_string(), (64 * 1024 * 1024).to_string())]
+}
+
+fn env_refs(envs: &[(String, String)]) -> Vec<(&str, &str)> {
+    envs.iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect()
 }
 
 fn tauri_check() -> Result<()> {


### PR DESCRIPTION
## Summary
- iroh / iroh-relay / iroh-docs / iroh-blobs / iroh-gossip / DHT lookup を stable 1.0 系へ更新
- Windows の transient UDP recv error 対策として netwatch を upstream 修正 rev に一時 patch
- CaTlsConfig API へ移行し、unreachable relay + concurrent direct dial の回帰テストを追加
- .gitignore と third-party notices / runbook も更新

## Validation
- cargo xtask doctor
- cargo xtask check
- cargo xtask test
- cargo xtask cn-check
- cargo xtask cn-test
- cargo xtask e2e-smoke
- cargo xtask scenario community_node_public_connectivity
- cargo xtask scenario community_node_multi_device_connectivity
- targeted: new unreachable relay regression, relay/DHT/docs-sync/runtime recovery tests

## Notes
- netwatch の [patch.crates-io] は net-tools#166 が crates.io に出るまでの一時措置です。