### PR TITLE
feat(cn): add safety domain model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,6 +2972,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kukuri-cn-safety"
+version = "0.1.2"
+dependencies = [
+ "async-trait",
+ "kukuri-cn-safety",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "kukuri-cn-user-api"
 version = "0.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/cn-iroh-relay",
     "crates/cn-cli",
     "crates/cn-operator",
+    "crates/cn-safety",
 ]
 exclude = [
     "apps/desktop/src-tauri",

--- a/crates/cn-safety/Cargo.toml
+++ b/crates/cn-safety/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "kukuri-cn-safety"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "kukuri_cn_safety"
+path = "src/lib.rs"
+
+[features]
+# deterministic な mock provider / signer。production の既定 API には含めない
+# （非暗号の MockSigner を本番経路で誤用させないため）。テストでは下の self
+# dev-dependency が有効化する。
+mock = []
+
+[dependencies]
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+# 自分自身を mock feature 付きで dev-dependency にすることで、tests/ から mock を使える
+# （feature unification によりテストビルド時のみ mock が有効になる）。
+kukuri-cn-safety = { path = ".", features = ["mock"] }
+tokio.workspace = true

--- a/crates/cn-safety/src/capability.rs
+++ b/crates/cn-safety/src/capability.rs
@@ -1,0 +1,62 @@
+//! safety / moderation provider の capability モデル（#353）。
+//!
+//! provider は単一の boolean ではなく capability として扱う。これにより、known CSAM hash
+//! matching のみを行う provider と、unknown CSAM classifier / 一般 moderation を行う provider を
+//! 役割で区別できる。public-node の readiness（後続段階）は「known CSAM hash match capability を
+//! 持つ provider が設定されているか」を capability 単位で検査できる。
+
+use serde::{Deserialize, Serialize};
+
+/// safety / moderation provider が提供し得る capability。
+///
+/// `docs/safety/community-node-critical-safety.md` の provider capability 例と、
+/// Issue #353 の `SafetyProviderCapability` に対応する。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SafetyProviderCapability {
+    /// 既知 CSAM の hash 一致（confirmed 判定の根拠になり得る）。
+    KnownCsamHashMatch,
+    /// 知覚ハッシュ（perceptual hash）一致。
+    PerceptualHashMatch,
+    /// 未知 CSAM 画像の classifier（suspected 判定）。
+    NovelCsamImageClassifier,
+    /// 未知 CSAM 動画の classifier（suspected 判定）。
+    NovelCsamVideoClassifier,
+    /// CSE（child sexual exploitation）テキスト classifier。
+    CseTextClassifier,
+    /// grooming テキスト classifier。
+    GroomingTextClassifier,
+    /// 一般メディア moderation（nsfw / violence 等）。
+    GeneralMediaModeration,
+    /// spam / abuse moderation。
+    SpamAbuseModeration,
+    /// malware / phishing 検出。
+    MalwarePhishingDetection,
+    /// 通報ワークフロー連携。
+    ReportingWorkflow,
+}
+
+impl SafetyProviderCapability {
+    /// この capability が critical safety（CSAM / CSE）に直接関与するか。
+    ///
+    /// general moderation route（nsfw / spam / malware 等）と critical route を
+    /// 取り違えないための補助。route の最終判定は policy router が行う。
+    pub fn is_critical_safety(self) -> bool {
+        matches!(
+            self,
+            SafetyProviderCapability::KnownCsamHashMatch
+                | SafetyProviderCapability::PerceptualHashMatch
+                | SafetyProviderCapability::NovelCsamImageClassifier
+                | SafetyProviderCapability::NovelCsamVideoClassifier
+                | SafetyProviderCapability::CseTextClassifier
+                | SafetyProviderCapability::GroomingTextClassifier
+        )
+    }
+
+    /// この capability が「既知 CSAM の confirmed 判定」を生み得るか。
+    ///
+    /// known hash match のみ confirmed の根拠になり、classifier 系は suspected に留める。
+    pub fn can_confirm_known_csam(self) -> bool {
+        matches!(self, SafetyProviderCapability::KnownCsamHashMatch)
+    }
+}

--- a/crates/cn-safety/src/event.rs
+++ b/crates/cn-safety/src/event.rs
@@ -1,0 +1,91 @@
+//! signed moderation event（#353 / moderation-event-trust-semantics）。
+//!
+//! 危険判定・index 除外・quarantine は signed moderation event として記録する。
+//! event は issuer node によって署名され、その効果は issuer node の authority scope に限定される。
+//! network-wide command ではない（`docs/architecture/moderation-event-trust-semantics.md`）。
+//!
+//! 署名対象（canonical body）と署名を分離する。
+//! - [`ModerationEventBody`] — 未署名の canonical 本体。`canonical_bytes()` で決定論的な
+//!   バイト列を得る。
+//! - [`SignedModerationEvent`] — body と signature の組。
+//! - [`ModerationEventSigner`] — 署名抽象。実鍵署名（secp256k1）は後続段階で実装する。
+//!
+//! 本 crate には mock signer のみを置き、production credentials に依存しない。
+
+use serde::{Deserialize, Serialize};
+
+use crate::provider::SubjectKind;
+use crate::verdict::{Basis, ModerationAction, ReasonCode, SafetyLabel, Severity, Visibility};
+
+/// 未署名の moderation event 本体（署名対象の canonical 表現）。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ModerationEventBody {
+    /// event ID（呼び出し側が採番する）。
+    pub id: String,
+    /// 発行・署名した node の ID。
+    pub issuer_node_id: String,
+    pub target_type: SubjectKind,
+    pub target_id: String,
+    pub action: ModerationAction,
+    #[serde(default)]
+    pub labels: Vec<SafetyLabel>,
+    pub reason_code: ReasonCode,
+    pub severity: Severity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<u8>,
+    pub basis: Basis,
+    pub visibility: Visibility,
+    pub policy_version: String,
+    /// 作成時刻（RFC3339）。この crate は時計を持たず、呼び出し側が与える。
+    pub created_at: String,
+}
+
+impl ModerationEventBody {
+    /// 署名対象の決定論的バイト列を返す。
+    ///
+    /// 同一の論理内容に対して常に同じバイト列を返す。フィールド順序が固定された struct を
+    /// `serde_json` で文字列化する（`serde_json` は struct を宣言順でシリアライズし、map を
+    /// 使わないため出力は決定論的）。crate 内テストで安定性を固定する。
+    ///
+    /// 注意: 本実装は同一バージョンでの決定性を担保する。クロス実装で厳密に一致させる
+    /// canonical 形式（フィールドのソート / 正規化）が必要になった段階で、実鍵署名導入
+    /// （後続）と合わせて強化する。
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        self.canonical_json().into_bytes()
+    }
+
+    /// 署名対象の決定論的 JSON 文字列。
+    pub fn canonical_json(&self) -> String {
+        serde_json::to_string(self).expect("moderation event body serializes to JSON")
+    }
+}
+
+/// 署名済み moderation event。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SignedModerationEvent {
+    pub body: ModerationEventBody,
+    /// issuer node による署名（表現は signer 実装に依存する文字列）。
+    pub signature: String,
+}
+
+/// moderation event の署名抽象。
+///
+/// 実鍵署名（secp256k1）は後続段階で実装する。本 crate は決定論的な mock signer のみ提供する。
+pub trait ModerationEventSigner {
+    /// 署名者（issuer）の node ID。
+    fn issuer_node_id(&self) -> &str;
+
+    /// canonical body に対する署名文字列を返す。
+    fn sign(&self, body: &ModerationEventBody) -> String;
+}
+
+/// body に署名して [`SignedModerationEvent`] を作る。
+pub fn issue_signed_event(
+    body: ModerationEventBody,
+    signer: &dyn ModerationEventSigner,
+) -> SignedModerationEvent {
+    let signature = signer.sign(&body);
+    SignedModerationEvent { body, signature }
+}

--- a/crates/cn-safety/src/lib.rs
+++ b/crates/cn-safety/src/lib.rs
@@ -1,0 +1,54 @@
+//! kukuri community node 向け CSAM / critical safety moderation の **pure domain 層**（#353 段階2）。
+//!
+//! この crate は DB / network / production provider credentials に依存しない。
+//! safety domain model・provider abstraction・mock provider・policy router を提供し、
+//! deterministic な単体テストで verdict 分岐と fail-closed 挙動を固定する。
+//!
+//! 設計の真実源:
+//! - `docs/safety/community-node-critical-safety.md`
+//!   - §7 verdict model and routing（action と label の分離、`csam_confirmed` と `csam_suspected` の区別）
+//!   - §8 fail-closed invariants（unscanned / scan failure / provider unavailable を allow にしない）
+//!   - §12 implementation prerequisites（provider abstraction / mock provider / policy routing）
+//! - `docs/architecture/moderation-event-trust-semantics.md`
+//!   - moderation event / risk signal は issuer node の authority scope 内の advisory であり
+//!     network-wide command ではない。visibility は local / subscribed_nodes / public の3段階で、
+//!     suspected unknown CSAM / CSE は既定 `local`。
+//!
+//! スコープ境界（本 crate に含まないもの）:
+//! - public-node readiness check / `safety` CLI（段階3）
+//! - 本番 provider 接続（#391 Project Arachnid Shield 等）
+//! - fail-closed indexing 本体（search / discovery / recommendation 除外の DB 制約）
+//! - moderation event の実鍵署名（secp256k1）と P2P 配布
+//!
+//! serde 表現は既存 community-node crate（`cn-core` / `desktop-runtime`）に合わせて
+//! すべて `snake_case`。client（TS）向けの wire 変換が必要になった段階で別途変換層を入れる。
+
+pub mod capability;
+pub mod event;
+pub mod policy;
+pub mod provider;
+pub mod signal;
+pub mod verdict;
+
+/// deterministic な mock provider / signer。`mock` feature でのみ有効。
+///
+/// `MockSigner` は非暗号（FNV-1a）であり本番経路で署名として誤用しないよう、production の
+/// 既定 API には含めない。テスト / 開発では `mock` feature を有効にして使う。
+#[cfg(feature = "mock")]
+pub mod mock;
+
+pub use capability::SafetyProviderCapability;
+pub use event::{
+    ModerationEventBody, ModerationEventSigner, SignedModerationEvent, issue_signed_event,
+};
+#[cfg(feature = "mock")]
+pub use mock::{MockSafetyProvider, MockSigner};
+pub use policy::{SafetyPolicy, route};
+pub use provider::{
+    ProviderScanRequest, ProviderScanResult, SafetyProvider, ScanError, ScanOutcome, SubjectKind,
+};
+pub use signal::{AppealStatus, RiskSignalTarget, SafetyRiskSignal};
+pub use verdict::{
+    Basis, ModerationAction, ReasonCode, SafetyAction, SafetyCategory, SafetyLabel, SafetyVerdict,
+    Severity, Visibility,
+};

--- a/crates/cn-safety/src/mock.rs
+++ b/crates/cn-safety/src/mock.rs
@@ -1,0 +1,239 @@
+//! deterministic な mock 実装（#353）。
+//!
+//! production provider / credentials に依存せず、policy router と fail-closed 挙動を
+//! 決定論的にテストするための mock。
+//!
+//! - [`MockSafetyProvider`] — subject_id ごとに返す scan 結果を事前設定できる provider。
+//! - [`MockSigner`] — canonical body の決定論的ハッシュを署名として返す signer。実鍵（secp256k1）は
+//!   使わない。
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use crate::capability::SafetyProviderCapability;
+use crate::event::{ModerationEventBody, ModerationEventSigner};
+use crate::provider::{
+    ProviderScanRequest, ProviderScanResult, SafetyProvider, ScanError, ScanOutcome,
+};
+use crate::verdict::SafetyLabel;
+
+/// subject_id ごとに決定論的な結果を返す mock provider。
+///
+/// 設定が無い subject_id に対しては既定の振る舞い（`default_outcome`）を返す。
+#[derive(Clone, Debug)]
+pub struct MockSafetyProvider {
+    name: String,
+    capabilities: Vec<SafetyProviderCapability>,
+    results: HashMap<String, ProviderScanResult>,
+    /// 設定外 subject に対する既定の outcome。fail-closed テストのため `Unavailable` 等も選べる。
+    default_outcome: DefaultOutcome,
+}
+
+#[derive(Clone, Debug)]
+enum DefaultOutcome {
+    /// 既知一致なし（safe ではない）。
+    NoKnownMatch,
+    /// scan 失敗。
+    Failed,
+    /// provider 利用不可。
+    Unavailable,
+    /// 呼び出し自体をエラーにする。
+    Error(ScanError),
+}
+
+impl MockSafetyProvider {
+    /// known CSAM hash match provider の mock。既定は「一致なし」。
+    pub fn known_csam(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            capabilities: vec![SafetyProviderCapability::KnownCsamHashMatch],
+            results: HashMap::new(),
+            default_outcome: DefaultOutcome::NoKnownMatch,
+        }
+    }
+
+    /// 任意 capability の mock。既定は「一致なし」。
+    pub fn with_capabilities(
+        name: impl Into<String>,
+        capabilities: Vec<SafetyProviderCapability>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            capabilities,
+            results: HashMap::new(),
+            default_outcome: DefaultOutcome::NoKnownMatch,
+        }
+    }
+
+    /// 設定外 subject を「scan 失敗」にする（fail-closed テスト用）。
+    pub fn default_failed(mut self) -> Self {
+        self.default_outcome = DefaultOutcome::Failed;
+        self
+    }
+
+    /// 設定外 subject を「provider 利用不可」にする（fail-closed テスト用）。
+    pub fn default_unavailable(mut self) -> Self {
+        self.default_outcome = DefaultOutcome::Unavailable;
+        self
+    }
+
+    /// 設定外 subject で `scan` 自体をエラーにする（呼び出し側の fail-closed 写像テスト用）。
+    pub fn default_error(mut self, error: ScanError) -> Self {
+        self.default_outcome = DefaultOutcome::Error(error);
+        self
+    }
+
+    /// subject_id を既知 CSAM hash 一致にする。
+    pub fn with_known_hash_match(mut self, subject_id: impl Into<String>) -> Self {
+        let capability = self
+            .capabilities
+            .first()
+            .copied()
+            .unwrap_or(SafetyProviderCapability::KnownCsamHashMatch);
+        let result = ProviderScanResult {
+            provider: self.name.clone(),
+            capability,
+            outcome: ScanOutcome::Completed,
+            known_hash_match: true,
+            score: None,
+            labels: vec![
+                SafetyLabel::new(crate::verdict::SafetyCategory::Csam)
+                    .with_provider_capability(capability),
+            ],
+        };
+        self.results.insert(subject_id.into(), result);
+        self
+    }
+
+    /// subject_id に classifier スコアを与える（suspected 判定の入力）。
+    pub fn with_score(
+        mut self,
+        subject_id: impl Into<String>,
+        capability: SafetyProviderCapability,
+        category: crate::verdict::SafetyCategory,
+        score: u8,
+    ) -> Self {
+        let result = ProviderScanResult {
+            provider: self.name.clone(),
+            capability,
+            outcome: ScanOutcome::Completed,
+            known_hash_match: false,
+            score: Some(score),
+            labels: vec![
+                SafetyLabel::new(category)
+                    .with_confidence(score)
+                    .with_provider_capability(capability),
+            ],
+        };
+        self.results.insert(subject_id.into(), result);
+        self
+    }
+
+    /// subject_id を明示的に scan 失敗にする。
+    pub fn with_failure(mut self, subject_id: impl Into<String>) -> Self {
+        let capability = self
+            .capabilities
+            .first()
+            .copied()
+            .unwrap_or(SafetyProviderCapability::KnownCsamHashMatch);
+        let result = ProviderScanResult {
+            provider: self.name.clone(),
+            capability,
+            outcome: ScanOutcome::Failed,
+            known_hash_match: false,
+            score: None,
+            labels: Vec::new(),
+        };
+        self.results.insert(subject_id.into(), result);
+        self
+    }
+
+    /// subject_id を「既知一致なし（completed だが NoKnownMatch）」にする。
+    pub fn with_no_known_match(mut self, subject_id: impl Into<String>) -> Self {
+        let capability = self
+            .capabilities
+            .first()
+            .copied()
+            .unwrap_or(SafetyProviderCapability::KnownCsamHashMatch);
+        let mut result = ProviderScanResult::completed(self.name.clone(), capability);
+        result.outcome = ScanOutcome::NoKnownMatch;
+        self.results.insert(subject_id.into(), result);
+        self
+    }
+
+    fn default_result(&self) -> Result<ProviderScanResult, ScanError> {
+        let capability = self
+            .capabilities
+            .first()
+            .copied()
+            .unwrap_or(SafetyProviderCapability::KnownCsamHashMatch);
+        let outcome = match &self.default_outcome {
+            DefaultOutcome::NoKnownMatch => ScanOutcome::NoKnownMatch,
+            DefaultOutcome::Failed => ScanOutcome::Failed,
+            DefaultOutcome::Unavailable => ScanOutcome::Unavailable,
+            DefaultOutcome::Error(err) => return Err(err.clone()),
+        };
+        let mut result = ProviderScanResult::completed(self.name.clone(), capability);
+        result.outcome = outcome;
+        Ok(result)
+    }
+}
+
+#[async_trait]
+impl SafetyProvider for MockSafetyProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn capabilities(&self) -> &[SafetyProviderCapability] {
+        &self.capabilities
+    }
+
+    async fn scan(&self, request: &ProviderScanRequest) -> Result<ProviderScanResult, ScanError> {
+        match request.subject_id.as_deref() {
+            Some(id) => match self.results.get(id) {
+                Some(result) => Ok(result.clone()),
+                None => self.default_result(),
+            },
+            None => self.default_result(),
+        }
+    }
+}
+
+/// 決定論的な mock signer。canonical body の安定ハッシュを署名として返す。
+///
+/// 実鍵署名（secp256k1）ではない。署名の決定性のみを保証する。
+#[derive(Clone, Debug)]
+pub struct MockSigner {
+    issuer_node_id: String,
+}
+
+impl MockSigner {
+    pub fn new(issuer_node_id: impl Into<String>) -> Self {
+        Self {
+            issuer_node_id: issuer_node_id.into(),
+        }
+    }
+}
+
+impl ModerationEventSigner for MockSigner {
+    fn issuer_node_id(&self) -> &str {
+        &self.issuer_node_id
+    }
+
+    fn sign(&self, body: &ModerationEventBody) -> String {
+        let digest = fnv1a_64(&body.canonical_bytes());
+        format!("mock:{}:{:016x}", self.issuer_node_id, digest)
+    }
+}
+
+/// 依存を増やさない決定論的な 64bit ハッシュ（FNV-1a）。暗号学的強度は無く、mock 署名専用。
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}

--- a/crates/cn-safety/src/policy.rs
+++ b/crates/cn-safety/src/policy.rs
@@ -1,0 +1,321 @@
+//! policy router（#353）。provider の scan 結果群から最終 verdict を決める純関数。
+//!
+//! `docs/safety/community-node-critical-safety.md` §7 / §8 に従い:
+//! - 既知 CSAM hash match → `exclude`（critical / confirmed）
+//! - 未知 CSAM / CSE 疑い（classifier score >= threshold）→ `hold` / `quarantine`（critical / suspected）
+//! - 一般 moderation（nsfw / spam / malware / phishing）→ critical とは別 route
+//! - scan failure / provider unavailable / unscanned → fail-closed（`allow` にしない）
+//! - 既知一致なし（`NoKnownMatch`）→ safe と断定しない（`reason_code = NoKnownMatch`）
+//!
+//! この関数は時計・I/O・乱数を持たない。`scanned_at` は呼び出し側が与える。
+
+use serde::{Deserialize, Serialize};
+
+use crate::capability::SafetyProviderCapability;
+use crate::provider::{ProviderScanResult, ScanOutcome};
+use crate::verdict::{Basis, ReasonCode, SafetyAction, SafetyCategory, SafetyLabel, SafetyVerdict};
+
+/// router の挙動を決める policy。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SafetyPolicy {
+    pub policy_version: String,
+    /// scan 前 index を許すか（public-node では false 固定）。
+    pub index_before_scan: bool,
+    /// scan failure / provider unavailable / unscanned 時の action（fail-closed）。`Allow` にしない。
+    pub on_scan_error: SafetyAction,
+    /// 未知 CSAM / CSE 疑いの classifier スコア閾値（0-100）。
+    pub unknown_csam_score_threshold: u8,
+    /// 未知 CSAM / CSE 疑いに対する action（`Hold` または `Quarantine`）。
+    pub suspected_critical_action: SafetyAction,
+    /// 一般 nsfw（高信頼）に対する action。
+    pub on_high_confidence_nsfw: SafetyAction,
+    /// spam に対する action。
+    pub on_spam: SafetyAction,
+    /// malware / phishing に対する action。
+    pub on_malware_phishing: SafetyAction,
+    /// public-node が known CSAM provider を必須とするか（readiness で使う。router では参照のみ）。
+    pub require_known_csam: bool,
+}
+
+impl SafetyPolicy {
+    /// public community node の最小既定（fail-closed 寄り）。
+    pub fn public_node_default() -> Self {
+        Self {
+            policy_version: "2026-06-public-node-v1".to_string(),
+            index_before_scan: false,
+            on_scan_error: SafetyAction::Hold,
+            unknown_csam_score_threshold: 80,
+            suspected_critical_action: SafetyAction::Quarantine,
+            on_high_confidence_nsfw: SafetyAction::Exclude,
+            on_spam: SafetyAction::Exclude,
+            on_malware_phishing: SafetyAction::Exclude,
+            require_known_csam: true,
+        }
+    }
+
+    fn fail_closed_action(&self) -> SafetyAction {
+        // 万一 policy が `Allow`（indexable）を設定していても fail-closed を保証する。
+        ensure_non_indexing(self.on_scan_error, SafetyAction::Hold)
+    }
+}
+
+/// 設定された action が index を許す（`allows_indexing()`）場合に、必ず非 index の fallback へ倒す。
+///
+/// fail-closed が要求される全経路（scan error / suspected critical / critical 検知の取りこぼし）で
+/// 共通して使い、「configured action が indexable なら採用しない」という不変条件を 1 箇所に集約する。
+fn ensure_non_indexing(action: SafetyAction, fallback: SafetyAction) -> SafetyAction {
+    debug_assert!(
+        !fallback.allows_indexing(),
+        "fail-closed fallback must not allow indexing"
+    );
+    if action.allows_indexing() {
+        fallback
+    } else {
+        action
+    }
+}
+
+/// scan 結果群から最終 verdict を決める。
+///
+/// `scanned_at` は RFC3339 等の時刻文字列を呼び出し側が与える（router は時計を持たない）。
+pub fn route(
+    scan_outcomes: &[ProviderScanResult],
+    policy: &SafetyPolicy,
+    scanned_at: impl Into<String>,
+) -> SafetyVerdict {
+    let scanned_at = scanned_at.into();
+    let base = |action: SafetyAction, reason: ReasonCode, critical: bool| SafetyVerdict {
+        action,
+        labels: Vec::new(),
+        critical,
+        reason_code: reason,
+        confidence: None,
+        provider: None,
+        provider_capability: None,
+        policy_version: policy.policy_version.clone(),
+        scanned_at: scanned_at.clone(),
+    };
+
+    // 1. unscanned: scan 結果が無い → fail-closed（allow にしない）。
+    if scan_outcomes.is_empty() {
+        return base(policy.fail_closed_action(), ReasonCode::Unscanned, false);
+    }
+
+    // 2. known CSAM hash match → exclude（critical / confirmed）。
+    //    他 provider の失敗があっても confirmed を優先する。
+    if let Some(result) = scan_outcomes.iter().find(|r| r.known_hash_match) {
+        let mut verdict = base(SafetyAction::Exclude, ReasonCode::CsamConfirmed, true);
+        verdict.provider = Some(result.provider.clone());
+        verdict.provider_capability = Some(result.capability);
+        verdict.confidence = result.score;
+        verdict.labels = non_empty_labels(result, SafetyCategory::Csam);
+        return verdict;
+    }
+
+    // 3. 未知 CSAM / CSE 疑い（critical な検知 かつ effective score >= threshold）。
+    if let Some(result) = scan_outcomes
+        .iter()
+        .filter(|r| r.outcome == ScanOutcome::Completed && is_critical_detection(r))
+        .find(|r| {
+            effective_critical_score(r).is_some_and(|s| s >= policy.unknown_csam_score_threshold)
+        })
+    {
+        let category = critical_category(result).unwrap_or(SafetyCategory::Csam);
+        let reason = if category == SafetyCategory::Cse {
+            ReasonCode::CseSuspected
+        } else {
+            ReasonCode::CsamSuspected
+        };
+        let mut verdict = base(suspected_action(policy), reason, true);
+        verdict.provider = Some(result.provider.clone());
+        verdict.provider_capability = Some(result.capability);
+        verdict.confidence = effective_critical_score(result);
+        verdict.labels = non_empty_labels(result, category);
+        return verdict;
+    }
+
+    // 4. scan failure / provider unavailable → fail-closed（allow にしない）。
+    if let Some(result) = scan_outcomes.iter().find(|r| r.outcome.is_fail_closed()) {
+        let reason = match result.outcome {
+            ScanOutcome::Unavailable => ReasonCode::ProviderUnavailable,
+            _ => ReasonCode::ScanFailed,
+        };
+        let mut verdict = base(policy.fail_closed_action(), reason, false);
+        verdict.provider = Some(result.provider.clone());
+        verdict.provider_capability = Some(result.capability);
+        return verdict;
+    }
+
+    // 5. critical な検知があるが suspected 閾値に達しなかった / score が無いものを
+    //    Allow に取りこぼさない（fail-closed）。critical safety を safe と断定しない。
+    if let Some(result) = scan_outcomes
+        .iter()
+        .find(|r| r.outcome == ScanOutcome::Completed && is_critical_detection(r))
+    {
+        let category = critical_category(result).unwrap_or(SafetyCategory::Csam);
+        let reason = if category == SafetyCategory::Cse {
+            ReasonCode::CseSuspected
+        } else {
+            ReasonCode::CsamSuspected
+        };
+        let action = ensure_non_indexing(policy.suspected_critical_action, SafetyAction::Hold);
+        let mut verdict = base(action, reason, true);
+        verdict.provider = Some(result.provider.clone());
+        verdict.provider_capability = Some(result.capability);
+        verdict.confidence = effective_critical_score(result);
+        verdict.labels = non_empty_labels(result, category);
+        return verdict;
+    }
+
+    // 6. public-node で必須の known CSAM provider 結果が無いなら fail-closed。
+    //    general moderation が clean / allow を返せても、known CSAM scan 欠落時は index しない。
+    if policy.require_known_csam && !has_known_csam_scan_result(scan_outcomes) {
+        return base(
+            policy.fail_closed_action(),
+            ReasonCode::ProviderUnavailable,
+            false,
+        );
+    }
+
+    // 7. 一般 moderation（critical 以外のラベル）→ critical とは別 route（critical=false）。
+    if let Some((result, category)) = scan_outcomes
+        .iter()
+        .find_map(|r| general_category(r).map(|category| (r, category)))
+    {
+        let action = general_action(policy, category);
+        let mut verdict = base(action, ReasonCode::GeneralModeration, false);
+        verdict.provider = Some(result.provider.clone());
+        verdict.provider_capability = Some(result.capability);
+        verdict.confidence = result.score;
+        verdict.labels = non_empty_labels(result, category);
+        return verdict;
+    }
+
+    // 8. 検知なし。既知一致なし（NoKnownMatch）は safe と断定しない。
+    //    すべて Completed かつラベル無しのときのみ Clean とする。
+    let has_no_known_match = scan_outcomes
+        .iter()
+        .any(|r| r.outcome == ScanOutcome::NoKnownMatch);
+    let reason = if has_no_known_match {
+        ReasonCode::NoKnownMatch
+    } else {
+        ReasonCode::Clean
+    };
+    base(SafetyAction::Allow, reason, false)
+}
+
+/// suspected critical の action（`Allow`（indexable）は採用せず、必ず非 index に倒す）。
+fn suspected_action(policy: &SafetyPolicy) -> SafetyAction {
+    ensure_non_indexing(policy.suspected_critical_action, SafetyAction::Quarantine)
+}
+
+/// result が critical safety（CSAM / CSE / grooming）の検知か。
+///
+/// capability か、いずれかのラベル category のどちらかが critical safety なら true。
+/// score の有無に依存しない（categorical な検知でも取りこぼさないため）。
+fn is_critical_detection(result: &ProviderScanResult) -> bool {
+    result.capability.is_critical_safety()
+        || result
+            .labels
+            .iter()
+            .any(|l| l.category.is_critical_safety())
+}
+
+/// suspected 判定に使う実効スコア。
+///
+/// `result.score` を優先し、無ければ critical category ラベルの最大 confidence を使う。
+/// `score` と label `confidence` が独立フィールドであることによる取りこぼしを防ぐ。
+fn effective_critical_score(result: &ProviderScanResult) -> Option<u8> {
+    result.score.or_else(|| {
+        result
+            .labels
+            .iter()
+            .filter(|l| l.category.is_critical_safety())
+            .filter_map(|l| l.confidence)
+            .max()
+    })
+}
+
+/// reason / category 判定に使う critical category。
+///
+/// まず critical なラベル category を優先し、無ければ capability から導く
+/// （`labels.first()` に依存せず、CSE を CSAM と取り違えない）。
+fn critical_category(result: &ProviderScanResult) -> Option<SafetyCategory> {
+    result
+        .labels
+        .iter()
+        .map(|l| l.category)
+        .find(|c| c.is_critical_safety())
+        .or_else(|| critical_category_for_capability(result.capability))
+}
+
+/// critical capability から代表 category を導く。
+fn critical_category_for_capability(
+    capability: SafetyProviderCapability,
+) -> Option<SafetyCategory> {
+    match capability {
+        SafetyProviderCapability::KnownCsamHashMatch
+        | SafetyProviderCapability::PerceptualHashMatch
+        | SafetyProviderCapability::NovelCsamImageClassifier
+        | SafetyProviderCapability::NovelCsamVideoClassifier => Some(SafetyCategory::Csam),
+        SafetyProviderCapability::CseTextClassifier => Some(SafetyCategory::Cse),
+        SafetyProviderCapability::GroomingTextClassifier => Some(SafetyCategory::Grooming),
+        _ => None,
+    }
+}
+
+/// mandatory known CSAM provider の scan 結果が含まれているか。
+fn has_known_csam_scan_result(scan_outcomes: &[ProviderScanResult]) -> bool {
+    scan_outcomes
+        .iter()
+        .any(|r| r.capability == SafetyProviderCapability::KnownCsamHashMatch)
+}
+
+/// result が一般 moderation（critical 以外）のラベルを持つなら、その代表カテゴリを返す。
+fn general_category(result: &ProviderScanResult) -> Option<SafetyCategory> {
+    if result.outcome != ScanOutcome::Completed {
+        return None;
+    }
+    result
+        .labels
+        .iter()
+        .map(|l| l.category)
+        .find(|c| !c.is_critical_safety())
+}
+
+/// 一般カテゴリに対する action を policy から選ぶ。
+fn general_action(policy: &SafetyPolicy, category: SafetyCategory) -> SafetyAction {
+    match category {
+        SafetyCategory::Spam => policy.on_spam,
+        SafetyCategory::Malware | SafetyCategory::Phishing => policy.on_malware_phishing,
+        // nsfw / その他一般。
+        _ => policy.on_high_confidence_nsfw,
+    }
+}
+
+/// result のラベルを返す。空なら category から最小ラベルを補う。
+fn non_empty_labels(result: &ProviderScanResult, category: SafetyCategory) -> Vec<SafetyLabel> {
+    if result.labels.is_empty() {
+        let mut label = SafetyLabel::new(category).with_provider_capability(result.capability);
+        if let Some(score) = result.score {
+            label = label.with_confidence(score);
+        }
+        vec![label]
+    } else {
+        result.labels.clone()
+    }
+}
+
+// Basis を verdict に直接は載せていない（verdict は reason_code を持つ）。Basis は
+// moderation event / risk signal 側で使う。ここでは router が決めた reason_code から
+// 後段が basis を導出できるよう、対応関係を関数で提供する。
+/// reason_code から対応する基準（basis）を導く補助。
+pub fn basis_for_reason(reason: ReasonCode) -> Basis {
+    match reason {
+        ReasonCode::CsamConfirmed => Basis::KnownHashMatch,
+        ReasonCode::CsamSuspected | ReasonCode::CseSuspected => Basis::ClassifierScore,
+        ReasonCode::GeneralModeration => Basis::ProviderVerdict,
+        _ => Basis::LocalPolicy,
+    }
+}

--- a/crates/cn-safety/src/provider.rs
+++ b/crates/cn-safety/src/provider.rs
@@ -1,0 +1,156 @@
+//! provider abstraction（#353）。
+//!
+//! moderation server は provider credentials を保持し、必要に応じて blob を一時 fetch して
+//! scan provider を実行する。この crate はその abstraction（trait）と、provider が返す
+//! scan 結果の型のみを定義する。実際の I/O・credentials・本番 provider（#391）はこの trait の
+//! 実装として後続段階で追加する。
+//!
+//! trait は async。本番 provider は HTTP API を叩くため本質的に async であり、mock も async で
+//! 実装することで trait を変えずに差し替えられる。
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::capability::SafetyProviderCapability;
+use crate::verdict::SafetyLabel;
+
+/// scan 対象の種別。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectKind {
+    Post,
+    Blob,
+    User,
+    Peer,
+}
+
+/// provider への scan 要求。
+///
+/// 生コンテンツそのものではなく、provider が必要とする最小の参照（hash / CID / text）を渡す。
+/// community node は blob 本体を恒久保存しない前提のため、media は参照（hint）で表す。
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ProviderScanRequest {
+    pub subject_kind: Option<SubjectKind>,
+    /// 対象の識別子（post id / blob CID / pubkey / node id 等）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_id: Option<String>,
+    /// メディアの参照ヒント（hash / CID 等）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media_hint: Option<String>,
+    /// テキスト本文（text moderation / grooming classifier 用）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+
+impl ProviderScanRequest {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn for_subject(kind: SubjectKind, subject_id: impl Into<String>) -> Self {
+        Self {
+            subject_kind: Some(kind),
+            subject_id: Some(subject_id.into()),
+            media_hint: None,
+            text: None,
+        }
+    }
+
+    pub fn with_media_hint(mut self, media_hint: impl Into<String>) -> Self {
+        self.media_hint = Some(media_hint.into());
+        self
+    }
+
+    pub fn with_text(mut self, text: impl Into<String>) -> Self {
+        self.text = Some(text.into());
+        self
+    }
+}
+
+/// scan の完了状態。policy router の fail-closed 判定の入力になる。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScanOutcome {
+    /// scan が完了し、何らかの検知結果（labels / hash match / score）がある。
+    Completed,
+    /// scan は完了したが、この provider の既知データには一致しなかった。
+    ///
+    /// **safe / clean の証明ではない**（その provider の検査範囲で一致しなかっただけ）。
+    NoKnownMatch,
+    /// scan が失敗した（fail-closed の対象）。
+    Failed,
+    /// provider が利用不可だった（fail-closed の対象）。
+    Unavailable,
+}
+
+impl ScanOutcome {
+    /// この結果が fail-closed の対象か（scan failure / provider unavailable）。
+    pub fn is_fail_closed(self) -> bool {
+        matches!(self, ScanOutcome::Failed | ScanOutcome::Unavailable)
+    }
+}
+
+/// provider 1 つの scan 結果。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ProviderScanResult {
+    /// provider 名（verdict の `provider` フィールドに反映され得る）。
+    pub provider: String,
+    /// この結果を生んだ capability。
+    pub capability: SafetyProviderCapability,
+    pub outcome: ScanOutcome,
+    /// 既知 hash 一致（confirmed の根拠）。
+    #[serde(default)]
+    pub known_hash_match: bool,
+    /// classifier スコア（0-100。suspected 判定に使う）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub score: Option<u8>,
+    /// 検知ラベル。
+    #[serde(default)]
+    pub labels: Vec<SafetyLabel>,
+}
+
+impl ProviderScanResult {
+    /// completed かつ何も検知していない素の結果。
+    pub fn completed(provider: impl Into<String>, capability: SafetyProviderCapability) -> Self {
+        Self {
+            provider: provider.into(),
+            capability,
+            outcome: ScanOutcome::Completed,
+            known_hash_match: false,
+            score: None,
+            labels: Vec::new(),
+        }
+    }
+}
+
+/// provider 呼び出しのエラー。
+///
+/// 呼び出し側（moderation server / policy 適用層）は、このエラーを `ScanOutcome::Failed` /
+/// `Unavailable` の結果へ写像し、fail-closed に倒す。allow へ落とさない。
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum ScanError {
+    #[error("safety provider unavailable: {0}")]
+    Unavailable(String),
+    #[error("safety provider timed out: {0}")]
+    Timeout(String),
+    #[error("safety provider protocol error: {0}")]
+    Protocol(String),
+}
+
+/// safety / moderation provider の抽象。
+///
+/// 実装例: mock provider（本 crate）、#391 Project Arachnid Shield、一般 moderation provider。
+#[async_trait]
+pub trait SafetyProvider: Send + Sync {
+    /// provider 名（安定識別子）。
+    fn name(&self) -> &str;
+
+    /// この provider が提供する capability。
+    fn capabilities(&self) -> &[SafetyProviderCapability];
+
+    /// 対象を scan する。I/O 失敗は `ScanError` で返し、呼び出し側が fail-closed に写像する。
+    async fn scan(&self, request: &ProviderScanRequest) -> Result<ProviderScanResult, ScanError>;
+}

--- a/crates/cn-safety/src/signal.rs
+++ b/crates/cn-safety/src/signal.rs
@@ -1,0 +1,67 @@
+//! trustness / relation risk signal（#353 / moderation-event-trust-semantics）。
+//!
+//! trustness / relation には断定ラベルではなく、根拠つき risk signal として反映する。
+//! 受け手はこれを使って重み付けを決める（advisory であり command ではない）。
+//!
+//! 既定の visibility 規則:
+//! - suspected unknown CSAM / CSE → `Visibility::Local`（誤検知を public に拡散しない）。
+//! - known hash match / provider confirmed の場合のみ `SubscribedNodes` 以上を検討する。
+
+use serde::{Deserialize, Serialize};
+
+use crate::verdict::{Basis, SafetyCategory, Severity, Visibility};
+
+/// risk signal の対象種別。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskSignalTarget {
+    UserPubkey,
+    PeerNode,
+    PostId,
+    BlobCid,
+}
+
+/// 異議申し立ての状態。
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppealStatus {
+    #[default]
+    None,
+    Disputed,
+    Cleared,
+}
+
+/// 根拠つき risk signal。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SafetyRiskSignal {
+    pub target: RiskSignalTarget,
+    pub target_id: String,
+    pub category: SafetyCategory,
+    pub severity: Severity,
+    pub basis: Basis,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<u8>,
+    pub visibility: Visibility,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub appeal_status: Option<AppealStatus>,
+}
+
+impl SafetyRiskSignal {
+    /// この signal が安全側の既定で issuer node の外へ配布してよいか。
+    ///
+    /// suspected（`Basis::ClassifierScore`）の critical safety は `Local` 既定。
+    /// known hash match / provider confirmed のみ `SubscribedNodes` 以上を許す。
+    pub fn default_visibility_for(category: SafetyCategory, basis: Basis) -> Visibility {
+        let confirmed = matches!(basis, Basis::KnownHashMatch | Basis::ProviderVerdict);
+        if category.is_critical_safety() && !confirmed {
+            Visibility::Local
+        } else if confirmed {
+            Visibility::SubscribedNodes
+        } else {
+            Visibility::Local
+        }
+    }
+}

--- a/crates/cn-safety/src/verdict.rs
+++ b/crates/cn-safety/src/verdict.rs
@@ -1,0 +1,196 @@
+//! verdict model（#353）。検知ラベルと最終 action を分離する。
+//!
+//! `docs/safety/community-node-critical-safety.md` §7 に従い:
+//! - action（`allow` / `hold` / `quarantine` / `exclude`）と label を分ける。
+//! - `csam_confirmed`（known hash match / provider confirmed）と
+//!   `csam_suspected`（classifier high score / CSE 疑い）を区別する。
+//!
+//! confidence / score は等値比較とテストの決定性のため浮動小数ではなく整数 `u8`(0-100)。
+
+use serde::{Deserialize, Serialize};
+
+use crate::capability::SafetyProviderCapability;
+
+/// scan 後の最終 action。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SafetyAction {
+    /// index / surfacing を許可する唯一の action。
+    Allow,
+    /// 保留。index しない。
+    Hold,
+    /// 隔離。index しない。
+    Quarantine,
+    /// 排除。index しない。
+    Exclude,
+}
+
+impl SafetyAction {
+    /// この action が index / discovery / recommendation への surfacing を許すか。
+    ///
+    /// `Allow` のときだけ true。fail-closed の単一判定点。
+    pub fn allows_indexing(self) -> bool {
+        matches!(self, SafetyAction::Allow)
+    }
+}
+
+/// risk signal / moderation のカテゴリ。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SafetyCategory {
+    Csam,
+    Cse,
+    Grooming,
+    Nsfw,
+    Spam,
+    Malware,
+    Phishing,
+}
+
+impl SafetyCategory {
+    /// critical safety（CSAM / CSE / grooming）か。general moderation と区別する。
+    pub fn is_critical_safety(self) -> bool {
+        matches!(
+            self,
+            SafetyCategory::Csam | SafetyCategory::Cse | SafetyCategory::Grooming
+        )
+    }
+}
+
+/// severity。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Critical,
+    High,
+    Medium,
+    Low,
+}
+
+/// 判定の根拠。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Basis {
+    /// 既知 hash 一致（confirmed の根拠）。
+    KnownHashMatch,
+    /// provider が confirmed と返した。
+    ProviderVerdict,
+    /// classifier スコア（suspected の根拠）。
+    ClassifierScore,
+    /// ローカルポリシー判断。
+    LocalPolicy,
+}
+
+/// signal / event の配布範囲。
+///
+/// suspected unknown CSAM / CSE は既定 `Local`。known hash match / provider confirmed の場合のみ
+/// `SubscribedNodes` 以上を検討する（誤検知を public advisory として拡散しない）。
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Visibility {
+    /// issuer node 内のローカル判断にのみ使う（既定・最も安全側）。
+    #[default]
+    Local,
+    /// この node を trust input として購読している node にのみ配布。
+    SubscribedNodes,
+    /// 公開 advisory。
+    Public,
+}
+
+/// reason code。`csam_confirmed` と `csam_suspected` を型で分離する。
+///
+/// **重要**: `NoKnownMatch` を `Clean` / safe と同一視しないこと。known-hash provider のみの
+/// 場合、「未知 CSAM は未検査」であり、no match は安全の証明ではない。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasonCode {
+    /// 既知 CSAM の confirmed（known hash match / provider confirmed）。
+    CsamConfirmed,
+    /// 未知 CSAM の suspected（classifier high score）。
+    CsamSuspected,
+    /// CSE の suspected。
+    CseSuspected,
+    /// 一般 moderation（nsfw / violence / hate / harassment / spam / malware / phishing）。
+    GeneralModeration,
+    /// scan が失敗した（fail-closed の根拠）。
+    ScanFailed,
+    /// provider が利用不可だった（fail-closed の根拠）。
+    ProviderUnavailable,
+    /// scan 要求がそもそも無い（unscanned。fail-closed の根拠）。
+    Unscanned,
+    /// 既知 hash には一致しなかった（**safe の証明ではない**）。
+    NoKnownMatch,
+    /// 明示的に clean と判定できた（全 capability で問題なし）。
+    Clean,
+}
+
+/// 検知ラベル。action とは独立に「何を検知したか」を表す。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SafetyLabel {
+    pub category: SafetyCategory,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_capability: Option<SafetyProviderCapability>,
+}
+
+impl SafetyLabel {
+    pub fn new(category: SafetyCategory) -> Self {
+        Self {
+            category,
+            confidence: None,
+            provider_capability: None,
+        }
+    }
+
+    pub fn with_confidence(mut self, confidence: u8) -> Self {
+        self.confidence = Some(confidence);
+        self
+    }
+
+    pub fn with_provider_capability(mut self, capability: SafetyProviderCapability) -> Self {
+        self.provider_capability = Some(capability);
+        self
+    }
+}
+
+/// policy router が返す最終 verdict。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SafetyVerdict {
+    pub action: SafetyAction,
+    #[serde(default)]
+    pub labels: Vec<SafetyLabel>,
+    pub critical: bool,
+    pub reason_code: ReasonCode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_capability: Option<SafetyProviderCapability>,
+    pub policy_version: String,
+    /// scan 時刻（RFC3339）。この crate では時計を持たず、呼び出し側が与える。
+    pub scanned_at: String,
+}
+
+impl SafetyVerdict {
+    /// この verdict が index / discovery / recommendation への surfacing を許すか。
+    ///
+    /// `action == Allow` のときだけ true。`hold` / `quarantine` / `exclude` と
+    /// すべての fail-closed 経路（scan failure / provider unavailable / unscanned）は false。
+    pub fn is_indexable(&self) -> bool {
+        self.action.allows_indexing()
+    }
+}
+
+/// moderation event の action。risk_label を含むため `SafetyAction` とは別 enum。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModerationAction {
+    Exclude,
+    Hold,
+    Quarantine,
+    RiskLabel,
+}

--- a/crates/cn-safety/tests/domain_model.rs
+++ b/crates/cn-safety/tests/domain_model.rs
@@ -1,0 +1,293 @@
+//! safety domain model の serde 表現と型の決定論的な振る舞いを固定する（#353）。
+
+use kukuri_cn_safety::event::{ModerationEventBody, issue_signed_event};
+use kukuri_cn_safety::provider::{ProviderScanResult, ScanOutcome, SubjectKind};
+use kukuri_cn_safety::verdict::SafetyVerdict;
+use kukuri_cn_safety::{
+    AppealStatus, Basis, MockSigner, ModerationAction, ModerationEventSigner, ReasonCode,
+    RiskSignalTarget, SafetyAction, SafetyCategory, SafetyLabel, SafetyProviderCapability,
+    SafetyRiskSignal, Severity, Visibility,
+};
+use serde_json::json;
+
+#[test]
+fn safety_action_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_value(SafetyAction::Allow).unwrap(),
+        json!("allow")
+    );
+    assert_eq!(
+        serde_json::to_value(SafetyAction::Quarantine).unwrap(),
+        json!("quarantine")
+    );
+    assert_eq!(
+        serde_json::to_value(SafetyAction::Exclude).unwrap(),
+        json!("exclude")
+    );
+}
+
+#[test]
+fn basis_and_visibility_serialize_snake_case() {
+    assert_eq!(
+        serde_json::to_value(Basis::KnownHashMatch).unwrap(),
+        json!("known_hash_match")
+    );
+    assert_eq!(
+        serde_json::to_value(Basis::ClassifierScore).unwrap(),
+        json!("classifier_score")
+    );
+    assert_eq!(
+        serde_json::to_value(Visibility::SubscribedNodes).unwrap(),
+        json!("subscribed_nodes")
+    );
+}
+
+#[test]
+fn reason_code_distinguishes_confirmed_and_suspected() {
+    assert_eq!(
+        serde_json::to_value(ReasonCode::CsamConfirmed).unwrap(),
+        json!("csam_confirmed")
+    );
+    assert_eq!(
+        serde_json::to_value(ReasonCode::CsamSuspected).unwrap(),
+        json!("csam_suspected")
+    );
+    // confirmed と suspected は別 variant であり、型レベルで混同しない。
+    assert_ne!(ReasonCode::CsamConfirmed, ReasonCode::CsamSuspected);
+    // NoKnownMatch と Clean も別物（no match を safe と同一視しない）。
+    assert_ne!(ReasonCode::NoKnownMatch, ReasonCode::Clean);
+}
+
+#[test]
+fn provider_capability_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_value(SafetyProviderCapability::KnownCsamHashMatch).unwrap(),
+        json!("known_csam_hash_match")
+    );
+    assert_eq!(
+        serde_json::to_value(SafetyProviderCapability::NovelCsamImageClassifier).unwrap(),
+        json!("novel_csam_image_classifier")
+    );
+}
+
+#[test]
+fn capability_critical_vs_general_separation() {
+    assert!(SafetyProviderCapability::KnownCsamHashMatch.is_critical_safety());
+    assert!(SafetyProviderCapability::CseTextClassifier.is_critical_safety());
+    assert!(!SafetyProviderCapability::GeneralMediaModeration.is_critical_safety());
+    assert!(!SafetyProviderCapability::SpamAbuseModeration.is_critical_safety());
+
+    // confirmed を生み得るのは known hash match のみ。
+    assert!(SafetyProviderCapability::KnownCsamHashMatch.can_confirm_known_csam());
+    assert!(!SafetyProviderCapability::NovelCsamImageClassifier.can_confirm_known_csam());
+}
+
+#[test]
+fn category_critical_classification() {
+    assert!(SafetyCategory::Csam.is_critical_safety());
+    assert!(SafetyCategory::Cse.is_critical_safety());
+    assert!(SafetyCategory::Grooming.is_critical_safety());
+    assert!(!SafetyCategory::Nsfw.is_critical_safety());
+    assert!(!SafetyCategory::Spam.is_critical_safety());
+}
+
+#[test]
+fn visibility_defaults_to_local() {
+    assert_eq!(Visibility::default(), Visibility::Local);
+}
+
+#[test]
+fn safety_verdict_round_trips_snake_case() {
+    let verdict = SafetyVerdict {
+        action: SafetyAction::Hold,
+        labels: vec![
+            SafetyLabel::new(SafetyCategory::Csam)
+                .with_confidence(91)
+                .with_provider_capability(SafetyProviderCapability::NovelCsamImageClassifier),
+        ],
+        critical: true,
+        reason_code: ReasonCode::CsamSuspected,
+        confidence: Some(91),
+        provider: Some("mock-classifier".to_string()),
+        provider_capability: Some(SafetyProviderCapability::NovelCsamImageClassifier),
+        policy_version: "2026-06-public-node-v1".to_string(),
+        scanned_at: "2026-06-29T00:00:00Z".to_string(),
+    };
+    let value = serde_json::to_value(&verdict).unwrap();
+    assert_eq!(value["action"], "hold");
+    assert_eq!(value["reason_code"], "csam_suspected");
+    assert_eq!(value["provider_capability"], "novel_csam_image_classifier");
+
+    let back: SafetyVerdict = serde_json::from_value(value).unwrap();
+    assert_eq!(back, verdict);
+}
+
+#[test]
+fn verdict_is_indexable_only_when_allow() {
+    let allow = make_verdict(SafetyAction::Allow);
+    assert!(allow.is_indexable());
+    for action in [
+        SafetyAction::Hold,
+        SafetyAction::Quarantine,
+        SafetyAction::Exclude,
+    ] {
+        assert!(
+            !make_verdict(action).is_indexable(),
+            "{action:?} must not index"
+        );
+    }
+}
+
+fn make_verdict(action: SafetyAction) -> SafetyVerdict {
+    SafetyVerdict {
+        action,
+        labels: Vec::new(),
+        critical: false,
+        reason_code: ReasonCode::Clean,
+        confidence: None,
+        provider: None,
+        provider_capability: None,
+        policy_version: "v1".to_string(),
+        scanned_at: "2026-06-29T00:00:00Z".to_string(),
+    }
+}
+
+#[test]
+fn risk_signal_round_trips_snake_case() {
+    let signal = SafetyRiskSignal {
+        target: RiskSignalTarget::BlobCid,
+        target_id: "bafy...".to_string(),
+        category: SafetyCategory::Csam,
+        severity: Severity::Critical,
+        basis: Basis::KnownHashMatch,
+        confidence: None,
+        visibility: Visibility::SubscribedNodes,
+        expires_at: None,
+        appeal_status: Some(AppealStatus::None),
+    };
+    let value = serde_json::to_value(&signal).unwrap();
+    assert_eq!(value["target"], "blob_cid");
+    assert_eq!(value["basis"], "known_hash_match");
+    assert_eq!(value["visibility"], "subscribed_nodes");
+    assert_eq!(value["appeal_status"], "none");
+
+    let back: SafetyRiskSignal = serde_json::from_value(value).unwrap();
+    assert_eq!(back, signal);
+}
+
+#[test]
+fn risk_signal_default_visibility_keeps_suspected_local() {
+    // suspected unknown CSAM/CSE（classifier score）は local 既定。
+    assert_eq!(
+        SafetyRiskSignal::default_visibility_for(SafetyCategory::Csam, Basis::ClassifierScore),
+        Visibility::Local
+    );
+    assert_eq!(
+        SafetyRiskSignal::default_visibility_for(SafetyCategory::Cse, Basis::ClassifierScore),
+        Visibility::Local
+    );
+    // known hash match / provider confirmed のみ subscribed 以上を許す。
+    assert_eq!(
+        SafetyRiskSignal::default_visibility_for(SafetyCategory::Csam, Basis::KnownHashMatch),
+        Visibility::SubscribedNodes
+    );
+}
+
+#[test]
+fn moderation_event_body_canonical_is_deterministic() {
+    let body = sample_body();
+    // 同一内容なら canonical bytes は安定。
+    assert_eq!(body.canonical_bytes(), body.clone().canonical_bytes());
+    // 内容が変われば canonical bytes も変わる。
+    let mut other = body.clone();
+    other.target_id = "different".to_string();
+    assert_ne!(body.canonical_bytes(), other.canonical_bytes());
+}
+
+#[test]
+fn moderation_event_body_round_trips_snake_case() {
+    let body = sample_body();
+    let value = serde_json::to_value(&body).unwrap();
+    assert_eq!(value["issuer_node_id"], "node-1");
+    assert_eq!(value["target_type"], "blob");
+    assert_eq!(value["action"], "exclude");
+    assert_eq!(value["reason_code"], "csam_confirmed");
+    assert_eq!(value["basis"], "known_hash_match");
+
+    let back: ModerationEventBody = serde_json::from_value(value).unwrap();
+    assert_eq!(back, body);
+}
+
+#[test]
+fn moderation_action_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_value(ModerationAction::RiskLabel).unwrap(),
+        json!("risk_label")
+    );
+}
+
+#[test]
+fn provider_scan_result_round_trips() {
+    let result = ProviderScanResult {
+        provider: "mock".to_string(),
+        capability: SafetyProviderCapability::KnownCsamHashMatch,
+        outcome: ScanOutcome::NoKnownMatch,
+        known_hash_match: false,
+        score: None,
+        labels: Vec::new(),
+    };
+    let value = serde_json::to_value(&result).unwrap();
+    assert_eq!(value["outcome"], "no_known_match");
+    assert_eq!(value["capability"], "known_csam_hash_match");
+    let back: ProviderScanResult = serde_json::from_value(value).unwrap();
+    assert_eq!(back, result);
+}
+
+#[test]
+fn mock_signer_is_deterministic_and_separates_body_from_signature() {
+    let signer = MockSigner::new("node-1");
+    assert_eq!(signer.issuer_node_id(), "node-1");
+
+    let body = sample_body();
+    let signed_a = issue_signed_event(body.clone(), &signer);
+    let signed_b = issue_signed_event(body.clone(), &signer);
+    // 同一 body・同一 signer なら署名は決定論的。
+    assert_eq!(signed_a.signature, signed_b.signature);
+    // body は signature と分離して保持される。
+    assert_eq!(signed_a.body, body);
+
+    // body が変われば署名も変わる。
+    let mut other = body.clone();
+    other.target_id = "other-target".to_string();
+    let signed_other = issue_signed_event(other, &signer);
+    assert_ne!(signed_a.signature, signed_other.signature);
+}
+
+#[test]
+fn signed_event_round_trips_snake_case() {
+    let signer = MockSigner::new("node-1");
+    let signed = issue_signed_event(sample_body(), &signer);
+    let value = serde_json::to_value(&signed).unwrap();
+    assert!(value["body"].is_object());
+    assert!(value["signature"].is_string());
+    let back: kukuri_cn_safety::SignedModerationEvent = serde_json::from_value(value).unwrap();
+    assert_eq!(back, signed);
+}
+
+fn sample_body() -> ModerationEventBody {
+    ModerationEventBody {
+        id: "evt-1".to_string(),
+        issuer_node_id: "node-1".to_string(),
+        target_type: SubjectKind::Blob,
+        target_id: "bafy-target".to_string(),
+        action: ModerationAction::Exclude,
+        labels: vec![SafetyLabel::new(SafetyCategory::Csam)],
+        reason_code: ReasonCode::CsamConfirmed,
+        severity: Severity::Critical,
+        confidence: None,
+        basis: Basis::KnownHashMatch,
+        visibility: Visibility::SubscribedNodes,
+        policy_version: "2026-06-public-node-v1".to_string(),
+        created_at: "2026-06-29T00:00:00Z".to_string(),
+    }
+}

--- a/crates/cn-safety/tests/policy_router.rs
+++ b/crates/cn-safety/tests/policy_router.rs
@@ -1,0 +1,395 @@
+//! policy router の verdict 分岐と fail-closed 挙動を固定する（#353）。
+//!
+//! 受け入れ条件:
+//! - known CSAM match → exclude（critical / confirmed）
+//! - unknown CSAM/CSE suspected を confirmed と分けて扱う
+//! - general moderation と critical safety route が分離される
+//! - scan failure / provider unavailable / unscanned で fail-closed（allow にしない）
+//! - `NoKnownMatch` を safe / clean 扱いしない
+
+use kukuri_cn_safety::provider::{
+    ProviderScanRequest, ProviderScanResult, SafetyProvider, ScanError, ScanOutcome, SubjectKind,
+};
+use kukuri_cn_safety::verdict::{ReasonCode, SafetyAction, SafetyCategory};
+use kukuri_cn_safety::{
+    MockSafetyProvider, SafetyLabel, SafetyPolicy, SafetyProviderCapability, route,
+};
+
+const SCANNED_AT: &str = "2026-06-29T00:00:00Z";
+
+fn known_hash_result() -> ProviderScanResult {
+    ProviderScanResult {
+        provider: "known-csam".to_string(),
+        capability: SafetyProviderCapability::KnownCsamHashMatch,
+        outcome: ScanOutcome::Completed,
+        known_hash_match: true,
+        score: None,
+        labels: vec![SafetyLabel::new(SafetyCategory::Csam)],
+    }
+}
+
+fn no_known_match_result() -> ProviderScanResult {
+    ProviderScanResult {
+        provider: "known-csam".to_string(),
+        capability: SafetyProviderCapability::KnownCsamHashMatch,
+        outcome: ScanOutcome::NoKnownMatch,
+        known_hash_match: false,
+        score: None,
+        labels: Vec::new(),
+    }
+}
+
+fn score_result(
+    capability: SafetyProviderCapability,
+    category: SafetyCategory,
+    score: u8,
+) -> ProviderScanResult {
+    ProviderScanResult {
+        provider: "classifier".to_string(),
+        capability,
+        outcome: ScanOutcome::Completed,
+        known_hash_match: false,
+        score: Some(score),
+        labels: vec![SafetyLabel::new(category).with_confidence(score)],
+    }
+}
+
+fn general_result(category: SafetyCategory) -> ProviderScanResult {
+    ProviderScanResult {
+        provider: "general".to_string(),
+        capability: SafetyProviderCapability::GeneralMediaModeration,
+        outcome: ScanOutcome::Completed,
+        known_hash_match: false,
+        score: Some(95),
+        labels: vec![SafetyLabel::new(category).with_confidence(95)],
+    }
+}
+
+#[test]
+fn known_csam_match_is_excluded_and_confirmed() {
+    let policy = SafetyPolicy::public_node_default();
+    let verdict = route(&[known_hash_result()], &policy, SCANNED_AT);
+    assert_eq!(verdict.action, SafetyAction::Exclude);
+    assert!(verdict.critical);
+    assert_eq!(verdict.reason_code, ReasonCode::CsamConfirmed);
+    assert!(!verdict.is_indexable());
+}
+
+#[test]
+fn suspected_unknown_csam_is_quarantined_not_confirmed() {
+    let policy = SafetyPolicy::public_node_default();
+    let outcomes = [score_result(
+        SafetyProviderCapability::NovelCsamImageClassifier,
+        SafetyCategory::Csam,
+        policy.unknown_csam_score_threshold,
+    )];
+    let verdict = route(&outcomes, &policy, SCANNED_AT);
+    // suspected は confirmed と別扱い。
+    assert_eq!(verdict.reason_code, ReasonCode::CsamSuspected);
+    assert_ne!(verdict.reason_code, ReasonCode::CsamConfirmed);
+    assert!(verdict.critical);
+    assert_eq!(verdict.action, SafetyAction::Quarantine);
+    assert!(!verdict.is_indexable());
+}
+
+#[test]
+fn cse_suspected_uses_cse_reason() {
+    let policy = SafetyPolicy::public_node_default();
+    let outcomes = [score_result(
+        SafetyProviderCapability::CseTextClassifier,
+        SafetyCategory::Cse,
+        90,
+    )];
+    let verdict = route(&outcomes, &policy, SCANNED_AT);
+    assert_eq!(verdict.reason_code, ReasonCode::CseSuspected);
+    assert!(verdict.critical);
+}
+
+#[test]
+fn score_below_threshold_critical_detection_fails_closed_not_allow() {
+    let policy = SafetyPolicy::public_node_default();
+    let outcomes = [score_result(
+        SafetyProviderCapability::NovelCsamImageClassifier,
+        SafetyCategory::Csam,
+        policy.unknown_csam_score_threshold - 1,
+    )];
+    let verdict = route(&outcomes, &policy, SCANNED_AT);
+    // 閾値未満でも critical な検知は safe と断定せず fail-closed する（Allow にしない）。
+    assert!(
+        !verdict.is_indexable(),
+        "below-threshold CSAM must not index"
+    );
+    assert!(verdict.critical);
+    assert_ne!(verdict.reason_code, ReasonCode::Clean);
+}
+
+#[test]
+fn critical_detection_with_no_score_fails_closed() {
+    // score=None でも critical capability の Completed 検知は Allow に取りこぼさない。
+    let policy = SafetyPolicy::public_node_default();
+    let result = ProviderScanResult {
+        provider: "classifier".to_string(),
+        capability: SafetyProviderCapability::NovelCsamImageClassifier,
+        outcome: ScanOutcome::Completed,
+        known_hash_match: false,
+        score: None,
+        labels: vec![SafetyLabel::new(SafetyCategory::Csam)],
+    };
+    let verdict = route(&[result], &policy, SCANNED_AT);
+    assert!(!verdict.is_indexable());
+    assert!(verdict.critical);
+}
+
+#[test]
+fn critical_label_confidence_drives_suspected_when_score_absent() {
+    // result.score が無くても label.confidence>=threshold なら suspected として扱う。
+    let policy = SafetyPolicy::public_node_default();
+    let result = ProviderScanResult {
+        provider: "classifier".to_string(),
+        capability: SafetyProviderCapability::NovelCsamImageClassifier,
+        outcome: ScanOutcome::Completed,
+        known_hash_match: false,
+        score: None,
+        labels: vec![
+            SafetyLabel::new(SafetyCategory::Csam)
+                .with_confidence(policy.unknown_csam_score_threshold),
+        ],
+    };
+    let verdict = route(&[result], &policy, SCANNED_AT);
+    assert_eq!(verdict.reason_code, ReasonCode::CsamSuspected);
+    assert!(verdict.critical);
+    assert!(!verdict.is_indexable());
+}
+
+#[test]
+fn cse_first_label_noncritical_still_reports_cse_not_csam() {
+    // CSE capability で先頭ラベルが非 critical(Nsfw) でも、CSE として報告する（取り違えない）。
+    let policy = SafetyPolicy::public_node_default();
+    let result = ProviderScanResult {
+        provider: "cse".to_string(),
+        capability: SafetyProviderCapability::CseTextClassifier,
+        outcome: ScanOutcome::Completed,
+        known_hash_match: false,
+        score: Some(95),
+        labels: vec![
+            SafetyLabel::new(SafetyCategory::Nsfw).with_confidence(95),
+            SafetyLabel::new(SafetyCategory::Cse).with_confidence(95),
+        ],
+    };
+    let verdict = route(&[result], &policy, SCANNED_AT);
+    assert_eq!(verdict.reason_code, ReasonCode::CseSuspected);
+    assert_ne!(verdict.reason_code, ReasonCode::CsamSuspected);
+    assert!(verdict.critical);
+}
+
+#[test]
+fn general_moderation_is_separate_route_from_critical() {
+    let policy = SafetyPolicy::public_node_default();
+    let verdict = route(
+        &[
+            no_known_match_result(),
+            general_result(SafetyCategory::Nsfw),
+        ],
+        &policy,
+        SCANNED_AT,
+    );
+    assert_eq!(verdict.reason_code, ReasonCode::GeneralModeration);
+    assert!(!verdict.critical);
+    // 既定 policy では high-confidence nsfw は exclude だが critical ではない。
+    assert_eq!(verdict.action, SafetyAction::Exclude);
+}
+
+#[test]
+fn spam_uses_general_route() {
+    let policy = SafetyPolicy::public_node_default();
+    let verdict = route(
+        &[
+            no_known_match_result(),
+            general_result(SafetyCategory::Spam),
+        ],
+        &policy,
+        SCANNED_AT,
+    );
+    assert_eq!(verdict.reason_code, ReasonCode::GeneralModeration);
+    assert!(!verdict.critical);
+}
+
+#[test]
+fn missing_required_known_csam_provider_fails_closed() {
+    let policy = SafetyPolicy::public_node_default();
+    let clean_general = ProviderScanResult {
+        provider: "general".to_string(),
+        capability: SafetyProviderCapability::GeneralMediaModeration,
+        outcome: ScanOutcome::Completed,
+        known_hash_match: false,
+        score: None,
+        labels: Vec::new(),
+    };
+    let verdict = route(&[clean_general], &policy, SCANNED_AT);
+    assert_eq!(verdict.reason_code, ReasonCode::ProviderUnavailable);
+    assert_ne!(verdict.action, SafetyAction::Allow);
+    assert!(!verdict.is_indexable());
+}
+
+#[test]
+fn scan_failure_fails_closed_not_allow() {
+    let policy = SafetyPolicy::public_node_default();
+    let failed = ProviderScanResult {
+        provider: "known-csam".to_string(),
+        capability: SafetyProviderCapability::KnownCsamHashMatch,
+        outcome: ScanOutcome::Failed,
+        known_hash_match: false,
+        score: None,
+        labels: Vec::new(),
+    };
+    let verdict = route(&[failed], &policy, SCANNED_AT);
+    assert_eq!(verdict.reason_code, ReasonCode::ScanFailed);
+    assert_ne!(verdict.action, SafetyAction::Allow);
+    assert!(!verdict.is_indexable());
+}
+
+#[test]
+fn provider_unavailable_fails_closed_not_allow() {
+    let policy = SafetyPolicy::public_node_default();
+    let unavailable = ProviderScanResult {
+        provider: "known-csam".to_string(),
+        capability: SafetyProviderCapability::KnownCsamHashMatch,
+        outcome: ScanOutcome::Unavailable,
+        known_hash_match: false,
+        score: None,
+        labels: Vec::new(),
+    };
+    let verdict = route(&[unavailable], &policy, SCANNED_AT);
+    assert_eq!(verdict.reason_code, ReasonCode::ProviderUnavailable);
+    assert_ne!(verdict.action, SafetyAction::Allow);
+    assert!(!verdict.is_indexable());
+}
+
+#[test]
+fn empty_scan_outcomes_fail_closed_unscanned() {
+    let policy = SafetyPolicy::public_node_default();
+    let verdict = route(&[], &policy, SCANNED_AT);
+    assert_eq!(verdict.reason_code, ReasonCode::Unscanned);
+    assert_ne!(verdict.action, SafetyAction::Allow);
+    assert!(!verdict.is_indexable());
+}
+
+#[test]
+fn no_known_match_is_not_treated_as_clean() {
+    let policy = SafetyPolicy::public_node_default();
+    let no_match = ProviderScanResult {
+        provider: "known-csam".to_string(),
+        capability: SafetyProviderCapability::KnownCsamHashMatch,
+        outcome: ScanOutcome::NoKnownMatch,
+        known_hash_match: false,
+        score: None,
+        labels: Vec::new(),
+    };
+    let verdict = route(&[no_match], &policy, SCANNED_AT);
+    // no match は safe の証明ではない: reason_code は NoKnownMatch（Clean ではない）。
+    assert_eq!(verdict.reason_code, ReasonCode::NoKnownMatch);
+    assert_ne!(verdict.reason_code, ReasonCode::Clean);
+}
+
+#[test]
+fn known_match_takes_priority_over_other_failures() {
+    let policy = SafetyPolicy::public_node_default();
+    let failed = ProviderScanResult {
+        provider: "classifier".to_string(),
+        capability: SafetyProviderCapability::NovelCsamImageClassifier,
+        outcome: ScanOutcome::Failed,
+        known_hash_match: false,
+        score: None,
+        labels: Vec::new(),
+    };
+    let verdict = route(&[failed, known_hash_result()], &policy, SCANNED_AT);
+    // confirmed CSAM は他 provider の失敗より優先して exclude。
+    assert_eq!(verdict.action, SafetyAction::Exclude);
+    assert_eq!(verdict.reason_code, ReasonCode::CsamConfirmed);
+}
+
+#[test]
+fn policy_with_allow_on_scan_error_is_overridden_to_fail_closed() {
+    // policy が誤って on_scan_error=Allow を設定しても fail-closed を保証する。
+    let mut policy = SafetyPolicy::public_node_default();
+    policy.on_scan_error = SafetyAction::Allow;
+    let verdict = route(&[], &policy, SCANNED_AT);
+    assert_ne!(verdict.action, SafetyAction::Allow);
+}
+
+// --- provider abstraction / mock ---
+
+#[tokio::test]
+async fn mock_provider_returns_configured_known_match() {
+    let provider =
+        MockSafetyProvider::known_csam("arachnid-mock").with_known_hash_match("blob-bad");
+    let result = provider
+        .scan(&ProviderScanRequest::for_subject(
+            SubjectKind::Blob,
+            "blob-bad",
+        ))
+        .await
+        .unwrap();
+    assert!(result.known_hash_match);
+    assert_eq!(result.outcome, ScanOutcome::Completed);
+    assert_eq!(provider.name(), "arachnid-mock");
+    assert_eq!(
+        provider.capabilities(),
+        &[SafetyProviderCapability::KnownCsamHashMatch]
+    );
+}
+
+#[tokio::test]
+async fn mock_provider_default_is_no_known_match_not_clean() {
+    let provider = MockSafetyProvider::known_csam("arachnid-mock");
+    let result = provider
+        .scan(&ProviderScanRequest::for_subject(
+            SubjectKind::Blob,
+            "unconfigured",
+        ))
+        .await
+        .unwrap();
+    // 既定は NoKnownMatch（safe ではない）。
+    assert_eq!(result.outcome, ScanOutcome::NoKnownMatch);
+    assert!(!result.known_hash_match);
+}
+
+#[tokio::test]
+async fn mock_provider_can_be_unavailable_for_fail_closed_tests() {
+    let provider = MockSafetyProvider::known_csam("arachnid-mock").default_unavailable();
+    let result = provider
+        .scan(&ProviderScanRequest::for_subject(SubjectKind::Blob, "x"))
+        .await
+        .unwrap();
+    assert_eq!(result.outcome, ScanOutcome::Unavailable);
+    assert!(result.outcome.is_fail_closed());
+}
+
+#[tokio::test]
+async fn mock_provider_can_error() {
+    let provider = MockSafetyProvider::known_csam("arachnid-mock")
+        .default_error(ScanError::Timeout("deadline".to_string()));
+    let err = provider
+        .scan(&ProviderScanRequest::for_subject(SubjectKind::Blob, "x"))
+        .await
+        .unwrap_err();
+    assert_eq!(err, ScanError::Timeout("deadline".to_string()));
+}
+
+#[tokio::test]
+async fn end_to_end_known_match_to_exclude_verdict() {
+    let policy = SafetyPolicy::public_node_default();
+    let provider =
+        MockSafetyProvider::known_csam("arachnid-mock").with_known_hash_match("blob-bad");
+    let scan = provider
+        .scan(&ProviderScanRequest::for_subject(
+            SubjectKind::Blob,
+            "blob-bad",
+        ))
+        .await
+        .unwrap();
+    let verdict = route(&[scan], &policy, SCANNED_AT);
+    assert_eq!(verdict.action, SafetyAction::Exclude);
+    assert!(verdict.critical);
+    assert!(!verdict.is_indexable());
+}

--- a/docs/progress/2026-06-29-353-safety-domain-model.md
+++ b/docs/progress/2026-06-29-353-safety-domain-model.md
@@ -1,0 +1,114 @@
+# #353 段階2: safety domain model / provider abstraction
+
+最終更新日: 2026-06-29
+
+## 位置づけ
+
+Issue #353（Public community node 向け CSAM / critical safety moderation 基盤）の段階2の
+最初の単位として、CSAM / critical safety の **pure domain 層**を新規 crate `crates/cn-safety`
+に実装した。index 本体・readiness CLI・本番 provider 接続は含まない。
+
+設計の真実源:
+- `docs/safety/community-node-critical-safety.md`（§7 verdict model, §8 fail-closed invariants, §12 prerequisites）
+- `docs/architecture/moderation-event-trust-semantics.md`（advisory ≠ command, visibility 3段階）
+
+## 本 PR で実装した範囲
+
+新規 crate `crates/cn-safety`（`kukuri-cn-safety`）。DB / network / production credentials に
+依存しない pure domain crate。
+
+- domain model（`snake_case` serde, 既存 cn-* crate と統一）
+  - `SafetyProviderCapability`（capability.rs）
+  - `SafetyAction` / `SafetyCategory` / `Severity` / `Basis` / `Visibility` / `ReasonCode` /
+    `SafetyLabel` / `SafetyVerdict` / `ModerationAction`（verdict.rs）
+  - `ModerationEventBody`（unsigned canonical）/ `SignedModerationEvent` /
+    `ModerationEventSigner` / `issue_signed_event`（event.rs）
+  - `SafetyRiskSignal` / `RiskSignalTarget` / `AppealStatus`（signal.rs）
+- provider abstraction（provider.rs）
+  - `#[async_trait] SafetyProvider`（name / capabilities / scan）
+  - `ProviderScanRequest` / `ProviderScanResult` / `ScanOutcome` / `ScanError` / `SubjectKind`
+- mock（mock.rs, `mock` feature でのみ有効）
+  - `MockSafetyProvider`（subject_id ごとに決定論的結果。fail-closed 用に
+    failed / unavailable / error も設定可能）
+  - `MockSigner`（canonical body の決定論的ハッシュを署名として返す。実鍵ではない）
+  - **production の既定 API には含めない**。`MockSigner` は非暗号（FNV-1a）であり本番経路で
+    署名として誤用しないよう `#[cfg(feature = "mock")]` で gate する。テストは self
+    dev-dependency（`features = ["mock"]`）で有効化する。
+- policy router（policy.rs）
+  - `route(&[ProviderScanResult], &SafetyPolicy, scanned_at) -> SafetyVerdict` 純関数
+  - `SafetyPolicy`（閾値・on_scan_error 等）/ `SafetyPolicy::public_node_default()`
+  - fail-closed 保証: unscanned / scan failure / provider unavailable は `Allow` にしない。
+    policy が誤って `on_scan_error = Allow`（indexable）でも `ensure_non_indexing` で Hold に倒す。
+  - mandatory known CSAM provider の欠落防止: `require_known_csam=true` で
+    `KnownCsamHashMatch` capability の scan 結果が無い場合、general moderation が clean/allow でも
+    `ProviderUnavailable` として fail-closed する。
+  - critical safety の取りこぼし防止: critical capability / critical label を持つ `Completed`
+    検知は、suspected 閾値未満や `score=None` でも `Allow`/`Clean` に落とさず fail-closed する
+    （`is_critical_detection` + 最終 critical 取りこぼしガード）。
+  - suspected 判定の実効スコアは `result.score` または critical label の最大 `confidence`
+    （`effective_critical_score`）。score と label confidence の独立性による取りこぼしを防ぐ。
+  - reason / category は critical label を優先し、無ければ capability から導く
+    （`critical_category`）。CSE を CSAM と取り違えない。
+  - `NoKnownMatch` を `Clean` と同一視しない。
+
+配線:
+- ルート `Cargo.toml` の workspace members に `crates/cn-safety` を追加。
+- `xtask` の `CN_PACKAGES` に `kukuri-cn-safety` を追加（`cargo xtask cn-check` / `cn-test` 対象）。
+
+テスト（DB 不要・決定論的、`mock` feature 有効）:
+- `tests/domain_model.rs`: serde round-trip、`csam_confirmed` ≠ `csam_suspected`、
+  `NoKnownMatch` ≠ `Clean`、canonical 決定性、mock signer 決定性と body/署名分離、
+  `is_indexable()` が `Allow` のときだけ true。
+- `tests/policy_router.rs`: known match → exclude/critical/confirmed、suspected →
+  quarantine/critical（confirmed と別）、general route 分離（critical=false）、
+  scan failure / unavailable / unscanned の fail-closed、mock provider の決定論的挙動。
+  追加: 閾値未満の critical 検知 / `score=None` の critical 検知が fail-closed すること、
+  label confidence のみで suspected になること、CSE が CsamSuspected に誤分類されないこと。
+
+## 受け入れ条件（Issue #353）との対応
+
+本 PR で満たす:
+- [x] moderation server / provider abstraction の設計と実装（abstraction + mock。server 本体は後続）
+- [x] known CSAM hash match capability を表現できる
+- [x] unknown CSAM / CSE suspected を confirmed と分けて扱える
+- [x] general moderation と critical safety route が分離されている
+- [x] scan failure / provider unavailable 時に fail-closed する（router レベル）
+- [x] signed moderation event を生成できる（型 + signer 抽象 + mock。実鍵 / 永続化は後続）
+- [x] trustness / relation に反映する risk signal 型を定義
+- [x] mock provider によるテストがある
+
+後続 PR に残す:
+- [ ] community node が scan 前 media を index しない（indexing 本体 + DB 制約）
+- [ ] `allow` 以外が search / discovery / recommendation に入らない（indexing 本体）
+- [ ] public-node readiness check / `safety` CLI（known CSAM provider 必須検査など）
+- [ ] provider credential 未設定の public-node profile が起動 / readiness で失敗する
+- [ ] blob 本体を恒久保存しないことのテスト / 設定保証
+- [ ] #391 本番 provider 接続（Project Arachnid Shield）と moderation event の実鍵署名（secp256k1）
+
+## prerequisites（critical-safety doc §12）との対応
+
+- [x] provider abstraction and provider capability modeling
+- [x] mock provider coverage for deterministic tests
+- [x] policy routing that separates known CSAM / suspected unknown CSAM / general moderation
+- [ ] readiness checks for public-node profiles（後続）
+- [ ] fail-closed indexing constraints（router の verdict は実装済み。DB 制約は後続）
+- [x] signed moderation event generation（型 + mock signer。実鍵は後続）
+- [x] risk signal persistence and distribution semantics の型（永続化は後続）
+
+## 検証
+
+- `cargo test -p kukuri-cn-safety`（DB 不要、mock feature）: 37 tests pass。
+- `cargo check -p kukuri-cn-safety --no-default-features`（production ビルド = mock 無し）: pass。
+- `cargo clippy -p kukuri-cn-safety --all-targets --all-features -- -D warnings`: clean。
+- `cargo fmt -p kukuri-cn-safety --check`: clean。
+- `cargo xtask cn-check`（CN slice の check）。
+
+## 既知の制約 / 注意
+
+- `canonical_bytes()` は `serde_json` の決定論的出力（struct 宣言順、map 不使用）に依存する。
+  同一バージョン内での決定性を担保する。クロス実装で厳密一致が必要なら、実鍵署名導入時に
+  canonical 形式（フィールドソート等）を強化する。
+- `MockSigner` の署名は FNV-1a ベースで暗号学的強度を持たない。テスト専用であり `mock`
+  feature でのみ公開する（production の既定 API には出さない）。
+- `Availability::Planned`（`Moderation` / `CommunityIndex` / `CommunityLocalTrust`）は本 PR では
+  変更しない。public indexing の解禁は段階3完了まで行わない（docs の制約を維持）。

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,12 +6,13 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
-const CN_PACKAGES: [&str; 5] = [
+const CN_PACKAGES: [&str; 6] = [
     "kukuri-cn-core",
     "kukuri-cn-user-api",
     "kukuri-cn-iroh-relay",
     "kukuri-cn-cli",
     "kukuri-cn-operator",
+    "kukuri-cn-safety",
 ];
 const SERIAL_RUST_PACKAGE: &str = "kukuri-harness";
 const TAURI_CHECK_TARGET_DIR: &str = "target/desktop-tauri-check";


### PR DESCRIPTION
## Summary
- Refs #353 の段階2として cn-safety crate を追加
- safety domain model / provider abstraction / mock provider / policy router を実装
- fail-closed router tests と progress doc を追加

## Testing
- cargo check -p kukuri-cn-safety --no-default-features
- cargo test -p kukuri-cn-safety
- cargo clippy -p kukuri-cn-safety --all-targets --all-features -- -D warnings
- cargo fmt -p kukuri-cn-safety --check
- cargo xtask cn-check
- cargo test -p xtask
- cargo check --workspace --exclude kukuri-harness