### PR TITLE
feat(cn): add system scan clock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,6 +2990,7 @@ name = "kukuri-cn-safety-runtime"
 version = "0.1.2"
 dependencies = [
  "async-trait",
+ "chrono",
  "kukuri-cn-safety",
  "serde",
  "serde_json",

--- a/crates/cn-safety-runtime/Cargo.toml
+++ b/crates/cn-safety-runtime/Cargo.toml
@@ -9,6 +9,7 @@ name = "kukuri_cn_safety_runtime"
 path = "src/lib.rs"
 
 [dependencies]
+chrono.workspace = true
 kukuri-cn-safety = { path = "../cn-safety" }
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/cn-safety-runtime/src/clock.rs
+++ b/crates/cn-safety-runtime/src/clock.rs
@@ -1,14 +1,37 @@
-//! scan 時刻の供給抽象（#353 段階3b）。
+//! scan 時刻の供給抽象と本番実装（#353 段階3b / #398）。
 //!
 //! `cn-safety` の `route()` は時計を持たず、`scanned_at`（RFC3339 文字列）を呼び出し側が与える。
-//! orchestrator も時計依存を持たず、この trait を注入される。これにより本 crate は pure に保たれ、
-//! テストでは固定時刻 clock で verdict / event を決定論的に検証できる。
+//! orchestrator も時計依存を持たず、この trait を注入される。これによりテストでは固定時刻 clock で
+//! verdict / event を決定論的に検証できる。
 //!
-//! 本番の system clock 実装（`std::time` / `chrono` ベース）は本 crate のスコープ外であり、
-//! runtime 組み込み段階で別途追加する（別 Issue 化済み）。
+//! 本番では [`SystemScanClock`] を `Arc<dyn ScanClock>` として注入し、system clock（UTC）から
+//! RFC3339 文字列を得る。
+
+use chrono::{SecondsFormat, Utc};
 
 /// scan 実行時刻を RFC3339 文字列で返す clock 抽象。
 pub trait ScanClock: Send + Sync {
     /// 現在時刻を RFC3339（例: `2026-06-29T09:00:00Z`）で返す。
     fn now_rfc3339(&self) -> String;
+}
+
+/// system clock（UTC）ベースの本番 [`ScanClock`] 実装。
+///
+/// `now_rfc3339()` は UTC・秒精度・`Z` suffix に正規化した RFC3339 文字列を返す
+/// （例: `2026-06-29T09:00:00Z`）。scan / moderation event の監査時刻として秒未満は不要のため、
+/// fractional seconds は含めない。
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemScanClock;
+
+impl SystemScanClock {
+    /// 新しい `SystemScanClock` を作る。
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ScanClock for SystemScanClock {
+    fn now_rfc3339(&self) -> String {
+        Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+    }
 }

--- a/crates/cn-safety-runtime/src/lib.rs
+++ b/crates/cn-safety-runtime/src/lib.rs
@@ -6,15 +6,16 @@
 //! `SafetyRiskSignal`）を生成する。
 //!
 //! この crate は DB / network / production credentials に依存しない。時刻と event id は
-//! [`ScanClock`] / [`EventIdGenerator`] として注入され、本番実装は runtime 組み込み段階で
-//! 追加する（別 Issue）。
+//! [`ScanClock`] / [`EventIdGenerator`] として注入される。時刻の本番実装は
+//! [`SystemScanClock`]（system clock, UTC RFC3339）として提供する。event id の本番実装は
+//! runtime 組み込み段階で追加する（#399）。
 //!
 //! スコープ境界（本 crate に含まないもの）:
 //! - 本番 provider 接続（#391 Project Arachnid Shield 等）
 //! - moderation event の実鍵署名（secp256k1）と永続化、risk signal の永続化
 //! - fail-closed indexing 本体（search / discovery / recommendation 除外の DB 制約）
 //! - blob の一時 fetch / moderation server 本体（HTTP）
-//! - 本番 [`ScanClock`] / [`EventIdGenerator`] 実装
+//! - 本番 [`EventIdGenerator`] 実装（#399）
 //!
 //! 設計の真実源:
 //! - `docs/safety/community-node-critical-safety.md`（§5 component boundary, §6 data flow,
@@ -27,7 +28,7 @@ pub mod error;
 pub mod id;
 pub mod orchestrator;
 
-pub use clock::ScanClock;
+pub use clock::{ScanClock, SystemScanClock};
 pub use error::SafetyRuntimeError;
 pub use id::EventIdGenerator;
 pub use orchestrator::{

--- a/crates/cn-safety-runtime/tests/clock.rs
+++ b/crates/cn-safety-runtime/tests/clock.rs
@@ -1,0 +1,68 @@
+//! `SystemScanClock` の本番 clock contract テスト（#398）。
+//!
+//! 現在時刻そのものは固定せず、RFC3339 / UTC / 秒精度の契約と orchestrator への注入可能性だけを
+//! 検証する。
+
+use std::sync::Arc;
+
+use chrono::DateTime;
+use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
+use kukuri_cn_safety::verdict::SafetyAction;
+use kukuri_cn_safety::{MockSafetyProvider, SafetyPolicy};
+use kukuri_cn_safety_runtime::{EventIdGenerator, SafetyOrchestrator, ScanClock, SystemScanClock};
+
+#[test]
+fn system_clock_returns_parseable_rfc3339() {
+    let clock = SystemScanClock::new();
+    let now = clock.now_rfc3339();
+    let parsed = DateTime::parse_from_rfc3339(&now)
+        .unwrap_or_else(|err| panic!("now_rfc3339 must be RFC3339: {now} ({err})"));
+    // UTC（offset 0 秒）であること。
+    assert_eq!(
+        parsed.offset().local_minus_utc(),
+        0,
+        "expected UTC offset: {now}"
+    );
+}
+
+#[test]
+fn system_clock_is_utc_z_suffixed_and_second_precision() {
+    let now = SystemScanClock.now_rfc3339();
+    // UTC は `Z` suffix で表す（`+00:00` ではない）。
+    assert!(now.ends_with('Z'), "expected Z suffix: {now}");
+    // 秒精度であり fractional seconds を含まない。
+    assert!(!now.contains('.'), "expected no fractional seconds: {now}");
+    // `YYYY-MM-DDTHH:MM:SSZ` は 20 文字。
+    assert_eq!(now.len(), 20, "expected second precision length: {now}");
+}
+
+struct SequentialIdGenerator;
+impl EventIdGenerator for SequentialIdGenerator {
+    fn next_id(&self) -> String {
+        "evt-0".to_string()
+    }
+}
+
+#[tokio::test]
+async fn system_clock_can_drive_orchestrator() {
+    let clock: Arc<dyn ScanClock> = Arc::new(SystemScanClock::new());
+    let ids: Arc<dyn EventIdGenerator> = Arc::new(SequentialIdGenerator);
+    let provider =
+        Arc::new(MockSafetyProvider::known_csam("known").with_known_hash_match("blob-1"));
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock, ids)
+        .policy(SafetyPolicy::public_node_default())
+        .provider(provider)
+        .build()
+        .unwrap();
+
+    let request = ProviderScanRequest::for_subject(SubjectKind::Blob, "blob-1");
+    let report = orchestrator.scan_subject(&request).await;
+
+    assert_eq!(report.verdict.action, SafetyAction::Exclude);
+    let event = report.moderation_event.expect("event for excluded content");
+    // orchestrator は clock の値を scanned_at / created_at に伝播する。
+    DateTime::parse_from_rfc3339(&report.verdict.scanned_at)
+        .expect("verdict.scanned_at must be RFC3339");
+    DateTime::parse_from_rfc3339(&event.created_at).expect("event.created_at must be RFC3339");
+    assert_eq!(report.verdict.scanned_at, event.created_at);
+}

--- a/docs/progress/2026-06-29-353-safety-domain-model.md
+++ b/docs/progress/2026-06-29-353-safety-domain-model.md
@@ -276,10 +276,12 @@ indexing 本体に入る前の DB 非依存作業として、`cn-safety` の pur
   credentials なし）。
   - workspace members と `xtask` `CN_PACKAGES` に追加（`cargo xtask cn-check` / `cn-test` 対象）。
 - 抽象注入:
-  - `ScanClock { fn now_rfc3339(&self) -> String }` … scan 時刻供給。crate 自体は時計非依存。
-  - `EventIdGenerator { fn next_id(&self) -> String }` … moderation event id 供給。
-  - 本番実装（system clock / UUID・ULID）は本 crate のスコープ外（別 Issue 起票）。テストは
-    integration test 内の固定 clock / 連番 id で決定論的に検証。
+  - `ScanClock { fn now_rfc3339(&self) -> String }` … scan 時刻供給。orchestrator は clock 注入のまま維持。
+    本番実装 `SystemScanClock`（system clock, UTC RFC3339）を追加済み（#398）。
+  - `EventIdGenerator { fn next_id(&self) -> String }` … moderation event id 供給。本番実装
+    （UUID / ULID）は本 crate のスコープ外（#399）。
+  - テストは orchestrator 経路を固定 clock / 連番 id で決定論的に検証し、`SystemScanClock` は
+    RFC3339 / UTC / 秒精度の契約を別 contract test で検証。
 - `SafetyOrchestrator`（builder で provider を登録順に保持）:
   - `scan_subject(&ProviderScanRequest) -> SafetyScanReport`。
   - provider を**登録順に逐次実行**し、各 `ProviderScanResult` を集約して 1 回 `route()` に渡す。
@@ -316,16 +318,36 @@ indexing 本体に入る前の DB 非依存作業として、`cn-safety` の pur
 
 ### 後続への申し送り（別 Issue）
 
-- 本番 `ScanClock`（system clock, RFC3339）実装 … Issue #398。
-- 本番 `EventIdGenerator`（UUID / ULID）実装 … Issue #399。
-- いずれも cn-safety-runtime を runtime に組み込む段階で必要。
+- 本番 `ScanClock`（system clock, RFC3339）実装 … Issue #398（`SystemScanClock` として実装済み）。
+- 本番 `EventIdGenerator`（UUID / ULID）実装 … Issue #399（未実装）。
+- runtime 組み込み時は `SystemScanClock` を注入し、event id には #399 の本番実装を追加して使う。
 
 ### 検証
 
-- `cargo test -p kukuri-cn-safety-runtime`（mock provider / 固定 clock / 連番 id、DB 不要）: 17 tests pass。
+- `cargo test -p kukuri-cn-safety-runtime`（mock provider / 固定 clock / 連番 id、DB 不要 + SystemScanClock contract）: 20 tests pass。
 - `cargo check -p kukuri-cn-safety-runtime --no-default-features`（production ビルド = mock 無し）: pass。
 - `cargo clippy -p kukuri-cn-safety-runtime --all-targets --all-features -- -D warnings`: clean。
 - `cargo fmt -p kukuri-cn-safety-runtime --check`: clean。
 - `cargo xtask cn-check`（CN slice。新 crate を含む）。
 - `cargo xtask cn-test`（CN slice の test。Postgres/Valkey harness 起動を含む）。
 - `cargo test -p xtask`（`CN_PACKAGES` 長変更の回帰確認）。
+
+## #398: 本番 ScanClock（SystemScanClock）
+
+cn-safety-runtime に system clock ベースの本番 `ScanClock` 実装 `SystemScanClock` を追加した。
+
+### 実装範囲
+
+- `crates/cn-safety-runtime/src/clock.rs` に `SystemScanClock` を追加。
+  - `now_rfc3339()` は `chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)` を返す。
+  - UTC・秒精度・`Z` suffix に正規化（例: `2026-06-29T09:00:00Z`）。監査時刻として秒未満は不要。
+- crate root から `SystemScanClock` を re-export。`Arc<dyn ScanClock>` として
+  `SafetyOrchestrator::builder` に渡せる。
+- `chrono` を `cn-safety-runtime` の通常依存に追加（workspace dependency。新規外部 dependency は増やさない）。
+- `ScanClock` trait と orchestrator のシグネチャは変更しない。テストの固定 clock も従来どおり。
+
+### 検証
+
+- `cargo test -p kukuri-cn-safety-runtime --test clock`: 3 tests pass（RFC3339 / UTC / 秒精度 / orchestrator 注入）。
+- `cargo check -p kukuri-cn-safety-runtime --no-default-features`: pass。
+- 残課題: 本番 `EventIdGenerator`（#399）。


### PR DESCRIPTION
## Summary
- Refs #398
- kukuri-cn-safety-runtime に本番 SystemScanClock を追加
- 
ow_rfc3339() を UTC・秒精度・Z suffix の RFC3339 に正規化
- SystemScanClock を crate root から re-export し、orchestrator 注入 contract test を追加

## Testing
- cargo check -p kukuri-cn-safety-runtime --no-default-features
- cargo test -p kukuri-cn-safety-runtime
- cargo fmt -p kukuri-cn-safety-runtime --check
- cargo clippy -p kukuri-cn-safety-runtime --all-targets -- -D warnings
- cargo clippy -p kukuri-cn-safety-runtime --all-targets --all-features -- -D warnings
- cargo xtask cn-check
- cargo test -p xtask