### PR TITLE
feat: add community node consent review flow

### DIFF
--- a/apps/desktop/src/components/settings/CommunityNodeConsentDialog.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodeConsentDialog.tsx
@@ -1,0 +1,135 @@
+import { useTranslation } from 'react-i18next';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Notice } from '@/components/ui/notice';
+
+import { type CommunityNodeConsentView } from './types';
+
+type CommunityNodeConsentDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  baseUrl: string;
+  consent: CommunityNodeConsentView;
+  busy: boolean;
+  onAccept: () => void;
+};
+
+export function CommunityNodeConsentDialog({
+  open,
+  onOpenChange,
+  baseUrl,
+  consent,
+  busy,
+  onAccept,
+}: CommunityNodeConsentDialogProps) {
+  const { t } = useTranslation(['common', 'settings']);
+
+  const acceptDisabled =
+    busy || !consent.authenticated || !consent.loaded || consent.allRequiredAccepted;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-h-[88vh] w-[min(40rem,92vw)] overflow-hidden'>
+        <DialogHeader>
+          <DialogTitle>{t('settings:communityNode.consent.title')}</DialogTitle>
+          <p className='break-all font-mono text-xs text-[var(--muted-foreground)]'>{baseUrl}</p>
+        </DialogHeader>
+
+        <DialogBody className='max-h-[60vh] space-y-4 overflow-y-auto'>
+          {!consent.authenticated ? (
+            <Notice tone='warning'>{t('settings:communityNode.consent.authRequired')}</Notice>
+          ) : null}
+
+          {consent.authenticated && !consent.loaded ? (
+            <Notice>{t('settings:communityNode.consent.notLoaded')}</Notice>
+          ) : null}
+
+          {consent.authenticated && consent.loaded && consent.hasPendingUpdate ? (
+            <Notice tone='warning'>{t('settings:communityNode.consent.updatedNotice')}</Notice>
+          ) : null}
+
+          {consent.authenticated && consent.loaded && consent.policies.length === 0 ? (
+            <Notice>{t('settings:communityNode.consent.noPolicies')}</Notice>
+          ) : null}
+
+          {consent.loaded
+            ? consent.policies.map((policy) => (
+                <section
+                  key={policy.policySlug}
+                  className='space-y-3 rounded-[16px] border border-[var(--border-subtle)] bg-[var(--surface-panel-soft)] p-4'
+                >
+              <div className='flex flex-wrap items-start justify-between gap-2'>
+                <div className='min-w-0 space-y-1'>
+                  <h5 className='break-words text-sm font-semibold text-foreground'>
+                    {policy.title}
+                  </h5>
+                  <p className='text-xs font-semibold uppercase tracking-[0.08em] text-[var(--muted-foreground)]'>
+                    v{policy.policyVersion}
+                  </p>
+                </div>
+                <div className='flex flex-wrap items-center gap-2'>
+                  {policy.required ? (
+                    <Badge tone='accent'>{t('settings:communityNode.consent.required')}</Badge>
+                  ) : (
+                    <Badge tone='neutral'>{t('settings:communityNode.consent.optional')}</Badge>
+                  )}
+                  {policy.updated ? (
+                    <Badge tone='warning'>{t('settings:communityNode.consent.updatedBadge')}</Badge>
+                  ) : null}
+                </div>
+              </div>
+
+              {policy.updated && policy.previouslyAcceptedVersion != null ? (
+                <p className='text-xs text-[var(--muted-foreground)]'>
+                  {t('settings:communityNode.consent.updatedDetail', {
+                    previous: policy.previouslyAcceptedVersion,
+                    current: policy.policyVersion,
+                  })}
+                </p>
+              ) : null}
+
+              <p className='text-sm text-[var(--muted-foreground)]'>
+                {policy.acceptedAtLabel
+                  ? t('settings:communityNode.consent.acceptedAt', {
+                      timestamp: policy.acceptedAtLabel,
+                    })
+                  : t('settings:communityNode.consent.notAccepted')}
+              </p>
+
+              {policy.body.trim() ? (
+                <p className='whitespace-pre-wrap break-words text-sm leading-6 text-foreground'>
+                  {policy.body}
+                </p>
+              ) : (
+                <p className='text-sm italic text-[var(--muted-foreground)]'>
+                  {t('settings:communityNode.consent.noBody')}
+                </p>
+              )}
+                </section>
+              ))
+            : null}
+        </DialogBody>
+
+        <DialogFooter className='flex flex-wrap justify-end gap-2'>
+          <Button variant='secondary' onClick={() => onOpenChange(false)}>
+            {t('common:actions.close')}
+          </Button>
+          <Button disabled={acceptDisabled} onClick={onAccept}>
+            {consent.allRequiredAccepted
+              ? t('settings:communityNode.consent.allAccepted')
+              : t('common:actions.accept')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/settings/CommunityNodePanel.stories.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.stories.tsx
@@ -33,6 +33,13 @@ function CommunityNodePanelStory({
                 saved: false,
                 diagnostics: [],
                 dependency: { diagnostics: [], boundaryNotes: [] },
+                consent: {
+                  authenticated: false,
+                  loaded: false,
+                  allRequiredAccepted: false,
+                  hasPendingUpdate: false,
+                  policies: [],
+                },
                 lastError: null,
               },
             ])

--- a/apps/desktop/src/components/settings/CommunityNodePanel.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -5,6 +6,7 @@ import { Card, CardHeader } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Notice } from '@/components/ui/notice';
 
+import { CommunityNodeConsentDialog } from './CommunityNodeConsentDialog';
 import { SettingsActionRow } from './SettingsActionRow';
 import { SettingsDiagnosticList } from './SettingsDiagnosticList';
 import { SettingsEditorField } from './SettingsEditorField';
@@ -24,8 +26,8 @@ type CommunityNodePanelProps = {
   onReset: () => void;
   onClearNodes: () => void;
   onAuthenticate: (baseUrl: string) => void;
-  onFetchConsents: (baseUrl: string) => void;
-  onAcceptConsents: (baseUrl: string) => void;
+  onFetchConsents: (baseUrl: string) => void | Promise<void>;
+  onAcceptConsents: (baseUrl: string) => void | Promise<void>;
   onRefresh: (baseUrl: string) => void;
   onClearToken: (baseUrl: string) => void;
 };
@@ -50,6 +52,47 @@ export function CommunityNodePanel({
   onClearToken,
 }: CommunityNodePanelProps) {
   const { t } = useTranslation(['common', 'settings']);
+  const [consentDialogNodeBaseUrl, setConsentDialogNodeBaseUrl] = useState<string | null>(null);
+  const [consentDialogLoadedBaseUrl, setConsentDialogLoadedBaseUrl] = useState<string | null>(null);
+  const [consentBusy, setConsentBusy] = useState(false);
+
+  const consentDialogNode =
+    consentDialogNodeBaseUrl != null
+      ? view.nodes.find((node) => node.baseUrl === consentDialogNodeBaseUrl)
+      : undefined;
+  const consentDialogView = consentDialogNode
+    ? {
+        ...consentDialogNode.consent,
+        loaded:
+          consentDialogNode.consent.loaded &&
+          consentDialogLoadedBaseUrl === consentDialogNode.baseUrl,
+      }
+    : null;
+
+  async function openConsentDialog(baseUrl: string) {
+    setConsentDialogNodeBaseUrl(baseUrl);
+    setConsentDialogLoadedBaseUrl(null);
+    setConsentBusy(true);
+    try {
+      await onFetchConsents(baseUrl);
+      setConsentDialogLoadedBaseUrl(baseUrl);
+    } catch {
+      setConsentDialogLoadedBaseUrl(null);
+    } finally {
+      setConsentBusy(false);
+    }
+  }
+
+  async function acceptConsentFromDialog(baseUrl: string) {
+    setConsentBusy(true);
+    try {
+      await onAcceptConsents(baseUrl);
+    } catch {
+      return;
+    } finally {
+      setConsentBusy(false);
+    }
+  }
 
   return (
     <Card className='min-w-0 space-y-4'>
@@ -163,16 +206,9 @@ export function CommunityNodePanel({
                 <Button
                   variant='secondary'
                   disabled={nodeActionsDisabled || !node.saved || !node.baseUrl.trim()}
-                  onClick={() => onFetchConsents(node.baseUrl)}
+                  onClick={() => void openConsentDialog(node.baseUrl)}
                 >
                   {t('common:actions.consents')}
-                </Button>
-                <Button
-                  variant='secondary'
-                  disabled={nodeActionsDisabled || !node.saved || !node.baseUrl.trim()}
-                  onClick={() => onAcceptConsents(node.baseUrl)}
-                >
-                  {t('common:actions.accept')}
                 </Button>
                 <Button
                   variant='secondary'
@@ -193,6 +229,22 @@ export function CommunityNodePanel({
           </section>
         ))}
       </div>
+
+      {consentDialogNode && consentDialogView ? (
+        <CommunityNodeConsentDialog
+          open={consentDialogNodeBaseUrl != null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setConsentDialogNodeBaseUrl(null);
+              setConsentDialogLoadedBaseUrl(null);
+            }
+          }}
+          baseUrl={consentDialogNode.baseUrl}
+          consent={consentDialogView}
+          busy={consentBusy}
+          onAccept={() => void acceptConsentFromDialog(consentDialogNode.baseUrl)}
+        />
+      ) : null}
     </Card>
   );
 }

--- a/apps/desktop/src/components/settings/SettingsPanels.test.tsx
+++ b/apps/desktop/src/components/settings/SettingsPanels.test.tsx
@@ -147,6 +147,7 @@ test('discovery panel keeps env-locked seed editor read-only', () => {
 
 test('community node panel renders ready and error states', async () => {
   const user = userEvent.setup();
+  const onFetchConsents = vi.fn();
   const onAcceptConsents = vi.fn();
   const communityNodePanelFixture = createCommunityNodePanelFixture();
 
@@ -167,7 +168,7 @@ test('community node panel renders ready and error states', async () => {
       onReset={() => {}}
       onClearNodes={() => {}}
       onAuthenticate={() => {}}
-      onFetchConsents={() => {}}
+      onFetchConsents={onFetchConsents}
       onAcceptConsents={onAcceptConsents}
       onRefresh={() => {}}
       onClearToken={() => {}}
@@ -177,8 +178,135 @@ test('community node panel renders ready and error states', async () => {
   expect(screen.getByText('failed to update community nodes')).toBeInTheDocument();
   expect(screen.getByDisplayValue('https://api.kukuri.app')).toBeInTheDocument();
 
-  await user.click(screen.getAllByRole('button', { name: 'Accept' })[0]);
+  await user.click(screen.getAllByRole('button', { name: 'Consents' })[0]);
+  expect(onFetchConsents).toHaveBeenCalledWith('https://api.kukuri.app');
+
+  // 既に全て同意済みのノードでは Accept が無効化され、誤受諾を防ぐ。
+  const consentDialog = await screen.findByRole('dialog');
+  expect(within(consentDialog).getByRole('button', { name: 'All accepted' })).toBeDisabled();
+  expect(onAcceptConsents).not.toHaveBeenCalled();
+});
+
+test('community node consent dialog shows policy body, version, and update notice', async () => {
+  const user = userEvent.setup();
+  const onFetchConsents = vi.fn();
+  const onAcceptConsents = vi.fn();
+  const communityNodePanelFixture = createCommunityNodePanelFixture();
+  const fixtureWithUpdate = {
+    ...communityNodePanelFixture,
+    nodes: communityNodePanelFixture.nodes.map((node, index) =>
+      index === 0
+        ? {
+            ...node,
+            consent: {
+              authenticated: true,
+              loaded: true,
+              allRequiredAccepted: false,
+              hasPendingUpdate: true,
+              policies: [
+                {
+                  policySlug: 'terms_of_service',
+                  title: 'Terms of Service',
+                  body: 'You must follow the community node terms of service.',
+                  policyVersion: 2,
+                  required: true,
+                  acceptedAtLabel: null,
+                  updated: true,
+                  previouslyAcceptedVersion: 1,
+                },
+              ],
+            },
+          }
+        : node
+    ),
+  };
+
+  render(
+    <CommunityNodePanel
+      view={fixtureWithUpdate}
+      saveDisabled={false}
+      resetDisabled={false}
+      clearDisabled={false}
+      onAddNode={() => {}}
+      onNodeBaseUrlChange={() => {}}
+      onNodeAutoApproveChange={() => {}}
+      onRemoveNode={() => {}}
+      onSaveNodes={() => {}}
+      onReset={() => {}}
+      onClearNodes={() => {}}
+      onAuthenticate={() => {}}
+      onFetchConsents={onFetchConsents}
+      onAcceptConsents={onAcceptConsents}
+      onRefresh={() => {}}
+      onClearToken={() => {}}
+    />
+  );
+
+  await user.click(screen.getAllByRole('button', { name: 'Consents' })[0]);
+
+  const consentDialog = await screen.findByRole('dialog');
+  expect(
+    within(consentDialog).getByText('You must follow the community node terms of service.')
+  ).toBeInTheDocument();
+  expect(within(consentDialog).getByText('v2')).toBeInTheDocument();
+  expect(
+    within(consentDialog).getByText('This node updated its policies. Review the changes and accept again to keep connecting.')
+  ).toBeInTheDocument();
+  expect(within(consentDialog).getByText('Updated from v1 to v2.')).toBeInTheDocument();
+
+  await user.click(within(consentDialog).getByRole('button', { name: 'Accept' }));
   expect(onAcceptConsents).toHaveBeenCalledWith('https://api.kukuri.app');
+});
+
+test('community node consent dialog disables accept when latest policy fetch fails', async () => {
+  const user = userEvent.setup();
+  const onFetchConsents = vi.fn().mockRejectedValue(new Error('offline'));
+  const onAcceptConsents = vi.fn();
+  const communityNodePanelFixture = createCommunityNodePanelFixture();
+  const fixtureWithPendingConsent = {
+    ...communityNodePanelFixture,
+    nodes: communityNodePanelFixture.nodes.map((node, index) =>
+      index === 0
+        ? {
+            ...node,
+            consent: {
+              ...node.consent,
+              allRequiredAccepted: false,
+            },
+          }
+        : node
+    ),
+  };
+
+  render(
+    <CommunityNodePanel
+      view={fixtureWithPendingConsent}
+      saveDisabled={false}
+      resetDisabled={false}
+      clearDisabled={false}
+      onAddNode={() => {}}
+      onNodeBaseUrlChange={() => {}}
+      onNodeAutoApproveChange={() => {}}
+      onRemoveNode={() => {}}
+      onSaveNodes={() => {}}
+      onReset={() => {}}
+      onClearNodes={() => {}}
+      onAuthenticate={() => {}}
+      onFetchConsents={onFetchConsents}
+      onAcceptConsents={onAcceptConsents}
+      onRefresh={() => {}}
+      onClearToken={() => {}}
+    />
+  );
+
+  await user.click(screen.getAllByRole('button', { name: 'Consents' })[0]);
+
+  const consentDialog = await screen.findByRole('dialog');
+  expect(within(consentDialog).getByText('Open this dialog to load the latest policies from the node.')).toBeInTheDocument();
+  expect(
+    within(consentDialog).queryByText('You must follow the community node terms of service.')
+  ).not.toBeInTheDocument();
+  expect(within(consentDialog).getByRole('button', { name: 'Accept' })).toBeDisabled();
 });
 
 test('settings panels avoid the legacy grid classname collision', () => {

--- a/apps/desktop/src/components/settings/fixtures.ts
+++ b/apps/desktop/src/components/settings/fixtures.ts
@@ -6,7 +6,7 @@ import type {
 } from './types';
 import { buildCommunityNodeDependencyView } from './communityNodeDependency';
 import i18n from '@/i18n';
-import { formatLocalizedTime, getResolvedLocale } from '@/i18n/format';
+import { formatLocalizedDateTime, formatLocalizedTime, getResolvedLocale } from '@/i18n/format';
 
 const fixtureTranslate = (key: string, options?: Record<string, unknown>): string =>
   i18n.t(key, options);
@@ -215,6 +215,24 @@ export function createCommunityNodePanelFixture(): CommunityNodePanelView {
           },
           fixtureTranslate
         ),
+        consent: {
+          authenticated: true,
+          loaded: true,
+          allRequiredAccepted: true,
+          hasPendingUpdate: false,
+          policies: [
+            {
+              policySlug: 'terms_of_service',
+              title: 'Terms of Service',
+              body: 'You must follow the community node terms of service.',
+              policyVersion: 1,
+              required: true,
+              acceptedAtLabel: formatLocalizedDateTime('2026-03-28T13:00:00Z'),
+              updated: false,
+              previouslyAcceptedVersion: 1,
+            },
+          ],
+        },
         lastError: null,
       },
       {
@@ -254,6 +272,13 @@ export function createCommunityNodePanelFixture(): CommunityNodePanelView {
           },
         ],
         dependency: buildCommunityNodeDependencyView({ status: 'absent' }, fixtureTranslate),
+        consent: {
+          authenticated: false,
+          loaded: false,
+          allRequiredAccepted: false,
+          hasPendingUpdate: false,
+          policies: [],
+        },
         lastError: i18n.t('common:errors.failedToRefreshCommunityNode'),
       },
     ],

--- a/apps/desktop/src/components/settings/types.ts
+++ b/apps/desktop/src/components/settings/types.ts
@@ -64,6 +64,31 @@ export type CommunityNodeDependencyView = {
   manifestError?: string | null;
 };
 
+// per-node consent ダイアログ（#384）で表示する 1 ポリシー分の行。
+export type CommunityNodeConsentPolicyView = {
+  policySlug: string;
+  title: string;
+  body: string;
+  policyVersion: number;
+  required: boolean;
+  acceptedAtLabel: string | null;
+  // 版が上がって再同意が必要な「更新」状態か。
+  updated: boolean;
+  previouslyAcceptedVersion: number | null;
+};
+
+// per-node consent ダイアログ全体の表示状態。
+export type CommunityNodeConsentView = {
+  // 認証済みでないと consent を取得・受諾できない。
+  authenticated: boolean;
+  // consent_state を一度でも取得できているか（未取得なら本文表示前に取得を促す）。
+  loaded: boolean;
+  allRequiredAccepted: boolean;
+  // 更新による未同意（再同意要求）が 1 つでもあるか。
+  hasPendingUpdate: boolean;
+  policies: CommunityNodeConsentPolicyView[];
+};
+
 export type CommunityNodeEntryView = {
   id: string;
   baseUrl: string;
@@ -71,6 +96,7 @@ export type CommunityNodeEntryView = {
   saved: boolean;
   diagnostics: SettingsDiagnosticItemView[];
   dependency: CommunityNodeDependencyView;
+  consent: CommunityNodeConsentView;
   lastError?: string | null;
 };
 

--- a/apps/desktop/src/components/shell/SettingsDrawer.stories.tsx
+++ b/apps/desktop/src/components/shell/SettingsDrawer.stories.tsx
@@ -91,6 +91,13 @@ function SettingsDrawerStory({ initialSection = 'connectivity' }: { initialSecti
                 saved: false,
                 diagnostics: [],
                 dependency: { diagnostics: [], boundaryNotes: [] },
+                consent: {
+                  authenticated: false,
+                  loaded: false,
+                  allRequiredAccepted: false,
+                  hasPendingUpdate: false,
+                  policies: [],
+                },
                 lastError: null,
               },
             ])

--- a/apps/desktop/src/i18n/format.ts
+++ b/apps/desktop/src/i18n/format.ts
@@ -20,6 +20,17 @@ export function formatLocalizedTime(
   }).format(date);
 }
 
+export function formatLocalizedDateTime(
+  value: Date | number | string,
+  locale?: string | null
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+  return new Intl.DateTimeFormat(getResolvedLocale(locale), {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
 export function formatLocalizedBytes(value: number, locale?: string | null): string {
   const resolvedLocale = getResolvedLocale(locale);
   if (value >= 1024 * 1024) {

--- a/apps/desktop/src/i18n/locales/en/settings.json
+++ b/apps/desktop/src/i18n/locales/en/settings.json
@@ -58,6 +58,21 @@
       }
     },
     "autoApproveLabel": "Auto-approve consent for this node",
+    "consent": {
+      "title": "Community node policies",
+      "authRequired": "Authenticate with this node before reviewing or accepting its policies.",
+      "notLoaded": "Open this dialog to load the latest policies from the node.",
+      "updatedNotice": "This node updated its policies. Review the changes and accept again to keep connecting.",
+      "noPolicies": "This node does not require any policy consent.",
+      "noBody": "This policy does not provide a body text.",
+      "required": "Required",
+      "optional": "Optional",
+      "updatedBadge": "Updated",
+      "updatedDetail": "Updated from v{{previous}} to v{{current}}.",
+      "acceptedAt": "Accepted at {{timestamp}}",
+      "notAccepted": "Not accepted yet",
+      "allAccepted": "All accepted"
+    },
     "baseUrlLabel": "Base URL",
     "baseUrlsHint": "One HTTPS base URL per line.",
     "baseUrlsLabel": "Base URLs",

--- a/apps/desktop/src/i18n/locales/ja/settings.json
+++ b/apps/desktop/src/i18n/locales/ja/settings.json
@@ -58,6 +58,21 @@
       }
     },
     "autoApproveLabel": "このノードの consent を自動承認する",
+    "consent": {
+      "title": "コミュニティノードのポリシー",
+      "authRequired": "ポリシーを確認・同意する前に、このノードで認証してください。",
+      "notLoaded": "このダイアログを開くと、ノードから最新のポリシーを取得します。",
+      "updatedNotice": "このノードはポリシーを更新しました。変更内容を確認し、再度同意すると接続を継続できます。",
+      "noPolicies": "このノードは同意が必要なポリシーを持っていません。",
+      "noBody": "このポリシーには本文がありません。",
+      "required": "必須",
+      "optional": "任意",
+      "updatedBadge": "更新",
+      "updatedDetail": "v{{previous}} から v{{current}} に更新されました。",
+      "acceptedAt": "{{timestamp}} に同意済み",
+      "notAccepted": "未同意",
+      "allAccepted": "すべて同意済み"
+    },
     "baseUrlLabel": "ベース URL",
     "baseUrlsHint": "HTTPS の base URL を 1 行に 1 つ入力します。",
     "baseUrlsLabel": "ベース URL",

--- a/apps/desktop/src/i18n/locales/zh-CN/settings.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/settings.json
@@ -56,6 +56,21 @@
         "defaultNotAuthority": "即使是默认节点，也不是整个网络的运营者或权限方。"
       }
     },
+    "consent": {
+      "title": "社区节点政策",
+      "authRequired": "在查看或接受其政策前，请先与该节点完成认证。",
+      "notLoaded": "打开此对话框以从节点加载最新政策。",
+      "updatedNotice": "该节点更新了政策。请查看变更并再次接受以继续连接。",
+      "noPolicies": "该节点不需要任何政策同意。",
+      "noBody": "该政策未提供正文。",
+      "required": "必需",
+      "optional": "可选",
+      "updatedBadge": "已更新",
+      "updatedDetail": "已从 v{{previous}} 更新至 v{{current}}。",
+      "acceptedAt": "已于 {{timestamp}} 接受",
+      "notAccepted": "尚未接受",
+      "allAccepted": "已全部接受"
+    },
     "baseUrlsHint": "每行一个 HTTPS 基础 URL。",
     "baseUrlsLabel": "基础 URL",
     "baseUrlsPlaceholder": "https://community.example.com",

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -415,8 +415,10 @@ export type CommunityNodeConsentItem = {
   policy_slug: string;
   policy_version: number;
   title: string;
+  body?: string;
   required: boolean;
   accepted_at?: number | null;
+  previously_accepted_version?: number | null;
 };
 
 export type CommunityNodeConsentStatus = {

--- a/apps/desktop/src/mocks/desktopApiMock.ts
+++ b/apps/desktop/src/mocks/desktopApiMock.ts
@@ -135,12 +135,32 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
       },
     ],
   };
+  const mockConsentItems = (accepted: boolean) => [
+    {
+      policy_slug: 'terms_of_service',
+      policy_version: 1,
+      title: 'Terms of Service',
+      body: 'You must follow the community node terms of service.',
+      required: true,
+      accepted_at: accepted ? Math.floor(Date.now() / 1000) : null,
+      previously_accepted_version: accepted ? 1 : null,
+    },
+    {
+      policy_slug: 'privacy_policy',
+      policy_version: 1,
+      title: 'Privacy Policy',
+      body: 'You must acknowledge the community node privacy policy.',
+      required: true,
+      accepted_at: accepted ? Math.floor(Date.now() / 1000) : null,
+      previously_accepted_version: accepted ? 1 : null,
+    },
+  ];
   let communityNodeStatuses: CommunityNodeNodeStatus[] = [
     {
       base_url: 'https://api.kukuri.app',
       auto_approve: true,
       auth_state: { authenticated: true, expires_at: Date.now() + 60_000 },
-      consent_state: { all_required_accepted: true, items: [] },
+      consent_state: { all_required_accepted: true, items: mockConsentItems(true) },
       resolved_urls: {
         public_base_url: 'https://api.kukuri.app',
         connectivity_urls: ['https://api.kukuri.app'],
@@ -1365,7 +1385,7 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
           ? {
               ...status,
               auth_state: { authenticated: true, expires_at: Date.now() },
-              consent_state: { all_required_accepted: false, items: [] },
+              consent_state: { all_required_accepted: false, items: mockConsentItems(false) },
               session_phase: status.auto_approve ? 'accepting' : 'authenticating',
             }
           : status
@@ -1395,7 +1415,7 @@ export function createDesktopMockApi(options?: DesktopMockApiOptions): DesktopAp
         status.base_url === baseUrl
           ? {
               ...status,
-              consent_state: { all_required_accepted: true, items: [] },
+              consent_state: { all_required_accepted: true, items: mockConsentItems(true) },
               resolved_urls: resolvedUrls,
               session_phase: 'ready',
               retry_after: null,

--- a/apps/desktop/src/shell/actions/profileTopicChannel.ts
+++ b/apps/desktop/src/shell/actions/profileTopicChannel.ts
@@ -764,6 +764,7 @@ export function createProfileTopicChannelActions({
           ? consentError.message
           : translate('common:errors.failedToFetchConsentStatus')
       );
+      throw consentError;
     }
   }
 
@@ -780,6 +781,7 @@ export function createProfileTopicChannelActions({
           ? consentError.message
           : translate('common:errors.failedToAcceptConsents')
       );
+      throw consentError;
     }
   }
 

--- a/apps/desktop/src/shell/page/DesktopShellSettingsDrawer.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellSettingsDrawer.tsx
@@ -187,8 +187,8 @@ export function DesktopShellSettingsDrawer({
           }}
           onClearNodes={() => void handleClearCommunityNodes()}
           onAuthenticate={(baseUrl) => void handleAuthenticateCommunityNode(baseUrl)}
-          onFetchConsents={(baseUrl) => void handleFetchCommunityNodeConsents(baseUrl)}
-          onAcceptConsents={(baseUrl) => void handleAcceptCommunityNodeConsents(baseUrl)}
+          onFetchConsents={(baseUrl) => handleFetchCommunityNodeConsents(baseUrl)}
+          onAcceptConsents={(baseUrl) => handleAcceptCommunityNodeConsents(baseUrl)}
           onRefresh={(baseUrl) => void handleRefreshCommunityNode(baseUrl)}
           onClearToken={(baseUrl) => void handleClearCommunityNodeToken(baseUrl)}
         />

--- a/apps/desktop/src/shell/selectors.ts
+++ b/apps/desktop/src/shell/selectors.ts
@@ -20,9 +20,14 @@ import {
   type TimelineScope,
   type TopicSyncStatus,
 } from '@/lib/api';
+import type {
+  CommunityNodeConsentPolicyView,
+  CommunityNodeConsentView,
+} from '@/components/settings/types';
 import i18n from '@/i18n';
 import {
   formatLocalizedBytes,
+  formatLocalizedDateTime,
   formatLocalizedNumber,
   formatLocalizedTime,
 } from '@/i18n/format';
@@ -419,6 +424,43 @@ export function communityNodeConsentLabel(status?: CommunityNodeNodeStatus): str
   return status.consent_state.all_required_accepted
     ? translate('common:states.accepted')
     : translate('common:states.required');
+}
+
+function formatConsentAcceptedAt(value: number | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  return formatLocalizedDateTime(value * 1000);
+}
+
+// per-node consent ダイアログ（#384）用の view を組み立てる。
+// 認証状態・取得有無・各ポリシー（本文/版/必須/受諾日時/更新フラグ）をまとめる。
+export function communityNodeConsentView(
+  status?: CommunityNodeNodeStatus
+): CommunityNodeConsentView {
+  const authenticated = status?.auth_state.authenticated ?? false;
+  const consentState = status?.consent_state ?? null;
+  const policies: CommunityNodeConsentPolicyView[] = (consentState?.items ?? []).map((item) => {
+    const previouslyAcceptedVersion = item.previously_accepted_version ?? null;
+    const updated = item.accepted_at == null && previouslyAcceptedVersion != null;
+    return {
+      policySlug: item.policy_slug,
+      title: item.title,
+      body: item.body ?? '',
+      policyVersion: item.policy_version,
+      required: item.required,
+      acceptedAtLabel: formatConsentAcceptedAt(item.accepted_at),
+      updated,
+      previouslyAcceptedVersion,
+    };
+  });
+  return {
+    authenticated,
+    loaded: consentState != null,
+    allRequiredAccepted: consentState?.all_required_accepted ?? false,
+    hasPendingUpdate: policies.some((policy) => policy.required && policy.updated),
+    policies,
+  };
 }
 
 export function translateTopicConnectionText(label: string): string {

--- a/apps/desktop/src/shell/useDesktopShellViewModels.ts
+++ b/apps/desktop/src/shell/useDesktopShellViewModels.ts
@@ -66,6 +66,7 @@ import {
   communityNodeAuthLabel,
   communityNodeConnectivityUrlsLabel,
   communityNodeConsentLabel,
+  communityNodeConsentView,
   communityNodeNextStepLabel,
   communityNodeRetryAfterLabel,
   communityNodeSessionPhaseLabel,
@@ -1021,6 +1022,7 @@ export function useDesktopShellViewModels({
             communityNodeManifests[node.base_url],
             t
           ),
+          consent: communityNodeConsentView(status),
           lastError: status?.last_error ?? null,
         };
       }),

--- a/crates/cn-core/src/consents.rs
+++ b/crates/cn-core/src/consents.rs
@@ -15,13 +15,22 @@ pub async fn get_consent_status(pool: &PgPool, pubkey: &str) -> Result<Community
             p.policy_slug,
             p.policy_version,
             p.title,
+            p.body_markdown,
             p.required,
-            c.accepted_at
+            c.accepted_at,
+            prev.previously_accepted_version
          FROM cn_admin.policies p
          LEFT JOIN cn_user.policy_consents c
            ON c.policy_slug = p.policy_slug
           AND c.policy_version = p.policy_version
           AND c.subscriber_pubkey = $1
+         LEFT JOIN (
+            SELECT policy_slug, MAX(policy_version) AS previously_accepted_version
+            FROM cn_user.policy_consents
+            WHERE subscriber_pubkey = $1
+            GROUP BY policy_slug
+         ) prev
+           ON prev.policy_slug = p.policy_slug
          ORDER BY p.policy_slug ASC",
     )
     .bind(&pubkey)
@@ -37,8 +46,10 @@ pub async fn get_consent_status(pool: &PgPool, pubkey: &str) -> Result<Community
                 policy_slug: row.try_get("policy_slug")?,
                 policy_version: row.try_get("policy_version")?,
                 title: row.try_get("title")?,
+                body: row.try_get("body_markdown")?,
                 required: row.try_get("required")?,
                 accepted_at,
+                previously_accepted_version: row.try_get("previously_accepted_version")?,
             })
         })
         .collect::<Result<Vec<_>>>()?;

--- a/crates/cn-core/src/models.rs
+++ b/crates/cn-core/src/models.rs
@@ -101,8 +101,14 @@ pub struct CommunityNodeConsentItem {
     pub policy_slug: String,
     pub policy_version: i32,
     pub title: String,
+    #[serde(default)]
+    pub body: String,
     pub required: bool,
     pub accepted_at: Option<i64>,
+    /// その policy_slug で過去に同意した最大 version（version 不問）。
+    /// `accepted_at` が None でこれが Some なら、版が上がって再同意が必要な「更新」を意味する。
+    #[serde(default)]
+    pub previously_accepted_version: Option<i32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/cn-user-api/tests/contract.rs
+++ b/crates/cn-user-api/tests/contract.rs
@@ -211,6 +211,20 @@ async fn bootstrap_requires_bearer_then_consents() -> Result<()> {
             .iter()
             .all(|item| item.accepted_at.is_none())
     );
+    // #384: client が規約本文を表示できるよう body が返ること。
+    assert!(
+        consent_status
+            .items
+            .iter()
+            .all(|item| !item.body.trim().is_empty())
+    );
+    // 初回（過去同意なし）は previously_accepted_version が None であること。
+    assert!(
+        consent_status
+            .items
+            .iter()
+            .all(|item| item.previously_accepted_version.is_none())
+    );
 
     let accepted = client
         .post(format!("{}/v1/consents", server.base_url))
@@ -222,6 +236,13 @@ async fn bootstrap_requires_bearer_then_consents() -> Result<()> {
         .json::<kukuri_cn_core::CommunityNodeConsentStatus>()
         .await?;
     assert!(accepted.all_required_accepted);
+    // 受諾後は accepted_at と previously_accepted_version が設定されること。
+    assert!(
+        accepted
+            .items
+            .iter()
+            .all(|item| item.accepted_at.is_some() && item.previously_accepted_version.is_some())
+    );
 
     let bootstrap = client
         .get(format!("{}/v1/bootstrap/nodes", server.base_url))

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -41,6 +41,19 @@ pub use report_routing_support::{
 };
 pub(crate) use token_storage_support::*;
 
+/// 「版が上がって再同意が必要（更新）」な required ポリシーが存在するか。
+///
+/// `accepted_at` が None（現行版を未同意）かつ `previously_accepted_version` が Some
+/// （過去に別版を同意済み）の required ポリシーがあれば true。auto_approve の node でも、
+/// 更新時は黙って再受諾せずユーザーへ本文を再提示するための判定。
+pub(crate) fn community_node_consent_has_pending_update(
+    status: &CommunityNodeConsentStatus,
+) -> bool {
+    status.items.iter().any(|item| {
+        item.required && item.accepted_at.is_none() && item.previously_accepted_version.is_some()
+    })
+}
+
 pub(crate) const COMMUNITY_NODE_TOKEN_PURPOSE: &str = "community-node-token";
 pub(crate) const COMMUNITY_NODE_PREVIEW_BASE_URL: &str = "https://api.kukuri.app";
 pub(crate) const COMMUNITY_NODE_BOOTSTRAP_HEARTBEAT_INTERVAL_SECONDS: i64 = 30;
@@ -178,4 +191,65 @@ pub struct CommunityNodeNodeStatus {
 pub(crate) struct StoredCommunityNodeToken {
     pub(crate) access_token: String,
     pub(crate) expires_at: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kukuri_cn_core::CommunityNodeConsentItem;
+
+    fn consent_item(
+        accepted: bool,
+        previously_accepted_version: Option<i32>,
+        required: bool,
+    ) -> CommunityNodeConsentItem {
+        CommunityNodeConsentItem {
+            policy_slug: "terms_of_service".to_string(),
+            policy_version: 2,
+            title: "Terms of Service".to_string(),
+            body: "body".to_string(),
+            required,
+            accepted_at: accepted.then_some(1_700_000_000),
+            previously_accepted_version,
+        }
+    }
+
+    #[test]
+    fn pending_update_false_when_first_time_not_accepted() {
+        // 初回未同意（過去版の同意なし）は「更新」ではない。auto_approve の auto 受諾を許す。
+        let status = CommunityNodeConsentStatus {
+            all_required_accepted: false,
+            items: vec![consent_item(false, None, true)],
+        };
+        assert!(!community_node_consent_has_pending_update(&status));
+    }
+
+    #[test]
+    fn pending_update_true_when_previous_version_accepted_but_current_not() {
+        // 旧版を同意済みだが現行版を未同意 = 版が上がった「更新」。auto_approve でも再提示。
+        let status = CommunityNodeConsentStatus {
+            all_required_accepted: false,
+            items: vec![consent_item(false, Some(1), true)],
+        };
+        assert!(community_node_consent_has_pending_update(&status));
+    }
+
+    #[test]
+    fn pending_update_false_when_current_version_accepted() {
+        let status = CommunityNodeConsentStatus {
+            all_required_accepted: true,
+            items: vec![consent_item(true, Some(2), true)],
+        };
+        assert!(!community_node_consent_has_pending_update(&status));
+    }
+
+    #[test]
+    fn pending_update_ignores_optional_policies() {
+        // optional ポリシーの更新は接続 gate に影響しないため pending update としない。
+        let status = CommunityNodeConsentStatus {
+            all_required_accepted: true,
+            items: vec![consent_item(false, Some(1), false)],
+        };
+        assert!(!community_node_consent_has_pending_update(&status));
+    }
 }

--- a/crates/desktop-runtime/src/community_node/requests_support.rs
+++ b/crates/desktop-runtime/src/community_node/requests_support.rs
@@ -681,7 +681,7 @@ impl DesktopRuntime {
                 self.set_community_node_cached_consent(base_url, Some(consent_status.clone()))
                     .await;
                 if !consent_status.all_required_accepted {
-                    if !auto_approve {
+                    if !auto_approve || community_node_consent_has_pending_update(&consent_status) {
                         self.set_community_node_session_phase(
                             base_url,
                             CommunityNodeSessionPhase::Idle,
@@ -709,6 +709,21 @@ impl DesktopRuntime {
                 .map_err(CommunityNodeRequestError::into_anyhow)
             }
             Err(CommunityNodeRequestError::ConsentRequired) if auto_approve => {
+                // 版が上がっての再同意（更新）かどうかを判定するため、現在の consent 状態を取得する。
+                // 更新が含まれる場合は auto_approve でも黙って再受諾せず、ユーザーへ本文を再提示する。
+                let consent_status = self
+                    .fetch_community_node_consent_status_with_retry(base_url, token, false)
+                    .await?;
+                self.set_community_node_cached_consent(base_url, Some(consent_status.clone()))
+                    .await;
+                if community_node_consent_has_pending_update(&consent_status) {
+                    self.set_community_node_session_phase(
+                        base_url,
+                        CommunityNodeSessionPhase::Idle,
+                    )
+                    .await;
+                    return Ok(());
+                }
                 self.set_community_node_session_phase(
                     base_url,
                     CommunityNodeSessionPhase::Accepting,

--- a/crates/desktop-runtime/src/community_node/session_runtime_support.rs
+++ b/crates/desktop-runtime/src/community_node/session_runtime_support.rs
@@ -83,7 +83,7 @@ impl DesktopRuntime {
         self.set_community_node_cached_consent(base_url.as_str(), Some(consent_status.clone()))
             .await;
         if !consent_status.all_required_accepted {
-            if !auto_approve {
+            if !auto_approve || community_node_consent_has_pending_update(&consent_status) {
                 self.clear_community_node_retry_state(base_url.as_str())
                     .await;
                 self.set_community_node_session_phase(

--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -125,7 +125,10 @@ impl DesktopRuntime {
             .await?;
         self.set_community_node_cached_consent(base_url.as_str(), Some(consent_state.clone()))
             .await;
-        if !consent_state.all_required_accepted && node.auto_approve {
+        if !consent_state.all_required_accepted
+            && node.auto_approve
+            && !community_node_consent_has_pending_update(&consent_state)
+        {
             self.set_community_node_session_phase(
                 base_url.as_str(),
                 CommunityNodeSessionPhase::Accepting,

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -35,11 +35,12 @@ use crate::community_node::{
     CommunityNodeManifestFetch, CommunityNodeNodeConfig, CommunityNodeNodeStatus,
     CommunityNodeReconnectState, CommunityNodeSessionPhase, CommunityNodeTargetRequest,
     SetCommunityNodeConfigRequest, SubmitCommunityNodeReportRequest,
-    SubmitCommunityNodeReportResult, community_node_seed_peers,
-    default_preview_community_node_config, effective_seed_peer_apply_state,
-    load_community_node_config_from_file, load_community_node_token,
-    normalize_community_node_config, relay_config_from_community_node_config,
-    runtime_connectivity_assist_state, save_community_node_config,
+    SubmitCommunityNodeReportResult, community_node_consent_has_pending_update,
+    community_node_seed_peers, default_preview_community_node_config,
+    effective_seed_peer_apply_state, load_community_node_config_from_file,
+    load_community_node_token, normalize_community_node_config,
+    relay_config_from_community_node_config, runtime_connectivity_assist_state,
+    save_community_node_config,
 };
 use crate::discovery::{
     DiscoveryConfig, SetDiscoverySeedsRequest, parse_seed_entries,

--- a/crates/desktop-runtime/src/tests/community_node/session.rs
+++ b/crates/desktop-runtime/src/tests/community_node/session.rs
@@ -33,6 +33,7 @@ async fn auto_approve_node_bootstraps_session_on_status_refresh() {
         consent_accept_hits: Arc::new(AtomicUsize::new(0)),
         heartbeat_hits: Arc::new(AtomicUsize::new(0)),
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
+        simulate_pending_update: Arc::new(AtomicBool::new(false)),
     });
     let app = Router::new()
         .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
@@ -131,6 +132,7 @@ async fn near_expiry_token_triggers_proactive_community_node_reauthentication() 
         consent_accept_hits: Arc::new(AtomicUsize::new(0)),
         heartbeat_hits: Arc::new(AtomicUsize::new(0)),
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
+        simulate_pending_update: Arc::new(AtomicBool::new(false)),
     });
     let app = Router::new()
         .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
@@ -225,6 +227,7 @@ async fn consent_required_node_without_auto_approve_stays_pending() {
         consent_accept_hits: Arc::new(AtomicUsize::new(0)),
         heartbeat_hits: Arc::new(AtomicUsize::new(0)),
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
+        simulate_pending_update: Arc::new(AtomicBool::new(false)),
     });
     let app = Router::new()
         .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
@@ -340,8 +343,10 @@ async fn community_node_status_does_not_require_restart_when_connectivity_is_act
                     policy_slug: "community-basic".to_string(),
                     policy_version: 1,
                     title: "Community Basic".to_string(),
+                    body: "Community basic policy body.".to_string(),
                     required: true,
                     accepted_at: Some(Utc::now().timestamp()),
+                    previously_accepted_version: Some(1),
                 }],
             }),
             None,
@@ -371,4 +376,112 @@ async fn community_node_status_does_not_require_restart_when_connectivity_is_act
     timeout(test_timeout, runtime.shutdown())
         .await
         .expect("runtime shutdown timeout");
+}
+
+#[tokio::test]
+async fn auto_approve_node_does_not_silently_reaccept_policy_update() {
+    // #384: auto_approve でも、版が上がった「更新」のときは黙って再受諾せず Idle に留める。
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-auto-approve-update.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let state = Arc::new(MockManagedCommunityNodeState {
+        base_url: base_url.clone(),
+        seed_peers: vec![],
+        consent_accepted: Arc::new(AtomicBool::new(false)),
+        current_token: Arc::new(Mutex::new("update-pending-token".into())),
+        challenge_hits: Arc::new(AtomicUsize::new(0)),
+        verify_hits: Arc::new(AtomicUsize::new(0)),
+        consent_status_hits: Arc::new(AtomicUsize::new(0)),
+        consent_accept_hits: Arc::new(AtomicUsize::new(0)),
+        heartbeat_hits: Arc::new(AtomicUsize::new(0)),
+        bootstrap_hits: Arc::new(AtomicUsize::new(0)),
+        simulate_pending_update: Arc::new(AtomicBool::new(true)),
+    });
+    let app = Router::new()
+        .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
+        .route("/v1/auth/verify", post(mock_managed_auth_verify))
+        .route("/v1/consents/status", get(mock_managed_consent_status))
+        .route("/v1/consents", post(mock_managed_accept_consents))
+        .route(
+            "/v1/bootstrap/heartbeat",
+            post(mock_managed_bootstrap_heartbeat),
+        )
+        .route("/v1/bootstrap/nodes", get(mock_managed_bootstrap_nodes))
+        .with_state(state.clone());
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    persist_community_node_token(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        base_url.as_str(),
+        &StoredCommunityNodeToken {
+            access_token: "update-pending-token".into(),
+            expires_at: Utc::now().timestamp() + 3600,
+        },
+    )
+    .expect("persist token");
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.clone(),
+            auto_approve: true,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
+                    .expect("resolved urls"),
+            ),
+        }],
+    };
+
+    let statuses = runtime
+        .get_community_node_statuses()
+        .await
+        .expect("community node statuses");
+    // 更新時は auto 受諾しない。
+    assert_eq!(state.consent_status_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(state.consent_accept_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.bootstrap_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        statuses[0].session_phase,
+        crate::CommunityNodeSessionPhase::Idle
+    );
+    let consent_state = statuses[0].consent_state.as_ref().expect("consent state");
+    assert!(!consent_state.all_required_accepted);
+    // 更新（旧版同意済み・現行版未同意）が client に見えている。
+    let item = &consent_state.items[0];
+    assert!(item.accepted_at.is_none());
+    assert_eq!(item.previously_accepted_version, Some(1));
+
+    // ユーザーが明示的に受諾すれば ready になる。
+    let accepted = runtime
+        .accept_community_node_consents(crate::AcceptCommunityNodeConsentsRequest {
+            base_url: base_url.clone(),
+            policy_slugs: vec![],
+        })
+        .await
+        .expect("accept consents");
+    assert!(
+        accepted
+            .consent_state
+            .as_ref()
+            .expect("consent state")
+            .all_required_accepted
+    );
+    assert_eq!(state.consent_accept_hits.load(Ordering::SeqCst), 1);
+
+    runtime.shutdown().await;
+    server.abort();
 }

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -1780,17 +1780,36 @@ struct MockManagedCommunityNodeState {
     consent_accept_hits: Arc<AtomicUsize>,
     heartbeat_hits: Arc<AtomicUsize>,
     bootstrap_hits: Arc<AtomicUsize>,
+    // true の場合、未同意状態を「版が上がった更新（旧版は同意済み）」として返す。
+    // auto_approve でも黙って再受諾せずユーザーへ提示する挙動の検証に使う（#384）。
+    simulate_pending_update: Arc<AtomicBool>,
 }
 
 fn managed_community_node_consent_status(accepted: bool) -> CommunityNodeConsentStatus {
+    managed_community_node_consent_status_with_update(accepted, false)
+}
+
+fn managed_community_node_consent_status_with_update(
+    accepted: bool,
+    pending_update: bool,
+) -> CommunityNodeConsentStatus {
+    // 未同意でも「更新（pending_update=true）」のときは過去版の同意を示す previously_accepted_version
+    // を返し、初回未同意（previously_accepted_version=None）と区別できるようにする。
+    let previously_accepted_version = if accepted || pending_update {
+        Some(1)
+    } else {
+        None
+    };
     CommunityNodeConsentStatus {
         all_required_accepted: accepted,
         items: vec![kukuri_cn_core::CommunityNodeConsentItem {
             policy_slug: "builder-preview".into(),
-            policy_version: 1,
+            policy_version: if pending_update { 2 } else { 1 },
             title: "Builder Preview".into(),
+            body: "Builder preview policy body.".into(),
             required: true,
             accepted_at: accepted.then(|| Utc::now().timestamp()),
+            previously_accepted_version,
         }],
     }
 }
@@ -1848,8 +1867,10 @@ async fn mock_managed_consent_status(
 ) -> std::result::Result<Json<CommunityNodeConsentStatus>, StatusCode> {
     authorize_managed_community_node_request(&headers, state.as_ref()).await?;
     state.consent_status_hits.fetch_add(1, Ordering::SeqCst);
-    Ok(Json(managed_community_node_consent_status(
-        state.consent_accepted.load(Ordering::SeqCst),
+    let accepted = state.consent_accepted.load(Ordering::SeqCst);
+    Ok(Json(managed_community_node_consent_status_with_update(
+        accepted,
+        !accepted && state.simulate_pending_update.load(Ordering::SeqCst),
     )))
 }
 


### PR DESCRIPTION
## Summary
- Add community-node policy body and previous consent version to consent status responses.
- Stop auto-approve from silently re-accepting required policy version updates; users must review and accept updates in settings.
- Add a settings consent dialog with policy body/version/accepted-at display and i18n, mocks, stories, and tests.

Closes #384

## Validation
- cargo xtask check
- cargo xtask cn-check
- cargo test -p kukuri-cn-core
- cargo test -p kukuri-cn-user-api --no-run
- cargo test -p kukuri-desktop-runtime --lib community_node
- cargo test -p kukuri-desktop-runtime --lib community_node::tests
- cd apps/desktop && npx pnpm@10.16.1 test