### PR TITLE
feat(cn): add uuid event id generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,6 +2996,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/cn-core/tests/runtime_init.rs
+++ b/crates/cn-core/tests/runtime_init.rs
@@ -4,7 +4,7 @@ use kukuri_cn_core::{
     initialize_database_for_runtime,
 };
 
-const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:55432/cn";
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
 
 fn integration_test_admin_database_url() -> Option<String> {
     let enabled = std::env::var("KUKURI_CN_RUN_INTEGRATION_TESTS")

--- a/crates/cn-safety-runtime/Cargo.toml
+++ b/crates/cn-safety-runtime/Cargo.toml
@@ -13,9 +13,11 @@ chrono.workspace = true
 kukuri-cn-safety = { path = "../cn-safety" }
 serde.workspace = true
 thiserror.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
 kukuri-cn-safety = { path = "../cn-safety", features = ["mock"] }
 serde_json.workspace = true
 tokio.workspace = true
+uuid.workspace = true

--- a/crates/cn-safety-runtime/src/id.rs
+++ b/crates/cn-safety-runtime/src/id.rs
@@ -1,13 +1,36 @@
-//! moderation event id の供給抽象（#353 段階3b）。
+//! moderation event id の供給抽象と本番実装（#353 段階3b / #399）。
 //!
 //! 未署名 `ModerationEventBody` の `id` を生成する。orchestrator は id 生成方式に依存せず、
 //! この trait を注入される。テストでは決定論的な連番 generator で event id を固定できる。
 //!
-//! 本番の id 実装（UUID / ULID）は本 crate のスコープ外であり、runtime 組み込み段階で別途
-//! 追加する（別 Issue 化済み）。
+//! 本番では [`UuidEventIdGenerator`] を `Arc<dyn EventIdGenerator>` として注入し、UUID v4 を
+//! moderation event id として使う。
+
+use uuid::Uuid;
 
 /// moderation event の一意 id を生成する抽象。
 pub trait EventIdGenerator: Send + Sync {
     /// 新しい event id を返す。
     fn next_id(&self) -> String;
+}
+
+/// UUID v4 ベースの本番 [`EventIdGenerator`] 実装。
+///
+/// `next_id()` はハイフン付き小文字の UUID v4 文字列を返す
+/// （例: `550e8400-e29b-41d4-a716-446655440000`）。乱数ベースのため event id は
+/// プロセス / ノードをまたいで衝突しない前提で扱える。
+#[derive(Clone, Copy, Debug, Default)]
+pub struct UuidEventIdGenerator;
+
+impl UuidEventIdGenerator {
+    /// 新しい `UuidEventIdGenerator` を作る。
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl EventIdGenerator for UuidEventIdGenerator {
+    fn next_id(&self) -> String {
+        Uuid::new_v4().to_string()
+    }
 }

--- a/crates/cn-safety-runtime/src/lib.rs
+++ b/crates/cn-safety-runtime/src/lib.rs
@@ -6,16 +6,15 @@
 //! `SafetyRiskSignal`）を生成する。
 //!
 //! この crate は DB / network / production credentials に依存しない。時刻と event id は
-//! [`ScanClock`] / [`EventIdGenerator`] として注入される。時刻の本番実装は
-//! [`SystemScanClock`]（system clock, UTC RFC3339）として提供する。event id の本番実装は
-//! runtime 組み込み段階で追加する（#399）。
+//! [`ScanClock`] / [`EventIdGenerator`] として注入される。本番実装として時刻は
+//! [`SystemScanClock`]（system clock, UTC RFC3339）、event id は
+//! [`UuidEventIdGenerator`]（UUID v4）を提供する。
 //!
 //! スコープ境界（本 crate に含まないもの）:
 //! - 本番 provider 接続（#391 Project Arachnid Shield 等）
 //! - moderation event の実鍵署名（secp256k1）と永続化、risk signal の永続化
 //! - fail-closed indexing 本体（search / discovery / recommendation 除外の DB 制約）
 //! - blob の一時 fetch / moderation server 本体（HTTP）
-//! - 本番 [`EventIdGenerator`] 実装（#399）
 //!
 //! 設計の真実源:
 //! - `docs/safety/community-node-critical-safety.md`（§5 component boundary, §6 data flow,
@@ -30,7 +29,7 @@ pub mod orchestrator;
 
 pub use clock::{ScanClock, SystemScanClock};
 pub use error::SafetyRuntimeError;
-pub use id::EventIdGenerator;
+pub use id::{EventIdGenerator, UuidEventIdGenerator};
 pub use orchestrator::{
     SafetyOrchestrator, SafetyOrchestratorBuilder, SafetyScanReport, map_scan_error,
 };

--- a/crates/cn-safety-runtime/tests/id.rs
+++ b/crates/cn-safety-runtime/tests/id.rs
@@ -1,0 +1,60 @@
+//! `UuidEventIdGenerator` の本番 id contract テスト（#399）。
+//!
+//! 乱数 id の一意性そのものは確率的性質のため固定せず、UUID v4 として parse できること・
+//! version が v4 であること・orchestrator へ注入できることを検証する。
+
+use std::sync::Arc;
+
+use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
+use kukuri_cn_safety::verdict::SafetyAction;
+use kukuri_cn_safety::{MockSafetyProvider, SafetyPolicy};
+use kukuri_cn_safety_runtime::{
+    EventIdGenerator, SafetyOrchestrator, ScanClock, UuidEventIdGenerator,
+};
+use uuid::{Uuid, Version};
+
+struct FixedClock;
+impl ScanClock for FixedClock {
+    fn now_rfc3339(&self) -> String {
+        "2026-06-29T09:00:00Z".to_string()
+    }
+}
+
+#[test]
+fn next_id_is_uuid_v4() {
+    let ids = UuidEventIdGenerator::new();
+    let id = ids.next_id();
+    let parsed = Uuid::parse_str(&id).unwrap_or_else(|err| panic!("id must be UUID: {id} ({err})"));
+    assert_eq!(
+        parsed.get_version(),
+        Some(Version::Random),
+        "expected v4: {id}"
+    );
+}
+
+#[test]
+fn next_id_is_unique_per_call() {
+    let ids = UuidEventIdGenerator;
+    assert_ne!(ids.next_id(), ids.next_id());
+}
+
+#[tokio::test]
+async fn uuid_generator_can_drive_orchestrator() {
+    let clock: Arc<dyn ScanClock> = Arc::new(FixedClock);
+    let ids: Arc<dyn EventIdGenerator> = Arc::new(UuidEventIdGenerator::new());
+    let provider =
+        Arc::new(MockSafetyProvider::known_csam("known").with_known_hash_match("blob-1"));
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock, ids)
+        .policy(SafetyPolicy::public_node_default())
+        .provider(provider)
+        .build()
+        .unwrap();
+
+    let request = ProviderScanRequest::for_subject(SubjectKind::Blob, "blob-1");
+    let report = orchestrator.scan_subject(&request).await;
+
+    assert_eq!(report.verdict.action, SafetyAction::Exclude);
+    let event = report.moderation_event.expect("event for excluded content");
+    Uuid::parse_str(&event.id)
+        .unwrap_or_else(|err| panic!("event id must be UUID: {} ({err})", event.id));
+}

--- a/crates/cn-user-api/tests/contract.rs
+++ b/crates/cn-user-api/tests/contract.rs
@@ -15,8 +15,8 @@ use redis::AsyncCommands;
 use reqwest::{Client, StatusCode};
 use sqlx::postgres::PgPool;
 
-const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:55432/cn";
-const DEFAULT_RENDEZVOUS_REDIS_URL: &str = "redis://127.0.0.1:56379/";
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+const DEFAULT_RENDEZVOUS_REDIS_URL: &str = "redis://127.0.0.1:16379/";
 
 struct TestServer {
     task: tokio::task::JoinHandle<()>,

--- a/crates/cn-user-api/tests/reports.rs
+++ b/crates/cn-user-api/tests/reports.rs
@@ -11,8 +11,8 @@ use kukuri_cn_core::{JwtConfig, TestDatabase};
 use kukuri_cn_user_api::{UserApiConfig, app_router, build_state};
 use reqwest::{Client, StatusCode};
 
-const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:55432/cn";
-const DEFAULT_RENDEZVOUS_REDIS_URL: &str = "redis://127.0.0.1:56379/";
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+const DEFAULT_RENDEZVOUS_REDIS_URL: &str = "redis://127.0.0.1:16379/";
 
 /// report_endpoint capability を有効化した operator config。
 const REPORT_ENABLED_YAML: &str = r#"server:

--- a/crates/harness/src/runtime.rs
+++ b/crates/harness/src/runtime.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
-const DEFAULT_CN_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:55432/cn";
-const DEFAULT_CN_RENDEZVOUS_REDIS_URL: &str = "redis://127.0.0.1:56379/";
+const DEFAULT_CN_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+const DEFAULT_CN_RENDEZVOUS_REDIS_URL: &str = "redis://127.0.0.1:16379/";
 const EXTERNAL_CN_BASE_URL_ENV: &str = "KUKURI_HARNESS_COMMUNITY_NODE_BASE_URL";
 const EXTERNAL_CN_CONNECTIVITY_URLS_ENV: &str = "KUKURI_HARNESS_COMMUNITY_NODE_CONNECTIVITY_URLS";
 

--- a/docker-compose.community-node.yml
+++ b/docker-compose.community-node.yml
@@ -17,7 +17,7 @@ services:
     environment: *cn-postgres-env
     restart: unless-stopped
     ports:
-      - "${CN_POSTGRES_HOST_BIND_IP:-127.0.0.1}:${CN_POSTGRES_PORT:-55432}:5432"
+      - "${CN_POSTGRES_HOST_BIND_IP:-127.0.0.1}:${CN_POSTGRES_PORT:-15432}:5432"
     healthcheck:
       test:
         [
@@ -34,7 +34,7 @@ services:
     image: valkey/valkey:8-alpine
     restart: unless-stopped
     ports:
-      - "${CN_VALKEY_HOST_BIND_IP:-127.0.0.1}:${CN_VALKEY_PORT:-56379}:6379"
+      - "${CN_VALKEY_HOST_BIND_IP:-127.0.0.1}:${CN_VALKEY_PORT:-16379}:6379"
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 5s

--- a/docs/progress/2026-06-29-353-safety-domain-model.md
+++ b/docs/progress/2026-06-29-353-safety-domain-model.md
@@ -278,8 +278,8 @@ indexing 本体に入る前の DB 非依存作業として、`cn-safety` の pur
 - 抽象注入:
   - `ScanClock { fn now_rfc3339(&self) -> String }` … scan 時刻供給。orchestrator は clock 注入のまま維持。
     本番実装 `SystemScanClock`（system clock, UTC RFC3339）を追加済み（#398）。
-  - `EventIdGenerator { fn next_id(&self) -> String }` … moderation event id 供給。本番実装
-    （UUID / ULID）は本 crate のスコープ外（#399）。
+  - `EventIdGenerator { fn next_id(&self) -> String }` … moderation event id 供給。
+    本番実装 `UuidEventIdGenerator`（UUID v4）を追加済み（#399）。
   - テストは orchestrator 経路を固定 clock / 連番 id で決定論的に検証し、`SystemScanClock` は
     RFC3339 / UTC / 秒精度の契約を別 contract test で検証。
 - `SafetyOrchestrator`（builder で provider を登録順に保持）:
@@ -319,12 +319,12 @@ indexing 本体に入る前の DB 非依存作業として、`cn-safety` の pur
 ### 後続への申し送り（別 Issue）
 
 - 本番 `ScanClock`（system clock, RFC3339）実装 … Issue #398（`SystemScanClock` として実装済み）。
-- 本番 `EventIdGenerator`（UUID / ULID）実装 … Issue #399（未実装）。
-- runtime 組み込み時は `SystemScanClock` を注入し、event id には #399 の本番実装を追加して使う。
+- 本番 `EventIdGenerator`（UUID / ULID）実装 … Issue #399（`UuidEventIdGenerator` として実装済み）。
+- runtime 組み込み時は `SystemScanClock` と `UuidEventIdGenerator` を注入する。
 
 ### 検証
 
-- `cargo test -p kukuri-cn-safety-runtime`（mock provider / 固定 clock / 連番 id、DB 不要 + SystemScanClock contract）: 20 tests pass。
+- `cargo test -p kukuri-cn-safety-runtime`（mock provider / 固定 clock / 連番 id、DB 不要 + SystemScanClock / UuidEventIdGenerator contract）: 23 tests pass。
 - `cargo check -p kukuri-cn-safety-runtime --no-default-features`（production ビルド = mock 無し）: pass。
 - `cargo clippy -p kukuri-cn-safety-runtime --all-targets --all-features -- -D warnings`: clean。
 - `cargo fmt -p kukuri-cn-safety-runtime --check`: clean。
@@ -350,4 +350,25 @@ cn-safety-runtime に system clock ベースの本番 `ScanClock` 実装 `System
 
 - `cargo test -p kukuri-cn-safety-runtime --test clock`: 3 tests pass（RFC3339 / UTC / 秒精度 / orchestrator 注入）。
 - `cargo check -p kukuri-cn-safety-runtime --no-default-features`: pass。
-- 残課題: 本番 `EventIdGenerator`（#399）。
+- #399（本番 `EventIdGenerator`）も対応済み。下記 #399 節を参照。
+
+## #399: 本番 EventIdGenerator（UuidEventIdGenerator）
+
+cn-safety-runtime に UUID v4 ベースの本番 `EventIdGenerator` 実装 `UuidEventIdGenerator` を追加した。
+
+### 実装範囲
+
+- `crates/cn-safety-runtime/src/id.rs` に `UuidEventIdGenerator` を追加。
+  - `next_id()` は `uuid::Uuid::new_v4().to_string()`（ハイフン付き小文字 UUID v4）を返す。
+- crate root から `UuidEventIdGenerator` を re-export。`Arc<dyn EventIdGenerator>` として
+  `SafetyOrchestrator::builder` に渡せる。
+- `uuid` を `cn-safety-runtime` の通常依存に追加（workspace dependency。lockfile 解決済みで
+  新規外部 dependency は増やさない）。
+- ULID ではなく UUID を採用。`uuid` が `features=["serde","v4"]` 付きで既存 workspace dep のため、
+  追加コストなく v4 を利用できる（`ulid` は未導入で「新規外部 dependency を増やさない」方針に反する）。
+- `EventIdGenerator` trait と orchestrator のシグネチャは変更しない。テストの連番 id 生成器も従来どおり。
+
+### 検証
+
+- `cargo test -p kukuri-cn-safety-runtime --test id`: 3 tests pass（UUID v4 parse / 一意性 / orchestrator 注入）。
+- `cargo check -p kukuri-cn-safety-runtime --no-default-features`: pass。

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -54,7 +54,7 @@ docker compose --env-file .env.community-node -f docker-compose.community-node.y
 docker compose --env-file .env.community-node -f docker-compose.community-node.yml up --build cn-user-api cn-iroh-relay
 ```
 
-- host port の既定値は `18080` (`cn-user-api`), `13340` (`cn-iroh-relay`), `55432` (`cn-postgres`)
+- host port の既定値は `18080` (`cn-user-api`), `13340` (`cn-iroh-relay`), `15432` (`cn-postgres`), `16379` (`cn-valkey`)
 - host 側 bind の既定値は loopback (`127.0.0.1`) なので、LAN/WireGuard 越しに公開する場合は `CN_*_HOST_BIND_IP` を上書きする
 - compose 内の service 名は `cn-postgres`, `cn-migrate`, `cn-user-api`, `cn-iroh-relay`
 - public URL を変える場合は `CN_BASE_URL`, `CN_PUBLIC_BASE_URL`, `COMMUNITY_NODE_CONNECTIVITY_URLS` を上書きする

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -739,7 +739,7 @@ fn cn_test_database_url() -> String {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "55432".to_string());
+        .unwrap_or_else(|| "15432".to_string());
     format!("postgres://cn:cn_password@127.0.0.1:{port}/cn")
 }
 
@@ -748,12 +748,32 @@ fn cn_test_rendezvous_redis_url() -> String {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "56379".to_string());
+        .unwrap_or_else(|| "16379".to_string());
     format!("redis://127.0.0.1:{port}/")
 }
 
 fn with_cn_postgres<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
     let root = root_dir();
+    // 15432 / 16379 は Linux の一般的な ephemeral port range (32768-60999) 外に置き、
+    // outgoing connection の一時ポートとの衝突を避ける。
+    // さらに起動前に残骸スタックを掃除しておく。前回の cn-test が異常終了して compose スタックが
+    // 残っていると固定ホストポートが専有されたままになり、`up` が "address already in use" で
+    // 失敗する。pre-up の down は冪等で、残骸が無ければ no-op。
+    // docker 未起動などの環境異常では失敗し得るが、その場合は後続の `up` が本来のエラーを
+    // 返すため、ここでは best-effort（結果を無視）にする。
+    let _ = run_with_env(
+        "docker",
+        [
+            "compose",
+            "-f",
+            "docker-compose.community-node.yml",
+            "down",
+            "-v",
+            "--remove-orphans",
+        ],
+        &root,
+        &cn_compose_envs(),
+    );
     run_with_env(
         "docker",
         [


### PR DESCRIPTION
## Summary
- Closes #399
- kukuri-cn-safety-runtime に本番 UuidEventIdGenerator を追加
- UUID v4 event id を EventIdGenerator として生成し、crate root から re-export
- orchestrator 注入 contract test と progress doc 更新を追加

## Testing
- cargo check -p kukuri-cn-safety-runtime --no-default-features
- cargo test -p kukuri-cn-safety-runtime
- cargo fmt -p kukuri-cn-safety-runtime --check
- cargo clippy -p kukuri-cn-safety-runtime --all-targets --all-features -- -D warnings
- cargo xtask cn-check