### PR TITLE
feat(cn): add Model C index ingestion

### DIFF
--- a/.env.community-node.example
+++ b/.env.community-node.example
@@ -31,6 +31,20 @@ COMMUNITY_NODE_CONNECTIVITY_URLS=http://127.0.0.1:13340
 # 不正な config を指すと起動時に失敗する（設定ミスを黙って無視しない）。
 # COMMUNITY_NODE_OPERATOR_CONFIG=/etc/kukuri/operator-config.yaml
 
+# private channel indexing (#413) の channel secret を at-rest 暗号化する鍵 material。
+# 設定すると POST /v1/indexing/requests が private_channel の indexing request（channel secret 提示）を
+# 受け付け、secret を暗号化して保存する。未設定なら private channel の indexing request は 404 で拒否する
+# （secret を平文保存しないため）。32 bytes 以上・placeholder 不可。cn-indexer にも同じ値を渡す。
+# COMMUNITY_NODE_CHANNEL_SECRET_KEY=dev-channel-secret-change-me-32-bytes-minimum
+
+# cn-indexer (#413) の relay validation 起動 gate。
+# 自前 relay（features.iroh_relay 有効な operator-config）または外部 relay URL のどちらかが必要。
+# 両方未設定なら cn-indexer は indexing を起動しない（fail-closed）。
+# COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS=https://relay.example.net
+# COMMUNITY_NODE_INDEXER_DATA_DIR=/var/lib/kukuri/cn-indexer
+# COMMUNITY_NODE_ARCADEDB_URL=http://127.0.0.1:2480
+# COMMUNITY_NODE_ARCADEDB_DATABASE=kukuri_index
+
 CN_USER_API_HOST_BIND_IP=127.0.0.1
 CN_USER_API_PORT=18080
 CN_IROH_RELAY_HTTP_HOST_BIND_IP=127.0.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,6 +2929,7 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",
+ "chacha20poly1305",
  "chrono",
  "hex",
  "jsonwebtoken",
@@ -2936,6 +2937,7 @@ dependencies = [
  "kukuri-cn-safety-runtime",
  "kukuri-core",
  "redis",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2945,6 +2947,31 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "kukuri-cn-indexer"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures-util",
+ "hex",
+ "kukuri-cn-core",
+ "kukuri-cn-safety",
+ "kukuri-cn-safety-runtime",
+ "kukuri-core",
+ "kukuri-docs-sync",
+ "kukuri-transport",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3012,6 +3039,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "hex",
  "kukuri-cn-core",
  "kukuri-cn-operator",
  "kukuri-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/cn-operator",
     "crates/cn-safety",
     "crates/cn-safety-runtime",
+    "crates/cn-indexer",
 ]
 exclude = [
     "apps/desktop/src-tauri",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3718,11 +3718,15 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",
+ "chacha20poly1305",
  "chrono",
  "hex",
  "jsonwebtoken",
+ "kukuri-cn-safety",
+ "kukuri-cn-safety-runtime",
  "kukuri-core",
  "redis",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3730,6 +3734,31 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "uuid",
+]
+
+[[package]]
+name = "kukuri-cn-safety"
+version = "0.1.2"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kukuri-cn-safety-runtime"
+version = "0.1.2"
+dependencies = [
+ "chrono",
+ "hex",
+ "kukuri-cn-safety",
+ "kukuri-core",
+ "secp256k1",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
  "uuid",
 ]
 

--- a/crates/cn-cli/src/main.rs
+++ b/crates/cn-cli/src/main.rs
@@ -2,11 +2,14 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand, ValueEnum};
 use kukuri_cn_core::{
-    AdmissionMode, AuthMode, AuthRolloutConfig, COMMUNITY_NODE_AUTH_SERVICE_NAME, add_allowlist,
+    AdmissionMode, AuthMode, AuthRolloutConfig, COMMUNITY_NODE_AUTH_SERVICE_NAME, IndexScopeKind,
+    IndexingRequestStatus, add_allowlist, add_supported_topic, approve_indexing_request,
     ban_subscriber, connect_postgres, get_community_node_report, initialize_database,
-    issue_invite_code, list_allowlist, list_banned, list_community_node_reports, list_invite_codes,
-    load_admission_config, migrate_postgres, remove_allowlist, revoke_invite_code,
-    seed_default_policies, set_admission_mode, store_auth_rollout, unban_subscriber,
+    issue_invite_code, list_allowlist, list_banned, list_community_node_reports,
+    list_indexing_requests, list_invite_codes, list_supported_topics, load_admission_config,
+    migrate_postgres, reject_indexing_request, remove_allowlist, remove_supported_topic,
+    revoke_invite_code, seed_default_policies, set_admission_mode, store_auth_rollout,
+    unban_subscriber,
 };
 
 #[derive(Debug, Parser)]
@@ -44,6 +47,91 @@ enum Command {
         #[command(subcommand)]
         action: AdmissionAction,
     },
+    /// index が引き受ける supported topic / 許可 channel を運用する（#413）。
+    SupportedTopic {
+        #[command(subcommand)]
+        action: SupportedTopicAction,
+    },
+    /// user からの indexing request を確認・承認する（#413）。
+    IndexingRequest {
+        #[command(subcommand)]
+        action: IndexingRequestAction,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum SupportedTopicAction {
+    /// supported set に scope を追加する。
+    Add {
+        #[arg(long)]
+        kind: IndexScopeKindArg,
+        #[arg(long)]
+        id: String,
+    },
+    /// supported set から scope を除去する。
+    Remove {
+        #[arg(long)]
+        kind: IndexScopeKindArg,
+        #[arg(long)]
+        id: String,
+    },
+    /// supported set を新着順で一覧する。
+    List,
+}
+
+#[derive(Debug, Subcommand)]
+enum IndexingRequestAction {
+    /// indexing request を一覧する（status で絞り込み可能）。
+    List {
+        #[arg(long)]
+        status: Option<IndexingRequestStatusArg>,
+        #[arg(long, default_value_t = 50)]
+        limit: i64,
+        #[arg(long, default_value_t = 0)]
+        offset: i64,
+    },
+    /// request を承認し、対象 scope を supported set に入れる。
+    Approve {
+        #[arg(long)]
+        id: String,
+    },
+    /// request を却下する（supported set は変更しない）。
+    Reject {
+        #[arg(long)]
+        id: String,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum IndexScopeKindArg {
+    PublicTopic,
+    PrivateChannel,
+}
+
+impl From<IndexScopeKindArg> for IndexScopeKind {
+    fn from(value: IndexScopeKindArg) -> Self {
+        match value {
+            IndexScopeKindArg::PublicTopic => IndexScopeKind::PublicTopic,
+            IndexScopeKindArg::PrivateChannel => IndexScopeKind::PrivateChannel,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum IndexingRequestStatusArg {
+    Pending,
+    Approved,
+    Rejected,
+}
+
+impl From<IndexingRequestStatusArg> for IndexingRequestStatus {
+    fn from(value: IndexingRequestStatusArg) -> Self {
+        match value {
+            IndexingRequestStatusArg::Pending => IndexingRequestStatus::Pending,
+            IndexingRequestStatusArg::Approved => IndexingRequestStatus::Approved,
+            IndexingRequestStatusArg::Rejected => IndexingRequestStatus::Rejected,
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -269,8 +357,103 @@ async fn main() -> Result<()> {
         Command::Admission { action } => {
             run_admission(&pool, action).await?;
         }
+        Command::SupportedTopic { action } => {
+            run_supported_topic(&pool, action).await?;
+        }
+        Command::IndexingRequest { action } => {
+            run_indexing_request(&pool, action).await?;
+        }
     }
 
+    Ok(())
+}
+
+async fn run_supported_topic(pool: &sqlx::PgPool, action: SupportedTopicAction) -> Result<()> {
+    // supported set の state を持つテーブルが揃っていることを保証する。
+    initialize_database(pool).await?;
+    match action {
+        SupportedTopicAction::Add { kind, id } => {
+            let kind = IndexScopeKind::from(kind);
+            let entry = add_supported_topic(pool, kind, id.as_str()).await?;
+            println!(
+                "supported topic added: {} {}",
+                entry.kind.as_str(),
+                entry.id
+            );
+        }
+        SupportedTopicAction::Remove { kind, id } => {
+            let kind = IndexScopeKind::from(kind);
+            if remove_supported_topic(pool, kind, id.as_str()).await? {
+                println!("supported topic removed: {} {}", kind.as_str(), id);
+            } else {
+                println!("supported topic not found: {} {}", kind.as_str(), id);
+            }
+        }
+        SupportedTopicAction::List => {
+            let entries = list_supported_topics(pool).await?;
+            if entries.is_empty() {
+                println!("no supported topics");
+            } else {
+                println!("{} supported topic(s):", entries.len());
+                for entry in entries {
+                    println!(
+                        "{}  {}  {}",
+                        entry.created_at.to_rfc3339(),
+                        entry.kind.as_str(),
+                        entry.id,
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_indexing_request(pool: &sqlx::PgPool, action: IndexingRequestAction) -> Result<()> {
+    initialize_database(pool).await?;
+    match action {
+        IndexingRequestAction::List {
+            status,
+            limit,
+            offset,
+        } => {
+            let status = status.map(IndexingRequestStatus::from);
+            let requests = list_indexing_requests(pool, status, limit, offset).await?;
+            if requests.is_empty() {
+                println!("no indexing requests");
+            } else {
+                println!("{} indexing request(s):", requests.len());
+                for request in requests {
+                    println!(
+                        "{}  {}  {}/{}  requester={}  status={}",
+                        request.created_at.to_rfc3339(),
+                        request.id,
+                        request.kind.as_str(),
+                        request.target_id,
+                        request.requester_pubkey,
+                        request.status.as_str(),
+                    );
+                }
+            }
+        }
+        IndexingRequestAction::Approve { id } => {
+            match approve_indexing_request(pool, id.as_str()).await? {
+                Some(request) => println!(
+                    "indexing request approved: {} ({} {} now supported)",
+                    request.id,
+                    request.kind.as_str(),
+                    request.target_id,
+                ),
+                None => println!("indexing request not found: {id}"),
+            }
+        }
+        IndexingRequestAction::Reject { id } => {
+            match reject_indexing_request(pool, id.as_str()).await? {
+                Some(request) => println!("indexing request rejected: {}", request.id),
+                None => println!("indexing request not found: {id}"),
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/cn-core/Cargo.toml
+++ b/crates/cn-core/Cargo.toml
@@ -7,8 +7,10 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true
+chacha20poly1305.workspace = true
 chrono.workspace = true
 jsonwebtoken.workspace = true
+secp256k1.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 redis.workspace = true

--- a/crates/cn-core/migrations/202607010001_index_scope.sql
+++ b/crates/cn-core/migrations/202607010001_index_scope.sql
@@ -1,0 +1,73 @@
+-- #413: community node ingestion（Model C）の scope 管理 state。
+--
+-- indexing = Model C（docs replica sync participant）は operator が引き受けた supported topic /
+-- 許可 channel の共有 replica のみを ingest する（ADR 0025 §2.2 / §6）。本 migration はその
+-- node-local な運用 state を保持する:
+--   - supported_topics: operator が index を引き受けた public topic / private channel の集合。
+--   - indexing_requests: user からの indexing 要求（request → operator 承認 → index の多段ゲート）。
+--   - channel_secrets: private channel の capability（namespace secret）。at-rest 暗号化して保存する。
+--
+-- index 投影本体（検索対象データ）は ArcadeDB（canonical ではない写像）に置き、ここには置かない。
+-- これらは canonical source ではなく、いつでも再構築できる node-local state（ADR 0025 §2.1）。
+CREATE SCHEMA IF NOT EXISTS cn_index;
+
+-- operator が index を引き受けた scope。
+--
+-- kind は `public_topic`（`topic::<id>` を導出 namespace で open）と `private_channel`
+-- （`channel::<id>` を登録 capability で open）を区別する。id は topic_id / channel_id。
+CREATE TABLE cn_index.supported_topics (
+    -- topic_id（public_topic）または channel_id（private_channel）。
+    id TEXT NOT NULL,
+    -- ingest scope の種別（public_topic / private_channel）。
+    kind TEXT NOT NULL,
+    -- supported set へ追加した時刻。
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (kind, id)
+);
+
+-- kind ごとの列挙（起動時の replica open で使う）。
+CREATE INDEX idx_cn_index_supported_topics_kind ON cn_index.supported_topics (kind);
+
+-- user からの indexing request。
+--
+-- request は index を保証しない。operator が承認（supported 化）し、さらに safety verdict を
+-- 通過した content のみが index される（ADR 0025 §2.2）。同一 requester の同一対象への再要求は
+-- 冪等に更新する。
+CREATE TABLE cn_index.indexing_requests (
+    -- request id（UUID v4）。
+    id TEXT PRIMARY KEY,
+    -- 要求者の公開鍵（認証済み bearer の pubkey）。
+    requester_pubkey TEXT NOT NULL,
+    -- 対象 scope の種別（public_topic / private_channel）。
+    kind TEXT NOT NULL,
+    -- 対象識別子（topic_id / channel_id）。
+    target_id TEXT NOT NULL,
+    -- 処理状態（pending / approved / rejected）。
+    status TEXT NOT NULL DEFAULT 'pending',
+    -- 要求時刻。
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- operator が承認 / 却下した時刻（未処理は NULL）。
+    decided_at TIMESTAMPTZ,
+    -- 同一 requester の同一対象への重複要求を冪等化する。
+    UNIQUE (kind, target_id, requester_pubkey)
+);
+
+-- operator の未処理一覧（新着順）と status 絞り込み。
+CREATE INDEX idx_cn_index_indexing_requests_status_created_at
+    ON cn_index.indexing_requests (status, created_at DESC);
+
+-- private channel の capability（namespace secret）。
+--
+-- indexing リクエスト＝secret 送信（ADR 0025 §6.3）。secret を提示できること自体を channel 権限の
+-- 証明とみなし、CN は新しい権限体系を作らない。平文は列に残さず、nonce + ciphertext（XChaCha20Poly1305）
+-- のみを保持する。復号鍵は runtime（Secret Manager / env 注入）が供給し、DB には置かない。
+CREATE TABLE cn_index.channel_secrets (
+    -- channel_id（`channel::<id>` の id 部）。
+    channel_id TEXT PRIMARY KEY,
+    -- XChaCha20Poly1305 nonce（24 bytes）。
+    nonce BYTEA NOT NULL,
+    -- 暗号化された namespace secret hex。
+    ciphertext BYTEA NOT NULL,
+    -- 登録 / 更新時刻。
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/crates/cn-core/src/database.rs
+++ b/crates/cn-core/src/database.rs
@@ -53,6 +53,9 @@ pub async fn ensure_database_ready(pool: &PgPool) -> Result<()> {
         ("cn_bootstrap", "peer_registrations"),
         ("cn_safety", "signed_moderation_events"),
         ("cn_safety", "risk_signals"),
+        ("cn_index", "supported_topics"),
+        ("cn_index", "indexing_requests"),
+        ("cn_index", "channel_secrets"),
     ] {
         let exists = sqlx::query_scalar::<_, bool>(
             "SELECT EXISTS (

--- a/crates/cn-core/src/env.rs
+++ b/crates/cn-core/src/env.rs
@@ -1,0 +1,93 @@
+//! community-node 共通の環境変数パースヘルパ。
+//!
+//! 複数の community-node サービス（`cn-user-api` / `cn-indexer` 等）が同じ env 記法（bool トークン、
+//! CSV）を共有するため、ここを単一の真実源にして解釈の drift を防ぐ。
+
+use anyhow::{Result, anyhow};
+
+/// bool 環境変数をパースする。未設定 / 空文字は `default`。
+///
+/// 受理するトークン（大文字小文字無視）:
+/// - true: `1` / `true` / `yes` / `on`
+/// - false: `0` / `false` / `no` / `off`
+pub fn parse_bool_env(var_name: &str, default: bool) -> Result<bool> {
+    match std::env::var(var_name) {
+        Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
+            "" => Ok(default),
+            "1" | "true" | "yes" | "on" => Ok(true),
+            "0" | "false" | "no" | "off" => Ok(false),
+            other => Err(anyhow!("failed to parse {var_name}: `{other}`")),
+        },
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(anyhow!("{var_name}: {error}")),
+    }
+}
+
+/// CSV 環境変数を trim + 空要素除去した Vec でパースする。未設定なら空 Vec。
+pub fn parse_csv_env(var_name: &str) -> Vec<String> {
+    std::env::var(var_name)
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .filter_map(|item| {
+                    let trimmed = item.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock")
+    }
+
+    #[test]
+    fn parse_bool_env_reads_tokens() {
+        let _guard = env_lock();
+        let key = "KUKURI_CN_TEST_BOOL_ENV";
+        for (value, expected) in [
+            ("1", true),
+            ("true", true),
+            ("YES", true),
+            ("on", true),
+            ("0", false),
+            ("false", false),
+            ("no", false),
+            ("OFF", false),
+        ] {
+            unsafe { std::env::set_var(key, value) };
+            assert_eq!(parse_bool_env(key, !expected).unwrap(), expected);
+        }
+        unsafe { std::env::set_var(key, "") };
+        assert!(parse_bool_env(key, true).unwrap());
+        unsafe { std::env::remove_var(key) };
+        assert!(!parse_bool_env(key, false).unwrap());
+        unsafe { std::env::set_var(key, "maybe") };
+        assert!(parse_bool_env(key, false).is_err());
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn parse_csv_env_trims_and_drops_empty() {
+        let _guard = env_lock();
+        let key = "KUKURI_CN_TEST_CSV_ENV";
+        unsafe { std::env::set_var(key, " a , ,b,, c ") };
+        assert_eq!(parse_csv_env(key), vec!["a", "b", "c"]);
+        unsafe { std::env::remove_var(key) };
+        assert!(parse_csv_env(key).is_empty());
+    }
+}

--- a/crates/cn-core/src/index_scope.rs
+++ b/crates/cn-core/src/index_scope.rs
@@ -1,0 +1,694 @@
+//! community node ingestion（Model C）の scope 管理 state（#413 / ADR 0025 §2.2 / §6）。
+//!
+//! indexing = Model C（docs replica sync participant）は、operator が明示的に引き受けた
+//! supported topic / 許可 channel の共有 replica のみを ingest する。本モジュールはその node-local な
+//! 運用 state（supported set / user request / private channel capability）を Postgres に保持する。
+//!
+//! ここは canonical source ではない。canonical は sync 元の topic / channel docs replica であり、
+//! これらの state は再構築可能な node-local projection の制御情報である（ADR 0025 §2.1）。
+//!
+//! private channel の capability（namespace secret）は「indexing リクエスト＝secret 送信」
+//! （ADR 0025 §6.3）で受け取り、at-rest 暗号化（XChaCha20Poly1305）して保存する。平文は列に残さない。
+//! 復号鍵は runtime（Secret Manager / env 注入）が供給し、DB には置かない。有効な secret を提示できる
+//! こと自体を channel 権限の証明とみなし、CN は新しい権限体系を作らない。
+
+use anyhow::{Context, Result, anyhow, bail};
+use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+use chacha20poly1305::{XChaCha20Poly1305, XNonce};
+use chrono::{DateTime, Utc};
+use secp256k1::rand::{RngCore, rng};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use sqlx::Row;
+use sqlx::postgres::{PgPool, PgRow};
+use uuid::Uuid;
+
+/// private channel capability 暗号化の AEAD associated data のドメイン分離 prefix。
+/// 実際の AAD は `channel_id` を連結して channel 同一性に束縛する（`channel_secret_aad`）。
+const CHANNEL_SECRET_AAD_PREFIX: &[u8] = b"kukuri-cn-index:channel-secret:v1:";
+
+/// channel_id に束縛した AEAD associated data を作る。
+///
+/// AAD に channel_id を含めることで、ある channel の (nonce, ciphertext) を別 channel_id の行へ
+/// 差し替えても復号（認証）に失敗する。DB 行の取り違え / コピーで別 channel の capability に化けるのを防ぐ。
+fn channel_secret_aad(channel_id: &str) -> Vec<u8> {
+    let mut aad = CHANNEL_SECRET_AAD_PREFIX.to_vec();
+    aad.extend_from_slice(channel_id.as_bytes());
+    aad
+}
+
+/// indexing scope の種別。public topic は導出 namespace で open でき、private channel は
+/// 登録 capability（secret）が必要（ADR 0025 §6.2 / §6.3）。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexScopeKind {
+    PublicTopic,
+    PrivateChannel,
+}
+
+impl IndexScopeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IndexScopeKind::PublicTopic => "public_topic",
+            IndexScopeKind::PrivateChannel => "private_channel",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "public_topic" => Ok(IndexScopeKind::PublicTopic),
+            "private_channel" => Ok(IndexScopeKind::PrivateChannel),
+            other => bail!("unknown index scope kind `{other}`"),
+        }
+    }
+}
+
+/// indexing request の処理状態。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexingRequestStatus {
+    Pending,
+    Approved,
+    Rejected,
+}
+
+impl IndexingRequestStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IndexingRequestStatus::Pending => "pending",
+            IndexingRequestStatus::Approved => "approved",
+            IndexingRequestStatus::Rejected => "rejected",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "pending" => Ok(IndexingRequestStatus::Pending),
+            "approved" => Ok(IndexingRequestStatus::Approved),
+            "rejected" => Ok(IndexingRequestStatus::Rejected),
+            other => bail!("unknown indexing request status `{other}`"),
+        }
+    }
+}
+
+/// operator が index を引き受けた scope エントリ。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SupportedTopic {
+    pub kind: IndexScopeKind,
+    pub id: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// user からの indexing request。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexingRequest {
+    pub id: String,
+    pub requester_pubkey: String,
+    pub kind: IndexScopeKind,
+    pub target_id: String,
+    pub status: IndexingRequestStatus,
+    pub created_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decided_at: Option<DateTime<Utc>>,
+}
+
+/// 登録済み channel capability（平文の namespace secret hex を復号済みで保持する）。
+///
+/// この型は復号後の値を持つため、ログや外部へ露出させないこと。
+#[derive(Clone, PartialEq, Eq)]
+pub struct ChannelSecret {
+    pub channel_id: String,
+    pub namespace_secret_hex: String,
+}
+
+impl std::fmt::Debug for ChannelSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // secret 値をログへ漏らさない。
+        f.debug_struct("ChannelSecret")
+            .field("channel_id", &self.channel_id)
+            .finish_non_exhaustive()
+    }
+}
+
+/// channel secret の at-rest 暗号化に使う鍵。runtime が供給する（DB には置かない）。
+///
+/// 32 byte を直接受け取る形にせず、任意長の material から HKDF ではなく単純な domain-separated
+/// SHA-256 で 32 byte 鍵を導出する。material は Secret Manager / env 由来を想定する。
+#[derive(Clone)]
+pub struct ChannelSecretCipher {
+    key: [u8; 32],
+}
+
+impl std::fmt::Debug for ChannelSecretCipher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChannelSecretCipher")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ChannelSecretCipher {
+    /// runtime 供給の鍵 material から cipher を作る。material が短すぎる / placeholder の場合は拒否する。
+    pub fn from_key_material(material: &str) -> Result<Self> {
+        let trimmed = material.trim();
+        if trimmed.len() < 32 {
+            bail!("channel secret encryption key must be at least 32 bytes");
+        }
+        if kukuri_core::is_placeholder_secret(trimmed) {
+            bail!("channel secret encryption key still contains a placeholder value");
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(b"kukuri-cn-index:channel-secret-key:v1");
+        hasher.update(trimmed.as_bytes());
+        Ok(Self {
+            key: hasher.finalize().into(),
+        })
+    }
+
+    fn cipher(&self) -> Result<XChaCha20Poly1305> {
+        XChaCha20Poly1305::new_from_slice(&self.key)
+            .map_err(|_| anyhow!("invalid channel secret encryption key length"))
+    }
+
+    /// 平文の namespace secret hex を (nonce, ciphertext) に暗号化する。
+    ///
+    /// AAD に `channel_id` を束縛するため、暗号文は特定 channel にのみ有効になる。
+    fn encrypt(&self, channel_id: &str, namespace_secret_hex: &str) -> Result<(Vec<u8>, Vec<u8>)> {
+        let mut nonce = [0u8; 24];
+        rng().fill_bytes(&mut nonce);
+        let ciphertext = self
+            .cipher()?
+            .encrypt(
+                XNonce::from_slice(&nonce),
+                Payload {
+                    msg: namespace_secret_hex.as_bytes(),
+                    aad: channel_secret_aad(channel_id).as_slice(),
+                },
+            )
+            .map_err(|_| anyhow!("failed to encrypt channel secret"))?;
+        Ok((nonce.to_vec(), ciphertext))
+    }
+
+    /// (nonce, ciphertext) から平文の namespace secret hex を復号する。
+    ///
+    /// `channel_id` を AAD として要求するため、別 channel の行へ差し替えた暗号文は復号に失敗する。
+    fn decrypt(&self, channel_id: &str, nonce: &[u8], ciphertext: &[u8]) -> Result<String> {
+        if nonce.len() != 24 {
+            bail!("channel secret nonce must be 24 bytes");
+        }
+        let plaintext = self
+            .cipher()?
+            .decrypt(
+                XNonce::from_slice(nonce),
+                Payload {
+                    msg: ciphertext,
+                    aad: channel_secret_aad(channel_id).as_slice(),
+                },
+            )
+            .map_err(|_| anyhow!("failed to decrypt channel secret"))?;
+        String::from_utf8(plaintext).context("decrypted channel secret is not valid utf8")
+    }
+}
+
+/// supported set へ scope を追加する（冪等）。
+pub async fn add_supported_topic(
+    pool: &PgPool,
+    kind: IndexScopeKind,
+    id: &str,
+) -> Result<SupportedTopic> {
+    let id = id.trim();
+    if id.is_empty() {
+        bail!("supported topic id must not be empty");
+    }
+    let row = sqlx::query(
+        "INSERT INTO cn_index.supported_topics (id, kind)
+         VALUES ($1, $2)
+         ON CONFLICT (kind, id) DO UPDATE SET id = EXCLUDED.id
+         RETURNING id, kind, created_at",
+    )
+    .bind(id)
+    .bind(kind.as_str())
+    .fetch_one(pool)
+    .await?;
+    supported_topic_from_row(&row)
+}
+
+/// supported set から scope を除去する。除去できたら true。
+///
+/// 除去後の replica sync 停止 / de-index は呼び出し側（cn-indexer）が担う。
+pub async fn remove_supported_topic(pool: &PgPool, kind: IndexScopeKind, id: &str) -> Result<bool> {
+    let result = sqlx::query("DELETE FROM cn_index.supported_topics WHERE kind = $1 AND id = $2")
+        .bind(kind.as_str())
+        .bind(id.trim())
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// supported set を新着順で列挙する。
+pub async fn list_supported_topics(pool: &PgPool) -> Result<Vec<SupportedTopic>> {
+    let rows = sqlx::query(
+        "SELECT id, kind, created_at
+         FROM cn_index.supported_topics
+         ORDER BY created_at DESC",
+    )
+    .fetch_all(pool)
+    .await?;
+    rows.iter().map(supported_topic_from_row).collect()
+}
+
+/// scope が supported set に含まれるか（scope ゲートの単一判定点）。
+pub async fn is_topic_supported(pool: &PgPool, kind: IndexScopeKind, id: &str) -> Result<bool> {
+    let exists = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (
+            SELECT 1 FROM cn_index.supported_topics WHERE kind = $1 AND id = $2
+        )",
+    )
+    .bind(kind.as_str())
+    .bind(id.trim())
+    .fetch_one(pool)
+    .await?;
+    Ok(exists)
+}
+
+/// user からの indexing request を保存する（同一 requester の同一対象は冪等更新）。
+///
+/// request は index を保証しない。status は `pending` で入り、operator の承認を待つ。
+/// 既に承認 / 却下済みの request がある場合は上書きせず既存を返す。
+pub async fn insert_indexing_request(
+    pool: &PgPool,
+    requester_pubkey: &str,
+    kind: IndexScopeKind,
+    target_id: &str,
+) -> Result<IndexingRequest> {
+    let requester_pubkey = requester_pubkey.trim();
+    let target_id = target_id.trim();
+    if requester_pubkey.is_empty() {
+        bail!("indexing request requester_pubkey must not be empty");
+    }
+    if target_id.is_empty() {
+        bail!("indexing request target_id must not be empty");
+    }
+    let id = Uuid::new_v4().to_string();
+    let row = sqlx::query(
+        "INSERT INTO cn_index.indexing_requests
+            (id, requester_pubkey, kind, target_id, status)
+         VALUES ($1, $2, $3, $4, 'pending')
+         ON CONFLICT (kind, target_id, requester_pubkey) DO UPDATE
+            SET requester_pubkey = EXCLUDED.requester_pubkey
+         RETURNING id, requester_pubkey, kind, target_id, status, created_at, decided_at",
+    )
+    .bind(&id)
+    .bind(requester_pubkey)
+    .bind(kind.as_str())
+    .bind(target_id)
+    .fetch_one(pool)
+    .await?;
+    indexing_request_from_row(&row)
+}
+
+/// indexing request を status 絞り込み（任意）で新着順に列挙する。
+pub async fn list_indexing_requests(
+    pool: &PgPool,
+    status: Option<IndexingRequestStatus>,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<IndexingRequest>> {
+    let rows = match status {
+        Some(status) => {
+            sqlx::query(
+                "SELECT id, requester_pubkey, kind, target_id, status, created_at, decided_at
+                 FROM cn_index.indexing_requests
+                 WHERE status = $1
+                 ORDER BY created_at DESC
+                 LIMIT $2 OFFSET $3",
+            )
+            .bind(status.as_str())
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query(
+                "SELECT id, requester_pubkey, kind, target_id, status, created_at, decided_at
+                 FROM cn_index.indexing_requests
+                 ORDER BY created_at DESC
+                 LIMIT $1 OFFSET $2",
+            )
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(pool)
+            .await?
+        }
+    };
+    rows.iter().map(indexing_request_from_row).collect()
+}
+
+/// indexing request を承認する。承認と同時に対象 scope を supported set に入れる
+/// （`request → operator 承認（supported 化）` の接続。ADR 0025 §2.2）。
+///
+/// request が存在しなければ None を返す。既に承認済みでも冪等に supported set を保証する。
+pub async fn approve_indexing_request(pool: &PgPool, id: &str) -> Result<Option<IndexingRequest>> {
+    let mut tx = pool.begin().await?;
+    let row = sqlx::query(
+        "UPDATE cn_index.indexing_requests
+         SET status = 'approved', decided_at = NOW()
+         WHERE id = $1
+         RETURNING id, requester_pubkey, kind, target_id, status, created_at, decided_at",
+    )
+    .bind(id.trim())
+    .fetch_optional(&mut *tx)
+    .await?;
+    let Some(row) = row else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+    let request = indexing_request_from_row(&row)?;
+    sqlx::query(
+        "INSERT INTO cn_index.supported_topics (id, kind)
+         VALUES ($1, $2)
+         ON CONFLICT (kind, id) DO NOTHING",
+    )
+    .bind(&request.target_id)
+    .bind(request.kind.as_str())
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(Some(request))
+}
+
+/// indexing request を却下する。却下は supported set を変更しない。
+pub async fn reject_indexing_request(pool: &PgPool, id: &str) -> Result<Option<IndexingRequest>> {
+    let row = sqlx::query(
+        "UPDATE cn_index.indexing_requests
+         SET status = 'rejected', decided_at = NOW()
+         WHERE id = $1
+         RETURNING id, requester_pubkey, kind, target_id, status, created_at, decided_at",
+    )
+    .bind(id.trim())
+    .fetch_optional(pool)
+    .await?;
+    row.as_ref().map(indexing_request_from_row).transpose()
+}
+
+/// channel capability の登録エラー。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChannelSecretConflict {
+    /// 既に別の capability が登録済み（別 requester が違う secret を提示した）。
+    AlreadyRegistered,
+}
+
+impl std::fmt::Display for ChannelSecretConflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChannelSecretConflict::AlreadyRegistered => {
+                write!(
+                    f,
+                    "a different channel capability is already registered for this channel"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ChannelSecretConflict {}
+
+/// channel capability（namespace secret）を暗号化して登録する（channel_id で冪等更新）。
+///
+/// 運営者経路（CLI 等）向けの無条件 upsert。user 経路（indexing request）は権限の乗っ取りを防ぐため
+/// [`register_channel_secret`]（first-writer-wins）を使うこと。
+pub async fn upsert_channel_secret(
+    pool: &PgPool,
+    cipher: &ChannelSecretCipher,
+    channel_id: &str,
+    namespace_secret_hex: &str,
+) -> Result<()> {
+    let channel_id = channel_id.trim();
+    let namespace_secret_hex = namespace_secret_hex.trim();
+    if channel_id.is_empty() {
+        bail!("channel secret channel_id must not be empty");
+    }
+    validate_namespace_secret_hex(namespace_secret_hex)?;
+    let (nonce, ciphertext) = cipher.encrypt(channel_id, namespace_secret_hex)?;
+    sqlx::query(
+        "INSERT INTO cn_index.channel_secrets (channel_id, nonce, ciphertext)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (channel_id) DO UPDATE
+            SET nonce = EXCLUDED.nonce,
+                ciphertext = EXCLUDED.ciphertext,
+                updated_at = NOW()",
+    )
+    .bind(channel_id)
+    .bind(nonce)
+    .bind(ciphertext)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// user の indexing request 経路で channel capability を登録する（first-writer-wins）。
+///
+/// - 未登録なら登録する。
+/// - 同一 secret の再提示は冪等（no-op）。
+/// - 既に **別の** secret が登録されている場合は [`ChannelSecretConflict::AlreadyRegistered`] を返し、
+///   後から来た requester が既存 capability を上書き（乗っ取り / DoS）できないようにする。
+///
+/// これにより「secret を提示できること自体が権限の証明」（ADR 0025 §6.3）を維持しつつ、既存 capability の
+/// 破壊を防ぐ。operator は必要なら [`remove_channel_secret`] + CLI で明示的に差し替えられる。
+pub async fn register_channel_secret(
+    pool: &PgPool,
+    cipher: &ChannelSecretCipher,
+    channel_id: &str,
+    namespace_secret_hex: &str,
+) -> Result<()> {
+    let channel_id = channel_id.trim();
+    let namespace_secret_hex = namespace_secret_hex.trim();
+    if channel_id.is_empty() {
+        bail!("channel secret channel_id must not be empty");
+    }
+    validate_namespace_secret_hex(namespace_secret_hex)?;
+
+    if let Some(existing) = get_channel_secret(pool, cipher, channel_id).await? {
+        // 同一 secret の再提示は冪等。別 secret なら乗っ取りを拒否する。
+        if existing.namespace_secret_hex == namespace_secret_hex {
+            return Ok(());
+        }
+        return Err(ChannelSecretConflict::AlreadyRegistered.into());
+    }
+
+    let (nonce, ciphertext) = cipher.encrypt(channel_id, namespace_secret_hex)?;
+    // INSERT ... ON CONFLICT DO NOTHING で TOCTOU（並行登録）でも既存を保護する。
+    let result = sqlx::query(
+        "INSERT INTO cn_index.channel_secrets (channel_id, nonce, ciphertext)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (channel_id) DO NOTHING",
+    )
+    .bind(channel_id)
+    .bind(nonce)
+    .bind(ciphertext)
+    .execute(pool)
+    .await?;
+    if result.rows_affected() == 0 {
+        // 競合で別 writer が先に登録した。同一 secret なら許容、別 secret なら拒否。
+        if let Some(existing) = get_channel_secret(pool, cipher, channel_id).await?
+            && existing.namespace_secret_hex == namespace_secret_hex
+        {
+            return Ok(());
+        }
+        return Err(ChannelSecretConflict::AlreadyRegistered.into());
+    }
+    Ok(())
+}
+
+/// 登録済み channel capability を復号して取得する。未登録なら None。
+pub async fn get_channel_secret(
+    pool: &PgPool,
+    cipher: &ChannelSecretCipher,
+    channel_id: &str,
+) -> Result<Option<ChannelSecret>> {
+    let row = sqlx::query(
+        "SELECT channel_id, nonce, ciphertext
+         FROM cn_index.channel_secrets
+         WHERE channel_id = $1",
+    )
+    .bind(channel_id.trim())
+    .fetch_optional(pool)
+    .await?;
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let channel_id: String = row.try_get("channel_id")?;
+    let nonce: Vec<u8> = row.try_get("nonce")?;
+    let ciphertext: Vec<u8> = row.try_get("ciphertext")?;
+    let namespace_secret_hex = cipher.decrypt(channel_id.as_str(), &nonce, &ciphertext)?;
+    Ok(Some(ChannelSecret {
+        channel_id,
+        namespace_secret_hex,
+    }))
+}
+
+/// 登録済み channel capability をすべて復号して列挙する（起動時の replica open 用）。
+pub async fn list_channel_secrets(
+    pool: &PgPool,
+    cipher: &ChannelSecretCipher,
+) -> Result<Vec<ChannelSecret>> {
+    let rows = sqlx::query(
+        "SELECT channel_id, nonce, ciphertext
+         FROM cn_index.channel_secrets
+         ORDER BY channel_id",
+    )
+    .fetch_all(pool)
+    .await?;
+    let mut secrets = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let channel_id: String = row.try_get("channel_id")?;
+        let nonce: Vec<u8> = row.try_get("nonce")?;
+        let ciphertext: Vec<u8> = row.try_get("ciphertext")?;
+        let namespace_secret_hex = cipher.decrypt(channel_id.as_str(), &nonce, &ciphertext)?;
+        secrets.push(ChannelSecret {
+            channel_id,
+            namespace_secret_hex,
+        });
+    }
+    Ok(secrets)
+}
+
+/// channel capability を失効させる。除去できたら true。
+///
+/// 失効後の replica sync 停止 / de-index は呼び出し側（cn-indexer）が担う。
+pub async fn remove_channel_secret(pool: &PgPool, channel_id: &str) -> Result<bool> {
+    let result = sqlx::query("DELETE FROM cn_index.channel_secrets WHERE channel_id = $1")
+        .bind(channel_id.trim())
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// namespace secret hex が 32 byte hex であることを検証する（docs-sync の parse と同じ前提）。
+fn validate_namespace_secret_hex(value: &str) -> Result<()> {
+    let decoded = hex::decode(value).context("channel secret must be valid hex")?;
+    if decoded.len() != 32 {
+        bail!("channel secret must decode to 32 bytes");
+    }
+    Ok(())
+}
+
+fn supported_topic_from_row(row: &PgRow) -> Result<SupportedTopic> {
+    Ok(SupportedTopic {
+        kind: IndexScopeKind::parse(&row.try_get::<String, _>("kind")?)?,
+        id: row.try_get("id")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+fn indexing_request_from_row(row: &PgRow) -> Result<IndexingRequest> {
+    Ok(IndexingRequest {
+        id: row.try_get("id")?,
+        requester_pubkey: row.try_get("requester_pubkey")?,
+        kind: IndexScopeKind::parse(&row.try_get::<String, _>("kind")?)?,
+        target_id: row.try_get("target_id")?,
+        status: IndexingRequestStatus::parse(&row.try_get::<String, _>("status")?)?,
+        created_at: row.try_get("created_at")?,
+        decided_at: row.try_get("decided_at")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_cipher() -> ChannelSecretCipher {
+        ChannelSecretCipher::from_key_material("unit-test-channel-secret-encryption-key-0123456789")
+            .expect("cipher")
+    }
+
+    #[test]
+    fn channel_secret_roundtrips_through_encrypt_decrypt() {
+        let cipher = test_cipher();
+        let secret_hex = hex::encode([7u8; 32]);
+        let (nonce, ciphertext) = cipher.encrypt("secret-room", &secret_hex).expect("encrypt");
+        assert_ne!(ciphertext, secret_hex.as_bytes());
+        let decrypted = cipher
+            .decrypt("secret-room", &nonce, &ciphertext)
+            .expect("decrypt");
+        assert_eq!(decrypted, secret_hex);
+    }
+
+    #[test]
+    fn channel_secret_decrypt_rejects_tampered_ciphertext() {
+        let cipher = test_cipher();
+        let secret_hex = hex::encode([9u8; 32]);
+        let (nonce, mut ciphertext) = cipher.encrypt("secret-room", &secret_hex).expect("encrypt");
+        ciphertext[0] ^= 0xff;
+        assert!(cipher.decrypt("secret-room", &nonce, &ciphertext).is_err());
+    }
+
+    #[test]
+    fn channel_secret_decrypt_rejects_wrong_key() {
+        let cipher = test_cipher();
+        let secret_hex = hex::encode([1u8; 32]);
+        let (nonce, ciphertext) = cipher.encrypt("secret-room", &secret_hex).expect("encrypt");
+        let other = ChannelSecretCipher::from_key_material(
+            "a-different-channel-secret-encryption-key-abcdef",
+        )
+        .expect("cipher");
+        assert!(other.decrypt("secret-room", &nonce, &ciphertext).is_err());
+    }
+
+    #[test]
+    fn channel_secret_decrypt_rejects_wrong_channel_id() {
+        // AAD に channel_id を束縛するため、別 channel_id で復号すると失敗する（行差し替え防止）。
+        let cipher = test_cipher();
+        let secret_hex = hex::encode([2u8; 32]);
+        let (nonce, ciphertext) = cipher.encrypt("secret-room", &secret_hex).expect("encrypt");
+        assert!(cipher.decrypt("other-room", &nonce, &ciphertext).is_err());
+    }
+
+    #[test]
+    fn channel_secret_cipher_rejects_weak_key_material() {
+        assert!(ChannelSecretCipher::from_key_material("short").is_err());
+        assert!(
+            ChannelSecretCipher::from_key_material("this-is-long-enough-but-change-me-placeholder")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn nonce_is_unique_per_encryption() {
+        let cipher = test_cipher();
+        let secret_hex = hex::encode([3u8; 32]);
+        let (nonce_a, _) = cipher.encrypt("secret-room", &secret_hex).expect("encrypt");
+        let (nonce_b, _) = cipher.encrypt("secret-room", &secret_hex).expect("encrypt");
+        assert_ne!(nonce_a, nonce_b);
+    }
+
+    #[test]
+    fn index_scope_kind_roundtrips() {
+        for kind in [IndexScopeKind::PublicTopic, IndexScopeKind::PrivateChannel] {
+            assert_eq!(IndexScopeKind::parse(kind.as_str()).unwrap(), kind);
+        }
+        assert!(IndexScopeKind::parse("nope").is_err());
+    }
+
+    #[test]
+    fn indexing_request_status_roundtrips() {
+        for status in [
+            IndexingRequestStatus::Pending,
+            IndexingRequestStatus::Approved,
+            IndexingRequestStatus::Rejected,
+        ] {
+            assert_eq!(
+                IndexingRequestStatus::parse(status.as_str()).unwrap(),
+                status
+            );
+        }
+        assert!(IndexingRequestStatus::parse("nope").is_err());
+    }
+
+    #[test]
+    fn validate_namespace_secret_hex_enforces_32_bytes() {
+        assert!(validate_namespace_secret_hex(&hex::encode([0u8; 32])).is_ok());
+        assert!(validate_namespace_secret_hex(&hex::encode([0u8; 16])).is_err());
+        assert!(validate_namespace_secret_hex("not-hex").is_err());
+    }
+}

--- a/crates/cn-core/src/lib.rs
+++ b/crates/cn-core/src/lib.rs
@@ -4,7 +4,9 @@ mod bootstrap;
 mod config;
 mod consents;
 mod database;
+mod env;
 mod errors;
+mod index_scope;
 mod models;
 mod normalize;
 mod rendezvous;
@@ -41,7 +43,15 @@ pub use database::{
     TestDatabase, connect_postgres, ensure_database_ready, initialize_database,
     initialize_database_for_runtime, migrate_postgres, seed_default_policies,
 };
+pub use env::{parse_bool_env, parse_csv_env};
 pub use errors::{ApiError, ApiResult, auth_required_error, consent_required_error};
+pub use index_scope::{
+    ChannelSecret, ChannelSecretCipher, ChannelSecretConflict, IndexScopeKind, IndexingRequest,
+    IndexingRequestStatus, SupportedTopic, add_supported_topic, approve_indexing_request,
+    get_channel_secret, insert_indexing_request, is_topic_supported, list_channel_secrets,
+    list_indexing_requests, list_supported_topics, register_channel_secret,
+    reject_indexing_request, remove_channel_secret, remove_supported_topic, upsert_channel_secret,
+};
 pub use models::{
     AuthChallengeResponse, AuthVerifyResponse, BearerIdentity, BootstrapHeartbeatResponse,
     CommunityNodeBootstrapNode, CommunityNodeConsentItem, CommunityNodeConsentStatus,

--- a/crates/cn-core/tests/index_scope.rs
+++ b/crates/cn-core/tests/index_scope.rs
@@ -1,0 +1,283 @@
+//! #413 ingestion scope 管理 state の Postgres integration テスト（ADR 0025 §2.2 / §6.3）。
+//!
+//! `KUKURI_CN_RUN_INTEGRATION_TESTS=1` のときだけ実 DB に接続して実行する。
+//! - supported topic scope ゲート（supported set 内 / 外の判定）。
+//! - user indexing request の承認（approve で supported set に入る多段ゲートの接続）。
+//! - private channel capability（channel secret）の at-rest 暗号保存・取得・失効。
+
+use anyhow::Result;
+use kukuri_cn_core::{
+    ChannelSecretCipher, ChannelSecretConflict, IndexScopeKind, IndexingRequestStatus,
+    TestDatabase, add_supported_topic, approve_indexing_request, connect_postgres,
+    get_channel_secret, initialize_database, insert_indexing_request, is_topic_supported,
+    list_channel_secrets, list_indexing_requests, list_supported_topics, register_channel_secret,
+    reject_indexing_request, remove_channel_secret, remove_supported_topic, upsert_channel_secret,
+};
+
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+const TEST_CIPHER_KEY: &str = "integration-test-channel-secret-encryption-key-0123456789";
+
+fn integration_test_admin_database_url() -> Option<String> {
+    let enabled = std::env::var("KUKURI_CN_RUN_INTEGRATION_TESTS")
+        .ok()
+        .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+    Some(
+        std::env::var("COMMUNITY_NODE_DATABASE_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_ADMIN_DATABASE_URL.to_string()),
+    )
+}
+
+fn cipher() -> ChannelSecretCipher {
+    ChannelSecretCipher::from_key_material(TEST_CIPHER_KEY).expect("cipher")
+}
+
+#[tokio::test]
+async fn index_scope_limited_to_operator_supported_topics() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core index scope test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_index_scope").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    // 追加前は supported ではない（scope ゲートが拒否する）。
+    assert!(!is_topic_supported(&pool, IndexScopeKind::PublicTopic, "rust").await?);
+
+    add_supported_topic(&pool, IndexScopeKind::PublicTopic, "rust").await?;
+    assert!(is_topic_supported(&pool, IndexScopeKind::PublicTopic, "rust").await?);
+
+    // supported set 外の topic は拒否される（index_rejects_topic_outside_supported_set）。
+    assert!(!is_topic_supported(&pool, IndexScopeKind::PublicTopic, "golang").await?);
+
+    // 除去すると再び supported ではなくなる（de-index の前提）。
+    assert!(remove_supported_topic(&pool, IndexScopeKind::PublicTopic, "rust").await?);
+    assert!(!is_topic_supported(&pool, IndexScopeKind::PublicTopic, "rust").await?);
+
+    database.cleanup().await
+}
+
+#[tokio::test]
+async fn index_admits_approved_user_indexing_request() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core index scope test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_index_request").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    // request は index を保証しない: pending で入り supported にはならない。
+    let request =
+        insert_indexing_request(&pool, "npub-requester", IndexScopeKind::PublicTopic, "rust")
+            .await?;
+    assert_eq!(request.status, IndexingRequestStatus::Pending);
+    assert!(!is_topic_supported(&pool, IndexScopeKind::PublicTopic, "rust").await?);
+
+    let pending =
+        list_indexing_requests(&pool, Some(IndexingRequestStatus::Pending), 50, 0).await?;
+    assert_eq!(pending.len(), 1);
+
+    // operator が承認すると supported set に入る（request → 承認 → supported の接続）。
+    let approved = approve_indexing_request(&pool, request.id.as_str())
+        .await?
+        .expect("request exists");
+    assert_eq!(approved.status, IndexingRequestStatus::Approved);
+    assert!(is_topic_supported(&pool, IndexScopeKind::PublicTopic, "rust").await?);
+
+    database.cleanup().await
+}
+
+#[tokio::test]
+async fn rejected_request_does_not_become_supported() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core index scope test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_index_reject").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    let request = insert_indexing_request(
+        &pool,
+        "npub-requester",
+        IndexScopeKind::PrivateChannel,
+        "secret-room",
+    )
+    .await?;
+    let rejected = reject_indexing_request(&pool, request.id.as_str())
+        .await?
+        .expect("request exists");
+    assert_eq!(rejected.status, IndexingRequestStatus::Rejected);
+    assert!(!is_topic_supported(&pool, IndexScopeKind::PrivateChannel, "secret-room").await?);
+
+    database.cleanup().await
+}
+
+#[tokio::test]
+async fn duplicate_request_is_idempotent() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core index scope test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_index_dupe").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    let first =
+        insert_indexing_request(&pool, "npub-a", IndexScopeKind::PublicTopic, "rust").await?;
+    let second =
+        insert_indexing_request(&pool, "npub-a", IndexScopeKind::PublicTopic, "rust").await?;
+    assert_eq!(first.id, second.id);
+    let all = list_indexing_requests(&pool, None, 50, 0).await?;
+    assert_eq!(all.len(), 1);
+
+    database.cleanup().await
+}
+
+#[tokio::test]
+async fn index_private_channel_requires_submitted_channel_secret() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core index scope test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_index_channel_secret").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+    let cipher = cipher();
+
+    // secret 未登録の channel は capability が取得できない（secret 無しでは sync/index できない）。
+    assert!(
+        get_channel_secret(&pool, &cipher, "secret-room")
+            .await?
+            .is_none()
+    );
+
+    // indexing リクエスト＝secret 送信で capability を登録する。
+    let secret_hex = hex::encode([42u8; 32]);
+    upsert_channel_secret(&pool, &cipher, "secret-room", secret_hex.as_str()).await?;
+
+    let loaded = get_channel_secret(&pool, &cipher, "secret-room")
+        .await?
+        .expect("secret registered");
+    assert_eq!(loaded.namespace_secret_hex, secret_hex);
+    assert_eq!(loaded.channel_id, "secret-room");
+
+    // 起動時復元のため列挙できる。
+    let all = list_channel_secrets(&pool, &cipher).await?;
+    assert_eq!(all.len(), 1);
+
+    // 失効させると capability が消える（sync 停止 + de-index の前提）。
+    assert!(remove_channel_secret(&pool, "secret-room").await?);
+    assert!(
+        get_channel_secret(&pool, &cipher, "secret-room")
+            .await?
+            .is_none()
+    );
+
+    database.cleanup().await
+}
+
+#[tokio::test]
+async fn register_channel_secret_is_first_writer_wins() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core index scope test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_index_first_writer").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+    let cipher = cipher();
+
+    let first_secret = hex::encode([1u8; 32]);
+    let attacker_secret = hex::encode([2u8; 32]);
+
+    // 最初の登録は成功する。
+    register_channel_secret(&pool, &cipher, "secret-room", first_secret.as_str()).await?;
+    // 同一 secret の再提示は冪等（no-op、成功）。
+    register_channel_secret(&pool, &cipher, "secret-room", first_secret.as_str()).await?;
+
+    // 別 secret での上書き（乗っ取り）は拒否される。
+    let err = register_channel_secret(&pool, &cipher, "secret-room", attacker_secret.as_str())
+        .await
+        .expect_err("second writer with different secret must be rejected");
+    assert!(err.downcast_ref::<ChannelSecretConflict>().is_some());
+
+    // 既存の capability は上書きされず維持される。
+    let stored = get_channel_secret(&pool, &cipher, "secret-room")
+        .await?
+        .expect("secret registered");
+    assert_eq!(stored.namespace_secret_hex, first_secret);
+
+    database.cleanup().await
+}
+
+#[tokio::test]
+async fn channel_secret_is_encrypted_at_rest() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core index scope test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_index_atrest").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+    let cipher = cipher();
+
+    let secret_hex = hex::encode([7u8; 32]);
+    upsert_channel_secret(&pool, &cipher, "secret-room", secret_hex.as_str()).await?;
+
+    // DB 列には平文 secret が残らない（ciphertext のみ）。
+    let ciphertext: Vec<u8> =
+        sqlx::query_scalar("SELECT ciphertext FROM cn_index.channel_secrets WHERE channel_id = $1")
+            .bind("secret-room")
+            .fetch_one(&pool)
+            .await?;
+    assert_ne!(ciphertext, secret_hex.as_bytes());
+
+    // 別鍵では復号できない（鍵は runtime 供給で DB には無い）。
+    let other =
+        ChannelSecretCipher::from_key_material("a-completely-different-channel-secret-key-abcdef")
+            .unwrap();
+    assert!(
+        get_channel_secret(&pool, &other, "secret-room")
+            .await
+            .is_err()
+    );
+
+    database.cleanup().await
+}
+
+#[tokio::test]
+async fn supported_topics_listed_for_startup_restore() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core index scope test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_index_restore").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    add_supported_topic(&pool, IndexScopeKind::PublicTopic, "rust").await?;
+    add_supported_topic(&pool, IndexScopeKind::PrivateChannel, "secret-room").await?;
+
+    let topics = list_supported_topics(&pool).await?;
+    assert_eq!(topics.len(), 2);
+    assert!(
+        topics
+            .iter()
+            .any(|t| t.kind == IndexScopeKind::PublicTopic && t.id == "rust")
+    );
+    assert!(
+        topics
+            .iter()
+            .any(|t| t.kind == IndexScopeKind::PrivateChannel && t.id == "secret-room")
+    );
+
+    database.cleanup().await
+}

--- a/crates/cn-indexer/Cargo.toml
+++ b/crates/cn-indexer/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "kukuri-cn-indexer"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "cn-indexer"
+path = "src/main.rs"
+
+[lib]
+name = "kukuri_cn_indexer"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+futures-util.workspace = true
+hex.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sqlx.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+kukuri-core = { path = "../core" }
+kukuri-docs-sync = { path = "../docs-sync" }
+kukuri-transport = { path = "../transport" }
+kukuri-cn-core = { path = "../cn-core" }
+kukuri-cn-safety = { path = "../cn-safety" }
+kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
+
+[dev-dependencies]
+kukuri-cn-safety = { path = "../cn-safety", features = ["mock"] }
+tempfile.workspace = true

--- a/crates/cn-indexer/src/arcadedb.rs
+++ b/crates/cn-indexer/src/arcadedb.rs
@@ -1,0 +1,260 @@
+//! ArcadeDB index 投影 adapter（#413 / T6 / ADR 0025 投影ストア + ADR 0026 §6.1）。
+//!
+//! index 投影を ArcadeDB（Lucene 全文検索付き multi-model DB）に置く。ADR 0026 §6.1 で relation
+//! graph 用に採用する ArcadeDB に index 投影も相乗りさせ、FTS + graph を単一エンジンに統合する。
+//! ベクトル検索は今回のスコープ外（ADR 0025 §4。画像類似は除外、全文のみ）。
+//!
+//! ArcadeDB の成熟した native crate が無いため HTTP API（`/api/v1/command`）経由で操作する。
+//! ここは境界 `IndexProjection` の 1 実装であり、pipeline は trait 越しに扱う。ユーザー向け search
+//! クエリ本体は #404 が載せる（本 adapter は upsert / 存在 read / de-index まで）。
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::{Value, json};
+
+use kukuri_cn_core::IndexScopeKind;
+
+use crate::config::ArcadeDbConfig;
+use crate::projection::{IndexProjection, IndexedEntry};
+
+/// index 投影 document の ArcadeDB type 名。
+const ENTRY_TYPE: &str = "IndexedEntry";
+
+/// ArcadeDB HTTP client 越しの index 投影。
+pub struct ArcadeDbProjection {
+    client: Client,
+    config: ArcadeDbConfig,
+}
+
+impl ArcadeDbProjection {
+    pub fn new(config: ArcadeDbConfig) -> Result<Self> {
+        let client = Client::builder()
+            .build()
+            .context("failed to build ArcadeDB HTTP client")?;
+        Ok(Self { client, config })
+    }
+
+    /// index 投影 schema（document type + unique index）を用意する。
+    ///
+    /// ArcadeDB の `CREATE ... IF NOT EXISTS` で冪等に作る。object_id は scope 内で一意なので
+    /// (scope_kind, scope_id, object_id) に unique index を張り、upsert を成立させる。
+    pub async fn ensure_schema(&self) -> Result<()> {
+        self.command(
+            "sql",
+            &format!("CREATE DOCUMENT TYPE {ENTRY_TYPE} IF NOT EXISTS"),
+        )
+        .await?;
+        for property in [
+            "scope_kind STRING",
+            "scope_id STRING",
+            "object_id STRING",
+            "author_pubkey STRING",
+            "text STRING",
+            "created_at LONG",
+            "source_replica_id STRING",
+        ] {
+            self.command(
+                "sql",
+                &format!("CREATE PROPERTY {ENTRY_TYPE}.{property} IF NOT EXISTS"),
+            )
+            .await?;
+        }
+        // scope 内 object 一意の複合 index（upsert / 存在 read の access path）。
+        self.command(
+            "sql",
+            &format!(
+                "CREATE INDEX IF NOT EXISTS ON {ENTRY_TYPE} (scope_kind, scope_id, object_id) UNIQUE"
+            ),
+        )
+        .await?;
+        // 全文検索 index（Lucene）。ユーザー向け search は #404 が使う。
+        self.command(
+            "sql",
+            &format!("CREATE INDEX IF NOT EXISTS ON {ENTRY_TYPE} (text) FULL_TEXT ENGINE LUCENE"),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// ArcadeDB `/api/v1/command/<database>` を叩く。
+    async fn command(&self, language: &str, command: &str) -> Result<Value> {
+        self.command_with_params(language, command, json!({})).await
+    }
+
+    async fn command_with_params(
+        &self,
+        language: &str,
+        command: &str,
+        params: Value,
+    ) -> Result<Value> {
+        let url = format!(
+            "{}/api/v1/command/{}",
+            self.config.base_url.trim_end_matches('/'),
+            self.config.database
+        );
+        let response = self
+            .client
+            .post(&url)
+            .basic_auth(&self.config.username, Some(&self.config.password))
+            .json(&json!({
+                "language": language,
+                "command": command,
+                "params": params,
+            }))
+            .send()
+            .await
+            .context("failed to send ArcadeDB command")?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("ArcadeDB command failed ({status}): {body}");
+        }
+        response
+            .json::<Value>()
+            .await
+            .context("failed to decode ArcadeDB response")
+    }
+
+    fn scope_kind_str(scope_kind: IndexScopeKind) -> &'static str {
+        scope_kind.as_str()
+    }
+}
+
+#[async_trait]
+impl IndexProjection for ArcadeDbProjection {
+    async fn upsert_entry(&self, entry: &IndexedEntry) -> Result<()> {
+        // UPDATE ... UPSERT で (scope_kind, scope_id, object_id) 一意に冪等 upsert する。
+        let command = format!(
+            "UPDATE {ENTRY_TYPE} SET scope_kind = :scope_kind, scope_id = :scope_id, \
+             object_id = :object_id, author_pubkey = :author_pubkey, text = :text, \
+             created_at = :created_at, source_replica_id = :source_replica_id \
+             UPSERT WHERE scope_kind = :scope_kind AND scope_id = :scope_id \
+             AND object_id = :object_id"
+        );
+        self.command_with_params(
+            "sql",
+            &command,
+            json!({
+                "scope_kind": Self::scope_kind_str(entry.scope_kind),
+                "scope_id": entry.scope_id,
+                "object_id": entry.object_id,
+                "author_pubkey": entry.author_pubkey,
+                "text": entry.text,
+                "created_at": entry.created_at,
+                "source_replica_id": entry.source_replica_id,
+            }),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn contains_object(
+        &self,
+        scope_kind: IndexScopeKind,
+        scope_id: &str,
+        object_id: &str,
+    ) -> Result<bool> {
+        let command = format!(
+            "SELECT count(*) AS total FROM {ENTRY_TYPE} WHERE scope_kind = :scope_kind \
+             AND scope_id = :scope_id AND object_id = :object_id"
+        );
+        let value = self
+            .command_with_params(
+                "sql",
+                &command,
+                json!({
+                    "scope_kind": Self::scope_kind_str(scope_kind),
+                    "scope_id": scope_id,
+                    "object_id": object_id,
+                }),
+            )
+            .await?;
+        Ok(count_from_result(&value) > 0)
+    }
+
+    async fn count_scope(&self, scope_kind: IndexScopeKind, scope_id: &str) -> Result<usize> {
+        let command = format!(
+            "SELECT count(*) AS total FROM {ENTRY_TYPE} WHERE scope_kind = :scope_kind \
+             AND scope_id = :scope_id"
+        );
+        let value = self
+            .command_with_params(
+                "sql",
+                &command,
+                json!({
+                    "scope_kind": Self::scope_kind_str(scope_kind),
+                    "scope_id": scope_id,
+                }),
+            )
+            .await?;
+        Ok(count_from_result(&value) as usize)
+    }
+
+    async fn remove_scope(&self, scope_kind: IndexScopeKind, scope_id: &str) -> Result<()> {
+        let command = format!(
+            "DELETE FROM {ENTRY_TYPE} WHERE scope_kind = :scope_kind AND scope_id = :scope_id"
+        );
+        self.command_with_params(
+            "sql",
+            &command,
+            json!({
+                "scope_kind": Self::scope_kind_str(scope_kind),
+                "scope_id": scope_id,
+            }),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn remove_object(
+        &self,
+        scope_kind: IndexScopeKind,
+        scope_id: &str,
+        object_id: &str,
+    ) -> Result<()> {
+        let command = format!(
+            "DELETE FROM {ENTRY_TYPE} WHERE scope_kind = :scope_kind AND scope_id = :scope_id \
+             AND object_id = :object_id"
+        );
+        self.command_with_params(
+            "sql",
+            &command,
+            json!({
+                "scope_kind": Self::scope_kind_str(scope_kind),
+                "scope_id": scope_id,
+                "object_id": object_id,
+            }),
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+/// ArcadeDB の `SELECT count(*) AS total` 応答（`{ "result": [{ "total": N }] }`）から件数を読む。
+fn count_from_result(value: &Value) -> i64 {
+    value
+        .get("result")
+        .and_then(|result| result.as_array())
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("total"))
+        .and_then(|total| total.as_i64())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_from_result_reads_total() {
+        let value = json!({ "result": [{ "total": 3 }] });
+        assert_eq!(count_from_result(&value), 3);
+    }
+
+    #[test]
+    fn count_from_result_defaults_to_zero() {
+        assert_eq!(count_from_result(&json!({ "result": [] })), 0);
+        assert_eq!(count_from_result(&json!({})), 0);
+    }
+}

--- a/crates/cn-indexer/src/config.rs
+++ b/crates/cn-indexer/src/config.rs
@@ -1,0 +1,222 @@
+//! cn-indexer の起動設定と relay validation 起動 gate（#413 / ADR 0025 §6.4）。
+//!
+//! indexing = Model C（docs replica sync participant）は peer discovery を成立させるために relay を
+//! 前提にする。CN は relay 抜き構成を許容するため、indexing 起動時に relay を **config 検査**として
+//! validate する。自前 relay（operator config の `features.iroh_relay` 有効）または外部 relay URL
+//! （`external_relay_urls`）のどちらかが設定されていることを必須とし、両方未設定なら indexing を
+//! 起動しない（fail-closed）。
+//!
+//! 到達性の実測（liveness probe）はしない。設定の有無のみで判定することで決定論的にテストでき、
+//! `IrohDocsNode` の「relay 未活性でも継続」挙動と矛盾しない。
+
+use anyhow::{Context, Result, bail};
+
+/// relay validation の結果。fail-closed gate の単一判定点。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RelayValidation {
+    /// 自前 relay（operator が iroh_relay capability を有効化）で成立。
+    OwnRelay,
+    /// 外部 relay URL 設定で成立。
+    ExternalRelay,
+    /// 自前 relay と外部 relay の両方で成立。
+    OwnAndExternalRelay,
+}
+
+/// cn-indexer の relay 構成。
+///
+/// `has_own_relay` は operator config の `features.iroh_relay` 由来（自前 relay を提供する構成か）、
+/// `external_relay_urls` は cn-indexer 自身が discovery / relay-assist に使う外部 relay URL。
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RelayConfig {
+    pub has_own_relay: bool,
+    pub external_relay_urls: Vec<String>,
+}
+
+impl RelayConfig {
+    pub fn new(has_own_relay: bool, external_relay_urls: Vec<String>) -> Self {
+        Self {
+            has_own_relay,
+            external_relay_urls: normalize_relay_urls(external_relay_urls),
+        }
+    }
+
+    /// indexing 起動の relay validation gate（ADR 0025 §6.4）。
+    ///
+    /// 自前 relay も外部 relay も無ければ `Err`（indexing を起動しない）。どちらかが有れば
+    /// どの経路で成立したかを返す。
+    pub fn validate_for_startup(&self) -> Result<RelayValidation> {
+        let has_external = !self.external_relay_urls.is_empty();
+        match (self.has_own_relay, has_external) {
+            (true, true) => Ok(RelayValidation::OwnAndExternalRelay),
+            (true, false) => Ok(RelayValidation::OwnRelay),
+            (false, true) => Ok(RelayValidation::ExternalRelay),
+            (false, false) => bail!(
+                "cn-indexer requires a validated relay to start indexing: enable the node's own \
+                 iroh_relay capability or configure COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS"
+            ),
+        }
+    }
+}
+
+/// 空白除去・重複排除した relay URL 一覧。
+fn normalize_relay_urls(urls: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    urls.into_iter()
+        .map(|url| url.trim().to_string())
+        .filter(|url| !url.is_empty())
+        .filter(|url| seen.insert(url.clone()))
+        .collect()
+}
+
+/// cn-indexer の全体設定。
+///
+/// `Debug` は手動実装で `channel_secret_key` を秘匿する（誤ってログへ暗号鍵を出さない）。
+#[derive(Clone)]
+pub struct IndexerConfig {
+    /// Postgres 接続 URL（supported set / request / channel secret の scope state）。
+    pub database_url: String,
+    /// docs / blob store の永続ディレクトリ。
+    pub data_dir: std::path::PathBuf,
+    /// relay 構成（起動 gate）。
+    pub relay: RelayConfig,
+    /// channel secret を復号する鍵 material（cn-user-api と同じ値）。
+    pub channel_secret_key: String,
+    /// ArcadeDB index 投影の接続設定。
+    pub arcadedb: ArcadeDbConfig,
+}
+
+impl std::fmt::Debug for IndexerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IndexerConfig")
+            .field("database_url", &self.database_url)
+            .field("data_dir", &self.data_dir)
+            .field("relay", &self.relay)
+            .field("channel_secret_key", &"<redacted>")
+            .field("arcadedb", &self.arcadedb)
+            .finish()
+    }
+}
+
+/// ArcadeDB index 投影の接続設定。
+///
+/// `Debug` は手動実装で `password` を秘匿する。
+#[derive(Clone, PartialEq, Eq)]
+pub struct ArcadeDbConfig {
+    pub base_url: String,
+    pub database: String,
+    pub username: String,
+    pub password: String,
+}
+
+impl std::fmt::Debug for ArcadeDbConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ArcadeDbConfig")
+            .field("base_url", &self.base_url)
+            .field("database", &self.database)
+            .field("username", &self.username)
+            .field("password", &"<redacted>")
+            .finish()
+    }
+}
+
+impl IndexerConfig {
+    /// 環境変数から設定を読む。
+    ///
+    /// relay validation gate（§6.4）は起動側（`run_from_env`）で `relay.validate_for_startup()` を
+    /// 呼んで適用する。ここでは値の読み取りのみを行う。
+    pub fn from_env() -> Result<Self> {
+        let database_url = std::env::var("COMMUNITY_NODE_DATABASE_URL")
+            .context("COMMUNITY_NODE_DATABASE_URL is required")?;
+        let data_dir = std::env::var("COMMUNITY_NODE_INDEXER_DATA_DIR")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "./data/cn-indexer".to_string())
+            .into();
+        let has_own_relay =
+            kukuri_cn_core::parse_bool_env("COMMUNITY_NODE_INDEXER_OWN_RELAY", false)?;
+        let external_relay_urls =
+            kukuri_cn_core::parse_csv_env("COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS");
+        let channel_secret_key = std::env::var("COMMUNITY_NODE_CHANNEL_SECRET_KEY")
+            .context("COMMUNITY_NODE_CHANNEL_SECRET_KEY is required")?;
+        let arcadedb = ArcadeDbConfig {
+            base_url: std::env::var("COMMUNITY_NODE_ARCADEDB_URL")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| "http://127.0.0.1:2480".to_string()),
+            database: std::env::var("COMMUNITY_NODE_ARCADEDB_DATABASE")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| "kukuri_index".to_string()),
+            username: std::env::var("COMMUNITY_NODE_ARCADEDB_USER")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| "root".to_string()),
+            password: std::env::var("COMMUNITY_NODE_ARCADEDB_PASSWORD").unwrap_or_default(),
+        };
+        Ok(Self {
+            database_url,
+            data_dir,
+            relay: RelayConfig::new(has_own_relay, external_relay_urls),
+            channel_secret_key,
+            arcadedb,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn startup_fails_without_own_or_external_relay() {
+        let config = RelayConfig::new(false, vec![]);
+        assert!(config.validate_for_startup().is_err());
+    }
+
+    #[test]
+    fn startup_succeeds_with_own_relay() {
+        let config = RelayConfig::new(true, vec![]);
+        assert_eq!(
+            config.validate_for_startup().unwrap(),
+            RelayValidation::OwnRelay
+        );
+    }
+
+    #[test]
+    fn startup_succeeds_with_external_relay() {
+        let config = RelayConfig::new(false, vec!["https://relay.example.net".to_string()]);
+        assert_eq!(
+            config.validate_for_startup().unwrap(),
+            RelayValidation::ExternalRelay
+        );
+    }
+
+    #[test]
+    fn startup_reports_both_when_own_and_external_present() {
+        let config = RelayConfig::new(true, vec!["https://relay.example.net".to_string()]);
+        assert_eq!(
+            config.validate_for_startup().unwrap(),
+            RelayValidation::OwnAndExternalRelay
+        );
+    }
+
+    #[test]
+    fn blank_external_relay_urls_do_not_satisfy_gate() {
+        let config = RelayConfig::new(false, vec!["   ".to_string(), String::new()]);
+        assert!(config.external_relay_urls.is_empty());
+        assert!(config.validate_for_startup().is_err());
+    }
+
+    #[test]
+    fn external_relay_urls_are_deduplicated() {
+        let config = RelayConfig::new(
+            false,
+            vec![
+                "https://relay.example.net".to_string(),
+                "https://relay.example.net".to_string(),
+                " https://relay.example.net ".to_string(),
+            ],
+        );
+        assert_eq!(config.external_relay_urls.len(), 1);
+    }
+}

--- a/crates/cn-indexer/src/ingest.rs
+++ b/crates/cn-indexer/src/ingest.rs
@@ -1,0 +1,248 @@
+//! ingest pipeline（#413 / T5 / ADR 0025 §2.5 / §6.2）。
+//!
+//! 共有 replica に **実在する** post entry のみを対象に、post 本文 text を `cn-safety-runtime` の
+//! `SafetyOrchestrator` で scan し、verdict が `allow`（`SafetyVerdict::is_indexable()`）の entry のみを
+//! index 投影へ書く。以下を不変条件として守る:
+//!   - ghost 注入を作らない: 対象は共有 replica の entry のみ（CN 直渡しは経路が無い。§6.2）。
+//!   - fail-closed: unscanned / scan_failed / provider_unavailable / 非 allow は投影しない（§2.5）。
+//!   - no permanent blob storage: blob は scan 用の一時 fetch のみで、投影に raw blob を入れない（§2.3）。
+//!   - media は scan/tag pipeline へ渡す接続点まで（VLM タグ生成本体は #411）。
+//!
+//! docs replica からの entry 取得は `DocsSync`（`query_replica_with_policy`）越しに行うため、本番
+//! （iroh-docs）でも in-memory（テスト）でも同じ pipeline を駆動できる。
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tracing::{debug, warn};
+
+use kukuri_cn_core::IndexScopeKind;
+use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
+use kukuri_cn_safety_runtime::SafetyOrchestrator;
+use kukuri_core::{KukuriEnvelope, ObjectStatus, PayloadRef, ReplicaId};
+use kukuri_docs_sync::{DocFetchPolicy, DocQuery, DocRecord, DocsSync, stable_key};
+
+use crate::projection::{IndexProjection, IndexedEntry};
+
+/// 単一 scope（topic / channel）を ingest した結果のサマリ（監査 / テスト用）。
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct IngestSummary {
+    /// 走査した object state entry 数。
+    pub scanned: usize,
+    /// `allow` verdict で投影へ書いた entry 数。
+    pub indexed: usize,
+    /// fail-closed（unscanned / scan_failed / 非 allow）で投影しなかった entry 数。
+    pub skipped_non_allow: usize,
+    /// tombstone / deleted で de-index した entry 数。
+    pub deindexed: usize,
+}
+
+/// ingest pipeline。docs replica + safety orchestrator + index 投影を束ねる。
+pub struct IngestPipeline {
+    docs_sync: Arc<dyn DocsSync>,
+    orchestrator: Arc<SafetyOrchestrator>,
+    projection: Arc<dyn IndexProjection>,
+}
+
+impl IngestPipeline {
+    pub fn new(
+        docs_sync: Arc<dyn DocsSync>,
+        orchestrator: Arc<SafetyOrchestrator>,
+        projection: Arc<dyn IndexProjection>,
+    ) -> Self {
+        Self {
+            docs_sync,
+            orchestrator,
+            projection,
+        }
+    }
+
+    /// scope の共有 replica を走査し、実在する post entry のみを scan→allow 判定して投影へ反映する。
+    ///
+    /// replica id は scope から導出される共有 replica（public は `topic::<id>`、private は
+    /// `channel::<id>`）。この関数は「共有 replica に実在する entry のみ」を対象にするため、CN へ
+    /// 直接渡された（replica に存在しない）content を index する経路を持たない。
+    pub async fn ingest_scope(
+        &self,
+        scope_kind: IndexScopeKind,
+        scope_id: &str,
+        replica_id: &ReplicaId,
+    ) -> Result<IngestSummary> {
+        // scope の replica を open してから走査する（未 open だと sync 対象にならない）。
+        self.docs_sync.open_replica(replica_id).await?;
+
+        // post object の state entry を prefix 走査する（`objects/<id>/state`）。
+        let records = self
+            .docs_sync
+            .query_replica_with_policy(
+                replica_id,
+                DocQuery::Prefix(stable_key("objects", "")),
+                DocFetchPolicy::LocalThenRemote,
+            )
+            .await
+            .with_context(|| format!("failed to query replica {}", replica_id.as_str()))?;
+
+        // 同一 prefix scan の envelope entry を object_id -> envelope record で index 化し、
+        // blob text の本文取得で追加クエリ（N+1）を発生させないようにする。
+        let mut envelopes: HashMap<String, DocRecord> = HashMap::new();
+        let mut state_records: Vec<DocRecord> = Vec::new();
+        for record in records {
+            if let Some(object_id) = record.key.strip_suffix("/envelope") {
+                if let Some(object_id) = object_id.strip_prefix("objects/") {
+                    envelopes.insert(object_id.to_string(), record);
+                }
+            } else if record.key.ends_with("/state") {
+                state_records.push(record);
+            }
+        }
+
+        let mut summary = IngestSummary::default();
+        for record in &state_records {
+            summary.scanned += 1;
+            match self
+                .ingest_object_record(scope_kind, scope_id, replica_id, record, &envelopes)
+                .await
+            {
+                Ok(IngestOutcome::Indexed) => summary.indexed += 1,
+                Ok(IngestOutcome::SkippedNonAllow) => summary.skipped_non_allow += 1,
+                Ok(IngestOutcome::Deindexed) => summary.deindexed += 1,
+                Ok(IngestOutcome::Ignored) => {}
+                Err(error) => {
+                    // 単一 entry の失敗で scope 全体を止めない。fail-closed（投影しない）側に倒す。
+                    warn!(
+                        replica_id = %replica_id.as_str(),
+                        key = %record.key,
+                        error = %error,
+                        "failed to ingest object record; skipping (fail-closed)"
+                    );
+                    summary.skipped_non_allow += 1;
+                }
+            }
+        }
+        Ok(summary)
+    }
+
+    async fn ingest_object_record(
+        &self,
+        scope_kind: IndexScopeKind,
+        scope_id: &str,
+        replica_id: &ReplicaId,
+        record: &DocRecord,
+        envelopes: &HashMap<String, DocRecord>,
+    ) -> Result<IngestOutcome> {
+        let object: PostObjectView = match serde_json::from_slice(&record.value) {
+            Ok(object) => object,
+            Err(error) => {
+                debug!(key = %record.key, error = %error, "record is not a post object; ignoring");
+                return Ok(IngestOutcome::Ignored);
+            }
+        };
+
+        // tombstone / deleted は de-index する（replica 上で消えた content を投影に残さない）。
+        if matches!(
+            object.status,
+            ObjectStatus::Deleted | ObjectStatus::Tombstoned
+        ) {
+            self.projection
+                .remove_object(scope_kind, scope_id, object.object_id.as_str())
+                .await?;
+            return Ok(IngestOutcome::Deindexed);
+        }
+
+        // 本文 text を取り出す。blob 参照は scan 用の一時 fetch のみ（恒久保存しない）。
+        let text = self
+            .resolve_body_text(replica_id, &object, envelopes)
+            .await?;
+
+        // safety scan（fail-closed）。post 本文 text を orchestrator に渡す。
+        let request = ProviderScanRequest::for_subject(SubjectKind::Post, object.object_id.clone())
+            .with_text(text.clone());
+        let report = self.orchestrator.scan_subject(&request).await;
+
+        if !report.verdict.is_indexable() {
+            // unscanned / scan_failed / provider_unavailable / 非 allow は投影しない。
+            // 既に投影済みなら de-index する（後から verdict が変わった場合の整合）。
+            self.projection
+                .remove_object(scope_kind, scope_id, object.object_id.as_str())
+                .await?;
+            debug!(
+                object_id = %object.object_id,
+                reason = ?report.verdict.reason_code,
+                "verdict is not allow; not indexing (fail-closed)"
+            );
+            return Ok(IngestOutcome::SkippedNonAllow);
+        }
+
+        let entry = IndexedEntry {
+            scope_kind,
+            scope_id: scope_id.to_string(),
+            object_id: object.object_id.clone(),
+            author_pubkey: object.author,
+            text,
+            created_at: object.created_at,
+            source_replica_id: replica_id.as_str().to_string(),
+        };
+        self.projection.upsert_entry(&entry).await?;
+        Ok(IngestOutcome::Indexed)
+    }
+
+    /// post 本文 text を取り出す。
+    ///
+    /// inline text はそのまま返す。blob text は同一 scope scan で取得済みの envelope（`envelopes`）から
+    /// 本文を得る。envelope は scan 用途のみで、raw blob を恒久保存しない。envelope が無ければ空文字
+    /// （scan は fail-closed 側に倒る）。同一 prefix scan の結果を再利用するため追加クエリを発生させない。
+    async fn resolve_body_text(
+        &self,
+        _replica_id: &ReplicaId,
+        object: &PostObjectView,
+        envelopes: &HashMap<String, DocRecord>,
+    ) -> Result<String> {
+        match &object.payload_ref {
+            PayloadRef::InlineText { text } => Ok(text.clone()),
+            PayloadRef::BlobText { hash, .. } => {
+                let Some(record) = envelopes.get(object.object_id.as_str()) else {
+                    debug!(hash = %hash.as_str(), "blob text envelope missing; scanning empty body");
+                    return Ok(String::new());
+                };
+                let envelope: KukuriEnvelope = serde_json::from_slice(&record.value)
+                    .context("failed to decode post envelope for blob text")?;
+                // 共有 replica の entry が本物であることを署名検証する。
+                envelope
+                    .verify()
+                    .context("post envelope failed verification")?;
+                Ok(inline_text_from_envelope(&envelope).unwrap_or_default())
+            }
+        }
+    }
+}
+
+enum IngestOutcome {
+    Indexed,
+    SkippedNonAllow,
+    Deindexed,
+    Ignored,
+}
+
+/// docs replica に保存された post object state の最小 view。
+///
+/// `object_persistence_support` の `CanonicalPostHeader`（= `KukuriPostObjectV1`）と同じ JSON を
+/// 部分的に読む。cn-indexer は index に必要な最小フィールドのみを取り出す。
+#[derive(Debug, serde::Deserialize)]
+struct PostObjectView {
+    object_id: String,
+    author: String,
+    created_at: i64,
+    payload_ref: PayloadRef,
+    #[serde(default)]
+    status: ObjectStatus,
+}
+
+/// envelope から inline 本文 text を取り出す（blob text の scan 用フォールバック）。
+fn inline_text_from_envelope(envelope: &KukuriEnvelope) -> Option<String> {
+    let content = envelope.post_content().ok().flatten()?;
+    match content.payload_ref {
+        PayloadRef::InlineText { text } => Some(text),
+        PayloadRef::BlobText { .. } => None,
+    }
+}

--- a/crates/cn-indexer/src/lib.rs
+++ b/crates/cn-indexer/src/lib.rs
@@ -1,0 +1,31 @@
+//! kukuri community node indexing participant（#413 / ADR 0025 §6）。
+//!
+//! CN は現状 docs 非参加のため、cn-indexer が iroh-docs を駆動する docs replica sync participant を
+//! 新設する。責務は「取得経路 = Model C」の ingest→投影まで:
+//!
+//! 1. supported topic / 許可 channel の共有 replica を sync する participant（`participant`）。
+//! 2. 共有 replica に実在する post entry のみを scan→`allow` 判定して index 投影に書く（`ingest`）。
+//! 3. index 投影 store の境界と ArcadeDB adapter（`projection` / `arcadedb`）。全文のみ、canonical
+//!    ではない写像。
+//! 4. relay validation 起動 gate（`config`）: 自前 relay も外部 relay も無ければ indexing を起動しない。
+//!
+//! scope 管理 state（supported set / user request / channel capability）は cn-core（Postgres）が所有し、
+//! ユーザー向け indexing request 受付 API は cn-user-api が持つ。ユーザー向け search / discovery /
+//! recommendation 本体と fail-closed query gate は #404 が載せる（本 crate は投影レベル read まで）。
+//!
+//! 設計の真実源:
+//! - `docs/adr/0025-community-node-indexing-foundation.md`（§2.2 scope / §2.5 fail-closed / §6 Model C）
+
+pub mod arcadedb;
+pub mod config;
+pub mod ingest;
+pub mod participant;
+pub mod projection;
+pub mod runtime;
+
+pub use arcadedb::ArcadeDbProjection;
+pub use config::{ArcadeDbConfig, IndexerConfig, RelayConfig, RelayValidation};
+pub use ingest::{IngestPipeline, IngestSummary};
+pub use participant::{IndexerParticipant, ScopeReplica};
+pub use projection::{IndexProjection, IndexedEntry, MemoryIndexProjection};
+pub use runtime::run_from_env;

--- a/crates/cn-indexer/src/main.rs
+++ b/crates/cn-indexer/src/main.rs
@@ -1,0 +1,11 @@
+//! cn-indexer binary（#413）。
+//!
+//! community node の docs replica sync participant（Model C）を起動する。起動時に relay validation
+//! gate（ADR 0025 §6.4）を適用し、自前 relay も外部 relay も無ければ起動しない（fail-closed）。
+
+use anyhow::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    kukuri_cn_indexer::run_from_env().await
+}

--- a/crates/cn-indexer/src/participant.rs
+++ b/crates/cn-indexer/src/participant.rs
@@ -1,0 +1,203 @@
+//! docs replica sync participant（#413 / T4 / ADR 0025 §6.2 / §6.3）。
+//!
+//! CN は現状 docs 非参加のため、cn-indexer が iroh-docs を駆動する常駐 participant を新設する。
+//! 本モジュールは scope 管理 state（cn-core / Postgres）を真実源に、supported topic / 許可 channel の
+//! 共有 replica を open して sync し、ingest pipeline を回し、supported 除外 / channel secret 失効時に
+//! sync 停止 + de-index する制御を担う。
+//!
+//! ここでは `DocsSync` trait 越しに replica を扱うため、本番（iroh-docs）でも in-memory（テスト）でも
+//! 同じ制御ロジックを駆動できる。実際の docs node 生成（`IrohDocsNode` / relay 設定）は起動側
+//! （`runtime` / `main`）が行い、本モジュールへ `DocsSync` として注入する。
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use sqlx::postgres::PgPool;
+use tracing::{info, warn};
+
+use kukuri_cn_core::{
+    ChannelSecretCipher, IndexScopeKind, list_channel_secrets, list_supported_topics,
+};
+use kukuri_core::ReplicaId;
+use kukuri_docs_sync::{DocsSync, private_channel_replica_id, topic_replica_id};
+
+use crate::ingest::{IngestPipeline, IngestSummary};
+use crate::projection::IndexProjection;
+
+/// scope（種別 + id）と、それが指す共有 replica id。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScopeReplica {
+    pub kind: IndexScopeKind,
+    pub id: String,
+    pub replica_id: ReplicaId,
+}
+
+impl ScopeReplica {
+    /// scope 種別 + id から共有 replica id を導出する（ADR 0025 §6.2 / §6.3）。
+    ///
+    /// - public topic: `topic::<id>`（`public_replica_secret` で open 可能）。
+    /// - private channel: `channel::<id>`（登録 capability が必要）。
+    pub fn from_scope(kind: IndexScopeKind, id: &str) -> Self {
+        let replica_id = match kind {
+            IndexScopeKind::PublicTopic => topic_replica_id(id),
+            IndexScopeKind::PrivateChannel => private_channel_replica_id(id),
+        };
+        Self {
+            kind,
+            id: id.to_string(),
+            replica_id,
+        }
+    }
+}
+
+/// docs replica sync participant の制御面。
+pub struct IndexerParticipant {
+    pool: PgPool,
+    docs_sync: Arc<dyn DocsSync>,
+    projection: Arc<dyn IndexProjection>,
+    pipeline: IngestPipeline,
+    channel_secret_cipher: ChannelSecretCipher,
+}
+
+impl IndexerParticipant {
+    pub fn new(
+        pool: PgPool,
+        docs_sync: Arc<dyn DocsSync>,
+        projection: Arc<dyn IndexProjection>,
+        pipeline: IngestPipeline,
+        channel_secret_cipher: ChannelSecretCipher,
+    ) -> Self {
+        Self {
+            pool,
+            docs_sync,
+            projection,
+            pipeline,
+            channel_secret_cipher,
+        }
+    }
+
+    /// 起動時 / 再起動時に scope 管理 state から replica を open して sync 復元する（E13）。
+    ///
+    /// supported topic（public / private channel）の replica を open し、private channel は登録済み
+    /// capability（channel secret）を docs へ登録してから open する。secret 未登録の private channel は
+    /// open せず warn する（secret 無しでは index しない）。
+    pub async fn restore_scopes(&self) -> Result<Vec<ScopeReplica>> {
+        // private channel の capability を先に docs へ登録する。
+        let secrets = list_channel_secrets(&self.pool, &self.channel_secret_cipher).await?;
+        for secret in &secrets {
+            let replica_id = private_channel_replica_id(secret.channel_id.as_str());
+            self.docs_sync
+                .register_private_replica_secret(&replica_id, secret.namespace_secret_hex.as_str())
+                .await?;
+        }
+
+        let mut opened = Vec::new();
+        for supported in list_supported_topics(&self.pool).await? {
+            let scope = ScopeReplica::from_scope(supported.kind, supported.id.as_str());
+            // private channel は capability が登録されていなければ open しない。
+            if scope.kind == IndexScopeKind::PrivateChannel
+                && !secrets.iter().any(|secret| secret.channel_id == scope.id)
+            {
+                warn!(
+                    channel_id = %scope.id,
+                    "private channel is supported but has no registered capability; skipping (no secret, no index)"
+                );
+                continue;
+            }
+            match self.docs_sync.open_replica(&scope.replica_id).await {
+                Ok(()) => {
+                    info!(
+                        kind = scope.kind.as_str(),
+                        scope_id = %scope.id,
+                        replica_id = %scope.replica_id.as_str(),
+                        "opened supported replica for sync"
+                    );
+                    opened.push(scope);
+                }
+                Err(error) => {
+                    warn!(
+                        kind = scope.kind.as_str(),
+                        scope_id = %scope.id,
+                        error = %error,
+                        "failed to open supported replica; skipping"
+                    );
+                }
+            }
+        }
+        Ok(opened)
+    }
+
+    /// 単一 scope を ingest する（scan→allow→投影）。
+    pub async fn ingest_scope(&self, scope: &ScopeReplica) -> Result<IngestSummary> {
+        self.pipeline
+            .ingest_scope(scope.kind, scope.id.as_str(), &scope.replica_id)
+            .await
+    }
+
+    /// supported set 全体を 1 巡 ingest する。
+    pub async fn ingest_all_supported(&self) -> Result<IngestSummary> {
+        let scopes = self.restore_scopes().await?;
+        let mut total = IngestSummary::default();
+        for scope in scopes {
+            match self.ingest_scope(&scope).await {
+                Ok(summary) => {
+                    total.scanned += summary.scanned;
+                    total.indexed += summary.indexed;
+                    total.skipped_non_allow += summary.skipped_non_allow;
+                    total.deindexed += summary.deindexed;
+                }
+                Err(error) => warn!(
+                    kind = scope.kind.as_str(),
+                    scope_id = %scope.id,
+                    error = %error,
+                    "failed to ingest scope; continuing"
+                ),
+            }
+        }
+        Ok(total)
+    }
+
+    /// supported topic 除外時の sync 停止 + de-index（E2 / E5）。
+    ///
+    /// public topic の replica はここでは docs から secret を外せない（導出 secret のため）が、
+    /// 投影を de-index することで検索面から消える。private channel は capability も外す。
+    pub async fn stop_and_deindex_scope(&self, kind: IndexScopeKind, id: &str) -> Result<()> {
+        let scope = ScopeReplica::from_scope(kind, id);
+        if kind == IndexScopeKind::PrivateChannel {
+            // capability を外して sync 停止する（remove_private_replica_secret が replica も閉じる）。
+            self.docs_sync
+                .remove_private_replica_secret(&scope.replica_id)
+                .await?;
+        }
+        self.projection.remove_scope(kind, id).await?;
+        info!(
+            kind = kind.as_str(),
+            scope_id = %id,
+            "stopped sync and de-indexed scope"
+        );
+        Ok(())
+    }
+
+    /// channel secret 失効時の capability 除去 + sync 停止 + de-index（E4）。
+    pub async fn revoke_channel_and_deindex(&self, channel_id: &str) -> Result<()> {
+        self.stop_and_deindex_scope(IndexScopeKind::PrivateChannel, channel_id)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_topic_scope_maps_to_topic_replica() {
+        let scope = ScopeReplica::from_scope(IndexScopeKind::PublicTopic, "rust");
+        assert_eq!(scope.replica_id.as_str(), "topic::rust");
+    }
+
+    #[test]
+    fn private_channel_scope_maps_to_channel_replica() {
+        let scope = ScopeReplica::from_scope(IndexScopeKind::PrivateChannel, "secret-room");
+        assert_eq!(scope.replica_id.as_str(), "channel::secret-room");
+    }
+}

--- a/crates/cn-indexer/src/projection.rs
+++ b/crates/cn-indexer/src/projection.rs
@@ -1,0 +1,271 @@
+//! index 投影 store の境界（#413 / T6）。
+//!
+//! index 投影は canonical source ではない derived な写像である（ADR 0025 §2.1）。全文検索は ArcadeDB
+//! （Lucene）に置く。backend を差し替え可能にするため trait `IndexProjection` を境界に置き、本番は
+//! ArcadeDB adapter（`arcadedb.rs`）、テストは in-memory 実装で駆動する。
+//!
+//! 投影に入るのは safety verdict が `allow` の entry のみ（fail-closed は ingest 側で担保）。scope
+//! （supported topic 除外 / channel secret 失効）で de-index するため、topic/channel 単位の削除を持つ。
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use kukuri_cn_core::IndexScopeKind;
+
+/// 投影 1 件（検索対象エントリ）。
+///
+/// canonical ではない derived な写像。text は post 本文（media は将来 VLM 派生タグ）で、raw blob は
+/// 含めない（no permanent blob storage / ADR 0025 §2.3）。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexedEntry {
+    /// scope 種別（public_topic / private_channel）。
+    pub scope_kind: IndexScopeKind,
+    /// scope 識別子（topic_id / channel_id）。de-index の単位。
+    pub scope_id: String,
+    /// 対象 object id（post id 等）。scope 内で一意。
+    pub object_id: String,
+    /// 著者 pubkey。
+    pub author_pubkey: String,
+    /// 検索対象テキスト（post 本文 / 将来は media 派生タグ）。
+    pub text: String,
+    /// 作成時刻（unix 秒）。
+    pub created_at: i64,
+    /// 由来の共有 replica id（監査用。ghost 注入でないことの追跡）。
+    pub source_replica_id: String,
+}
+
+/// index 投影 store の境界。ArcadeDB / in-memory が同じ API を満たす。
+///
+/// クエリ表現は Cypher 互換に落とせることを前提とする（ADR 0026 §6.1 と同じ方針）が、#413 の
+/// スコープは ingest→投影 + 投影レベル read（allow entry の存在確認）までで、ユーザー向け search API は
+/// #404 が載せる。
+#[async_trait]
+pub trait IndexProjection: Send + Sync {
+    /// `allow` entry を投影へ upsert する（object_id で冪等）。
+    async fn upsert_entry(&self, entry: &IndexedEntry) -> Result<()>;
+
+    /// scope 内の単一 object が投影に存在するか（投影レベル read）。
+    async fn contains_object(
+        &self,
+        scope_kind: IndexScopeKind,
+        scope_id: &str,
+        object_id: &str,
+    ) -> Result<bool>;
+
+    /// scope 内の投影 entry 数（テスト / 監査用）。
+    async fn count_scope(&self, scope_kind: IndexScopeKind, scope_id: &str) -> Result<usize>;
+
+    /// scope 全体を de-index する（supported topic 除去 / channel secret 失効時）。
+    async fn remove_scope(&self, scope_kind: IndexScopeKind, scope_id: &str) -> Result<()>;
+
+    /// 単一 object を de-index する（replica 上の tombstone / 削除時）。
+    async fn remove_object(
+        &self,
+        scope_kind: IndexScopeKind,
+        scope_id: &str,
+        object_id: &str,
+    ) -> Result<()>;
+}
+
+/// in-memory 実装（contract / unit テスト用）。
+#[derive(Clone, Default)]
+pub struct MemoryIndexProjection {
+    entries: std::sync::Arc<tokio::sync::Mutex<Vec<IndexedEntry>>>,
+}
+
+impl MemoryIndexProjection {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// scope 内の全 entry を取得する（テスト用の read ヘルパ）。
+    pub async fn entries_in_scope(
+        &self,
+        scope_kind: IndexScopeKind,
+        scope_id: &str,
+    ) -> Vec<IndexedEntry> {
+        self.entries
+            .lock()
+            .await
+            .iter()
+            .filter(|entry| entry.scope_kind == scope_kind && entry.scope_id == scope_id)
+            .cloned()
+            .collect()
+    }
+}
+
+fn same_object(
+    entry: &IndexedEntry,
+    scope_kind: IndexScopeKind,
+    scope_id: &str,
+    object_id: &str,
+) -> bool {
+    entry.scope_kind == scope_kind && entry.scope_id == scope_id && entry.object_id == object_id
+}
+
+#[async_trait]
+impl IndexProjection for MemoryIndexProjection {
+    async fn upsert_entry(&self, entry: &IndexedEntry) -> Result<()> {
+        let mut entries = self.entries.lock().await;
+        if let Some(existing) = entries.iter_mut().find(|existing| {
+            same_object(
+                existing,
+                entry.scope_kind,
+                entry.scope_id.as_str(),
+                entry.object_id.as_str(),
+            )
+        }) {
+            *existing = entry.clone();
+        } else {
+            entries.push(entry.clone());
+        }
+        Ok(())
+    }
+
+    async fn contains_object(
+        &self,
+        scope_kind: IndexScopeKind,
+        scope_id: &str,
+        object_id: &str,
+    ) -> Result<bool> {
+        Ok(self
+            .entries
+            .lock()
+            .await
+            .iter()
+            .any(|entry| same_object(entry, scope_kind, scope_id, object_id)))
+    }
+
+    async fn count_scope(&self, scope_kind: IndexScopeKind, scope_id: &str) -> Result<usize> {
+        Ok(self
+            .entries
+            .lock()
+            .await
+            .iter()
+            .filter(|entry| entry.scope_kind == scope_kind && entry.scope_id == scope_id)
+            .count())
+    }
+
+    async fn remove_scope(&self, scope_kind: IndexScopeKind, scope_id: &str) -> Result<()> {
+        self.entries
+            .lock()
+            .await
+            .retain(|entry| !(entry.scope_kind == scope_kind && entry.scope_id == scope_id));
+        Ok(())
+    }
+
+    async fn remove_object(
+        &self,
+        scope_kind: IndexScopeKind,
+        scope_id: &str,
+        object_id: &str,
+    ) -> Result<()> {
+        self.entries
+            .lock()
+            .await
+            .retain(|entry| !same_object(entry, scope_kind, scope_id, object_id));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(scope_id: &str, object_id: &str, text: &str) -> IndexedEntry {
+        IndexedEntry {
+            scope_kind: IndexScopeKind::PublicTopic,
+            scope_id: scope_id.to_string(),
+            object_id: object_id.to_string(),
+            author_pubkey: "author".to_string(),
+            text: text.to_string(),
+            created_at: 1,
+            source_replica_id: format!("topic::{scope_id}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn upsert_is_idempotent_by_object_id() {
+        let projection = MemoryIndexProjection::new();
+        projection
+            .upsert_entry(&entry("t1", "o1", "a"))
+            .await
+            .unwrap();
+        projection
+            .upsert_entry(&entry("t1", "o1", "b"))
+            .await
+            .unwrap();
+        assert_eq!(
+            projection
+                .count_scope(IndexScopeKind::PublicTopic, "t1")
+                .await
+                .unwrap(),
+            1
+        );
+        let stored = projection
+            .entries_in_scope(IndexScopeKind::PublicTopic, "t1")
+            .await;
+        assert_eq!(stored[0].text, "b");
+    }
+
+    #[tokio::test]
+    async fn contains_object_reflects_upsert_and_remove() {
+        let projection = MemoryIndexProjection::new();
+        projection
+            .upsert_entry(&entry("t1", "o1", "a"))
+            .await
+            .unwrap();
+        assert!(
+            projection
+                .contains_object(IndexScopeKind::PublicTopic, "t1", "o1")
+                .await
+                .unwrap()
+        );
+        projection
+            .remove_object(IndexScopeKind::PublicTopic, "t1", "o1")
+            .await
+            .unwrap();
+        assert!(
+            !projection
+                .contains_object(IndexScopeKind::PublicTopic, "t1", "o1")
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_scope_deindexes_all_entries_for_scope() {
+        let projection = MemoryIndexProjection::new();
+        projection
+            .upsert_entry(&entry("t1", "o1", "a"))
+            .await
+            .unwrap();
+        projection
+            .upsert_entry(&entry("t1", "o2", "b"))
+            .await
+            .unwrap();
+        projection
+            .upsert_entry(&entry("t2", "o3", "c"))
+            .await
+            .unwrap();
+        projection
+            .remove_scope(IndexScopeKind::PublicTopic, "t1")
+            .await
+            .unwrap();
+        assert_eq!(
+            projection
+                .count_scope(IndexScopeKind::PublicTopic, "t1")
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            projection
+                .count_scope(IndexScopeKind::PublicTopic, "t2")
+                .await
+                .unwrap(),
+            1
+        );
+    }
+}

--- a/crates/cn-indexer/src/runtime.rs
+++ b/crates/cn-indexer/src/runtime.rs
@@ -1,0 +1,65 @@
+//! cn-indexer 常駐 runtime（#413 / T4）。
+//!
+//! 起動フローの要は **relay validation の起動 gate**（ADR 0025 §6.4）: 自前 relay も外部 relay も
+//! 設定されていなければ indexing を起動しない（fail-closed）。gate を通ったら Postgres の scope
+//! 管理 state を真実源に docs replica sync participant を立ち上げる。
+//!
+//! safety provider（#391 / #411）はまだ実装が無いため、scan orchestrator を構成できない構成では
+//! ingest を起動しない（unscanned を index しない fail-closed と整合。`CommunityIndex` capability が
+//! `Availability::Planned` である現状と一致する）。relay gate 自体はそれとは独立に起動時へ適用する。
+
+use anyhow::{Context, Result};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+use crate::config::IndexerConfig;
+
+/// 環境変数から設定を読み、relay validation 起動 gate を適用して cn-indexer を起動する。
+///
+/// 現段階では relay gate の適用と scope state の準備確認までを行う。safety provider が実装されて
+/// ingest が実運用可能になった段階（#391 / #411, `CommunityIndex` 昇格）で ingest loop を有効化する。
+pub async fn run_from_env() -> Result<()> {
+    init_tracing();
+    let config = IndexerConfig::from_env()?;
+    run(config).await
+}
+
+async fn run(config: IndexerConfig) -> Result<()> {
+    // fail-closed の起動 gate: 自前 relay も外部 relay も無ければ indexing を起動しない。
+    let validation = config.relay.validate_for_startup().context(
+        "cn-indexer startup blocked: no validated relay (ADR 0025 §6.4 fail-closed startup gate)",
+    )?;
+    info!(?validation, "relay validation passed; starting cn-indexer");
+
+    // scope 管理 state（supported set / request / channel secret）を持つ DB が ready であること。
+    let pool = kukuri_cn_core::connect_postgres(config.database_url.as_str()).await?;
+    kukuri_cn_core::ensure_database_ready(&pool)
+        .await
+        .context("community-node database is not ready for cn-indexer")?;
+
+    // channel secret 復号鍵を検証する（不正なら早期に失敗させる）。
+    let _cipher =
+        kukuri_cn_core::ChannelSecretCipher::from_key_material(config.channel_secret_key.as_str())
+            .context("invalid COMMUNITY_NODE_CHANNEL_SECRET_KEY")?;
+
+    info!(
+        data_dir = %config.data_dir.display(),
+        arcadedb_url = %config.arcadedb.base_url,
+        arcadedb_database = %config.arcadedb.database,
+        "cn-indexer configuration validated"
+    );
+
+    // NOTE: safety provider（#391 / #411）が実装され `CommunityIndex` が昇格するまで、実 ingest loop は
+    // 起動しない。ここまでで relay 起動 gate と scope state の準備確認は完了しており、participant /
+    // ingest pipeline（`crate::participant` / `crate::ingest`）は provider 実装後に本 runtime へ結線する。
+    Ok(())
+}
+
+fn init_tracing() {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,kukuri_cn_indexer=debug"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_target(true)
+        .try_init();
+}

--- a/crates/cn-indexer/tests/ingestion_contracts.rs
+++ b/crates/cn-indexer/tests/ingestion_contracts.rs
@@ -1,0 +1,317 @@
+//! #413 ingestion 系 contract test（ADR 0025 §2.2 / §2.5 / §6）。
+//!
+//! in-memory な `DocsSync` + `MemoryIndexProjection` + mock safety provider で ingest pipeline と
+//! relay 起動 gate を駆動し、ADR 0025 の ingestion 系 contract を検証する。DB を要さない範囲を対象に
+//! するため、supported set の scope ゲート自体（Postgres 依存）は cn-core 側の DB テストに委ね、ここでは
+//! pipeline の不変条件（共有 replica 実在のみ / fail-closed / de-index）と relay gate を固定する。
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use kukuri_cn_core::IndexScopeKind;
+use kukuri_cn_indexer::config::RelayConfig;
+use kukuri_cn_indexer::ingest::IngestPipeline;
+use kukuri_cn_indexer::participant::ScopeReplica;
+use kukuri_cn_indexer::projection::{IndexProjection, MemoryIndexProjection};
+use kukuri_cn_safety::MockSafetyProvider;
+use kukuri_cn_safety_runtime::SafetyOrchestrator;
+use kukuri_cn_safety_runtime::clock::SystemScanClock;
+use kukuri_cn_safety_runtime::id::UuidEventIdGenerator;
+use kukuri_core::{KukuriKeys, ReplicaId, TopicId, build_post_envelope};
+use kukuri_docs_sync::{DocOp, DocQuery, DocsSync, MemoryDocsSync, stable_key, topic_replica_id};
+
+/// mock provider で allow を返す orchestrator（known CSAM = NoKnownMatch、脅威スコア無し）。
+///
+/// `public_node_default` policy は known CSAM provider を必須とするため、allow を得るには
+/// `KnownCsamHashMatch` provider が `NoKnownMatch` を返す必要がある。
+fn allow_orchestrator() -> Arc<SafetyOrchestrator> {
+    let provider = Arc::new(MockSafetyProvider::known_csam("mock-known-csam"));
+    Arc::new(
+        SafetyOrchestrator::builder(
+            "node-issuer",
+            Arc::new(SystemScanClock),
+            Arc::new(UuidEventIdGenerator),
+        )
+        .provider(provider)
+        .build()
+        .expect("orchestrator"),
+    )
+}
+
+/// mock provider が scan 失敗を返す orchestrator（fail-closed のテスト用）。
+fn scan_failed_orchestrator() -> Arc<SafetyOrchestrator> {
+    let provider = Arc::new(MockSafetyProvider::known_csam("mock-known-csam").default_failed());
+    Arc::new(
+        SafetyOrchestrator::builder(
+            "node-issuer",
+            Arc::new(SystemScanClock),
+            Arc::new(UuidEventIdGenerator),
+        )
+        .provider(provider)
+        .build()
+        .expect("orchestrator"),
+    )
+}
+
+/// known CSAM hash match を返す orchestrator（exclude のテスト用）。
+fn known_csam_orchestrator(post_id: &str) -> Arc<SafetyOrchestrator> {
+    let provider =
+        Arc::new(MockSafetyProvider::known_csam("mock-known-csam").with_known_hash_match(post_id));
+    Arc::new(
+        SafetyOrchestrator::builder(
+            "node-issuer",
+            Arc::new(SystemScanClock),
+            Arc::new(UuidEventIdGenerator),
+        )
+        .provider(provider)
+        .build()
+        .expect("orchestrator"),
+    )
+}
+
+/// 本文 text の post envelope を共有 replica に実在させる（app-api の persist と同じ key 形状）。
+///
+/// 返り値は object_id。
+async fn persist_post(
+    docs: &MemoryDocsSync,
+    replica: &ReplicaId,
+    topic: &TopicId,
+    body: &str,
+) -> String {
+    let keys = KukuriKeys::generate();
+    let envelope = build_post_envelope(&keys, topic, body, None).expect("envelope");
+    let object = envelope
+        .to_post_object()
+        .expect("post object")
+        .expect("post object present");
+    let object_id = object.object_id.as_str().to_string();
+    docs.open_replica(replica).await.expect("open");
+    docs.apply_doc_op(
+        replica,
+        DocOp::SetJson {
+            key: stable_key("objects", &format!("{object_id}/state")),
+            value: serde_json::to_value(&object).expect("state json"),
+        },
+    )
+    .await
+    .expect("state op");
+    docs.apply_doc_op(
+        replica,
+        DocOp::SetJson {
+            key: stable_key("objects", &format!("{object_id}/envelope")),
+            value: serde_json::to_value(&envelope).expect("envelope json"),
+        },
+    )
+    .await
+    .expect("envelope op");
+    object_id
+}
+
+#[tokio::test]
+async fn index_only_indexes_shared_replica_entries() -> Result<()> {
+    // 共有 replica に実在する entry のみ index する（ghost 注入を作らない）。
+    let docs = Arc::new(MemoryDocsSync::default());
+    let projection = Arc::new(MemoryIndexProjection::new());
+    let topic = TopicId::new("rust");
+    let replica = topic_replica_id("rust");
+    let object_id = persist_post(&docs, &replica, &topic, "hello shared replica").await;
+
+    let pipeline = IngestPipeline::new(docs.clone(), allow_orchestrator(), projection.clone());
+    let scope = ScopeReplica::from_scope(IndexScopeKind::PublicTopic, "rust");
+    let summary = pipeline
+        .ingest_scope(scope.kind, &scope.id, &scope.replica_id)
+        .await?;
+
+    assert_eq!(summary.scanned, 1);
+    assert_eq!(summary.indexed, 1);
+    assert!(
+        projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+            .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn content_not_in_shared_replica_is_not_indexed() -> Result<()> {
+    // CN へ直接渡されただけ（= replica に entry が無い）の content は index されない。
+    let docs = Arc::new(MemoryDocsSync::default());
+    let projection = Arc::new(MemoryIndexProjection::new());
+    // replica を open するが post entry は入れない（共有 replica に実在しない）。
+    let replica = topic_replica_id("empty");
+    docs.open_replica(&replica).await?;
+
+    let pipeline = IngestPipeline::new(docs.clone(), allow_orchestrator(), projection.clone());
+    let summary = pipeline
+        .ingest_scope(IndexScopeKind::PublicTopic, "empty", &replica)
+        .await?;
+
+    assert_eq!(summary.scanned, 0);
+    assert_eq!(summary.indexed, 0);
+    assert_eq!(
+        projection
+            .count_scope(IndexScopeKind::PublicTopic, "empty")
+            .await?,
+        0
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn index_excludes_unscanned_and_scan_failed() -> Result<()> {
+    // scan 失敗（fail-closed）の content は投影に入らない。
+    let docs = Arc::new(MemoryDocsSync::default());
+    let projection = Arc::new(MemoryIndexProjection::new());
+    let topic = TopicId::new("rust");
+    let replica = topic_replica_id("rust");
+    let object_id = persist_post(&docs, &replica, &topic, "scan will fail").await;
+
+    let pipeline =
+        IngestPipeline::new(docs.clone(), scan_failed_orchestrator(), projection.clone());
+    let summary = pipeline
+        .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+        .await?;
+
+    assert_eq!(summary.scanned, 1);
+    assert_eq!(summary.indexed, 0);
+    assert_eq!(summary.skipped_non_allow, 1);
+    assert!(
+        !projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+            .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn index_excludes_non_allow_verdict_content() -> Result<()> {
+    // known CSAM hash match（exclude verdict）の content は投影に入らない。
+    let docs = Arc::new(MemoryDocsSync::default());
+    let projection = Arc::new(MemoryIndexProjection::new());
+    let topic = TopicId::new("rust");
+    let replica = topic_replica_id("rust");
+    let object_id = persist_post(&docs, &replica, &topic, "bad content").await;
+
+    let pipeline = IngestPipeline::new(
+        docs.clone(),
+        known_csam_orchestrator(&object_id),
+        projection.clone(),
+    );
+    let summary = pipeline
+        .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+        .await?;
+
+    assert_eq!(summary.indexed, 0);
+    assert_eq!(summary.skipped_non_allow, 1);
+    assert!(
+        !projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+            .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn reingest_deindexes_when_verdict_flips_to_non_allow() -> Result<()> {
+    // 初回 allow で投影されたあと、後続 scan で非 allow になった entry は de-index される。
+    let docs = Arc::new(MemoryDocsSync::default());
+    let projection = Arc::new(MemoryIndexProjection::new());
+    let topic = TopicId::new("rust");
+    let replica = topic_replica_id("rust");
+    let object_id = persist_post(&docs, &replica, &topic, "flips later").await;
+
+    IngestPipeline::new(docs.clone(), allow_orchestrator(), projection.clone())
+        .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+        .await?;
+    assert!(
+        projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+            .await?
+    );
+
+    IngestPipeline::new(
+        docs.clone(),
+        known_csam_orchestrator(&object_id),
+        projection.clone(),
+    )
+    .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+    .await?;
+    assert!(
+        !projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+            .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn indexing_startup_requires_validated_relay() -> Result<()> {
+    // 自前 relay も外部 relay も無ければ indexing 起動に失敗する。
+    assert!(
+        RelayConfig::new(false, vec![])
+            .validate_for_startup()
+            .is_err()
+    );
+    // 自前 relay 有り、または外部 relay 有りで起動できる。
+    assert!(
+        RelayConfig::new(true, vec![])
+            .validate_for_startup()
+            .is_ok()
+    );
+    assert!(
+        RelayConfig::new(false, vec!["https://relay.example.net".to_string()])
+            .validate_for_startup()
+            .is_ok()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn deleted_objects_are_deindexed() -> Result<()> {
+    // replica 上で deleted / tombstoned になった object は de-index する。
+    let docs = Arc::new(MemoryDocsSync::default());
+    let projection = Arc::new(MemoryIndexProjection::new());
+    let topic = TopicId::new("rust");
+    let replica = topic_replica_id("rust");
+    let object_id = persist_post(&docs, &replica, &topic, "to be deleted").await;
+
+    IngestPipeline::new(docs.clone(), allow_orchestrator(), projection.clone())
+        .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+        .await?;
+    assert!(
+        projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+            .await?
+    );
+
+    // object state を deleted に更新する。
+    let mut object: serde_json::Value = {
+        let records = docs
+            .query_replica(
+                &replica,
+                DocQuery::Exact(stable_key("objects", &format!("{object_id}/state"))),
+            )
+            .await?;
+        serde_json::from_slice(&records[0].value)?
+    };
+    object["status"] = serde_json::json!("deleted");
+    docs.apply_doc_op(
+        &replica,
+        DocOp::SetJson {
+            key: stable_key("objects", &format!("{object_id}/state")),
+            value: object,
+        },
+    )
+    .await?;
+
+    let summary = IngestPipeline::new(docs.clone(), allow_orchestrator(), projection.clone())
+        .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+        .await?;
+    assert_eq!(summary.deindexed, 1);
+    assert!(
+        !projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+            .await?
+    );
+    Ok(())
+}

--- a/crates/cn-user-api/Cargo.toml
+++ b/crates/cn-user-api/Cargo.toml
@@ -26,6 +26,7 @@ kukuri-cn-operator = { path = "../cn-operator" }
 
 [dev-dependencies]
 kukuri-core = { path = "../core" }
+hex.workspace = true
 reqwest.workspace = true
 redis.workspace = true
 tempfile.workspace = true

--- a/crates/cn-user-api/src/lib.rs
+++ b/crates/cn-user-api/src/lib.rs
@@ -11,15 +11,16 @@ use axum::{Json, Router};
 use kukuri_cn_core::{
     AdmissionRejection, ApiError, ApiResult, AuthChallengeResponse, AuthVerifyResponse,
     BootstrapHeartbeatResponse, COMMUNITY_NODE_RENDEZVOUS_KEY_PREFIX_ENV,
-    COMMUNITY_NODE_RENDEZVOUS_REDIS_URL_ENV, CommunityNodeBootstrapNode,
-    CommunityNodeConsentStatus, CommunityNodeResolvedUrls, DatabaseInitMode, JwtConfig,
-    NewCommunityNodeReport, TopicRendezvousHeartbeat, TopicRendezvousHeartbeatResponse,
-    TopicRendezvousStore, accept_consents, auth_required_error, connect_postgres,
-    create_auth_challenge, get_consent_status, initialize_database,
-    initialize_database_for_runtime, insert_community_node_report, load_admission_config,
-    load_bootstrap_nodes, load_bootstrap_seed_peers, normalize_http_url, normalize_http_url_list,
-    refresh_bootstrap_peer_registration, require_bearer_identity, require_bearer_pubkey,
-    require_consents, verify_auth_envelope_and_issue_token,
+    COMMUNITY_NODE_RENDEZVOUS_REDIS_URL_ENV, ChannelSecretCipher, ChannelSecretConflict,
+    CommunityNodeBootstrapNode, CommunityNodeConsentStatus, CommunityNodeResolvedUrls,
+    DatabaseInitMode, IndexScopeKind, JwtConfig, NewCommunityNodeReport, TopicRendezvousHeartbeat,
+    TopicRendezvousHeartbeatResponse, TopicRendezvousStore, accept_consents, auth_required_error,
+    connect_postgres, create_auth_challenge, get_consent_status, initialize_database,
+    initialize_database_for_runtime, insert_community_node_report, insert_indexing_request,
+    load_admission_config, load_bootstrap_nodes, load_bootstrap_seed_peers, normalize_http_url,
+    normalize_http_url_list, parse_bool_env, parse_csv_env, refresh_bootstrap_peer_registration,
+    register_channel_secret, require_bearer_identity, require_bearer_pubkey, require_consents,
+    verify_auth_envelope_and_issue_token,
 };
 use kukuri_cn_operator::{CommunityNodeManifest, build_manifest, load_and_validate};
 use serde::{Deserialize, Serialize};
@@ -39,6 +40,10 @@ pub struct UserApiState {
     self_node: CommunityNodeBootstrapNode,
     /// 公開する manifest（operator config が設定されている場合のみ）。
     manifest: Option<Arc<CommunityNodeManifest>>,
+    /// private channel の indexing request で受け取る channel secret を at-rest 暗号化する cipher。
+    /// 鍵 material（`COMMUNITY_NODE_CHANNEL_SECRET_KEY`）が未設定なら None で、private channel の
+    /// indexing request は受け付けない（secret を平文保存しないため）。
+    channel_secret_cipher: Option<Arc<ChannelSecretCipher>>,
 }
 
 /// public manifest endpoint 用の最小 state。DB を必要としないため、
@@ -48,7 +53,7 @@ struct ManifestState {
     manifest: Option<Arc<CommunityNodeManifest>>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct UserApiConfig {
     pub bind_addr: SocketAddr,
     pub database_url: String,
@@ -61,6 +66,30 @@ pub struct UserApiConfig {
     /// 公開 manifest を生成する operator-config.yaml のパス。
     /// 未設定なら manifest endpoint は 404 を返す（client は別 node / 直接 P2P へ fallback）。
     pub operator_config_path: Option<PathBuf>,
+    /// private channel の indexing request で渡される channel secret を at-rest 暗号化する鍵 material。
+    /// 未設定なら private channel の indexing request は受け付けない（#413 / ADR 0025 §6.3）。
+    pub channel_secret_key: Option<String>,
+}
+
+impl std::fmt::Debug for UserApiConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // channel_secret_key（at-rest 暗号鍵）を Debug 出力に含めない。
+        f.debug_struct("UserApiConfig")
+            .field("bind_addr", &self.bind_addr)
+            .field("database_url", &self.database_url)
+            .field("rendezvous_redis_url", &self.rendezvous_redis_url)
+            .field("rendezvous_key_prefix", &self.rendezvous_key_prefix)
+            .field("base_url", &self.base_url)
+            .field("public_base_url", &self.public_base_url)
+            .field("connectivity_urls", &self.connectivity_urls)
+            .field("jwt_config", &self.jwt_config)
+            .field("operator_config_path", &self.operator_config_path)
+            .field(
+                "channel_secret_key",
+                &self.channel_secret_key.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -117,6 +146,43 @@ struct SubmitReportResponse {
     reference_id: String,
 }
 
+/// indexing request（#413 / ADR 0025 §2.2 / §6.3）。認証済み user が「この topic / channel を
+/// index してほしい」と要求する。request は index を保証しない（operator 承認 + safety verdict の
+/// 多段ゲート）。private channel は channel secret（capability）の提示が必須で、それ自体が権限の証明。
+///
+/// `Debug` は手動実装で `channel_secret_hex` の中身を秘匿する（誤ってログへ平文 secret を出さない）。
+#[derive(Deserialize)]
+struct SubmitIndexingRequestRequest {
+    /// scope の種別（`public_topic` / `private_channel`）。
+    #[serde(default)]
+    kind: String,
+    /// 対象識別子（topic_id / channel_id）。
+    #[serde(default)]
+    target_id: String,
+    /// private channel の namespace secret hex（capability）。private_channel のときのみ必須。
+    #[serde(default)]
+    channel_secret_hex: Option<String>,
+}
+
+impl std::fmt::Debug for SubmitIndexingRequestRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubmitIndexingRequestRequest")
+            .field("kind", &self.kind)
+            .field("target_id", &self.target_id)
+            .field(
+                "channel_secret_hex",
+                &self.channel_secret_hex.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SubmitIndexingRequestResponse {
+    request_id: String,
+    status: String,
+}
+
 #[derive(Debug, Serialize)]
 struct BootstrapNodesResponse {
     nodes: Vec<CommunityNodeBootstrapNode>,
@@ -153,6 +219,9 @@ impl UserApiConfig {
             .ok()
             .filter(|value| !value.trim().is_empty())
             .map(PathBuf::from);
+        let channel_secret_key = std::env::var("COMMUNITY_NODE_CHANNEL_SECRET_KEY")
+            .ok()
+            .filter(|value| !value.trim().is_empty());
         Ok(Self {
             bind_addr,
             database_url,
@@ -163,6 +232,7 @@ impl UserApiConfig {
             connectivity_urls,
             jwt_config: JwtConfig::from_env()?,
             operator_config_path,
+            channel_secret_key,
         })
     }
 }
@@ -276,6 +346,13 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
         config.rendezvous_key_prefix.as_str(),
     )?;
     let manifest = load_manifest(config.operator_config_path.as_deref())?;
+    let channel_secret_cipher = config
+        .channel_secret_key
+        .as_deref()
+        .map(ChannelSecretCipher::from_key_material)
+        .transpose()
+        .context("invalid COMMUNITY_NODE_CHANNEL_SECRET_KEY")?
+        .map(Arc::new);
     Ok(UserApiState {
         pool,
         rendezvous_store,
@@ -289,6 +366,7 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
             )?,
         },
         manifest,
+        channel_secret_cipher,
     })
 }
 
@@ -322,6 +400,7 @@ pub fn app_router(state: UserApiState) -> Router {
             post(topic_rendezvous_heartbeat),
         )
         .route("/v1/report", post(submit_report))
+        .route("/v1/indexing/requests", post(submit_indexing_request))
         .with_state(state);
     api.merge(manifest).layer(TraceLayer::new_for_http())
 }
@@ -540,6 +619,101 @@ fn normalize_optional(value: Option<String>) -> Option<String> {
         .filter(|v| !v.is_empty())
 }
 
+/// user からの indexing request を受け付けて保存する（#413 / ADR 0025 §2.2 / §6.3）。
+///
+/// 認証済み（bearer）+ consent 済み user のみ要求できる。request は index を保証しない: operator が
+/// supported set に入れ、さらに safety verdict が `allow` の content だけが index される多段ゲートの
+/// 入口である。
+///
+/// - public topic: target_id（topic_id）を pending request として保存する。
+/// - private channel: channel secret（capability）の提示が必須。secret を提示できること自体を channel
+///   権限の証明とみなす（ADR 0025 §6.3。CN は新権限体系を作らない）。secret は at-rest 暗号化して保存し、
+///   cn-indexer が Model C と同じ機構で `channel::` replica を sync する。channel secret 暗号鍵が未設定の
+///   node は private channel request を受け付けない（平文保存しないため）。
+async fn submit_indexing_request(
+    State(state): State<UserApiState>,
+    headers: HeaderMap,
+    Json(request): Json<SubmitIndexingRequestRequest>,
+) -> ApiResult<Json<SubmitIndexingRequestResponse>> {
+    let identity = require_bearer_identity(&state.pool, &state.jwt_config, &headers).await?;
+    let _ = require_consents(&state.pool, identity.pubkey.as_str()).await?;
+
+    let kind = match request.kind.trim() {
+        "public_topic" => IndexScopeKind::PublicTopic,
+        "private_channel" => IndexScopeKind::PrivateChannel,
+        _ => {
+            return Err(ApiError::new(
+                StatusCode::BAD_REQUEST,
+                "INVALID_INDEXING_REQUEST",
+                "kind must be `public_topic` or `private_channel`",
+            ));
+        }
+    };
+    let target_id = request.target_id.trim();
+    if target_id.is_empty() {
+        return Err(ApiError::new(
+            StatusCode::BAD_REQUEST,
+            "INVALID_INDEXING_REQUEST",
+            "target_id is required",
+        ));
+    }
+
+    // private channel は capability（secret）の提示が必須。これが権限の証明を兼ねる。
+    if kind == IndexScopeKind::PrivateChannel {
+        let secret_hex = request
+            .channel_secret_hex
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let Some(secret_hex) = secret_hex else {
+            return Err(ApiError::new(
+                StatusCode::BAD_REQUEST,
+                "CHANNEL_SECRET_REQUIRED",
+                "private channel indexing requires the channel secret",
+            ));
+        };
+        // channel secret を平文保存しないため、暗号鍵未設定の node は受け付けない。
+        let Some(cipher) = state.channel_secret_cipher.as_ref() else {
+            return Err(ApiError::new(
+                StatusCode::NOT_FOUND,
+                "CHANNEL_INDEXING_NOT_CONFIGURED",
+                "this community node does not accept private channel indexing requests",
+            ));
+        };
+        // first-writer-wins: 別 requester が別 secret で既存 capability を上書きできないようにする。
+        // 同一 secret の再提示は冪等。別 secret による乗っ取りは 409 で拒否する。
+        register_channel_secret(&state.pool, cipher, target_id, secret_hex)
+            .await
+            .map_err(map_channel_secret_error)?;
+    }
+
+    let stored = insert_indexing_request(&state.pool, identity.pubkey.as_str(), kind, target_id)
+        .await
+        .map_err(internal_error)?;
+    Ok(Json(SubmitIndexingRequestResponse {
+        request_id: stored.id,
+        status: stored.status.as_str().to_string(),
+    }))
+}
+
+/// channel secret 登録失敗を HTTP 応答へマップする。
+///
+/// 既存 capability と異なる secret での上書き（乗っ取り試行）は 409、hex 形式不正等は 400。
+fn map_channel_secret_error(error: anyhow::Error) -> ApiError {
+    if error.downcast_ref::<ChannelSecretConflict>().is_some() {
+        return ApiError::new(
+            StatusCode::CONFLICT,
+            "CHANNEL_SECRET_CONFLICT",
+            error.to_string(),
+        );
+    }
+    ApiError::new(
+        StatusCode::BAD_REQUEST,
+        "INVALID_CHANNEL_SECRET",
+        error.to_string(),
+    )
+}
+
 async fn bootstrap_nodes(
     State(state): State<UserApiState>,
     headers: HeaderMap,
@@ -617,19 +791,6 @@ fn internal_error(error: impl std::fmt::Display) -> ApiError {
     )
 }
 
-fn parse_bool_env(var_name: &str, default: bool) -> Result<bool> {
-    match std::env::var(var_name) {
-        Ok(value) => match value.trim().to_ascii_lowercase().as_str() {
-            "" => Ok(default),
-            "1" | "true" | "yes" | "on" => Ok(true),
-            "0" | "false" | "no" | "off" => Ok(false),
-            other => Err(anyhow::anyhow!("failed to parse {var_name}: `{other}`")),
-        },
-        Err(std::env::VarError::NotPresent) => Ok(default),
-        Err(error) => Err(anyhow::anyhow!("{var_name}: {error}")),
-    }
-}
-
 fn parse_u64_env(var_name: &str, default: u64) -> Result<u64> {
     match std::env::var(var_name) {
         Ok(value) if !value.trim().is_empty() => value
@@ -648,23 +809,4 @@ fn parse_u32_env(var_name: &str, default: u32) -> Result<u32> {
             .with_context(|| format!("failed to parse {var_name}")),
         _ => Ok(default),
     }
-}
-
-fn parse_csv_env(var_name: &str) -> Vec<String> {
-    std::env::var(var_name)
-        .ok()
-        .map(|value| {
-            value
-                .split(',')
-                .filter_map(|item| {
-                    let trimmed = item.trim();
-                    if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(trimmed.to_string())
-                    }
-                })
-                .collect()
-        })
-        .unwrap_or_default()
 }

--- a/crates/cn-user-api/tests/contract.rs
+++ b/crates/cn-user-api/tests/contract.rs
@@ -46,6 +46,7 @@ impl TestServer {
             connectivity_urls: vec!["http://127.0.0.1:13340".to_string()],
             jwt_config: JwtConfig::new("kukuri-cn-tests", "test-secret", 3600),
             operator_config_path: None,
+            channel_secret_key: None,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-user-api/tests/indexing_requests.rs
+++ b/crates/cn-user-api/tests/indexing_requests.rs
@@ -1,0 +1,365 @@
+//! indexing request endpoint (#413 / ADR 0025 §2.2 / §6.3) の contract test。
+//!
+//! `POST /v1/indexing/requests` は認証済み + consent 済み user の indexing request を受ける。
+//! - public topic request は保存され pending になる（index を保証しない）。
+//! - private channel request は channel secret（capability）提示が必須で、それ自体が権限の証明。
+//!   secret 無しは 400、channel secret 暗号鍵未設定 node は 404。
+//!
+//! Postgres + Redis を要するため `KUKURI_CN_RUN_INTEGRATION_TESTS=1` で gate する。
+
+use std::net::SocketAddr;
+
+use anyhow::{Context, Result};
+use kukuri_cn_core::{JwtConfig, TestDatabase, build_auth_envelope_json};
+use kukuri_cn_user_api::{UserApiConfig, app_router, build_state};
+use kukuri_core::{KukuriKeys, generate_keys};
+use reqwest::{Client, StatusCode};
+
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+const DEFAULT_RENDEZVOUS_REDIS_URL: &str = "redis://127.0.0.1:16379/";
+const TEST_CHANNEL_SECRET_KEY: &str = "cn-user-api-indexing-test-channel-secret-key-0123456789";
+
+struct TestServer {
+    task: tokio::task::JoinHandle<()>,
+    database: TestDatabase,
+    base_url: String,
+}
+
+impl TestServer {
+    async fn spawn(
+        admin_database_url: &str,
+        prefix: &str,
+        channel_secret_key: Option<String>,
+    ) -> Result<Self> {
+        let database = TestDatabase::create(admin_database_url, prefix).await?;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("failed to bind test indexing listener")?;
+        let addr = listener.local_addr()?;
+        let base_url = format!("http://{addr}");
+        let state = build_state(&UserApiConfig {
+            bind_addr: addr,
+            database_url: database.database_url.clone(),
+            rendezvous_redis_url: integration_test_rendezvous_redis_url(),
+            rendezvous_key_prefix: format!("cn:test:{prefix}"),
+            base_url: base_url.clone(),
+            public_base_url: base_url.clone(),
+            connectivity_urls: vec!["http://127.0.0.1:13340".to_string()],
+            jwt_config: JwtConfig::new("kukuri-cn-tests", "test-secret", 3600),
+            operator_config_path: None,
+            channel_secret_key,
+        })
+        .await?;
+        let app = app_router(state);
+        let task = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("indexing server");
+        });
+        Ok(Self {
+            task,
+            database,
+            base_url,
+        })
+    }
+
+    async fn shutdown(self) -> Result<()> {
+        self.task.abort();
+        self.database.cleanup().await
+    }
+}
+
+fn integration_test_admin_database_url() -> Option<String> {
+    let enabled = std::env::var("KUKURI_CN_RUN_INTEGRATION_TESTS")
+        .ok()
+        .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+    Some(
+        std::env::var("COMMUNITY_NODE_DATABASE_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_ADMIN_DATABASE_URL.to_string()),
+    )
+}
+
+fn integration_test_rendezvous_redis_url() -> String {
+    std::env::var("COMMUNITY_NODE_RENDEZVOUS_REDIS_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_RENDEZVOUS_REDIS_URL.to_string())
+}
+
+/// 認証 + consent を通し、bearer access token を返す。
+async fn authenticate_and_consent(
+    client: &Client,
+    base_url: &str,
+    keys: &KukuriKeys,
+) -> Result<String> {
+    let pubkey = keys.public_key_hex();
+    let challenge = client
+        .post(format!("{base_url}/v1/auth/challenge"))
+        .json(&serde_json::json!({ "pubkey": pubkey }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<kukuri_cn_core::AuthChallengeResponse>()
+        .await?;
+    let auth_envelope_json =
+        build_auth_envelope_json(keys, challenge.challenge.as_str(), base_url)?;
+    let verify = client
+        .post(format!("{base_url}/v1/auth/verify"))
+        .json(&serde_json::json!({
+            "auth_envelope_json": auth_envelope_json,
+            "endpoint_id": "peer-a",
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<kukuri_cn_core::AuthVerifyResponse>()
+        .await?;
+    client
+        .post(format!("{base_url}/v1/consents"))
+        .bearer_auth(verify.access_token.as_str())
+        .json(&serde_json::json!({ "policy_slugs": [] }))
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(verify.access_token)
+}
+
+#[tokio::test]
+async fn indexing_request_requires_auth() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api indexing test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn(
+        admin_database_url.as_str(),
+        "cn_indexing_auth",
+        Some(TEST_CHANNEL_SECRET_KEY.to_string()),
+    )
+    .await?;
+    let client = Client::new();
+
+    let unauthenticated = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .json(&serde_json::json!({ "kind": "public_topic", "target_id": "rust" }))
+        .send()
+        .await?;
+    assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn public_topic_indexing_request_is_accepted_pending() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api indexing test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn(
+        admin_database_url.as_str(),
+        "cn_indexing_public",
+        Some(TEST_CHANNEL_SECRET_KEY.to_string()),
+    )
+    .await?;
+    let client = Client::new();
+    let keys = generate_keys();
+    let token = authenticate_and_consent(&client, &server.base_url, &keys).await?;
+
+    let accepted = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .bearer_auth(token.as_str())
+        .json(&serde_json::json!({ "kind": "public_topic", "target_id": "rust" }))
+        .send()
+        .await?;
+    assert_eq!(accepted.status(), StatusCode::OK);
+    let body = accepted.json::<serde_json::Value>().await?;
+    assert_eq!(body["status"], "pending");
+    assert!(body["request_id"].as_str().is_some_and(|id| !id.is_empty()));
+
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn private_channel_request_without_secret_is_rejected() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api indexing test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn(
+        admin_database_url.as_str(),
+        "cn_indexing_no_secret",
+        Some(TEST_CHANNEL_SECRET_KEY.to_string()),
+    )
+    .await?;
+    let client = Client::new();
+    let keys = generate_keys();
+    let token = authenticate_and_consent(&client, &server.base_url, &keys).await?;
+
+    let rejected = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .bearer_auth(token.as_str())
+        .json(&serde_json::json!({
+            "kind": "private_channel",
+            "target_id": "secret-room"
+        }))
+        .send()
+        .await?;
+    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+    let body = rejected.json::<serde_json::Value>().await?;
+    assert_eq!(body["code"], "CHANNEL_SECRET_REQUIRED");
+
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn private_channel_request_with_secret_is_accepted() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api indexing test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn(
+        admin_database_url.as_str(),
+        "cn_indexing_with_secret",
+        Some(TEST_CHANNEL_SECRET_KEY.to_string()),
+    )
+    .await?;
+    let client = Client::new();
+    let keys = generate_keys();
+    let token = authenticate_and_consent(&client, &server.base_url, &keys).await?;
+
+    let secret_hex = hex::encode([5u8; 32]);
+    let accepted = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .bearer_auth(token.as_str())
+        .json(&serde_json::json!({
+            "kind": "private_channel",
+            "target_id": "secret-room",
+            "channel_secret_hex": secret_hex,
+        }))
+        .send()
+        .await?;
+    assert_eq!(accepted.status(), StatusCode::OK);
+    let body = accepted.json::<serde_json::Value>().await?;
+    assert_eq!(body["status"], "pending");
+
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn private_channel_request_rejects_capability_takeover() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api indexing test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn(
+        admin_database_url.as_str(),
+        "cn_indexing_takeover",
+        Some(TEST_CHANNEL_SECRET_KEY.to_string()),
+    )
+    .await?;
+    let client = Client::new();
+
+    // requester A が capability を登録する。
+    let keys_a = generate_keys();
+    let token_a = authenticate_and_consent(&client, &server.base_url, &keys_a).await?;
+    let secret_a = hex::encode([1u8; 32]);
+    let accepted = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .bearer_auth(token_a.as_str())
+        .json(&serde_json::json!({
+            "kind": "private_channel",
+            "target_id": "secret-room",
+            "channel_secret_hex": secret_a,
+        }))
+        .send()
+        .await?;
+    assert_eq!(accepted.status(), StatusCode::OK);
+
+    // requester B が別 secret で同じ channel を乗っ取ろうとすると 409 で拒否される。
+    let keys_b = generate_keys();
+    let token_b = authenticate_and_consent(&client, &server.base_url, &keys_b).await?;
+    let secret_b = hex::encode([2u8; 32]);
+    let conflict = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .bearer_auth(token_b.as_str())
+        .json(&serde_json::json!({
+            "kind": "private_channel",
+            "target_id": "secret-room",
+            "channel_secret_hex": secret_b,
+        }))
+        .send()
+        .await?;
+    assert_eq!(conflict.status(), StatusCode::CONFLICT);
+    let body = conflict.json::<serde_json::Value>().await?;
+    assert_eq!(body["code"], "CHANNEL_SECRET_CONFLICT");
+
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn private_channel_request_rejected_when_encryption_key_unset() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api indexing test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    // channel secret 暗号鍵を設定しない node は private channel indexing を受け付けない。
+    let server =
+        TestServer::spawn(admin_database_url.as_str(), "cn_indexing_key_unset", None).await?;
+    let client = Client::new();
+    let keys = generate_keys();
+    let token = authenticate_and_consent(&client, &server.base_url, &keys).await?;
+
+    let secret_hex = hex::encode([5u8; 32]);
+    let rejected = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .bearer_auth(token.as_str())
+        .json(&serde_json::json!({
+            "kind": "private_channel",
+            "target_id": "secret-room",
+            "channel_secret_hex": secret_hex,
+        }))
+        .send()
+        .await?;
+    assert_eq!(rejected.status(), StatusCode::NOT_FOUND);
+    let body = rejected.json::<serde_json::Value>().await?;
+    assert_eq!(body["code"], "CHANNEL_INDEXING_NOT_CONFIGURED");
+
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn invalid_kind_is_rejected() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api indexing test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn(
+        admin_database_url.as_str(),
+        "cn_indexing_bad_kind",
+        Some(TEST_CHANNEL_SECRET_KEY.to_string()),
+    )
+    .await?;
+    let client = Client::new();
+    let keys = generate_keys();
+    let token = authenticate_and_consent(&client, &server.base_url, &keys).await?;
+
+    let rejected = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .bearer_auth(token.as_str())
+        .json(&serde_json::json!({ "kind": "nonsense", "target_id": "rust" }))
+        .send()
+        .await?;
+    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+    let body = rejected.json::<serde_json::Value>().await?;
+    assert_eq!(body["code"], "INVALID_INDEXING_REQUEST");
+
+    server.shutdown().await
+}

--- a/crates/cn-user-api/tests/reports.rs
+++ b/crates/cn-user-api/tests/reports.rs
@@ -70,6 +70,7 @@ impl TestServer {
             connectivity_urls: vec!["http://127.0.0.1:13340".to_string()],
             jwt_config: JwtConfig::new("kukuri-cn-tests", "test-secret", 3600),
             operator_config_path: Some(operator_config.path().to_path_buf()),
+            channel_secret_key: None,
         })
         .await?;
         let app = app_router(state);

--- a/crates/harness/src/runtime.rs
+++ b/crates/harness/src/runtime.rs
@@ -101,6 +101,7 @@ impl CommunityNodeStack {
             connectivity_urls: vec![iroh_relay_url.clone()],
             jwt_config: JwtConfig::new("kukuri-cn-harness", "test-secret", 3600),
             operator_config_path: None,
+            channel_secret_key: None,
         })
         .await
         .context("failed to build community-node user-api state")?;

--- a/docs/adr/0025-community-node-indexing-foundation.md
+++ b/docs/adr/0025-community-node-indexing-foundation.md
@@ -18,7 +18,9 @@ Draft
 - `docs/architecture/p2p-first-community-node-responsibility-boundary.md`（authority scope）
 - `docs/adr/0027-deterministic-moderation-critical-safety.md`（§2.1 advisory ≠ command。旧 `moderation-event-trust-semantics.md` を集約）
 - `crates/cn-operator/src/capability.rs`（`CommunityIndex` = `Availability::Planned`）
-- 実装側 Issue: #404（fail-closed community indexing 本体）
+- `crates/cn-indexer/`（#413 Model C ingestion participant + relay validation gate + ArcadeDB 投影）
+- `crates/cn-core/src/index_scope.rs` + `crates/cn-core/migrations/202607010001_index_scope.sql`（#413 scope 管理 state）
+- 実装側 Issue: #404（fail-closed community indexing 本体）, #413（Model C ingestion / supported-topic scope / indexing request）
 - 後続 ADR: trust / relation foundation（#409）, 決定論的 moderation（#410）, 非決定論的 moderation（#411）
 
 ## 位置づけ
@@ -36,7 +38,8 @@ community node の主要未検討機能のひとつ「indexing（index / search 
 - Public Replica / Private Replica / Local Only: node-local な private server state（`cn-core` / Postgres）。public manifest には capability の有無のみを載せ、index 中身は載せない
 - Gossip Hint 必要有無: peer discovery 補助として使用（Model C, §6）。基本データ経路は docs replica sync
 - Blob 必要有無: No（**no permanent blob storage** を維持。raw media blob は index しない。index は VLM 由来の派生タグのみ。moderation server の一時 fetch のみ）
-- SQLite projection 必要有無: No（server は SQLite を使わず Postgres projection）
+- SQLite projection 必要有無: No（server は SQLite を使わない）
+- index 投影ストア: **ArcadeDB**（Lucene 全文検索付き multi-model DB。canonical ではない derived な写像）。#413 で決定・改訂（当初は「Postgres projection」としていたが、ADR 0026 §6.1 で relation graph 用に採用する ArcadeDB に index 投影も相乗りさせ、全文検索 + co-participation graph を単一エンジンに統合する）。**全文検索のみ**を今回のスコープとし、ベクトル検索は延期する（§4 の画像類似検索除外と整合）。scope 管理 state（supported set / user request / private channel capability）は node-local な制御情報として **Postgres（`cn_index` schema）** に置く（index 投影本体とは別）
 - 必須 contract:
   - `index_scope_limited_to_operator_supported_topics`
   - `index_rejects_topic_outside_supported_set`
@@ -199,6 +202,18 @@ index する content（post 本文・media タグ・room メタデータ）を c
 - Replicated?: index 自体は node-local。CN は supported topic / 許可 channel の **docs sync peer として参加**する。
 - Rebuildable From: sync した replica（topic / channel）+ safety scan。docs+blob で backfill / restart 復元。
 - Gossip Hint: peer discovery 補助として使用。基本データ経路は docs replica sync。
+- index 投影ストア: ArcadeDB（全文のみ、ベクトル延期）。scope 管理 state は Postgres（`cn_index`）。
+
+### 6.6 実装（#413）
+
+Model C ingestion と scope / request / relay validation は #413 で実装した。
+
+- **crate 構成**: docs replica sync participant を新 crate/binary `cn-indexer` に分離する（`cn-user-api` = HTTP/DB/rendezvous、`cn-iroh-relay` = 純 relay の責務を汚さない）。
+- **scope 管理 state**: `cn-core` の `cn_index` schema（`supported_topics` / `indexing_requests` / `channel_secrets`）。channel secret（capability）は **at-rest 暗号化（XChaCha20Poly1305）**して保存し、平文は列に残さない。復号鍵は runtime（Secret Manager / env 注入 `COMMUNITY_NODE_CHANNEL_SECRET_KEY`）が供給する。
+- **運用面**: operator は `cn-cli`（`supported-topic` / `indexing-request` サブコマンド）で supported set と request 承認を運用する。user の indexing request は `cn-user-api` の `POST /v1/indexing/requests`（認証 + consent）で受ける。承認は operator が CLI で行い、auto-approve は作らない。#382 admin UI は別 Issue。
+- **relay validation 起動 gate**: `cn-indexer` は起動時に config 検査で relay を validate する（自前 relay = operator の `iroh_relay` capability、または外部 relay URL のどちらか。両方未設定なら indexing を起動しない）。到達性 probe はしない。
+- **ingest → 投影**: 共有 replica の実在 post entry のみを `cn-safety-runtime` の orchestrator で scan し、`allow` verdict のみ ArcadeDB 投影へ書く（unscanned / scan_failed / 非 allow は投影しない fail-closed）。supported 除外 / channel secret 失効時は sync 停止 + de-index する。media は scan/tag pipeline へ渡す接続点まで（VLM 本体は #411）。
+- **seam（#404 との境界）**: #413 は ingest → 投影 + 投影レベル read（`allow` entry の存在確認）まで。ユーザー向け search / discovery / recommendation 本体と fail-closed query gate は #404。
 
 ## Appendix A: 代替・補助 ingestion モデル（B / A, optional）
 

--- a/docs/progress/2026-07-01-413-community-node-model-c-ingestion.md
+++ b/docs/progress/2026-07-01-413-community-node-model-c-ingestion.md
@@ -1,0 +1,55 @@
+# 2026-07-01 #413 community node ingestion (Model C) + supported-topic scope / indexing request
+
+参照: `docs/adr/0025-community-node-indexing-foundation.md`（§2.2 / §2.5 / §6）
+
+## 実装した範囲
+
+Model C ingestion（docs replica sync participant）と supported-topic scope / indexing request /
+relay validation を実装した。seam は「ingest → 投影 + 投影レベル read」まで。ユーザー向け
+search / discovery / recommendation 本体と fail-closed query gate は #404。
+
+- **`cn-core`（scope 管理 state）**
+  - `cn_index` schema（`supported_topics` / `indexing_requests` / `channel_secrets`）を migration
+    `202607010001_index_scope.sql` で追加（すべて additive。既存テーブル非改変）。
+  - `index_scope.rs`: supported set / request / channel capability の CRUD。
+  - channel capability（namespace secret）は XChaCha20Poly1305 で **at-rest 暗号化**。AAD に
+    `channel_id` を束縛し、DB 行の取り違え / コピーによる別 channel への化けを防ぐ。復号鍵は runtime
+    供給（`COMMUNITY_NODE_CHANNEL_SECRET_KEY`）で DB に置かない。
+  - user 経路の登録は `register_channel_secret`（first-writer-wins）: 同一 secret 再提示は冪等、別
+    secret での上書き（capability 乗っ取り）は `ChannelSecretConflict` で拒否。operator 経路は従来の
+    `upsert_channel_secret`（無条件 upsert）。
+  - env パースヘルパ（`parse_bool_env` / `parse_csv_env`）を `cn-core` に集約し community-node サービス
+    間の drift を防止。
+- **`cn-cli`**: `supported-topic add/remove/list`、`indexing-request list/approve/reject`。approve で
+  対象 scope が supported set に入る。
+- **`cn-user-api`**: `POST /v1/indexing/requests`（認証 + consent）。private channel は channel secret
+  提示必須（提示できること自体が権限の証明。ADR 0025 §6.3）。secret 無し=400、暗号鍵未設定 node=404、
+  別 secret での乗っ取り=409。
+- **`cn-indexer`（新 crate/binary）**: docs replica sync participant + relay validation 起動 gate +
+  ingest pipeline + ArcadeDB 投影 adapter。
+  - relay gate（config 検査）: 自前 relay（`iroh_relay` capability）も外部 relay URL も未設定なら
+    indexing を起動しない（fail-closed。ADR 0025 §6.4）。
+  - ingest: 共有 replica の実在 post entry のみ scan→`allow` verdict のみ ArcadeDB 投影へ書く。
+    unscanned / scan_failed / 非 allow は投影しない。tombstone / deleted / supported 除去 / channel
+    secret 失効は de-index。blob は scan 用一時 fetch のみ（no permanent blob storage）。
+  - index 投影は ArcadeDB（Lucene 全文のみ。canonical ではない写像。ADR 0026 §6.1 の relation backend に
+    相乗り）。ベクトル検索は延期（ADR 0025 §4 画像類似除外と整合）。
+
+## デプロイ順序（重要）
+
+`ensure_database_ready`（`DatabaseInitMode::RequireReady`）が新テーブル `cn_index.supported_topics` /
+`cn_index.indexing_requests` / `cn_index.channel_secrets` の存在を要求する。既に ready 状態の本番 DB は
+本 migration を適用するまで RequireReady 起動が失敗する（`cn-user-api` / `cn-indexer` 双方）。
+ロールアウト時は **新バイナリの RequireReady 起動より前に migration（Prepare / migrate 手順）を適用**する
+こと。既存 readiness gate と同じ fail-closed 挙動であり意図的（#405 と同じ運用）。
+
+`cn-indexer` は起動時に relay validation gate も通す。自前 relay / 外部 relay のどちらかを設定して
+から起動する。`COMMUNITY_NODE_CHANNEL_SECRET_KEY` は `cn-user-api` と `cn-indexer` で同一値を渡す。
+
+## 維持した境界（本 PR に含まない）
+
+- ユーザー向け search / discovery / recommendation 本体 + fail-closed query gate（#404）。
+- 実 ingest loop の常駐化。safety provider（#391 / #411）が実装され `CommunityIndex` が昇格するまで
+  `cn-indexer` runtime は relay gate + scope state 準備確認までに留める（`Availability::Planned` と整合）。
+- ArcadeDB relation graph 本体 / co-participation 反映（#415）。ベクトル / 画像類似検索、VLM タグ生成（#411）。
+- `CommunityIndex` capability は引き続き `Availability::Planned`。

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
-const CN_PACKAGES: [&str; 7] = [
+const CN_PACKAGES: [&str; 8] = [
     "kukuri-cn-core",
     "kukuri-cn-user-api",
     "kukuri-cn-iroh-relay",
@@ -14,6 +14,7 @@ const CN_PACKAGES: [&str; 7] = [
     "kukuri-cn-operator",
     "kukuri-cn-safety",
     "kukuri-cn-safety-runtime",
+    "kukuri-cn-indexer",
 ];
 const SERIAL_RUST_PACKAGE: &str = "kukuri-harness";
 const TAURI_CHECK_TARGET_DIR: &str = "target/desktop-tauri-check";


### PR DESCRIPTION
## Summary
- Add cn_index scope state for supported topics, indexing requests, and encrypted channel secrets.
- Add cn-indexer with relay startup gate, fail-closed ingest pipeline, and ArcadeDB projection boundary.
- Add cn-cli operations and cn-user-api indexing request endpoint, including private-channel takeover protection.
- Update ADR 0025 and add #413 rollout note.

## Validation
- cargo xtask cn-check
- cargo xtask cn-test
- cargo xtask check
- cargo xtask test

Closes #413