### PR TITLE
feat(cn): add safety runtime adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,6 +2986,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kukuri-cn-safety-runtime"
+version = "0.1.2"
+dependencies = [
+ "async-trait",
+ "kukuri-cn-safety",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "kukuri-cn-user-api"
 version = "0.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/cn-cli",
     "crates/cn-operator",
     "crates/cn-safety",
+    "crates/cn-safety-runtime",
 ]
 exclude = [
     "apps/desktop/src-tauri",

--- a/crates/cn-safety-runtime/Cargo.toml
+++ b/crates/cn-safety-runtime/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "kukuri-cn-safety-runtime"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "kukuri_cn_safety_runtime"
+path = "src/lib.rs"
+
+[dependencies]
+kukuri-cn-safety = { path = "../cn-safety" }
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+async-trait.workspace = true
+kukuri-cn-safety = { path = "../cn-safety", features = ["mock"] }
+serde_json.workspace = true
+tokio.workspace = true

--- a/crates/cn-safety-runtime/src/artifacts.rs
+++ b/crates/cn-safety-runtime/src/artifacts.rs
@@ -1,0 +1,196 @@
+//! verdict から未署名 moderation artifact を生成する規則（#353 段階3b）。
+//!
+//! `cn-safety` の `route()` が返した `SafetyVerdict` を、未署名・未永続化の
+//! `ModerationEventBody` / `SafetyRiskSignal` に写像する純粋ロジック。署名（secp256k1）と
+//! 永続化は後続段階で行うため、ここでは body / signal を組み立てるだけで `SignedModerationEvent`
+//! は作らない。
+//!
+//! 設計の真実源:
+//! - `docs/safety/community-node-critical-safety.md` §9（advisory / visibility 規則）
+//! - `docs/architecture/moderation-event-trust-semantics.md`
+//!
+//! 生成ガードレール:
+//! - indexable（`allow`）な verdict では artifact を生成しない。
+//! - target（subject_kind / subject_id）が欠けている場合は artifact を生成しない
+//!   （空 target_id / 不明 target_type の moderation event は監査上危険なため）。
+//! - operational fail-closed（scan_failed / provider_unavailable / unscanned）は content の
+//!   safety category を示さないため、risk signal を生成しない（虚偽の risk label を作らない）。
+//! - suspected unknown CSAM / CSE の visibility は既定 `Local`（誤検知を public に拡散しない）。
+
+use kukuri_cn_safety::policy::basis_for_reason;
+use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
+use kukuri_cn_safety::{
+    AppealStatus, Basis, ModerationAction, ModerationEventBody, ReasonCode, RiskSignalTarget,
+    SafetyAction, SafetyCategory, SafetyRiskSignal, SafetyVerdict, Severity, Visibility,
+};
+
+use crate::id::EventIdGenerator;
+
+/// verdict から未署名の moderation event / risk signal を生成する。
+///
+/// `issuer_node_id` と `scanned_at` は orchestrator が供給する。`ids` は event id 生成器。
+pub(crate) fn build_artifacts(
+    verdict: &SafetyVerdict,
+    request: &ProviderScanRequest,
+    issuer_node_id: &str,
+    ids: &dyn EventIdGenerator,
+) -> (Option<ModerationEventBody>, Option<SafetyRiskSignal>) {
+    // indexable（allow）な verdict では moderation artifact を作らない。
+    if verdict.is_indexable() {
+        return (None, None);
+    }
+
+    // target が揃っていない場合は artifact を作らない（空 target_id を作らない）。
+    let (Some(subject_kind), Some(subject_id)) =
+        (request.subject_kind, request.subject_id.as_deref())
+    else {
+        return (None, None);
+    };
+    let subject_id = subject_id.trim();
+    if subject_id.is_empty() {
+        return (None, None);
+    }
+
+    let basis = basis_for_reason(verdict.reason_code);
+    let category = primary_category(verdict);
+    let severity = severity_for(verdict);
+
+    let moderation_event = build_event(
+        verdict,
+        subject_kind,
+        subject_id,
+        issuer_node_id,
+        ids,
+        basis,
+        severity,
+        category,
+    );
+    let risk_signal =
+        build_risk_signal(verdict, subject_kind, subject_id, basis, severity, category);
+
+    (moderation_event, risk_signal)
+}
+
+/// verdict の主要 content category を導く。
+///
+/// critical reason は reason_code を優先する。provider が複数 label を返し、先頭が一般 label
+/// （例: `nsfw`）でも、`cse_suspected` を一般 moderation として扱わないため。
+/// general moderation は最初の non-critical label を使う。operational fail-closed
+/// （scan_failed / provider_unavailable / unscanned）や NoKnownMatch / Clean は content の
+/// category を持たないため `None`。
+fn primary_category(verdict: &SafetyVerdict) -> Option<SafetyCategory> {
+    match verdict.reason_code {
+        ReasonCode::CsamConfirmed | ReasonCode::CsamSuspected => Some(SafetyCategory::Csam),
+        ReasonCode::CseSuspected => Some(SafetyCategory::Cse),
+        ReasonCode::GeneralModeration => verdict
+            .labels
+            .iter()
+            .map(|label| label.category)
+            .find(|category| !category.is_critical_safety()),
+        ReasonCode::ScanFailed
+        | ReasonCode::ProviderUnavailable
+        | ReasonCode::Unscanned
+        | ReasonCode::NoKnownMatch
+        | ReasonCode::Clean => None,
+    }
+}
+
+/// verdict から severity を導く。
+fn severity_for(verdict: &SafetyVerdict) -> Severity {
+    if verdict.critical {
+        return Severity::Critical;
+    }
+    match verdict.action {
+        SafetyAction::Exclude | SafetyAction::Quarantine => Severity::High,
+        SafetyAction::Hold => Severity::Medium,
+        // allow は呼び出し前に弾かれている。安全側に倒す。
+        SafetyAction::Allow => Severity::Low,
+    }
+}
+
+/// visibility を導く。
+///
+/// content category がある場合は `SafetyRiskSignal::default_visibility_for` の規則に従い、
+/// suspected unknown CSAM / CSE は `Local`、confirmed のみ `SubscribedNodes` 以上。
+/// operational fail-closed（category 無し）は `Local`。
+fn visibility_for(category: Option<SafetyCategory>, basis: Basis) -> Visibility {
+    match category {
+        Some(category) => SafetyRiskSignal::default_visibility_for(category, basis),
+        None => Visibility::Local,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_event(
+    verdict: &SafetyVerdict,
+    subject_kind: SubjectKind,
+    subject_id: &str,
+    issuer_node_id: &str,
+    ids: &dyn EventIdGenerator,
+    basis: Basis,
+    severity: Severity,
+    category: Option<SafetyCategory>,
+) -> Option<ModerationEventBody> {
+    let action = moderation_action_for(verdict.action)?;
+    Some(ModerationEventBody {
+        id: ids.next_id(),
+        issuer_node_id: issuer_node_id.to_string(),
+        target_type: subject_kind,
+        target_id: subject_id.to_string(),
+        action,
+        labels: verdict.labels.clone(),
+        reason_code: verdict.reason_code,
+        severity,
+        confidence: verdict.confidence,
+        basis,
+        visibility: visibility_for(category, basis),
+        policy_version: verdict.policy_version.clone(),
+        created_at: verdict.scanned_at.clone(),
+    })
+}
+
+fn build_risk_signal(
+    verdict: &SafetyVerdict,
+    subject_kind: SubjectKind,
+    subject_id: &str,
+    basis: Basis,
+    severity: Severity,
+    category: Option<SafetyCategory>,
+) -> Option<SafetyRiskSignal> {
+    // content category が無い operational fail-closed では risk signal を作らない
+    // （scan failure は対象 content の safety category を示さない）。
+    let category = category?;
+    Some(SafetyRiskSignal {
+        target: risk_target_for(subject_kind),
+        target_id: subject_id.to_string(),
+        category,
+        severity,
+        basis,
+        confidence: verdict.confidence,
+        visibility: visibility_for(Some(category), basis),
+        expires_at: None,
+        appeal_status: Some(AppealStatus::None),
+    })
+}
+
+/// `SafetyAction` を moderation event の `ModerationAction` に写像する。
+///
+/// `allow` は event を作らない（呼び出し前に弾かれているが安全側に `None`）。
+fn moderation_action_for(action: SafetyAction) -> Option<ModerationAction> {
+    match action {
+        SafetyAction::Hold => Some(ModerationAction::Hold),
+        SafetyAction::Quarantine => Some(ModerationAction::Quarantine),
+        SafetyAction::Exclude => Some(ModerationAction::Exclude),
+        SafetyAction::Allow => None,
+    }
+}
+
+/// subject kind を risk signal の target 種別に写像する。
+fn risk_target_for(kind: SubjectKind) -> RiskSignalTarget {
+    match kind {
+        SubjectKind::Post => RiskSignalTarget::PostId,
+        SubjectKind::Blob => RiskSignalTarget::BlobCid,
+        SubjectKind::User => RiskSignalTarget::UserPubkey,
+        SubjectKind::Peer => RiskSignalTarget::PeerNode,
+    }
+}

--- a/crates/cn-safety-runtime/src/clock.rs
+++ b/crates/cn-safety-runtime/src/clock.rs
@@ -1,0 +1,14 @@
+//! scan 時刻の供給抽象（#353 段階3b）。
+//!
+//! `cn-safety` の `route()` は時計を持たず、`scanned_at`（RFC3339 文字列）を呼び出し側が与える。
+//! orchestrator も時計依存を持たず、この trait を注入される。これにより本 crate は pure に保たれ、
+//! テストでは固定時刻 clock で verdict / event を決定論的に検証できる。
+//!
+//! 本番の system clock 実装（`std::time` / `chrono` ベース）は本 crate のスコープ外であり、
+//! runtime 組み込み段階で別途追加する（別 Issue 化済み）。
+
+/// scan 実行時刻を RFC3339 文字列で返す clock 抽象。
+pub trait ScanClock: Send + Sync {
+    /// 現在時刻を RFC3339（例: `2026-06-29T09:00:00Z`）で返す。
+    fn now_rfc3339(&self) -> String;
+}

--- a/crates/cn-safety-runtime/src/error.rs
+++ b/crates/cn-safety-runtime/src/error.rs
@@ -1,0 +1,34 @@
+//! orchestrator 構築時のエラー（#353 段階3b）。
+//!
+//! scan 実行時の provider 失敗は `ScanError` を `ScanOutcome` に写像して fail-closed な
+//! verdict に集約するため、`scan_subject` は `Result` を返さない。ここで定義するエラーは
+//! orchestrator を **構築する時点** の構成不備のみを表す。
+
+use thiserror::Error;
+
+/// `SafetyOrchestrator` 構築時の構成エラー。
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum SafetyRuntimeError {
+    /// provider が capability を 1 つも宣言していない。
+    ///
+    /// provider が `Err` を返したとき、その結果を `ProviderScanResult` に写像するために
+    /// capability が必要になる。capability の無い provider は scan 失敗時に結果を合成できず
+    /// fail-closed の集約から漏れるため、構築時に拒否する。
+    #[error("safety provider '{provider}' declares no capabilities")]
+    ProviderWithoutCapability { provider: String },
+
+    /// provider 名が空。監査・verdict 反映で識別子が必要なため拒否する。
+    #[error("safety provider name must not be empty")]
+    EmptyProviderName,
+
+    /// issuer node id が空。moderation event の発行者として必須。
+    #[error("issuer_node_id must not be empty")]
+    EmptyIssuerNodeId,
+
+    /// provider が 1 つも登録されていない。
+    ///
+    /// provider が無いと scan 結果が空になり、route() は unscanned として fail-closed に倒すが、
+    /// 構成ミスを早期に検出するため構築時に拒否する。
+    #[error("at least one safety provider must be registered")]
+    NoProviders,
+}

--- a/crates/cn-safety-runtime/src/id.rs
+++ b/crates/cn-safety-runtime/src/id.rs
@@ -1,0 +1,13 @@
+//! moderation event id の供給抽象（#353 段階3b）。
+//!
+//! 未署名 `ModerationEventBody` の `id` を生成する。orchestrator は id 生成方式に依存せず、
+//! この trait を注入される。テストでは決定論的な連番 generator で event id を固定できる。
+//!
+//! 本番の id 実装（UUID / ULID）は本 crate のスコープ外であり、runtime 組み込み段階で別途
+//! 追加する（別 Issue 化済み）。
+
+/// moderation event の一意 id を生成する抽象。
+pub trait EventIdGenerator: Send + Sync {
+    /// 新しい event id を返す。
+    fn next_id(&self) -> String;
+}

--- a/crates/cn-safety-runtime/src/lib.rs
+++ b/crates/cn-safety-runtime/src/lib.rs
@@ -1,0 +1,35 @@
+//! kukuri community node 向け safety runtime adapter / scan orchestration（#353 段階3b）。
+//!
+//! `cn-safety` の pure domain（`SafetyProvider` / `SafetyPolicy` / `route()`）を実際に駆動する
+//! 境界。登録された provider を逐次実行し、provider 失敗を fail-closed な `ScanOutcome` に写像し、
+//! `route()` で `SafetyVerdict` を得て、未署名 moderation artifact（`ModerationEventBody` /
+//! `SafetyRiskSignal`）を生成する。
+//!
+//! この crate は DB / network / production credentials に依存しない。時刻と event id は
+//! [`ScanClock`] / [`EventIdGenerator`] として注入され、本番実装は runtime 組み込み段階で
+//! 追加する（別 Issue）。
+//!
+//! スコープ境界（本 crate に含まないもの）:
+//! - 本番 provider 接続（#391 Project Arachnid Shield 等）
+//! - moderation event の実鍵署名（secp256k1）と永続化、risk signal の永続化
+//! - fail-closed indexing 本体（search / discovery / recommendation 除外の DB 制約）
+//! - blob の一時 fetch / moderation server 本体（HTTP）
+//! - 本番 [`ScanClock`] / [`EventIdGenerator`] 実装
+//!
+//! 設計の真実源:
+//! - `docs/safety/community-node-critical-safety.md`（§5 component boundary, §6 data flow,
+//!   §8 fail-closed invariants, §9 signed events / risk signals）
+//! - `docs/architecture/moderation-event-trust-semantics.md`
+
+mod artifacts;
+pub mod clock;
+pub mod error;
+pub mod id;
+pub mod orchestrator;
+
+pub use clock::ScanClock;
+pub use error::SafetyRuntimeError;
+pub use id::EventIdGenerator;
+pub use orchestrator::{
+    SafetyOrchestrator, SafetyOrchestratorBuilder, SafetyScanReport, map_scan_error,
+};

--- a/crates/cn-safety-runtime/src/orchestrator.rs
+++ b/crates/cn-safety-runtime/src/orchestrator.rs
@@ -1,0 +1,192 @@
+//! scan orchestration（#353 段階3b）。
+//!
+//! 登録された `SafetyProvider` を登録順に逐次実行し、各 `ProviderScanResult`（provider が
+//! `Err` を返した場合は `ScanError` を `ScanOutcome` に写像して合成）を集約して `route()` に
+//! 渡し、`SafetyVerdict` と未署名 moderation artifact を返す。
+//!
+//! fail-closed の要: provider が `Err` を返しても結果集合から除外せず、必ず `Failed` /
+//! `Unavailable` の `ProviderScanResult` を合成する。これにより一部成功 + 一部失敗の取りこぼしを
+//! 防ぐ。
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use kukuri_cn_safety::provider::{ProviderScanRequest, ProviderScanResult, ScanError, ScanOutcome};
+use kukuri_cn_safety::{
+    ModerationEventBody, SafetyPolicy, SafetyProvider, SafetyRiskSignal, SafetyVerdict, route,
+};
+
+use crate::artifacts::build_artifacts;
+use crate::clock::ScanClock;
+use crate::error::SafetyRuntimeError;
+use crate::id::EventIdGenerator;
+
+/// orchestrator の scan 出力。
+///
+/// `verdict` に加え、監査・テスト用の生 scan 結果と、未署名の moderation artifact を含む。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SafetyScanReport {
+    pub verdict: SafetyVerdict,
+    /// route() に渡した provider 結果（provider 失敗は写像済み）。
+    pub scan_results: Vec<ProviderScanResult>,
+    /// 未署名 moderation event。indexable / target 欠落時は `None`。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub moderation_event: Option<ModerationEventBody>,
+    /// risk signal。indexable / target 欠落 / content category 不明時は `None`。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk_signal: Option<SafetyRiskSignal>,
+}
+
+/// `ScanError` を fail-closed な `ScanOutcome` に写像する。
+///
+/// `Unavailable` は `Unavailable`、`Timeout` / `Protocol` は `Failed`。どのエラーも `allow` に
+/// 落ちる `ScanOutcome` には写像しない。
+pub fn map_scan_error(error: &ScanError) -> ScanOutcome {
+    match error {
+        ScanError::Unavailable(_) => ScanOutcome::Unavailable,
+        ScanError::Timeout(_) | ScanError::Protocol(_) => ScanOutcome::Failed,
+    }
+}
+
+/// safety provider を駆動し verdict / artifact を組み立てる orchestrator。
+pub struct SafetyOrchestrator {
+    providers: Vec<Arc<dyn SafetyProvider>>,
+    policy: SafetyPolicy,
+    issuer_node_id: String,
+    clock: Arc<dyn ScanClock>,
+    ids: Arc<dyn EventIdGenerator>,
+}
+
+impl std::fmt::Debug for SafetyOrchestrator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // trait object（providers / clock / ids）は Debug を持たないため、構成の要約のみ出す。
+        f.debug_struct("SafetyOrchestrator")
+            .field("provider_count", &self.providers.len())
+            .field("policy", &self.policy)
+            .field("issuer_node_id", &self.issuer_node_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SafetyOrchestrator {
+    /// builder を開始する。
+    pub fn builder(
+        issuer_node_id: impl Into<String>,
+        clock: Arc<dyn ScanClock>,
+        ids: Arc<dyn EventIdGenerator>,
+    ) -> SafetyOrchestratorBuilder {
+        SafetyOrchestratorBuilder {
+            providers: Vec::new(),
+            policy: None,
+            issuer_node_id: issuer_node_id.into(),
+            clock,
+            ids,
+        }
+    }
+
+    /// 単一 subject を scan して verdict / 未署名 artifact を返す。
+    ///
+    /// providers を登録順に逐次実行し、`Err` は `map_scan_error` で `ProviderScanResult` に
+    /// 合成する。集約結果を `route()` に渡して verdict を得て、未署名 moderation artifact を
+    /// 生成する。
+    pub async fn scan_subject(&self, request: &ProviderScanRequest) -> SafetyScanReport {
+        let scanned_at = self.clock.now_rfc3339();
+
+        let mut scan_results = Vec::with_capacity(self.providers.len());
+        for provider in &self.providers {
+            match provider.scan(request).await {
+                Ok(result) => scan_results.push(result),
+                Err(error) => scan_results.push(synthesize_failure(provider.as_ref(), &error)),
+            }
+        }
+
+        let verdict = route(&scan_results, &self.policy, scanned_at);
+        let (moderation_event, risk_signal) =
+            build_artifacts(&verdict, request, &self.issuer_node_id, self.ids.as_ref());
+
+        SafetyScanReport {
+            verdict,
+            scan_results,
+            moderation_event,
+            risk_signal,
+        }
+    }
+}
+
+/// provider が `Err` を返したときに合成する fail-closed な `ProviderScanResult`。
+///
+/// provider 名と最初の capability を保持し、`outcome` を写像値にする。エラーを握りつぶして
+/// 結果から除外しないことで、一部失敗の取りこぼしを防ぐ。
+fn synthesize_failure(provider: &dyn SafetyProvider, error: &ScanError) -> ProviderScanResult {
+    let capability = provider
+        .capabilities()
+        .first()
+        .copied()
+        .expect("provider capabilities are validated as non-empty at build time");
+    ProviderScanResult {
+        provider: provider.name().to_string(),
+        capability,
+        outcome: map_scan_error(error),
+        known_hash_match: false,
+        score: None,
+        labels: Vec::new(),
+    }
+}
+
+/// `SafetyOrchestrator` の builder。
+pub struct SafetyOrchestratorBuilder {
+    providers: Vec<Arc<dyn SafetyProvider>>,
+    policy: Option<SafetyPolicy>,
+    issuer_node_id: String,
+    clock: Arc<dyn ScanClock>,
+    ids: Arc<dyn EventIdGenerator>,
+}
+
+impl SafetyOrchestratorBuilder {
+    /// provider を登録順に追加する。
+    pub fn provider(mut self, provider: Arc<dyn SafetyProvider>) -> Self {
+        self.providers.push(provider);
+        self
+    }
+
+    /// policy を指定する（未指定なら `SafetyPolicy::public_node_default()`）。
+    pub fn policy(mut self, policy: SafetyPolicy) -> Self {
+        self.policy = Some(policy);
+        self
+    }
+
+    /// 構成を検証して `SafetyOrchestrator` を構築する。
+    ///
+    /// issuer node id の空、provider 不在、capability の無い provider、空 provider 名を拒否する。
+    pub fn build(self) -> Result<SafetyOrchestrator, SafetyRuntimeError> {
+        let issuer_node_id = self.issuer_node_id.trim().to_string();
+        if issuer_node_id.is_empty() {
+            return Err(SafetyRuntimeError::EmptyIssuerNodeId);
+        }
+        if self.providers.is_empty() {
+            return Err(SafetyRuntimeError::NoProviders);
+        }
+        for provider in &self.providers {
+            if provider.name().trim().is_empty() {
+                return Err(SafetyRuntimeError::EmptyProviderName);
+            }
+            if provider.capabilities().is_empty() {
+                return Err(SafetyRuntimeError::ProviderWithoutCapability {
+                    provider: provider.name().to_string(),
+                });
+            }
+        }
+
+        Ok(SafetyOrchestrator {
+            providers: self.providers,
+            policy: self
+                .policy
+                .unwrap_or_else(SafetyPolicy::public_node_default),
+            issuer_node_id,
+            clock: self.clock,
+            ids: self.ids,
+        })
+    }
+}

--- a/crates/cn-safety-runtime/tests/orchestrator.rs
+++ b/crates/cn-safety-runtime/tests/orchestrator.rs
@@ -1,0 +1,434 @@
+//! cn-safety-runtime の決定論的 contract テスト（#353 段階3b）。
+//!
+//! `cn-safety` の mock feature（MockSafetyProvider）と、ローカル定義の固定 clock / 連番 id を
+//! 使い、orchestrator の scan → route → verdict → 未署名 artifact 経路を DB 非依存で検証する。
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use kukuri_cn_safety::provider::{
+    ProviderScanRequest, ProviderScanResult, SafetyProvider, ScanError, ScanOutcome, SubjectKind,
+};
+use kukuri_cn_safety::verdict::{ReasonCode, SafetyAction, SafetyLabel};
+use kukuri_cn_safety::{
+    MockSafetyProvider, RiskSignalTarget, SafetyCategory, SafetyPolicy, SafetyProviderCapability,
+    Visibility,
+};
+use kukuri_cn_safety_runtime::{
+    EventIdGenerator, SafetyOrchestrator, SafetyRuntimeError, ScanClock, map_scan_error,
+};
+
+const SCANNED_AT: &str = "2026-06-29T09:00:00Z";
+
+struct FixedClock(&'static str);
+impl ScanClock for FixedClock {
+    fn now_rfc3339(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[derive(Default)]
+struct SequentialIdGenerator {
+    next: AtomicU64,
+}
+impl EventIdGenerator for SequentialIdGenerator {
+    fn next_id(&self) -> String {
+        let n = self.next.fetch_add(1, Ordering::SeqCst);
+        format!("evt-{n}")
+    }
+}
+
+fn clock() -> Arc<dyn ScanClock> {
+    Arc::new(FixedClock(SCANNED_AT))
+}
+
+fn ids() -> Arc<dyn EventIdGenerator> {
+    Arc::new(SequentialIdGenerator::default())
+}
+
+fn blob_request() -> ProviderScanRequest {
+    ProviderScanRequest::for_subject(SubjectKind::Blob, "blob-1")
+}
+
+#[derive(Clone)]
+struct StaticProvider {
+    name: &'static str,
+    capabilities: Vec<SafetyProviderCapability>,
+    result: ProviderScanResult,
+}
+
+#[async_trait]
+impl SafetyProvider for StaticProvider {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn capabilities(&self) -> &[SafetyProviderCapability] {
+        &self.capabilities
+    }
+
+    async fn scan(&self, _request: &ProviderScanRequest) -> Result<ProviderScanResult, ScanError> {
+        Ok(self.result.clone())
+    }
+}
+
+// --- ScanError 写像 ---
+
+#[test]
+fn scan_error_maps_to_fail_closed_outcomes() {
+    assert_eq!(
+        map_scan_error(&ScanError::Unavailable("x".into())),
+        ScanOutcome::Unavailable
+    );
+    assert_eq!(
+        map_scan_error(&ScanError::Timeout("x".into())),
+        ScanOutcome::Failed
+    );
+    assert_eq!(
+        map_scan_error(&ScanError::Protocol("x".into())),
+        ScanOutcome::Failed
+    );
+}
+
+// --- build 検証 ---
+
+#[test]
+fn build_rejects_empty_issuer() {
+    let provider = Arc::new(MockSafetyProvider::known_csam("known"));
+    let err = SafetyOrchestrator::builder("  ", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap_err();
+    assert_eq!(err, SafetyRuntimeError::EmptyIssuerNodeId);
+}
+
+#[test]
+fn build_rejects_no_providers() {
+    let err = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .build()
+        .unwrap_err();
+    assert_eq!(err, SafetyRuntimeError::NoProviders);
+}
+
+#[test]
+fn build_rejects_provider_without_capability() {
+    let provider = Arc::new(MockSafetyProvider::with_capabilities("empty", vec![]));
+    let err = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap_err();
+    assert_eq!(
+        err,
+        SafetyRuntimeError::ProviderWithoutCapability {
+            provider: "empty".to_string()
+        }
+    );
+}
+
+// --- known CSAM confirmed ---
+
+#[tokio::test]
+async fn known_hash_match_is_excluded_and_emits_event_and_signal() {
+    let provider =
+        Arc::new(MockSafetyProvider::known_csam("known").with_known_hash_match("blob-1"));
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    assert_eq!(report.verdict.action, SafetyAction::Exclude);
+    assert_eq!(report.verdict.reason_code, ReasonCode::CsamConfirmed);
+    assert!(report.verdict.critical);
+    assert!(!report.verdict.is_indexable());
+
+    let event = report.moderation_event.expect("event for excluded content");
+    assert_eq!(event.id, "evt-0");
+    assert_eq!(event.issuer_node_id, "node-1");
+    assert_eq!(event.target_id, "blob-1");
+    assert_eq!(event.created_at, SCANNED_AT);
+    // confirmed は subscribed_nodes 以上が許される。
+    assert_eq!(event.visibility, Visibility::SubscribedNodes);
+
+    let signal = report.risk_signal.expect("signal for excluded content");
+    assert_eq!(signal.target, RiskSignalTarget::BlobCid);
+    assert_eq!(signal.category, SafetyCategory::Csam);
+    assert_eq!(signal.visibility, Visibility::SubscribedNodes);
+}
+
+#[tokio::test]
+async fn issuer_node_id_is_trimmed_for_events() {
+    let provider =
+        Arc::new(MockSafetyProvider::known_csam("known").with_known_hash_match("blob-1"));
+    let orchestrator = SafetyOrchestrator::builder("  node-1  ", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+    assert_eq!(report.moderation_event.unwrap().issuer_node_id, "node-1");
+}
+
+// --- suspected unknown CSAM ---
+
+#[tokio::test]
+async fn suspected_unknown_csam_is_local_visibility() {
+    let provider = Arc::new(
+        MockSafetyProvider::with_capabilities(
+            "classifier",
+            vec![SafetyProviderCapability::NovelCsamImageClassifier],
+        )
+        .with_score(
+            "blob-1",
+            SafetyProviderCapability::NovelCsamImageClassifier,
+            SafetyCategory::Csam,
+            90,
+        ),
+    );
+    // known CSAM provider が無いと require_known_csam で fail-closed になるため、
+    // policy 側の require_known_csam を外して suspected 経路を検証する。
+    let mut policy = SafetyPolicy::public_node_default();
+    policy.require_known_csam = false;
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .policy(policy)
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    assert_eq!(report.verdict.reason_code, ReasonCode::CsamSuspected);
+    assert!(report.verdict.critical);
+    assert!(!report.verdict.is_indexable());
+
+    let signal = report.risk_signal.expect("signal for suspected content");
+    // suspected は誤検知拡散防止のため local 既定。
+    assert_eq!(signal.visibility, Visibility::Local);
+}
+
+#[tokio::test]
+async fn cse_suspected_artifacts_do_not_use_first_noncritical_label() {
+    let result = ProviderScanResult {
+        provider: "cse-classifier".to_string(),
+        capability: SafetyProviderCapability::CseTextClassifier,
+        outcome: ScanOutcome::Completed,
+        known_hash_match: false,
+        score: Some(90),
+        labels: vec![
+            SafetyLabel::new(SafetyCategory::Nsfw).with_confidence(90),
+            SafetyLabel::new(SafetyCategory::Cse).with_confidence(90),
+        ],
+    };
+    let provider = Arc::new(StaticProvider {
+        name: "cse-classifier",
+        capabilities: vec![SafetyProviderCapability::CseTextClassifier],
+        result,
+    });
+    let mut policy = SafetyPolicy::public_node_default();
+    policy.require_known_csam = false;
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .policy(policy)
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    assert_eq!(report.verdict.reason_code, ReasonCode::CseSuspected);
+    let signal = report
+        .risk_signal
+        .expect("signal for CSE suspected content");
+    assert_eq!(signal.category, SafetyCategory::Cse);
+    assert_eq!(signal.visibility, Visibility::Local);
+}
+
+// --- scan failure / unavailable fail-closed ---
+
+#[tokio::test]
+async fn scan_failure_fails_closed_without_risk_signal() {
+    // known CSAM provider が timeout → Failed に写像され fail-closed。
+    let provider = Arc::new(
+        MockSafetyProvider::known_csam("known")
+            .default_error(ScanError::Timeout("deadline".into())),
+    );
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    assert_eq!(report.verdict.reason_code, ReasonCode::ScanFailed);
+    assert_ne!(report.verdict.action, SafetyAction::Allow);
+    assert!(!report.verdict.is_indexable());
+    // scan failure は content category を示さないため risk signal は作らない。
+    assert!(report.risk_signal.is_none());
+    // fail-closed の moderation event は作る（target が揃っているため）。
+    let event = report.moderation_event.expect("event for held content");
+    assert_eq!(event.reason_code, ReasonCode::ScanFailed);
+    assert_eq!(event.visibility, Visibility::Local);
+}
+
+#[tokio::test]
+async fn provider_unavailable_fails_closed() {
+    let provider = Arc::new(
+        MockSafetyProvider::known_csam("known")
+            .default_error(ScanError::Unavailable("down".into())),
+    );
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    assert_eq!(report.verdict.reason_code, ReasonCode::ProviderUnavailable);
+    assert!(!report.verdict.is_indexable());
+    let mapped = &report.scan_results[0];
+    assert_eq!(mapped.outcome, ScanOutcome::Unavailable);
+}
+
+// --- 複数 provider 集約: confirmed を最優先 ---
+
+#[tokio::test]
+async fn confirmed_takes_priority_over_other_provider_failure() {
+    let known = Arc::new(MockSafetyProvider::known_csam("known").with_known_hash_match("blob-1"));
+    let classifier = Arc::new(
+        MockSafetyProvider::with_capabilities(
+            "classifier",
+            vec![SafetyProviderCapability::NovelCsamImageClassifier],
+        )
+        .default_error(ScanError::Timeout("late".into())),
+    );
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(known)
+        .provider(classifier)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    // confirmed が最優先される。
+    assert_eq!(report.verdict.action, SafetyAction::Exclude);
+    assert_eq!(report.verdict.reason_code, ReasonCode::CsamConfirmed);
+    // 2 provider 分の結果が集約される（失敗も除外せず保持）。
+    assert_eq!(report.scan_results.len(), 2);
+    assert!(
+        report
+            .scan_results
+            .iter()
+            .any(|r| r.outcome == ScanOutcome::Failed)
+    );
+}
+
+// --- known CSAM provider 欠落 fail-closed ---
+
+#[tokio::test]
+async fn missing_known_csam_provider_fails_closed() {
+    // general provider のみ、clean 相当を返す。require_known_csam=true（既定）。
+    let provider = Arc::new(
+        MockSafetyProvider::with_capabilities(
+            "general",
+            vec![SafetyProviderCapability::GeneralMediaModeration],
+        )
+        .with_no_known_match("blob-1"),
+    );
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    assert!(!report.verdict.is_indexable());
+    assert_eq!(report.verdict.reason_code, ReasonCode::ProviderUnavailable);
+}
+
+// --- clean / indexable は artifact なし ---
+
+#[tokio::test]
+async fn clean_allow_emits_no_artifacts() {
+    // known CSAM provider が NoKnownMatch を返し、policy が require_known_csam=false なら allow。
+    let provider = Arc::new(MockSafetyProvider::known_csam("known").with_no_known_match("blob-1"));
+    let mut policy = SafetyPolicy::public_node_default();
+    policy.require_known_csam = false;
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .policy(policy)
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    assert_eq!(report.verdict.action, SafetyAction::Allow);
+    // NoKnownMatch は Clean ではない reason_code を維持する。
+    assert_eq!(report.verdict.reason_code, ReasonCode::NoKnownMatch);
+    assert!(report.verdict.is_indexable());
+    assert!(report.moderation_event.is_none());
+    assert!(report.risk_signal.is_none());
+}
+
+// --- target 欠落時は artifact を作らない ---
+
+#[tokio::test]
+async fn missing_target_emits_no_artifacts_but_still_fails_closed() {
+    let provider = Arc::new(
+        MockSafetyProvider::known_csam("known").default_error(ScanError::Timeout("x".into())),
+    );
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap();
+    // subject_id / subject_kind の無い request。
+    let report = orchestrator.scan_subject(&ProviderScanRequest::new()).await;
+
+    assert!(!report.verdict.is_indexable());
+    assert!(report.moderation_event.is_none());
+    assert!(report.risk_signal.is_none());
+}
+
+#[tokio::test]
+async fn empty_target_id_emits_no_artifacts() {
+    let provider = Arc::new(MockSafetyProvider::known_csam("known").with_known_hash_match(""));
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap();
+    let request = ProviderScanRequest::for_subject(SubjectKind::Blob, "");
+    let report = orchestrator.scan_subject(&request).await;
+
+    assert!(!report.verdict.is_indexable());
+    assert!(report.moderation_event.is_none());
+    assert!(report.risk_signal.is_none());
+}
+
+// --- 決定論的 id / clock ---
+
+#[tokio::test]
+async fn event_ids_are_sequential_and_deterministic() {
+    let provider =
+        Arc::new(MockSafetyProvider::known_csam("known").with_known_hash_match("blob-1"));
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap();
+
+    let first = orchestrator.scan_subject(&blob_request()).await;
+    let second = orchestrator.scan_subject(&blob_request()).await;
+    assert_eq!(first.moderation_event.unwrap().id, "evt-0");
+    assert_eq!(second.moderation_event.unwrap().id, "evt-1");
+}
+
+// --- serde round-trip ---
+
+#[tokio::test]
+async fn report_round_trips_snake_case() {
+    let provider =
+        Arc::new(MockSafetyProvider::known_csam("known").with_known_hash_match("blob-1"));
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    let value = serde_json::to_value(&report).unwrap();
+    assert_eq!(value["verdict"]["action"], "exclude");
+    assert_eq!(value["moderation_event"]["action"], "exclude");
+    assert_eq!(value["risk_signal"]["target"], "blob_cid");
+
+    let back: kukuri_cn_safety_runtime::SafetyScanReport = serde_json::from_value(value).unwrap();
+    assert_eq!(back, report);
+}

--- a/docs/progress/2026-06-29-353-safety-domain-model.md
+++ b/docs/progress/2026-06-29-353-safety-domain-model.md
@@ -263,3 +263,69 @@ runtime / provider 接続後に残る `Unknown`:
 - `safety_readiness.rs` の `impl From<SafetyErrorAction> for kukuri_cn_safety::SafetyAction` を削除した。
   消費箇所が無く（`on_scan_error` → `SafetyAction` の写像は後続の runtime scan adapter で使う想定だが、本 PR スコープ外）、
   `pub` trait impl は `dead_code` lint の対象外のため検出されず残っていた。dead code を残さない方針に従い除去した。
+
+## 段階3b: safety runtime adapter / scan orchestration
+
+indexing 本体に入る前の DB 非依存作業として、`cn-safety` の pure domain（`SafetyProvider` /
+`SafetyPolicy` / `route()`）を実際に駆動する境界を新規 crate `crates/cn-safety-runtime`
+（`kukuri-cn-safety-runtime`）として追加した。
+
+### 実装範囲
+
+- 新規 crate `crates/cn-safety-runtime`（`cn-safety` にのみ依存。DB / network / production
+  credentials なし）。
+  - workspace members と `xtask` `CN_PACKAGES` に追加（`cargo xtask cn-check` / `cn-test` 対象）。
+- 抽象注入:
+  - `ScanClock { fn now_rfc3339(&self) -> String }` … scan 時刻供給。crate 自体は時計非依存。
+  - `EventIdGenerator { fn next_id(&self) -> String }` … moderation event id 供給。
+  - 本番実装（system clock / UUID・ULID）は本 crate のスコープ外（別 Issue 起票）。テストは
+    integration test 内の固定 clock / 連番 id で決定論的に検証。
+- `SafetyOrchestrator`（builder で provider を登録順に保持）:
+  - `scan_subject(&ProviderScanRequest) -> SafetyScanReport`。
+  - provider を**登録順に逐次実行**し、各 `ProviderScanResult` を集約して 1 回 `route()` に渡す。
+  - provider が `Err` を返した場合、`map_scan_error` で `ScanOutcome` に写像し、provider 名 /
+    capability を保持した `ProviderScanResult` を**合成**する（結果集合から除外しない）。
+    一部成功 + 一部失敗の取りこぼしを防ぐ fail-closed の要。
+  - build 時に issuer node id 空 / provider 不在 / capability 無し provider / 空 provider 名を
+    `SafetyRuntimeError` で拒否。
+- `ScanError → ScanOutcome` 写像:
+  - `Unavailable` → `Unavailable`、`Timeout` / `Protocol` → `Failed`。route() の既存 fail-closed
+    分岐（Unavailable→ProviderUnavailable, Failed→ScanFailed）と整合。
+- verdict からの**未署名** moderation artifact 生成（`SafetyScanReport.moderation_event` /
+  `risk_signal`）:
+  - indexable（`allow`）verdict では artifact を生成しない。
+  - target（subject_kind / subject_id）が欠けている場合や `subject_id` が空/空白の場合は artifact を生成しない（空 target_id の
+    moderation event を作らない）。
+  - operational fail-closed（scan_failed / provider_unavailable / unscanned）は content の safety
+    category を示さないため **risk signal を作らない**（虚偽の risk label を作らない）。moderation
+    event は target が揃えば生成（visibility=local）。
+  - visibility は `SafetyRiskSignal::default_visibility_for(category, basis)` に従い、suspected
+    unknown CSAM / CSE は `Local` 既定、confirmed のみ `SubscribedNodes` 以上。
+  - critical reason（`csam_confirmed` / `csam_suspected` / `cse_suspected`）は reason_code を優先して category を導出し、provider が先頭に一般 label を返しても critical category を取り違えない。
+  - 署名はしない（`SignedModerationEvent` は作らない。body のみ）。
+
+### 維持した境界
+
+- 本番 provider 接続（#391）、実鍵署名（secp256k1）、event / signal の永続化は未実装。
+- fail-closed indexing 本体（DB 制約）、moderation server の HTTP / blob 一時 fetch は未実装。
+- `cn-operator` / `cn-core` からの本 crate 利用結線（runtime 組み込み）は後続。
+- `Moderation` / `CommunityIndex` / `CommunityLocalTrust` は引き続き `Availability::Planned`。
+- mock（provider / clock / id）は production の既定 API に出さない（cn-safety の mock は
+  dev-dependency の `features = ["mock"]` 経由、runtime の clock / id mock は integration test 内
+  local 定義）。
+
+### 後続への申し送り（別 Issue）
+
+- 本番 `ScanClock`（system clock, RFC3339）実装 … Issue #398。
+- 本番 `EventIdGenerator`（UUID / ULID）実装 … Issue #399。
+- いずれも cn-safety-runtime を runtime に組み込む段階で必要。
+
+### 検証
+
+- `cargo test -p kukuri-cn-safety-runtime`（mock provider / 固定 clock / 連番 id、DB 不要）: 17 tests pass。
+- `cargo check -p kukuri-cn-safety-runtime --no-default-features`（production ビルド = mock 無し）: pass。
+- `cargo clippy -p kukuri-cn-safety-runtime --all-targets --all-features -- -D warnings`: clean。
+- `cargo fmt -p kukuri-cn-safety-runtime --check`: clean。
+- `cargo xtask cn-check`（CN slice。新 crate を含む）。
+- `cargo xtask cn-test`（CN slice の test。Postgres/Valkey harness 起動を含む）。
+- `cargo test -p xtask`（`CN_PACKAGES` 長変更の回帰確認）。

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,13 +6,14 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
-const CN_PACKAGES: [&str; 6] = [
+const CN_PACKAGES: [&str; 7] = [
     "kukuri-cn-core",
     "kukuri-cn-user-api",
     "kukuri-cn-iroh-relay",
     "kukuri-cn-cli",
     "kukuri-cn-operator",
     "kukuri-cn-safety",
+    "kukuri-cn-safety-runtime",
 ];
 const SERIAL_RUST_PACKAGE: &str = "kukuri-harness";
 const TAURI_CHECK_TARGET_DIR: &str = "target/desktop-tauri-check";


### PR DESCRIPTION
## Summary
- Refs #353 の段階3bとして kukuri-cn-safety-runtime crate を追加
- provider を登録順に逐次 scan し、ScanError を fail-closed な ScanOutcome に写像して oute() に集約
- SafetyVerdict から未署名 ModerationEventBody / SafetyRiskSignal を生成
- ScanClock / EventIdGenerator 抽象を追加し、本番実装は #398 / #399 に分離

## Testing
- cargo check -p kukuri-cn-safety-runtime --no-default-features
- cargo test -p kukuri-cn-safety-runtime
- cargo clippy -p kukuri-cn-safety-runtime --all-targets --all-features -- -D warnings
- cargo fmt -p kukuri-cn-safety-runtime --check
- cargo xtask cn-check
- cargo xtask cn-test
- cargo test -p xtask
- cargo xtask oversized-files