### PR TITLE
feat(cn): wire safety runtime and feed risk signals to trust reads (#406)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,11 +2928,13 @@ name = "kukuri-cn-core"
 version = "0.1.2"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "chacha20poly1305",
  "chrono",
  "hex",
  "jsonwebtoken",
+ "kukuri-cn-core",
  "kukuri-cn-safety",
  "kukuri-cn-safety-runtime",
  "kukuri-core",

--- a/crates/cn-core/Cargo.toml
+++ b/crates/cn-core/Cargo.toml
@@ -4,8 +4,14 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+# provider 実装名 `mock` を runtime 構築（build_safety_orchestrator）で解決できるようにする。
+# 本番 provider（#391 / #411）実装まで、contract test / 明示 opt-in 構成でのみ使う。
+safety-mock-provider = ["kukuri-cn-safety/mock"]
+
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 axum.workspace = true
 chacha20poly1305.workspace = true
 chrono.workspace = true
@@ -27,5 +33,8 @@ kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 
 [dev-dependencies]
 tempfile.workspace = true
-kukuri-cn-safety = { path = "../cn-safety" }
+kukuri-cn-safety = { path = "../cn-safety", features = ["mock"] }
 kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
+# 自分自身を feature 付き dev-dependency にすることで、tests/ から mock provider 解決を使える
+# （feature unification によりテストビルド時のみ有効になる。cn-safety と同じ流儀）。
+kukuri-cn-core = { path = ".", features = ["safety-mock-provider"] }

--- a/crates/cn-core/src/lib.rs
+++ b/crates/cn-core/src/lib.rs
@@ -13,8 +13,10 @@ mod rendezvous;
 mod reports;
 mod rollout;
 mod safety_events;
+mod safety_runtime;
 #[cfg(test)]
 mod tests;
+mod trust_inputs;
 
 pub use admission::{
     AdmissionConfig, AdmissionMode, AdmissionRejection, AllowlistEntry, BannedEntry,
@@ -75,4 +77,13 @@ pub use safety_events::{
     get_signed_moderation_event, list_distributable_moderation_events,
     list_distributable_risk_signals, list_risk_signals_for_target, list_signed_moderation_events,
     persist_risk_signal, persist_signed_moderation_event,
+};
+pub use safety_runtime::{
+    MemorySafetyArtifactStore, PgSafetyArtifactStore, SafetyArtifactStore, SafetyRuntimeConfig,
+    SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig, SafetyScanOutcome, SafetyScanService,
+    SafetyScanServiceBuilder, build_safety_orchestrator, build_safety_scan_service,
+};
+pub use trust_inputs::{
+    TrustComponentKind, TrustRiskInput, TrustRiskInputs, list_trust_risk_inputs,
+    trust_component_for, trust_risk_inputs_from,
 };

--- a/crates/cn-core/src/safety_runtime.rs
+++ b/crates/cn-core/src/safety_runtime.rs
@@ -1,0 +1,525 @@
+//! community node runtime の safety scan 結線（#406）。
+//!
+//! `cn-safety-runtime` の `SafetyOrchestrator`（scan → verdict → 未署名 artifact）と、
+//! `cn-core` の永続化（`safety_events`、#405）を合成する runtime 境界。ここまでの実装では
+//! orchestrator は verdict gate（`cn-indexer`）としてのみ使われ、`SafetyScanReport` の
+//! moderation event / risk signal は破棄されていた。本モジュールが scan と同時に
+//! artifact を署名・永続化し、risk signal を trust / relation reads（`trust_inputs`、#415）が
+//! 消費できる状態にする。
+//!
+//! 構成要素:
+//! - [`SafetyArtifactStore`] — artifact 永続化の抽象。本番は Postgres
+//!   （[`PgSafetyArtifactStore`]）、contract test は in-memory
+//!   （[`MemorySafetyArtifactStore`]）。
+//! - [`SafetyScanService`] — scan → risk signal persist → moderation event 署名 / persist を
+//!   合成する service。verdict の判定（allow / fail-closed / artifact 生成可否）は
+//!   `cn-safety-runtime` の artifacts ガードレールに委ね、ここで再判断しない（単一判定点）。
+//! - [`build_safety_orchestrator`] / [`build_safety_scan_service`] — 設定から
+//!   `SystemScanClock` + `UuidEventIdGenerator` + provider 群で orchestrator / service を
+//!   組み立てる構築境界。
+//!
+//! fail-closed の要:
+//! - 未知の provider 名は `required` の真偽に依らず Err（黙って skip すると「unknown_csam を
+//!   設定したつもりで未検査が素通りする」誤構成を隠すため）。
+//! - signed moderation event の emit が有効（既定）なのに signer が無い構成は build Err
+//!   （実行時 skip にしない）。
+//! - provider が 1 つも無い構成では service を構築しない（unscanned を index しない現状と整合）。
+//!
+//! 設計の真実源:
+//! - `docs/adr/0026-community-node-trust-relation-foundation.md` §2.7（risk signal の反映先契約）
+//! - `docs/adr/0027-deterministic-moderation-critical-safety.md` §2.5 / §2.6（signed event / risk
+//!   signal / visibility）
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use sqlx::PgPool;
+
+use kukuri_cn_safety::provider::ProviderScanRequest;
+use kukuri_cn_safety::{
+    ModerationEventSigner, SafetyPolicy, SafetyProvider, SafetyRiskSignal, SignedModerationEvent,
+    issue_signed_event,
+};
+use kukuri_cn_safety_runtime::{
+    SAFETY_SIGNING_KEY_ENV, SafetyOrchestrator, SafetyScanReport, Secp256k1ModerationEventSigner,
+    SystemScanClock, UuidEventIdGenerator,
+};
+
+use crate::safety_events::{persist_risk_signal, persist_signed_moderation_event};
+
+/// runtime 側の safety provider slot 設定。
+///
+/// operator config（`cn-operator` の `SafetyProvidersConfig`）と slot が 1:1 対応する。
+/// operator → env 注入 → runtime 消費という既存の流儀（`COMMUNITY_NODE_SAFETY_SIGNING_KEY` と
+/// 同じ経路）に合わせ、cn-operator には依存しない。
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SafetyRuntimeProvidersConfig {
+    /// 既知 CSAM hash match provider（ADR 0027 §2.7）。
+    pub known_csam: Option<SafetyRuntimeProviderEntry>,
+    /// 一般 moderation provider（nsfw / spam 等）。
+    pub general: Option<SafetyRuntimeProviderEntry>,
+    /// 未知 CSAM / CSE classifier provider（#411）。
+    pub unknown_csam: Option<SafetyRuntimeProviderEntry>,
+}
+
+impl SafetyRuntimeProvidersConfig {
+    /// provider が 1 つも設定されていないか。
+    pub fn is_empty(&self) -> bool {
+        self.known_csam.is_none() && self.general.is_none() && self.unknown_csam.is_none()
+    }
+}
+
+/// provider slot 1 つ分の設定。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SafetyRuntimeProviderEntry {
+    /// provider 実装名。現状解決できるのは `mock`（`safety-mock-provider` feature）のみで、
+    /// 本番 provider 実装名は #391 / #411 で追加する。未知の名前は fail-closed で Err。
+    pub provider: String,
+    /// operator が readiness 上必須と宣言した provider か。現段階の runtime 構築では挙動を
+    /// 変えない（未知名は required に依らず Err）が、operator config との 1:1 対応のため保持する。
+    pub required: bool,
+}
+
+/// safety scan runtime の構成。
+///
+/// env の読み込みは呼び出し側（`cn-indexer` の config 層）が行い、ここには値を渡す。
+/// `Debug` は手動実装で `signing_key` を秘匿する（誤ってログへ署名鍵を出さない）。
+#[derive(Clone, PartialEq, Eq)]
+pub struct SafetyRuntimeConfig {
+    pub providers: SafetyRuntimeProvidersConfig,
+    /// moderation event 署名鍵の値（`COMMUNITY_NODE_SAFETY_SIGNING_KEY` の中身）。
+    pub signing_key: Option<String>,
+    /// signed moderation event を発行するか（operator config の
+    /// `safety.events.emit_signed_moderation_events` に対応。既定 true）。
+    pub emit_signed_events: bool,
+    /// `emit_signed_events = false` のときに risk signal の issuer として使う node id。
+    /// 署名鍵がある場合は鍵から導出した公開鍵 hex を優先する。
+    pub issuer_node_id: Option<String>,
+}
+
+impl Default for SafetyRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            providers: SafetyRuntimeProvidersConfig::default(),
+            signing_key: None,
+            emit_signed_events: true,
+            issuer_node_id: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for SafetyRuntimeConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SafetyRuntimeConfig")
+            .field("providers", &self.providers)
+            .field(
+                "signing_key",
+                &self.signing_key.as_ref().map(|_| "<redacted>"),
+            )
+            .field("emit_signed_events", &self.emit_signed_events)
+            .field("issuer_node_id", &self.issuer_node_id)
+            .finish()
+    }
+}
+
+/// safety artifact（signed moderation event / risk signal）永続化の抽象。
+///
+/// 本番は Postgres（`cn_safety` schema、#405）、contract test は in-memory 実装を差す。
+#[async_trait]
+pub trait SafetyArtifactStore: Send + Sync {
+    /// 署名済み moderation event を保存する。
+    async fn persist_event(&self, event: &SignedModerationEvent) -> Result<()>;
+
+    /// risk signal を保存し、採番した id を返す。
+    async fn persist_signal(
+        &self,
+        issuer_node_id: &str,
+        signal: &SafetyRiskSignal,
+    ) -> Result<String>;
+}
+
+/// Postgres 実装。`safety_events`（#405）の persist API に委譲する。
+#[derive(Clone, Debug)]
+pub struct PgSafetyArtifactStore {
+    pool: PgPool,
+}
+
+impl PgSafetyArtifactStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl SafetyArtifactStore for PgSafetyArtifactStore {
+    async fn persist_event(&self, event: &SignedModerationEvent) -> Result<()> {
+        persist_signed_moderation_event(&self.pool, event)
+            .await
+            .map(|_| ())
+    }
+
+    async fn persist_signal(
+        &self,
+        issuer_node_id: &str,
+        signal: &SafetyRiskSignal,
+    ) -> Result<String> {
+        persist_risk_signal(&self.pool, issuer_node_id, signal)
+            .await
+            .map(|stored| stored.id)
+    }
+}
+
+/// contract test 用の in-memory 実装（`MemoryDocsSync` / `MemoryIndexProjection` と同じ流儀）。
+///
+/// 署名検証は行わない（Postgres 実装は persist 時に検証する）。テストは保存された event を
+/// 読み出して `verify_signed_event` で検証する。
+#[derive(Debug, Default)]
+pub struct MemorySafetyArtifactStore {
+    events: Mutex<Vec<SignedModerationEvent>>,
+    signals: Mutex<Vec<(String, SafetyRiskSignal)>>,
+}
+
+impl MemorySafetyArtifactStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// 保存済み signed moderation event のスナップショット。
+    pub fn events(&self) -> Vec<SignedModerationEvent> {
+        self.events.lock().expect("events mutex poisoned").clone()
+    }
+
+    /// 保存済み risk signal（issuer_node_id, signal）のスナップショット。
+    pub fn signals(&self) -> Vec<(String, SafetyRiskSignal)> {
+        self.signals.lock().expect("signals mutex poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl SafetyArtifactStore for MemorySafetyArtifactStore {
+    async fn persist_event(&self, event: &SignedModerationEvent) -> Result<()> {
+        self.events
+            .lock()
+            .expect("events mutex poisoned")
+            .push(event.clone());
+        Ok(())
+    }
+
+    async fn persist_signal(
+        &self,
+        issuer_node_id: &str,
+        signal: &SafetyRiskSignal,
+    ) -> Result<String> {
+        let mut signals = self.signals.lock().expect("signals mutex poisoned");
+        let id = format!("memory-signal-{}", signals.len() + 1);
+        signals.push((issuer_node_id.to_string(), signal.clone()));
+        Ok(id)
+    }
+}
+
+/// [`SafetyScanService::scan_and_record`] の結果。
+///
+/// verdict の判定（`is_indexable()` 等）は `report` を、永続化の結果は残りのフィールドを見る。
+#[derive(Clone, Debug)]
+pub struct SafetyScanOutcome {
+    /// orchestrator の生 scan 結果（verdict / scan_results / 未署名 artifact）。
+    pub report: SafetyScanReport,
+    /// 署名して store に保存した moderation event（signer 未構成の場合は None）。
+    pub signed_event: Option<SignedModerationEvent>,
+    /// store が採番した risk signal id（signal が生成されなかった場合は None）。
+    pub persisted_signal_id: Option<String>,
+}
+
+/// scan → verdict → artifact 署名 / 永続化を合成する runtime 境界（#406）。
+pub struct SafetyScanService {
+    orchestrator: Arc<SafetyOrchestrator>,
+    signer: Option<Arc<dyn ModerationEventSigner + Send + Sync>>,
+    store: Arc<dyn SafetyArtifactStore>,
+    issuer_node_id: String,
+}
+
+impl std::fmt::Debug for SafetyScanService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SafetyScanService")
+            .field("issuer_node_id", &self.issuer_node_id)
+            .field("has_signer", &self.signer.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl SafetyScanService {
+    /// builder を開始する。signed moderation event の emit は既定で有効（signer 必須）。
+    pub fn builder(
+        orchestrator: Arc<SafetyOrchestrator>,
+        store: Arc<dyn SafetyArtifactStore>,
+    ) -> SafetyScanServiceBuilder {
+        SafetyScanServiceBuilder {
+            orchestrator,
+            store,
+            signer: None,
+            unsigned_issuer: None,
+        }
+    }
+
+    /// この service が risk signal / moderation event の issuer として使う node id。
+    pub fn issuer_node_id(&self) -> &str {
+        &self.issuer_node_id
+    }
+
+    /// scan して、生成された artifact を署名・永続化する。
+    ///
+    /// 1. `SafetyOrchestrator::scan_subject`（provider 失敗は fail-closed に写像済み）。
+    /// 2. risk signal があれば store へ保存する（署名対象ではないため signer の有無に依らない）。
+    /// 3. moderation event body があり signer が構成されていれば、署名して store へ保存する。
+    ///
+    /// allow verdict / target 欠落 / operational fail-closed（scan_failed 等）で artifact を
+    /// 作らない判断は `cn-safety-runtime` の artifacts ガードレールに委ねる（ここで再判断しない）。
+    /// 永続化失敗は Err で返し、呼び出し側（ingest 等）の per-entry fail-closed に乗せる。
+    pub async fn scan_and_record(
+        &self,
+        request: &ProviderScanRequest,
+    ) -> Result<SafetyScanOutcome> {
+        let report = self.orchestrator.scan_subject(request).await;
+
+        let persisted_signal_id = match report.risk_signal.as_ref() {
+            Some(signal) => Some(
+                self.store
+                    .persist_signal(&self.issuer_node_id, signal)
+                    .await
+                    .context("failed to persist safety risk signal")?,
+            ),
+            None => None,
+        };
+
+        let signed_event = match (report.moderation_event.as_ref(), self.signer.as_ref()) {
+            (Some(body), Some(signer)) => {
+                let event = issue_signed_event(body.clone(), signer.as_ref());
+                self.store
+                    .persist_event(&event)
+                    .await
+                    .context("failed to persist signed moderation event")?;
+                Some(event)
+            }
+            _ => None,
+        };
+
+        Ok(SafetyScanOutcome {
+            report,
+            signed_event,
+            persisted_signal_id,
+        })
+    }
+}
+
+/// [`SafetyScanService`] の builder。
+pub struct SafetyScanServiceBuilder {
+    orchestrator: Arc<SafetyOrchestrator>,
+    store: Arc<dyn SafetyArtifactStore>,
+    signer: Option<Arc<dyn ModerationEventSigner + Send + Sync>>,
+    unsigned_issuer: Option<String>,
+}
+
+impl SafetyScanServiceBuilder {
+    /// moderation event の signer を設定する。issuer node id は signer から導出する。
+    ///
+    /// 注意: orchestrator の issuer_node_id（`ModerationEventBody.issuer_node_id` になる）と
+    /// signer の公開鍵は一致している必要がある（`verify_signed_event` / persist 時の署名検証が
+    /// 一致を要求する）。[`build_safety_scan_service`] は signer から issuer を導出して
+    /// orchestrator を組むため、構造的に一致する。
+    pub fn signer(mut self, signer: Arc<dyn ModerationEventSigner + Send + Sync>) -> Self {
+        self.signer = Some(signer);
+        self
+    }
+
+    /// signed moderation event の emit を明示的に無効化する（operator config
+    /// `safety.events.emit_signed_moderation_events = false` に対応）。
+    ///
+    /// moderation event は署名・永続化されない（report には未署名 body が残る）。risk signal は
+    /// 署名対象ではないため引き続き永続化され、その issuer として `issuer_node_id` を使う。
+    pub fn without_signed_events(mut self, issuer_node_id: impl Into<String>) -> Self {
+        self.unsigned_issuer = Some(issuer_node_id.into());
+        self
+    }
+
+    /// 構成を検証して [`SafetyScanService`] を構築する。
+    ///
+    /// fail-closed: signed event emit が有効（既定）なのに signer が無い構成は Err にする
+    /// （実行時に黙って署名を skip しない）。
+    pub fn build(self) -> Result<SafetyScanService> {
+        let (signer, issuer_node_id) = match (self.signer, self.unsigned_issuer) {
+            (Some(signer), None) => {
+                let issuer = signer.issuer_node_id().to_string();
+                (Some(signer), issuer)
+            }
+            (None, Some(issuer)) => {
+                let issuer = issuer.trim().to_string();
+                if issuer.is_empty() {
+                    bail!("safety scan service issuer_node_id must not be empty");
+                }
+                (None, issuer)
+            }
+            (None, None) => bail!(
+                "signed moderation events are enabled but no signer is configured \
+                 (set {SAFETY_SIGNING_KEY_ENV}, or disable emission explicitly with \
+                 without_signed_events)"
+            ),
+            (Some(_), Some(_)) => {
+                bail!("safety scan service cannot both sign moderation events and disable emission")
+            }
+        };
+
+        Ok(SafetyScanService {
+            orchestrator: self.orchestrator,
+            signer,
+            store: self.store,
+            issuer_node_id,
+        })
+    }
+}
+
+/// 設定から `SystemScanClock` + `UuidEventIdGenerator` + provider 群で
+/// [`SafetyOrchestrator`] を構築する（#406）。
+///
+/// fail-closed:
+/// - 未知の provider 名は `required` の真偽に依らず Err（黙って skip しない）。
+/// - provider が 1 つも無い構成は Err（orchestrator builder の NoProviders と同じ）。
+///
+/// policy 未指定なら `SafetyPolicy::public_node_default()`（orchestrator builder の既定）。
+pub fn build_safety_orchestrator(
+    issuer_node_id: &str,
+    providers: &SafetyRuntimeProvidersConfig,
+    policy: Option<SafetyPolicy>,
+) -> Result<SafetyOrchestrator> {
+    if providers.is_empty() {
+        bail!(
+            "no safety providers configured; refusing to build a scan orchestrator (fail-closed)"
+        );
+    }
+
+    let mut builder = SafetyOrchestrator::builder(
+        issuer_node_id,
+        Arc::new(SystemScanClock::new()),
+        Arc::new(UuidEventIdGenerator::new()),
+    );
+    let slots: [(&'static str, Option<&SafetyRuntimeProviderEntry>); 3] = [
+        ("known_csam", providers.known_csam.as_ref()),
+        ("general", providers.general.as_ref()),
+        ("unknown_csam", providers.unknown_csam.as_ref()),
+    ];
+    for (slot, entry) in slots {
+        let Some(entry) = entry else {
+            continue;
+        };
+        builder = builder.provider(resolve_provider(slot, entry)?);
+    }
+    if let Some(policy) = policy {
+        builder = builder.policy(policy);
+    }
+    builder
+        .build()
+        .context("failed to build safety orchestrator")
+}
+
+/// provider 実装名を実装に解決する。
+///
+/// 現状解決できるのは `mock`（`safety-mock-provider` feature 有効時）のみ。本番 provider
+/// 実装名（#391 Project Arachnid Shield 等）はここに match arm を追加する。未知の名前は
+/// `required` に依らず Err（fail-closed）。
+fn resolve_provider(
+    slot: &'static str,
+    entry: &SafetyRuntimeProviderEntry,
+) -> Result<Arc<dyn SafetyProvider>> {
+    match entry.provider.trim() {
+        #[cfg(feature = "safety-mock-provider")]
+        "mock" => Ok(mock_provider_for_slot(slot)),
+        other => bail!(
+            "unknown safety provider `{other}` for slot `{slot}` \
+             (fail-closed; production providers are added in #391 / #411)"
+        ),
+    }
+}
+
+/// slot に対応する capability を持つ mock provider を作る（test / 構成検証用）。
+#[cfg(feature = "safety-mock-provider")]
+fn mock_provider_for_slot(slot: &'static str) -> Arc<dyn SafetyProvider> {
+    use kukuri_cn_safety::MockSafetyProvider;
+    use kukuri_cn_safety::SafetyProviderCapability;
+
+    let name = format!("mock-{slot}");
+    let provider = match slot {
+        "known_csam" => MockSafetyProvider::known_csam(name),
+        "general" => MockSafetyProvider::with_capabilities(
+            name,
+            vec![
+                SafetyProviderCapability::GeneralMediaModeration,
+                SafetyProviderCapability::SpamAbuseModeration,
+            ],
+        ),
+        // unknown_csam slot は未知 CSAM / CSE classifier（suspected 判定、#411）。
+        _ => MockSafetyProvider::with_capabilities(
+            name,
+            vec![
+                SafetyProviderCapability::NovelCsamImageClassifier,
+                SafetyProviderCapability::CseTextClassifier,
+            ],
+        ),
+    };
+    Arc::new(provider)
+}
+
+/// 設定から [`SafetyScanService`] を構築する runtime 構築境界（#406）。
+///
+/// 戻り値:
+/// - `Ok(None)` — safety provider が未構成。scan orchestration は構成されず、呼び出し側は
+///   ingest を起動しない（unscanned を index しない fail-closed と整合）。
+/// - `Ok(Some(service))` — 構成が有効で service を構築した。
+/// - `Err` — provider があるのに構成が不正（未知 provider 名 / emit 有効なのに署名鍵なし等）。
+///   黙って縮退せず起動を失敗させる。
+pub fn build_safety_scan_service(
+    config: &SafetyRuntimeConfig,
+    store: Arc<dyn SafetyArtifactStore>,
+) -> Result<Option<SafetyScanService>> {
+    if config.providers.is_empty() {
+        return Ok(None);
+    }
+
+    // 署名鍵があれば issuer は常に鍵の公開鍵 hex（emit 無効でも issuer 詐称を避ける）。
+    let signer = match config.signing_key.as_deref() {
+        Some(secret) => Some(
+            Secp256k1ModerationEventSigner::from_secret(secret)
+                .context("invalid moderation event signing key")?,
+        ),
+        None => None,
+    };
+
+    if config.emit_signed_events {
+        let Some(signer) = signer else {
+            bail!(
+                "signed moderation events are enabled but no signing key is configured \
+                 (set {SAFETY_SIGNING_KEY_ENV} from Secret Manager, or disable \
+                 safety.events.emit_signed_moderation_events)"
+            );
+        };
+        let issuer = signer.issuer_node_id().to_string();
+        let orchestrator = build_safety_orchestrator(&issuer, &config.providers, None)?;
+        let service = SafetyScanService::builder(Arc::new(orchestrator), store)
+            .signer(Arc::new(signer))
+            .build()?;
+        return Ok(Some(service));
+    }
+
+    let issuer = match (&signer, config.issuer_node_id.as_deref()) {
+        (Some(signer), _) => signer.issuer_node_id().to_string(),
+        (None, Some(issuer)) if !issuer.trim().is_empty() => issuer.trim().to_string(),
+        _ => bail!(
+            "signed moderation events are disabled and no issuer node id is available \
+             (set a signing key or an explicit issuer node id)"
+        ),
+    };
+    let orchestrator = build_safety_orchestrator(&issuer, &config.providers, None)?;
+    let service = SafetyScanService::builder(Arc::new(orchestrator), store)
+        .without_signed_events(issuer)
+        .build()?;
+    Ok(Some(service))
+}

--- a/crates/cn-core/src/trust_inputs.rs
+++ b/crates/cn-core/src/trust_inputs.rs
@@ -1,0 +1,170 @@
+//! trust / relation reads への risk signal 供給（#406 → #415）。
+//!
+//! 永続化された risk signal（`cn_safety.risk_signals`、#405）を、trust / relation の read が
+//! 消費できる **根拠つき入力** として返す。ADR 0026 §2.7 に従い、signal の category で
+//! trust の **絶対成分**（CSAM 等 critical safety。relation 非依存・report-bomb 不動）と
+//! **相対成分**（nsfw / spam 等。relation 重み付け・viewer 相対）へ振り分ける。
+//!
+//! ここは供給契約のみを担う。trust の合成式（ADR 0026 §6.2）・relation の cluster proximity・
+//! read surface（`CommunityLocalTrust`）本体は #415 が実装し、本モジュールの
+//! [`list_trust_risk_inputs`] を入力として消費する。
+//!
+//! 断定ラベルにしない（ADR 0026 §2.5 / trust-semantics）: 入力は必ず basis / confidence /
+//! visibility / expiry / appeal を同伴し、read surface が説明可能性を落とせない形にする。
+//! cross-node 開示（confirmed 絶対成分のみ、§6.3）は本 API の責務外（node-local read）で、
+//! visibility を同伴して返すことで #415 側が開示判定できる。
+//!
+//! appeal の反映（ADR 0026 §6.2。code の `AppealStatus` は ADR の語彙と次の対応）:
+//! - `Disputed`（= ADR の `pending`）: 寄与を**据え置き**。入力に含めたまま返す
+//!   （申し立て中に勝手に緩めない）。
+//! - `Cleared`（= ADR の `accepted`）: 寄与を**除外**。入力に含めない。
+//! - `None`: 確定寄与（ADR の `rejected` 相当を含む、異議が立っていない状態）。
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+use kukuri_cn_safety::{
+    AppealStatus, Basis, RiskSignalTarget, SafetyCategory, Severity, Visibility,
+};
+
+use crate::safety_events::{StoredRiskSignal, list_risk_signals_for_target};
+
+/// risk signal category の trust 成分振り分け先（ADR 0026 §2.7）。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustComponentKind {
+    /// 絶対成分: critical safety（CSAM / CSE / grooming）。relation で重み付けせず、
+    /// 通報数で動かない（report-bomb 不動）。時間減衰もしない（§6.2、scoring は #415）。
+    Absolute,
+    /// 相対成分: nsfw / spam 等の community / 文化圏依存の指標。relation で重み付けし、
+    /// viewer / cluster 相対で扱う。半減期減衰する（§6.2、scoring は #415）。
+    Relative,
+}
+
+/// category → trust 成分の振り分け（初期規則。operator 可変化は #415）。
+///
+/// critical safety（`SafetyCategory::is_critical_safety()` = Csam / Cse / Grooming）は絶対成分、
+/// それ以外（nsfw / spam / malware / phishing 等）は相対成分（ADR 0026 §2.7）。
+pub fn trust_component_for(category: SafetyCategory) -> TrustComponentKind {
+    if category.is_critical_safety() {
+        TrustComponentKind::Absolute
+    } else {
+        TrustComponentKind::Relative
+    }
+}
+
+/// trust / relation read への入力 1 件（根拠つき advisory）。
+///
+/// 断定ラベルではない。basis / confidence / visibility / expiry / appeal を必ず同伴し、
+/// 消費側（#415）が issuer / 根拠 / 有効期限を説明できる状態を保つ。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TrustRiskInput {
+    /// 永続化側が採番した risk signal id。
+    pub signal_id: String,
+    /// この signal を発行した issuer node。
+    pub issuer_node_id: String,
+    /// 振り分け先の trust 成分。
+    pub component: TrustComponentKind,
+    pub category: SafetyCategory,
+    pub severity: Severity,
+    pub basis: Basis,
+    pub confidence: Option<u8>,
+    /// cross-node 開示の判定材料（§6.3。開示判定は消費側の責務）。
+    pub visibility: Visibility,
+    /// `Disputed`（= pending）は寄与据え置きのまま含まれる。消費側が状態を説明できるよう同伴する。
+    pub appeal_status: AppealStatus,
+    pub expires_at: Option<String>,
+    pub persisted_at: DateTime<Utc>,
+}
+
+/// 対象 1 つ分の trust 入力（絶対 / 相対に振り分け済み）。
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TrustRiskInputs {
+    /// 絶対成分への入力（critical safety）。
+    pub absolute: Vec<TrustRiskInput>,
+    /// 相対成分への入力（relation 重み付けの対象）。
+    pub relative: Vec<TrustRiskInput>,
+}
+
+impl TrustRiskInputs {
+    /// 入力が 1 件も無いか。
+    pub fn is_empty(&self) -> bool {
+        self.absolute.is_empty() && self.relative.is_empty()
+    }
+}
+
+/// 永続化済み risk signal 列から trust 入力を組み立てる純関数。
+///
+/// - `expires_at` が `now_rfc3339` 時点で失効した signal は除外する（`expires_at` が無い signal は
+///   無期限で残る。相対成分の半減期 decay 本体は #415）。
+/// - `AppealStatus::Cleared`（= accepted）は寄与除外。`Disputed`（= pending）は据え置きで含む。
+/// - category は [`trust_component_for`] で絶対 / 相対へ振り分ける。
+///
+/// 不正な RFC3339（`now_rfc3339` / `expires_at`）は Err（黙って含めたり落としたりしない）。
+pub fn trust_risk_inputs_from(
+    signals: &[StoredRiskSignal],
+    now_rfc3339: &str,
+) -> Result<TrustRiskInputs> {
+    let now = DateTime::parse_from_rfc3339(now_rfc3339)
+        .with_context(|| format!("invalid now timestamp `{now_rfc3339}` (expected RFC3339)"))?;
+
+    let mut inputs = TrustRiskInputs::default();
+    for stored in signals {
+        let signal = &stored.signal;
+
+        if let Some(expires_at) = signal.expires_at.as_deref() {
+            let expires = DateTime::parse_from_rfc3339(expires_at).with_context(|| {
+                format!(
+                    "risk signal `{}` has invalid expires_at `{expires_at}` (expected RFC3339)",
+                    stored.id
+                )
+            })?;
+            if expires <= now {
+                continue;
+            }
+        }
+
+        let appeal_status = signal.appeal_status.unwrap_or_default();
+        if appeal_status == AppealStatus::Cleared {
+            // accepted された異議は寄与から除外する（ADR 0026 §6.2）。
+            continue;
+        }
+
+        let component = trust_component_for(signal.category);
+        let input = TrustRiskInput {
+            signal_id: stored.id.clone(),
+            issuer_node_id: stored.issuer_node_id.clone(),
+            component,
+            category: signal.category,
+            severity: signal.severity,
+            basis: signal.basis,
+            confidence: signal.confidence,
+            visibility: signal.visibility,
+            appeal_status,
+            expires_at: signal.expires_at.clone(),
+            persisted_at: stored.persisted_at,
+        };
+        match component {
+            TrustComponentKind::Absolute => inputs.absolute.push(input),
+            TrustComponentKind::Relative => inputs.relative.push(input),
+        }
+    }
+    Ok(inputs)
+}
+
+/// 対象ごとの trust 入力 read（node-local）。
+///
+/// `list_risk_signals_for_target`（visibility を問わない node-local 参照）と
+/// [`trust_risk_inputs_from`] の合成。#415 の trust 絶対成分 / relation 相対重み付けが
+/// これを消費する。
+pub async fn list_trust_risk_inputs(
+    pool: &PgPool,
+    target: RiskSignalTarget,
+    target_id: &str,
+    now_rfc3339: &str,
+) -> Result<TrustRiskInputs> {
+    let signals = list_risk_signals_for_target(pool, target, target_id).await?;
+    trust_risk_inputs_from(&signals, now_rfc3339)
+}

--- a/crates/cn-core/tests/safety_events.rs
+++ b/crates/cn-core/tests/safety_events.rs
@@ -5,19 +5,26 @@
 //! - risk signal の保存・取得・対象別一覧。
 //! - visibility 配布境界（local 除外 / subscribed_nodes / public）と expires_at 失効。
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use kukuri_cn_core::{
-    DistributionAudience, TestDatabase, connect_postgres, get_signed_moderation_event,
-    initialize_database, list_distributable_moderation_events, list_distributable_risk_signals,
-    list_risk_signals_for_target, persist_risk_signal, persist_signed_moderation_event,
+    DistributionAudience, PgSafetyArtifactStore, SafetyScanService, TestDatabase, connect_postgres,
+    get_risk_signal, get_signed_moderation_event, initialize_database,
+    list_distributable_moderation_events, list_distributable_risk_signals,
+    list_risk_signals_for_target, list_trust_risk_inputs, persist_risk_signal,
+    persist_signed_moderation_event,
 };
 use kukuri_cn_safety::event::{ModerationEventBody, SignedModerationEvent, issue_signed_event};
-use kukuri_cn_safety::provider::SubjectKind;
+use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
 use kukuri_cn_safety::{
-    AppealStatus, Basis, ModerationAction, ModerationEventSigner, ReasonCode, RiskSignalTarget,
-    SafetyCategory, SafetyLabel, SafetyRiskSignal, Severity, Visibility,
+    AppealStatus, Basis, MockSafetyProvider, ModerationAction, ModerationEventSigner, ReasonCode,
+    RiskSignalTarget, SafetyCategory, SafetyLabel, SafetyRiskSignal, Severity, Visibility,
 };
-use kukuri_cn_safety_runtime::{Secp256k1ModerationEventSigner, verify_signed_event};
+use kukuri_cn_safety_runtime::{
+    SafetyOrchestrator, Secp256k1ModerationEventSigner, SystemScanClock, UuidEventIdGenerator,
+    verify_signed_event,
+};
 
 const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
 const TEST_SECRET: &str = "0000000000000000000000000000000000000000000000000000000000000001";
@@ -329,6 +336,121 @@ async fn empty_target_id_is_rejected() -> Result<()> {
                 .await
                 .is_err()
         );
+
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+    database.cleanup().await?;
+    result
+}
+
+// --- runtime 結線（#406）: SafetyScanService + Postgres store の integration ---
+
+#[tokio::test]
+async fn scan_and_record_persists_artifacts_via_postgres_store() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!(
+            "skipping cn-core safety integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1"
+        );
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_core_safety_runtime").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    let result = async {
+        initialize_database(&pool).await?;
+        let signer = signer();
+        let issuer = signer.issuer_node_id().to_string();
+
+        // 本番構成と同型: SystemScanClock + UuidEventIdGenerator + Postgres store。
+        // provider のみ mock（known hash match を決定論的に発火させる）。
+        let provider =
+            MockSafetyProvider::known_csam("mock-known-csam").with_known_hash_match("post-406");
+        let orchestrator = SafetyOrchestrator::builder(
+            &issuer,
+            Arc::new(SystemScanClock::new()),
+            Arc::new(UuidEventIdGenerator::new()),
+        )
+        .provider(Arc::new(provider))
+        .build()?;
+        let service = SafetyScanService::builder(
+            Arc::new(orchestrator),
+            Arc::new(PgSafetyArtifactStore::new(pool.clone())),
+        )
+        .signer(Arc::new(signer))
+        .build()?;
+
+        let outcome = service
+            .scan_and_record(&ProviderScanRequest::for_subject(
+                SubjectKind::Post,
+                "post-406",
+            ))
+            .await?;
+        assert!(!outcome.report.verdict.is_indexable());
+
+        // signed moderation event が cn_safety schema に入り、ロード後も署名検証が通る。
+        let event = outcome.signed_event.expect("signed moderation event");
+        let stored_event = get_signed_moderation_event(&pool, &event.body.id)
+            .await?
+            .expect("event persisted");
+        assert_eq!(stored_event.event, event);
+        verify_signed_event(&stored_event.event).expect("loaded event verifies");
+
+        // risk signal も採番 id で入り、対象別一覧から読み戻せる。
+        let signal_id = outcome.persisted_signal_id.expect("risk signal id");
+        let stored_signal = get_risk_signal(&pool, &signal_id)
+            .await?
+            .expect("risk signal persisted");
+        assert_eq!(stored_signal.issuer_node_id, issuer);
+        assert_eq!(stored_signal.signal.category, SafetyCategory::Csam);
+        let listed =
+            list_risk_signals_for_target(&pool, RiskSignalTarget::PostId, "post-406").await?;
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, signal_id);
+
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+    database.cleanup().await?;
+    result
+}
+
+#[tokio::test]
+async fn list_trust_risk_inputs_partitions_absolute_and_relative_from_postgres() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!(
+            "skipping cn-core safety integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1"
+        );
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_core_trust_inputs").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    let result = async {
+        initialize_database(&pool).await?;
+        let issuer = signer().issuer_node_id().to_string();
+
+        // 同一 user pubkey に critical（csam）と一般（nsfw）の signal を保存する。
+        let mut csam = risk_signal("pubkey-406", Visibility::Local, None);
+        csam.target = RiskSignalTarget::UserPubkey;
+        let mut nsfw = risk_signal("pubkey-406", Visibility::Local, None);
+        nsfw.target = RiskSignalTarget::UserPubkey;
+        nsfw.category = SafetyCategory::Nsfw;
+        nsfw.severity = Severity::Medium;
+        persist_risk_signal(&pool, &issuer, &csam).await?;
+        persist_risk_signal(&pool, &issuer, &nsfw).await?;
+
+        // trust 入力 read は category で絶対 / 相対成分へ振り分けて返す（ADR 0026 §2.7）。
+        let inputs = list_trust_risk_inputs(
+            &pool,
+            RiskSignalTarget::UserPubkey,
+            "pubkey-406",
+            "2026-07-02T09:00:00Z",
+        )
+        .await?;
+        assert_eq!(inputs.absolute.len(), 1);
+        assert_eq!(inputs.absolute[0].category, SafetyCategory::Csam);
+        assert_eq!(inputs.relative.len(), 1);
+        assert_eq!(inputs.relative[0].category, SafetyCategory::Nsfw);
+        assert_eq!(inputs.absolute[0].issuer_node_id, issuer);
 
         Ok::<(), anyhow::Error>(())
     }

--- a/crates/cn-core/tests/safety_runtime.rs
+++ b/crates/cn-core/tests/safety_runtime.rs
@@ -1,0 +1,301 @@
+//! SafetyScanService / 構築境界の決定論的 contract テスト（#406）。DB 不要。
+//!
+//! mock provider + ローカル定義の固定 clock / 連番 id + 固定テスト鍵 signer +
+//! in-memory store で、runtime 経由の scan → verdict → artifact 署名 / 永続化と
+//! fail-closed を検証する。
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use kukuri_cn_core::{
+    MemorySafetyArtifactStore, SafetyRuntimeConfig, SafetyRuntimeProviderEntry,
+    SafetyRuntimeProvidersConfig, SafetyScanService, build_safety_orchestrator,
+    build_safety_scan_service,
+};
+use kukuri_cn_safety::provider::{ProviderScanRequest, ScanError, SubjectKind};
+use kukuri_cn_safety::{
+    MockSafetyProvider, ModerationEventSigner, ReasonCode, RiskSignalTarget, SafetyCategory,
+    SafetyProvider,
+};
+use kukuri_cn_safety_runtime::{
+    EventIdGenerator, SafetyOrchestrator, ScanClock, Secp256k1ModerationEventSigner,
+    verify_signed_event,
+};
+
+const SCANNED_AT: &str = "2026-07-02T09:00:00Z";
+const TEST_SECRET: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+
+struct FixedClock(&'static str);
+impl ScanClock for FixedClock {
+    fn now_rfc3339(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[derive(Default)]
+struct SequentialIdGenerator {
+    next: AtomicU64,
+}
+impl EventIdGenerator for SequentialIdGenerator {
+    fn next_id(&self) -> String {
+        let n = self.next.fetch_add(1, Ordering::SeqCst);
+        format!("evt-{n}")
+    }
+}
+
+fn signer() -> Secp256k1ModerationEventSigner {
+    Secp256k1ModerationEventSigner::from_secret(TEST_SECRET).unwrap()
+}
+
+fn orchestrator(issuer: &str, provider: MockSafetyProvider) -> Arc<SafetyOrchestrator> {
+    Arc::new(
+        SafetyOrchestrator::builder(
+            issuer,
+            Arc::new(FixedClock(SCANNED_AT)),
+            Arc::new(SequentialIdGenerator::default()),
+        )
+        .provider(Arc::new(provider) as Arc<dyn SafetyProvider>)
+        .build()
+        .unwrap(),
+    )
+}
+
+/// signer + memory store で組んだ service（本番構成と同型、DB のみ in-memory）。
+fn signed_service(
+    provider: MockSafetyProvider,
+) -> (SafetyScanService, Arc<MemorySafetyArtifactStore>, String) {
+    let signer = signer();
+    let issuer = signer.issuer_node_id().to_string();
+    let store = Arc::new(MemorySafetyArtifactStore::new());
+    let service = SafetyScanService::builder(orchestrator(&issuer, provider), store.clone())
+        .signer(Arc::new(signer))
+        .build()
+        .unwrap();
+    (service, store, issuer)
+}
+
+fn post_request(post_id: &str) -> ProviderScanRequest {
+    ProviderScanRequest::for_subject(SubjectKind::Post, post_id)
+}
+
+// --- scan → verdict → artifact 永続化（#406 受け入れ条件の runtime 経由 contract） ---
+
+#[tokio::test]
+async fn runtime_scan_known_csam_persists_signed_event_and_risk_signal() {
+    let provider =
+        MockSafetyProvider::known_csam("mock-known-csam").with_known_hash_match("post-1");
+    let (service, store, issuer) = signed_service(provider);
+
+    let outcome = service
+        .scan_and_record(&post_request("post-1"))
+        .await
+        .unwrap();
+
+    // verdict は exclude / confirmed（fail-closed gate 側の判定に使う）。
+    assert!(!outcome.report.verdict.is_indexable());
+    assert_eq!(
+        outcome.report.verdict.reason_code,
+        ReasonCode::CsamConfirmed
+    );
+
+    // moderation event は実鍵署名され、検証に通る形で store に入る。
+    let event = outcome.signed_event.expect("signed moderation event");
+    verify_signed_event(&event).unwrap();
+    assert_eq!(event.body.issuer_node_id, issuer);
+    assert_eq!(event.body.target_id, "post-1");
+    assert_eq!(store.events().len(), 1);
+    assert_eq!(store.events()[0], event);
+
+    // risk signal も issuer つきで store に入る（trust/relation reads の入力になる）。
+    let signals = store.signals();
+    assert_eq!(signals.len(), 1);
+    let (signal_issuer, signal) = &signals[0];
+    assert_eq!(signal_issuer, &issuer);
+    assert_eq!(signal.target, RiskSignalTarget::PostId);
+    assert_eq!(signal.target_id, "post-1");
+    assert_eq!(signal.category, SafetyCategory::Csam);
+    assert!(outcome.persisted_signal_id.is_some());
+}
+
+#[tokio::test]
+async fn runtime_scan_allow_persists_no_artifacts() {
+    // known CSAM provider の既知一致なし → allow（NoKnownMatch。safe の証明ではない）。
+    let provider = MockSafetyProvider::known_csam("mock-known-csam");
+    let (service, store, _issuer) = signed_service(provider);
+
+    let outcome = service
+        .scan_and_record(&post_request("post-clean"))
+        .await
+        .unwrap();
+
+    assert!(outcome.report.verdict.is_indexable());
+    assert!(outcome.signed_event.is_none());
+    assert!(outcome.persisted_signal_id.is_none());
+    assert!(store.events().is_empty());
+    assert!(store.signals().is_empty());
+}
+
+// --- provider failure / unavailable の fail-closed（runtime 経由でも固定） ---
+
+#[tokio::test]
+async fn runtime_provider_failure_is_fail_closed_and_persists_no_risk_signal() {
+    let provider = MockSafetyProvider::known_csam("mock-known-csam").default_failed();
+    let (service, store, _issuer) = signed_service(provider);
+
+    let outcome = service
+        .scan_and_record(&post_request("post-x"))
+        .await
+        .unwrap();
+
+    assert!(!outcome.report.verdict.is_indexable());
+    assert_eq!(outcome.report.verdict.reason_code, ReasonCode::ScanFailed);
+    // operational fail-closed は content の safety category を示さないため、
+    // 虚偽の risk signal を作らない（監査用 moderation event は hold として残る）。
+    assert!(outcome.persisted_signal_id.is_none());
+    assert!(store.signals().is_empty());
+    assert_eq!(store.events().len(), 1);
+    assert_eq!(store.events()[0].body.reason_code, ReasonCode::ScanFailed);
+}
+
+#[tokio::test]
+async fn runtime_provider_unavailable_is_fail_closed() {
+    let provider = MockSafetyProvider::known_csam("mock-known-csam")
+        .default_error(ScanError::Unavailable("mock provider down".to_string()));
+    let (service, store, _issuer) = signed_service(provider);
+
+    let outcome = service
+        .scan_and_record(&post_request("post-x"))
+        .await
+        .unwrap();
+
+    assert!(!outcome.report.verdict.is_indexable());
+    assert_eq!(
+        outcome.report.verdict.reason_code,
+        ReasonCode::ProviderUnavailable
+    );
+    assert!(store.signals().is_empty());
+}
+
+// --- service builder の fail-closed ---
+
+#[test]
+fn runtime_requires_signer_when_signed_events_enabled() {
+    let store = Arc::new(MemorySafetyArtifactStore::new());
+    let error = SafetyScanService::builder(
+        orchestrator(
+            "issuer-node",
+            MockSafetyProvider::known_csam("mock-known-csam"),
+        ),
+        store,
+    )
+    .build()
+    .unwrap_err();
+    assert!(error.to_string().contains("no signer"), "{error}");
+}
+
+#[tokio::test]
+async fn runtime_without_signed_events_persists_risk_signal_only() {
+    let provider =
+        MockSafetyProvider::known_csam("mock-known-csam").with_known_hash_match("post-1");
+    let store = Arc::new(MemorySafetyArtifactStore::new());
+    let service = SafetyScanService::builder(orchestrator("issuer-node", provider), store.clone())
+        .without_signed_events("issuer-node")
+        .build()
+        .unwrap();
+
+    let outcome = service
+        .scan_and_record(&post_request("post-1"))
+        .await
+        .unwrap();
+
+    // moderation event は署名・永続化しない（report には未署名 body が残る）。
+    assert!(outcome.signed_event.is_none());
+    assert!(store.events().is_empty());
+    assert!(outcome.report.moderation_event.is_some());
+    // risk signal は署名対象ではないため引き続き永続化される。
+    assert_eq!(store.signals().len(), 1);
+    assert_eq!(store.signals()[0].0, "issuer-node");
+}
+
+// --- 構築境界（config → orchestrator / service）の fail-closed ---
+
+fn mock_slot() -> Option<SafetyRuntimeProviderEntry> {
+    Some(SafetyRuntimeProviderEntry {
+        provider: "mock".to_string(),
+        required: true,
+    })
+}
+
+#[test]
+fn build_orchestrator_rejects_unknown_provider_name() {
+    let providers = SafetyRuntimeProvidersConfig {
+        known_csam: Some(SafetyRuntimeProviderEntry {
+            provider: "arachnid-shield".to_string(),
+            required: false,
+        }),
+        ..Default::default()
+    };
+    let error = build_safety_orchestrator("issuer-node", &providers, None).unwrap_err();
+    assert!(
+        error.to_string().contains("unknown safety provider"),
+        "{error}"
+    );
+}
+
+#[test]
+fn build_orchestrator_rejects_empty_provider_set() {
+    let providers = SafetyRuntimeProvidersConfig::default();
+    let error = build_safety_orchestrator("issuer-node", &providers, None).unwrap_err();
+    assert!(error.to_string().contains("no safety providers"), "{error}");
+}
+
+#[test]
+fn build_scan_service_returns_none_without_providers() {
+    let config = SafetyRuntimeConfig::default();
+    let store = Arc::new(MemorySafetyArtifactStore::new());
+    let service = build_safety_scan_service(&config, store).unwrap();
+    assert!(service.is_none());
+}
+
+#[test]
+fn build_scan_service_requires_signing_key_when_emit_enabled() {
+    let config = SafetyRuntimeConfig {
+        providers: SafetyRuntimeProvidersConfig {
+            known_csam: mock_slot(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let store = Arc::new(MemorySafetyArtifactStore::new());
+    let error = build_safety_scan_service(&config, store).unwrap_err();
+    assert!(error.to_string().contains("no signing key"), "{error}");
+}
+
+#[tokio::test]
+async fn build_scan_service_constructs_mock_orchestrator_and_scans() {
+    // SystemScanClock + UuidEventIdGenerator + mock provider での組み立て（#406）。
+    // issuer は署名鍵の公開鍵 hex に構造的に一致する。
+    let config = SafetyRuntimeConfig {
+        providers: SafetyRuntimeProvidersConfig {
+            known_csam: mock_slot(),
+            general: mock_slot(),
+            unknown_csam: mock_slot(),
+        },
+        signing_key: Some(TEST_SECRET.to_string()),
+        ..Default::default()
+    };
+    let store = Arc::new(MemorySafetyArtifactStore::new());
+    let service = build_safety_scan_service(&config, store.clone())
+        .unwrap()
+        .expect("service should be constructed");
+    assert_eq!(service.issuer_node_id(), signer().issuer_node_id());
+
+    // 既知一致なし → allow（artifact なし）まで runtime 経由で通ることを確認する。
+    let outcome = service
+        .scan_and_record(&post_request("post-clean"))
+        .await
+        .unwrap();
+    assert!(outcome.report.verdict.is_indexable());
+    assert!(store.events().is_empty());
+    assert!(store.signals().is_empty());
+}

--- a/crates/cn-core/tests/trust_inputs.rs
+++ b/crates/cn-core/tests/trust_inputs.rs
@@ -1,0 +1,176 @@
+//! trust / relation reads への risk signal 供給契約の contract テスト（#406 → #415）。DB 不要。
+//!
+//! ADR 0026 §2.7（category による絶対 / 相対振り分け）・§6.2（appeal 反映）を純関数
+//! `trust_risk_inputs_from` に対して固定する。
+
+use chrono::Utc;
+
+use kukuri_cn_core::{
+    StoredRiskSignal, TrustComponentKind, trust_component_for, trust_risk_inputs_from,
+};
+use kukuri_cn_safety::{
+    AppealStatus, Basis, RiskSignalTarget, SafetyCategory, SafetyRiskSignal, Severity, Visibility,
+};
+
+const NOW: &str = "2026-07-02T09:00:00Z";
+
+fn stored_signal(
+    id: &str,
+    category: SafetyCategory,
+    expires_at: Option<&str>,
+    appeal_status: Option<AppealStatus>,
+) -> StoredRiskSignal {
+    StoredRiskSignal {
+        id: id.to_string(),
+        issuer_node_id: "issuer-node".to_string(),
+        signal: SafetyRiskSignal {
+            target: RiskSignalTarget::UserPubkey,
+            target_id: "pubkey-1".to_string(),
+            category,
+            severity: Severity::High,
+            basis: Basis::KnownHashMatch,
+            confidence: Some(97),
+            visibility: Visibility::Local,
+            expires_at: expires_at.map(str::to_string),
+            appeal_status,
+        },
+        persisted_at: Utc::now(),
+    }
+}
+
+// --- 絶対 / 相対振り分け（ADR 0026 §2.7） ---
+
+#[test]
+fn csam_risk_signal_feeds_absolute_component() {
+    // critical safety（CSAM / CSE / grooming）は絶対成分。relation 非依存・report-bomb 不動。
+    for category in [
+        SafetyCategory::Csam,
+        SafetyCategory::Cse,
+        SafetyCategory::Grooming,
+    ] {
+        assert_eq!(trust_component_for(category), TrustComponentKind::Absolute);
+    }
+
+    let signals = vec![stored_signal("sig-1", SafetyCategory::Csam, None, None)];
+    let inputs = trust_risk_inputs_from(&signals, NOW).unwrap();
+    assert_eq!(inputs.absolute.len(), 1);
+    assert!(inputs.relative.is_empty());
+    assert_eq!(inputs.absolute[0].component, TrustComponentKind::Absolute);
+}
+
+#[test]
+fn general_moderation_signal_feeds_relative_component() {
+    // nsfw / spam 等の文化圏依存の指標は相対成分（relation で重み付け）。
+    for category in [
+        SafetyCategory::Nsfw,
+        SafetyCategory::Spam,
+        SafetyCategory::Malware,
+        SafetyCategory::Phishing,
+    ] {
+        assert_eq!(trust_component_for(category), TrustComponentKind::Relative);
+    }
+
+    let signals = vec![
+        stored_signal("sig-1", SafetyCategory::Nsfw, None, None),
+        stored_signal("sig-2", SafetyCategory::Csam, None, None),
+    ];
+    let inputs = trust_risk_inputs_from(&signals, NOW).unwrap();
+    assert_eq!(inputs.absolute.len(), 1);
+    assert_eq!(inputs.relative.len(), 1);
+    assert_eq!(inputs.relative[0].signal_id, "sig-1");
+    assert_eq!(inputs.absolute[0].signal_id, "sig-2");
+}
+
+// --- expiry（失効 signal は寄与しない） ---
+
+#[test]
+fn expired_signal_is_excluded_from_trust_inputs() {
+    let signals = vec![
+        // NOW より過去に失効 → 除外。
+        stored_signal(
+            "sig-expired",
+            SafetyCategory::Csam,
+            Some("2026-07-01T00:00:00Z"),
+            None,
+        ),
+        // 失効前 → 含む。
+        stored_signal(
+            "sig-live",
+            SafetyCategory::Csam,
+            Some("2026-08-01T00:00:00Z"),
+            None,
+        ),
+        // expires_at なし → 無期限で含む。
+        stored_signal("sig-forever", SafetyCategory::Csam, None, None),
+    ];
+    let inputs = trust_risk_inputs_from(&signals, NOW).unwrap();
+    let ids: Vec<&str> = inputs
+        .absolute
+        .iter()
+        .map(|input| input.signal_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["sig-live", "sig-forever"]);
+}
+
+#[test]
+fn invalid_expires_at_is_an_error() {
+    // 不正な RFC3339 は黙って含めたり落としたりせず Err にする。
+    let signals = vec![stored_signal(
+        "sig-broken",
+        SafetyCategory::Csam,
+        Some("not-a-timestamp"),
+        None,
+    )];
+    let error = trust_risk_inputs_from(&signals, NOW).unwrap_err();
+    assert!(error.to_string().contains("invalid expires_at"), "{error}");
+}
+
+// --- appeal 反映（ADR 0026 §6.2。Disputed = pending / Cleared = accepted） ---
+
+#[test]
+fn cleared_appeal_excludes_contribution() {
+    let signals = vec![
+        stored_signal(
+            "sig-cleared",
+            SafetyCategory::Csam,
+            None,
+            Some(AppealStatus::Cleared),
+        ),
+        stored_signal("sig-kept", SafetyCategory::Csam, None, None),
+    ];
+    let inputs = trust_risk_inputs_from(&signals, NOW).unwrap();
+    assert_eq!(inputs.absolute.len(), 1);
+    assert_eq!(inputs.absolute[0].signal_id, "sig-kept");
+}
+
+#[test]
+fn disputed_appeal_holds_contribution() {
+    // 申し立て中（pending）は寄与据え置き: 含まれたまま、状態を同伴して返る。
+    let signals = vec![stored_signal(
+        "sig-disputed",
+        SafetyCategory::Nsfw,
+        None,
+        Some(AppealStatus::Disputed),
+    )];
+    let inputs = trust_risk_inputs_from(&signals, NOW).unwrap();
+    assert_eq!(inputs.relative.len(), 1);
+    assert_eq!(inputs.relative[0].appeal_status, AppealStatus::Disputed);
+}
+
+// --- 根拠つき advisory（断定ラベル化しない） ---
+
+#[test]
+fn trust_inputs_carry_basis_confidence_visibility() {
+    let signals = vec![stored_signal("sig-1", SafetyCategory::Csam, None, None)];
+    let inputs = trust_risk_inputs_from(&signals, NOW).unwrap();
+    let input = &inputs.absolute[0];
+    // 消費側（#415）が issuer / 根拠 / 有効期限を説明できるよう、根拠フィールドを欠落なく同伴する。
+    assert_eq!(input.issuer_node_id, "issuer-node");
+    assert_eq!(input.category, SafetyCategory::Csam);
+    assert_eq!(input.severity, Severity::High);
+    assert_eq!(input.basis, Basis::KnownHashMatch);
+    assert_eq!(input.confidence, Some(97));
+    assert_eq!(input.visibility, Visibility::Local);
+    assert_eq!(input.appeal_status, AppealStatus::None);
+    assert_eq!(input.expires_at, None);
+}

--- a/crates/cn-indexer/Cargo.toml
+++ b/crates/cn-indexer/Cargo.toml
@@ -28,7 +28,10 @@ tracing-subscriber.workspace = true
 kukuri-core = { path = "../core" }
 kukuri-docs-sync = { path = "../docs-sync" }
 kukuri-transport = { path = "../transport" }
-kukuri-cn-core = { path = "../cn-core" }
+# safety-mock-provider: 本番 provider（#391 / #411）実装まで、runtime 構築（provider 実装名
+# `mock`）と contract test を成立させるため有効化する。mock provider は operator が env で
+# 明示指定しない限り構成されず、未知の provider 名は fail-closed で Err になる。
+kukuri-cn-core = { path = "../cn-core", features = ["safety-mock-provider"] }
 kukuri-cn-safety = { path = "../cn-safety" }
 kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 

--- a/crates/cn-indexer/src/config.rs
+++ b/crates/cn-indexer/src/config.rs
@@ -11,6 +11,23 @@
 
 use anyhow::{Context, Result, bail};
 
+use kukuri_cn_core::{
+    SafetyRuntimeConfig, SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig,
+};
+use kukuri_cn_safety_runtime::SAFETY_SIGNING_KEY_ENV;
+
+/// safety provider slot（#406。operator config の `safety.providers.*` と 1:1）の env 名。
+/// 値は provider 実装名（現状 `mock` のみ。#391 / #411 で本番実装名を追加）。
+/// `<SLOT>_REQUIRED`（bool）で required 宣言を併記できる。
+pub const SAFETY_PROVIDER_KNOWN_CSAM_ENV: &str = "COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM";
+pub const SAFETY_PROVIDER_GENERAL_ENV: &str = "COMMUNITY_NODE_SAFETY_PROVIDER_GENERAL";
+pub const SAFETY_PROVIDER_UNKNOWN_CSAM_ENV: &str = "COMMUNITY_NODE_SAFETY_PROVIDER_UNKNOWN_CSAM";
+/// signed moderation event を発行するか（operator config の
+/// `safety.events.emit_signed_moderation_events` に対応。既定 true）。
+pub const SAFETY_EMIT_SIGNED_EVENTS_ENV: &str = "COMMUNITY_NODE_SAFETY_EMIT_SIGNED_EVENTS";
+/// signed event 無効時に risk signal issuer として使う node id。
+pub const SAFETY_ISSUER_NODE_ID_ENV: &str = "COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID";
+
 /// relay validation の結果。fail-closed gate の単一判定点。
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RelayValidation {
@@ -83,6 +100,8 @@ pub struct IndexerConfig {
     pub channel_secret_key: String,
     /// ArcadeDB index 投影の接続設定。
     pub arcadedb: ArcadeDbConfig,
+    /// safety scan runtime（#406）の構成。provider 未構成なら scan service は構築されない。
+    pub safety: SafetyRuntimeConfig,
 }
 
 impl std::fmt::Debug for IndexerConfig {
@@ -93,6 +112,8 @@ impl std::fmt::Debug for IndexerConfig {
             .field("relay", &self.relay)
             .field("channel_secret_key", &"<redacted>")
             .field("arcadedb", &self.arcadedb)
+            // SafetyRuntimeConfig の Debug は signing_key を秘匿する。
+            .field("safety", &self.safety)
             .finish()
     }
 }
@@ -153,19 +174,134 @@ impl IndexerConfig {
                 .unwrap_or_else(|| "root".to_string()),
             password: std::env::var("COMMUNITY_NODE_ARCADEDB_PASSWORD").unwrap_or_default(),
         };
+        let safety = SafetyRuntimeConfig {
+            providers: SafetyRuntimeProvidersConfig {
+                known_csam: safety_provider_entry(
+                    non_empty_env(SAFETY_PROVIDER_KNOWN_CSAM_ENV),
+                    kukuri_cn_core::parse_bool_env(
+                        &format!("{SAFETY_PROVIDER_KNOWN_CSAM_ENV}_REQUIRED"),
+                        false,
+                    )?,
+                ),
+                general: safety_provider_entry(
+                    non_empty_env(SAFETY_PROVIDER_GENERAL_ENV),
+                    kukuri_cn_core::parse_bool_env(
+                        &format!("{SAFETY_PROVIDER_GENERAL_ENV}_REQUIRED"),
+                        false,
+                    )?,
+                ),
+                unknown_csam: safety_provider_entry(
+                    non_empty_env(SAFETY_PROVIDER_UNKNOWN_CSAM_ENV),
+                    kukuri_cn_core::parse_bool_env(
+                        &format!("{SAFETY_PROVIDER_UNKNOWN_CSAM_ENV}_REQUIRED"),
+                        false,
+                    )?,
+                ),
+            },
+            signing_key: non_empty_env(SAFETY_SIGNING_KEY_ENV),
+            emit_signed_events: kukuri_cn_core::parse_bool_env(
+                SAFETY_EMIT_SIGNED_EVENTS_ENV,
+                true,
+            )?,
+            issuer_node_id: non_empty_env(SAFETY_ISSUER_NODE_ID_ENV),
+        };
         Ok(Self {
             database_url,
             data_dir,
             relay: RelayConfig::new(has_own_relay, external_relay_urls),
             channel_secret_key,
             arcadedb,
+            safety,
         })
     }
+}
+
+/// 空 / 空白のみの env は未設定として扱う。
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// provider slot env の値から entry を組む。空 / 空白は「slot 未構成」。
+fn safety_provider_entry(
+    provider: Option<String>,
+    required: bool,
+) -> Option<SafetyRuntimeProviderEntry> {
+    provider.map(|provider| SafetyRuntimeProviderEntry { provider, required })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    const TEST_SECRET: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+    const SAFETY_PROVIDER_KNOWN_CSAM_REQUIRED_ENV: &str =
+        "COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM_REQUIRED";
+    const SAFETY_PROVIDER_GENERAL_REQUIRED_ENV: &str =
+        "COMMUNITY_NODE_SAFETY_PROVIDER_GENERAL_REQUIRED";
+    const SAFETY_PROVIDER_UNKNOWN_CSAM_REQUIRED_ENV: &str =
+        "COMMUNITY_NODE_SAFETY_PROVIDER_UNKNOWN_CSAM_REQUIRED";
+    const INDEXER_ENV_KEYS: &[&str] = &[
+        "COMMUNITY_NODE_DATABASE_URL",
+        "COMMUNITY_NODE_INDEXER_DATA_DIR",
+        "COMMUNITY_NODE_INDEXER_OWN_RELAY",
+        "COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS",
+        "COMMUNITY_NODE_CHANNEL_SECRET_KEY",
+        "COMMUNITY_NODE_ARCADEDB_URL",
+        "COMMUNITY_NODE_ARCADEDB_DATABASE",
+        "COMMUNITY_NODE_ARCADEDB_USER",
+        "COMMUNITY_NODE_ARCADEDB_PASSWORD",
+        SAFETY_PROVIDER_KNOWN_CSAM_ENV,
+        SAFETY_PROVIDER_KNOWN_CSAM_REQUIRED_ENV,
+        SAFETY_PROVIDER_GENERAL_ENV,
+        SAFETY_PROVIDER_GENERAL_REQUIRED_ENV,
+        SAFETY_PROVIDER_UNKNOWN_CSAM_ENV,
+        SAFETY_PROVIDER_UNKNOWN_CSAM_REQUIRED_ENV,
+        SAFETY_SIGNING_KEY_ENV,
+        SAFETY_EMIT_SIGNED_EVENTS_ENV,
+        SAFETY_ISSUER_NODE_ID_ENV,
+    ];
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock")
+    }
+
+    fn with_clean_indexer_env<T>(f: impl FnOnce() -> T) -> T {
+        let _guard = env_lock();
+        let snapshot: Vec<(&'static str, Option<String>)> = INDEXER_ENV_KEYS
+            .iter()
+            .map(|key| (*key, std::env::var(key).ok()))
+            .collect();
+        for key in INDEXER_ENV_KEYS {
+            unsafe { std::env::remove_var(key) };
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+
+        for (key, value) in snapshot {
+            match value {
+                Some(value) => unsafe { std::env::set_var(key, value) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+        match result {
+            Ok(value) => value,
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    }
+
+    fn set_minimal_indexer_env() {
+        unsafe {
+            std::env::set_var("COMMUNITY_NODE_DATABASE_URL", "postgres://example");
+            std::env::set_var("COMMUNITY_NODE_CHANNEL_SECRET_KEY", "test-channel-secret");
+        }
+    }
 
     #[test]
     fn startup_fails_without_own_or_external_relay() {
@@ -218,5 +354,71 @@ mod tests {
             ],
         );
         assert_eq!(config.external_relay_urls.len(), 1);
+    }
+
+    #[test]
+    fn unset_safety_provider_env_yields_no_entry() {
+        // slot 未構成（env 未設定）は entry を作らない → provider 全 slot 未構成なら
+        // scan service は構築されない（fail-closed。cn-core 側 contract test で固定）。
+        assert!(safety_provider_entry(None, true).is_none());
+    }
+
+    #[test]
+    fn safety_provider_entry_keeps_name_and_required_flag() {
+        let entry = safety_provider_entry(Some("mock".to_string()), true).unwrap();
+        assert_eq!(entry.provider, "mock");
+        assert!(entry.required);
+    }
+
+    #[test]
+    fn safety_emit_signed_events_defaults_to_true() {
+        // operator config の default（emit_signed_moderation_events = true）と一致する。
+        assert!(SafetyRuntimeConfig::default().emit_signed_events);
+    }
+
+    #[test]
+    fn safety_service_is_absent_without_provider_config() {
+        with_clean_indexer_env(|| {
+            set_minimal_indexer_env();
+
+            let config = IndexerConfig::from_env().unwrap();
+            assert!(config.safety.providers.is_empty());
+
+            let store = Arc::new(kukuri_cn_core::MemorySafetyArtifactStore::new());
+            let service = kukuri_cn_core::build_safety_scan_service(&config.safety, store).unwrap();
+            assert!(service.is_none());
+        });
+    }
+
+    #[test]
+    fn safety_env_parses_provider_slots() {
+        with_clean_indexer_env(|| {
+            set_minimal_indexer_env();
+            unsafe {
+                std::env::set_var(SAFETY_PROVIDER_KNOWN_CSAM_ENV, " mock ");
+                std::env::set_var(SAFETY_PROVIDER_KNOWN_CSAM_REQUIRED_ENV, "true");
+                std::env::set_var(SAFETY_PROVIDER_GENERAL_ENV, "mock");
+                std::env::set_var(SAFETY_PROVIDER_GENERAL_REQUIRED_ENV, "false");
+                std::env::set_var(SAFETY_PROVIDER_UNKNOWN_CSAM_ENV, "mock");
+                std::env::set_var(SAFETY_PROVIDER_UNKNOWN_CSAM_REQUIRED_ENV, "1");
+                std::env::set_var(SAFETY_SIGNING_KEY_ENV, TEST_SECRET);
+                std::env::set_var(SAFETY_EMIT_SIGNED_EVENTS_ENV, "off");
+                std::env::set_var(SAFETY_ISSUER_NODE_ID_ENV, " issuer-node ");
+            }
+
+            let config = IndexerConfig::from_env().unwrap();
+            let known = config.safety.providers.known_csam.as_ref().unwrap();
+            assert_eq!(known.provider, "mock");
+            assert!(known.required);
+            let general = config.safety.providers.general.as_ref().unwrap();
+            assert_eq!(general.provider, "mock");
+            assert!(!general.required);
+            let unknown = config.safety.providers.unknown_csam.as_ref().unwrap();
+            assert_eq!(unknown.provider, "mock");
+            assert!(unknown.required);
+            assert_eq!(config.safety.signing_key.as_deref(), Some(TEST_SECRET));
+            assert!(!config.safety.emit_signed_events);
+            assert_eq!(config.safety.issuer_node_id.as_deref(), Some("issuer-node"));
+        });
     }
 }

--- a/crates/cn-indexer/src/ingest.rs
+++ b/crates/cn-indexer/src/ingest.rs
@@ -1,8 +1,9 @@
 //! ingest pipeline（#413 / T5 / ADR 0025 §2.5 / §6.2）。
 //!
-//! 共有 replica に **実在する** post entry のみを対象に、post 本文 text を `cn-safety-runtime` の
-//! `SafetyOrchestrator` で scan し、verdict が `allow`（`SafetyVerdict::is_indexable()`）の entry のみを
-//! index 投影へ書く。以下を不変条件として守る:
+//! 共有 replica に **実在する** post entry のみを対象に、post 本文 text を `cn-core` の
+//! `SafetyScanService`（#406。内部で `cn-safety-runtime` の `SafetyOrchestrator` を駆動し、
+//! moderation artifact を署名・永続化する）で scan し、verdict が `allow`
+//! （`SafetyVerdict::is_indexable()`）の entry のみを index 投影へ書く。以下を不変条件として守る:
 //!   - ghost 注入を作らない: 対象は共有 replica の entry のみ（CN 直渡しは経路が無い。§6.2）。
 //!   - fail-closed: unscanned / scan_failed / provider_unavailable / 非 allow は投影しない（§2.5）。
 //!   - no permanent blob storage: blob は scan 用の一時 fetch のみで、投影に raw blob を入れない（§2.3）。
@@ -17,9 +18,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use tracing::{debug, warn};
 
-use kukuri_cn_core::IndexScopeKind;
+use kukuri_cn_core::{IndexScopeKind, SafetyScanService};
 use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
-use kukuri_cn_safety_runtime::SafetyOrchestrator;
 use kukuri_core::{KukuriEnvelope, ObjectStatus, PayloadRef, ReplicaId};
 use kukuri_docs_sync::{DocFetchPolicy, DocQuery, DocRecord, DocsSync, stable_key};
 
@@ -38,22 +38,26 @@ pub struct IngestSummary {
     pub deindexed: usize,
 }
 
-/// ingest pipeline。docs replica + safety orchestrator + index 投影を束ねる。
+/// ingest pipeline。docs replica + safety scan service + index 投影を束ねる。
+///
+/// safety scan は `SafetyScanService`（#406）経由で行い、scan と同時に moderation artifact
+/// （signed moderation event / risk signal）が署名・永続化される。verdict gate（allow のみ投影）
+/// は従来どおり本 pipeline が担う。
 pub struct IngestPipeline {
     docs_sync: Arc<dyn DocsSync>,
-    orchestrator: Arc<SafetyOrchestrator>,
+    safety: Arc<SafetyScanService>,
     projection: Arc<dyn IndexProjection>,
 }
 
 impl IngestPipeline {
     pub fn new(
         docs_sync: Arc<dyn DocsSync>,
-        orchestrator: Arc<SafetyOrchestrator>,
+        safety: Arc<SafetyScanService>,
         projection: Arc<dyn IndexProjection>,
     ) -> Self {
         Self {
             docs_sync,
-            orchestrator,
+            safety,
             projection,
         }
     }
@@ -155,10 +159,12 @@ impl IngestPipeline {
             .resolve_body_text(replica_id, &object, envelopes)
             .await?;
 
-        // safety scan（fail-closed）。post 本文 text を orchestrator に渡す。
+        // safety scan（fail-closed）。post 本文 text を scan service に渡す。生成された
+        // moderation artifact（risk signal / signed event）は service が署名・永続化する（#406）。
+        // 永続化失敗は `?` で呼び出し側の per-entry fail-closed（投影しない）に乗る。
         let request = ProviderScanRequest::for_subject(SubjectKind::Post, object.object_id.clone())
             .with_text(text.clone());
-        let report = self.orchestrator.scan_subject(&request).await;
+        let report = self.safety.scan_and_record(&request).await?.report;
 
         if !report.verdict.is_indexable() {
             // unscanned / scan_failed / provider_unavailable / 非 allow は投影しない。

--- a/crates/cn-indexer/src/runtime.rs
+++ b/crates/cn-indexer/src/runtime.rs
@@ -1,16 +1,22 @@
-//! cn-indexer 常駐 runtime（#413 / T4）。
+//! cn-indexer 常駐 runtime（#413 / T4、safety runtime 結線 #406）。
 //!
 //! 起動フローの要は **relay validation の起動 gate**（ADR 0025 §6.4）: 自前 relay も外部 relay も
 //! 設定されていなければ indexing を起動しない（fail-closed）。gate を通ったら Postgres の scope
 //! 管理 state を真実源に docs replica sync participant を立ち上げる。
 //!
-//! safety provider（#391 / #411）はまだ実装が無いため、scan orchestrator を構成できない構成では
-//! ingest を起動しない（unscanned を index しない fail-closed と整合。`CommunityIndex` capability が
-//! `Availability::Planned` である現状と一致する）。relay gate 自体はそれとは独立に起動時へ適用する。
+//! safety scan の構築境界は #406 で結線済み: provider が構成されていれば
+//! `SafetyScanService`（scan → risk signal / signed event 永続化）を構築・検証する。
+//! provider 未構成なら scan service を構成せず ingest を起動しない（unscanned を index しない
+//! fail-closed と整合。`CommunityIndex` capability が `Availability::Planned` である現状と一致する）。
+//! relay gate 自体はそれとは独立に起動時へ適用する。
+
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
+
+use kukuri_cn_core::PgSafetyArtifactStore;
 
 use crate::config::IndexerConfig;
 
@@ -49,9 +55,25 @@ async fn run(config: IndexerConfig) -> Result<()> {
         "cn-indexer configuration validated"
     );
 
-    // NOTE: safety provider（#391 / #411）が実装され `CommunityIndex` が昇格するまで、実 ingest loop は
-    // 起動しない。ここまでで relay 起動 gate と scope state の準備確認は完了しており、participant /
-    // ingest pipeline（`crate::participant` / `crate::ingest`）は provider 実装後に本 runtime へ結線する。
+    // safety scan runtime の構築境界（#406）。provider が構成されていれば service を構築・検証する
+    // （構成不正 = 未知 provider 名 / emit 有効なのに署名鍵なし、は起動失敗）。未構成なら scan
+    // service を構成せず、ingest は起動されない（fail-closed）。
+    let safety = kukuri_cn_core::build_safety_scan_service(
+        &config.safety,
+        Arc::new(PgSafetyArtifactStore::new(pool.clone())),
+    )?;
+    match safety.as_ref() {
+        Some(service) => info!(
+            issuer_node_id = %service.issuer_node_id(),
+            "safety scan service constructed; ingest loop remains gated on #391 / #404"
+        ),
+        None => info!("safety providers not configured; ingest stays disabled (fail-closed)"),
+    }
+
+    // NOTE: 構築境界（orchestrator / scan service）は #406 で結線済み。実 ingest loop の起動は
+    // 本番 provider（#391 / #411）と fail-closed indexing 本体（#404）が揃い `CommunityIndex` が
+    // 昇格した段階で行う。participant / ingest pipeline（`crate::participant` / `crate::ingest`）は
+    // 上記 `safety` service を注入して起動する。
     Ok(())
 }
 

--- a/crates/cn-indexer/tests/ingestion_contracts.rs
+++ b/crates/cn-indexer/tests/ingestion_contracts.rs
@@ -8,65 +8,65 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use kukuri_cn_core::IndexScopeKind;
+use kukuri_cn_core::{IndexScopeKind, MemorySafetyArtifactStore, SafetyScanService};
 use kukuri_cn_indexer::config::RelayConfig;
 use kukuri_cn_indexer::ingest::IngestPipeline;
 use kukuri_cn_indexer::participant::ScopeReplica;
 use kukuri_cn_indexer::projection::{IndexProjection, MemoryIndexProjection};
-use kukuri_cn_safety::MockSafetyProvider;
-use kukuri_cn_safety_runtime::SafetyOrchestrator;
+use kukuri_cn_safety::{
+    MockSafetyProvider, ModerationEventSigner, RiskSignalTarget, SafetyCategory,
+};
 use kukuri_cn_safety_runtime::clock::SystemScanClock;
 use kukuri_cn_safety_runtime::id::UuidEventIdGenerator;
+use kukuri_cn_safety_runtime::{
+    SafetyOrchestrator, Secp256k1ModerationEventSigner, verify_signed_event,
+};
 use kukuri_core::{KukuriKeys, ReplicaId, TopicId, build_post_envelope};
 use kukuri_docs_sync::{DocOp, DocQuery, DocsSync, MemoryDocsSync, stable_key, topic_replica_id};
 
-/// mock provider で allow を返す orchestrator（known CSAM = NoKnownMatch、脅威スコア無し）。
+const TEST_SECRET: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+
+/// mock provider から scan service（#406）を組む。本番構成と同型（実鍵 signer +
+/// SystemScanClock + UuidEventIdGenerator）で、store のみ in-memory。
+///
+/// 返り値の store から、pipeline 経由で永続化された moderation artifact を検証できる。
+fn service_with(
+    provider: MockSafetyProvider,
+) -> (Arc<SafetyScanService>, Arc<MemorySafetyArtifactStore>) {
+    let signer = Secp256k1ModerationEventSigner::from_secret(TEST_SECRET).expect("signer");
+    let issuer = signer.issuer_node_id().to_string();
+    let store = Arc::new(MemorySafetyArtifactStore::new());
+    let orchestrator = SafetyOrchestrator::builder(
+        &issuer,
+        Arc::new(SystemScanClock),
+        Arc::new(UuidEventIdGenerator),
+    )
+    .provider(Arc::new(provider))
+    .build()
+    .expect("orchestrator");
+    let service = SafetyScanService::builder(Arc::new(orchestrator), store.clone())
+        .signer(Arc::new(signer))
+        .build()
+        .expect("service");
+    (Arc::new(service), store)
+}
+
+/// mock provider で allow を返す service（known CSAM = NoKnownMatch、脅威スコア無し）。
 ///
 /// `public_node_default` policy は known CSAM provider を必須とするため、allow を得るには
 /// `KnownCsamHashMatch` provider が `NoKnownMatch` を返す必要がある。
-fn allow_orchestrator() -> Arc<SafetyOrchestrator> {
-    let provider = Arc::new(MockSafetyProvider::known_csam("mock-known-csam"));
-    Arc::new(
-        SafetyOrchestrator::builder(
-            "node-issuer",
-            Arc::new(SystemScanClock),
-            Arc::new(UuidEventIdGenerator),
-        )
-        .provider(provider)
-        .build()
-        .expect("orchestrator"),
-    )
+fn allow_service() -> (Arc<SafetyScanService>, Arc<MemorySafetyArtifactStore>) {
+    service_with(MockSafetyProvider::known_csam("mock-known-csam"))
 }
 
-/// mock provider が scan 失敗を返す orchestrator（fail-closed のテスト用）。
-fn scan_failed_orchestrator() -> Arc<SafetyOrchestrator> {
-    let provider = Arc::new(MockSafetyProvider::known_csam("mock-known-csam").default_failed());
-    Arc::new(
-        SafetyOrchestrator::builder(
-            "node-issuer",
-            Arc::new(SystemScanClock),
-            Arc::new(UuidEventIdGenerator),
-        )
-        .provider(provider)
-        .build()
-        .expect("orchestrator"),
-    )
+/// mock provider が scan 失敗を返す service（fail-closed のテスト用）。
+fn scan_failed_service() -> (Arc<SafetyScanService>, Arc<MemorySafetyArtifactStore>) {
+    service_with(MockSafetyProvider::known_csam("mock-known-csam").default_failed())
 }
 
-/// known CSAM hash match を返す orchestrator（exclude のテスト用）。
-fn known_csam_orchestrator(post_id: &str) -> Arc<SafetyOrchestrator> {
-    let provider =
-        Arc::new(MockSafetyProvider::known_csam("mock-known-csam").with_known_hash_match(post_id));
-    Arc::new(
-        SafetyOrchestrator::builder(
-            "node-issuer",
-            Arc::new(SystemScanClock),
-            Arc::new(UuidEventIdGenerator),
-        )
-        .provider(provider)
-        .build()
-        .expect("orchestrator"),
-    )
+/// known CSAM hash match を返す service（exclude のテスト用）。
+fn known_csam_service(post_id: &str) -> (Arc<SafetyScanService>, Arc<MemorySafetyArtifactStore>) {
+    service_with(MockSafetyProvider::known_csam("mock-known-csam").with_known_hash_match(post_id))
 }
 
 /// 本文 text の post envelope を共有 replica に実在させる（app-api の persist と同じ key 形状）。
@@ -116,7 +116,7 @@ async fn index_only_indexes_shared_replica_entries() -> Result<()> {
     let replica = topic_replica_id("rust");
     let object_id = persist_post(&docs, &replica, &topic, "hello shared replica").await;
 
-    let pipeline = IngestPipeline::new(docs.clone(), allow_orchestrator(), projection.clone());
+    let pipeline = IngestPipeline::new(docs.clone(), allow_service().0, projection.clone());
     let scope = ScopeReplica::from_scope(IndexScopeKind::PublicTopic, "rust");
     let summary = pipeline
         .ingest_scope(scope.kind, &scope.id, &scope.replica_id)
@@ -141,7 +141,7 @@ async fn content_not_in_shared_replica_is_not_indexed() -> Result<()> {
     let replica = topic_replica_id("empty");
     docs.open_replica(&replica).await?;
 
-    let pipeline = IngestPipeline::new(docs.clone(), allow_orchestrator(), projection.clone());
+    let pipeline = IngestPipeline::new(docs.clone(), allow_service().0, projection.clone());
     let summary = pipeline
         .ingest_scope(IndexScopeKind::PublicTopic, "empty", &replica)
         .await?;
@@ -166,8 +166,7 @@ async fn index_excludes_unscanned_and_scan_failed() -> Result<()> {
     let replica = topic_replica_id("rust");
     let object_id = persist_post(&docs, &replica, &topic, "scan will fail").await;
 
-    let pipeline =
-        IngestPipeline::new(docs.clone(), scan_failed_orchestrator(), projection.clone());
+    let pipeline = IngestPipeline::new(docs.clone(), scan_failed_service().0, projection.clone());
     let summary = pipeline
         .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
         .await?;
@@ -194,7 +193,7 @@ async fn index_excludes_non_allow_verdict_content() -> Result<()> {
 
     let pipeline = IngestPipeline::new(
         docs.clone(),
-        known_csam_orchestrator(&object_id),
+        known_csam_service(&object_id).0,
         projection.clone(),
     );
     let summary = pipeline
@@ -220,7 +219,7 @@ async fn reingest_deindexes_when_verdict_flips_to_non_allow() -> Result<()> {
     let replica = topic_replica_id("rust");
     let object_id = persist_post(&docs, &replica, &topic, "flips later").await;
 
-    IngestPipeline::new(docs.clone(), allow_orchestrator(), projection.clone())
+    IngestPipeline::new(docs.clone(), allow_service().0, projection.clone())
         .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
         .await?;
     assert!(
@@ -231,7 +230,7 @@ async fn reingest_deindexes_when_verdict_flips_to_non_allow() -> Result<()> {
 
     IngestPipeline::new(
         docs.clone(),
-        known_csam_orchestrator(&object_id),
+        known_csam_service(&object_id).0,
         projection.clone(),
     )
     .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
@@ -275,7 +274,7 @@ async fn deleted_objects_are_deindexed() -> Result<()> {
     let replica = topic_replica_id("rust");
     let object_id = persist_post(&docs, &replica, &topic, "to be deleted").await;
 
-    IngestPipeline::new(docs.clone(), allow_orchestrator(), projection.clone())
+    IngestPipeline::new(docs.clone(), allow_service().0, projection.clone())
         .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
         .await?;
     assert!(
@@ -304,7 +303,7 @@ async fn deleted_objects_are_deindexed() -> Result<()> {
     )
     .await?;
 
-    let summary = IngestPipeline::new(docs.clone(), allow_orchestrator(), projection.clone())
+    let summary = IngestPipeline::new(docs.clone(), allow_service().0, projection.clone())
         .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
         .await?;
     assert_eq!(summary.deindexed, 1);
@@ -313,5 +312,96 @@ async fn deleted_objects_are_deindexed() -> Result<()> {
             .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
             .await?
     );
+    Ok(())
+}
+
+// --- runtime（pipeline）経由の moderation artifact 記録（#406） ---
+
+#[tokio::test]
+async fn ingest_known_csam_records_risk_signal_and_does_not_index() -> Result<()> {
+    // known CSAM hash match の post は投影に入らず、risk signal + 署名 event が store に入る。
+    let docs = Arc::new(MemoryDocsSync::default());
+    let projection = Arc::new(MemoryIndexProjection::new());
+    let topic = TopicId::new("rust");
+    let replica = topic_replica_id("rust");
+    let object_id = persist_post(&docs, &replica, &topic, "bad content").await;
+
+    let (service, store) = known_csam_service(&object_id);
+    let summary = IngestPipeline::new(docs.clone(), service, projection.clone())
+        .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+        .await?;
+
+    assert_eq!(summary.indexed, 0);
+    assert_eq!(summary.skipped_non_allow, 1);
+    assert!(
+        !projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+            .await?
+    );
+
+    // risk signal が trust/relation reads の入力として永続化される（根拠つき、断定ラベルなし）。
+    let signals = store.signals();
+    assert_eq!(signals.len(), 1);
+    let (_, signal) = &signals[0];
+    assert_eq!(signal.target, RiskSignalTarget::PostId);
+    assert_eq!(signal.target_id, object_id);
+    assert_eq!(signal.category, SafetyCategory::Csam);
+
+    // moderation event は実鍵署名済みで検証に通る。
+    let events = store.events();
+    assert_eq!(events.len(), 1);
+    verify_signed_event(&events[0]).expect("event verifies");
+    assert_eq!(events[0].body.target_id, object_id);
+    Ok(())
+}
+
+#[tokio::test]
+async fn ingest_scan_failure_is_fail_closed_and_records_no_risk_signal() -> Result<()> {
+    // provider failure は runtime（pipeline）経由でも fail-closed: 投影されず、
+    // content の safety category を示さないため risk signal も生成されない。
+    let docs = Arc::new(MemoryDocsSync::default());
+    let projection = Arc::new(MemoryIndexProjection::new());
+    let topic = TopicId::new("rust");
+    let replica = topic_replica_id("rust");
+    let object_id = persist_post(&docs, &replica, &topic, "scan will fail").await;
+
+    let (service, store) = scan_failed_service();
+    let summary = IngestPipeline::new(docs.clone(), service, projection.clone())
+        .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+        .await?;
+
+    assert_eq!(summary.indexed, 0);
+    assert_eq!(summary.skipped_non_allow, 1);
+    assert!(
+        !projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+            .await?
+    );
+    assert!(store.signals().is_empty(), "no false risk labels");
+    Ok(())
+}
+
+#[tokio::test]
+async fn ingest_allow_records_no_artifacts() -> Result<()> {
+    // allow verdict は投影のみで moderation artifact を作らない。
+    let docs = Arc::new(MemoryDocsSync::default());
+    let projection = Arc::new(MemoryIndexProjection::new());
+    let topic = TopicId::new("rust");
+    let replica = topic_replica_id("rust");
+    let object_id = persist_post(&docs, &replica, &topic, "clean content").await;
+
+    let (service, store) = allow_service();
+    let summary = IngestPipeline::new(docs.clone(), service, projection.clone())
+        .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+        .await?;
+
+    assert_eq!(summary.indexed, 1);
+    assert!(
+        projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+            .await?
+    );
+    assert!(store.events().is_empty());
+    assert!(store.signals().is_empty());
     Ok(())
 }


### PR DESCRIPTION
@
## 概要

Issue #406 の runtime 結線。community node runtime から `SafetyOrchestrator` を構築・呼び出す境界を作り、scan で生成される risk signal / signed moderation event を永続化して trust / relation reads が消費できる形で供給する。

これまで `SafetyScanReport` の `moderation_event` / `risk_signal` は ingest 時に破棄されており、本番経路（`cn-indexer/src/runtime.rs`）では orchestrator が一度も構築されていなかった。本 PR がその欠落を埋める。

## 変更内容

### cn-core（新規 `safety_runtime.rs`）
- `SafetyScanService::scan_and_record()`: scan → risk signal 永続化 → moderation event を secp256k1 実鍵署名して永続化を合成。allow / fail-closed / artifact 生成可否の判断は `cn-safety-runtime` の artifacts ガードレールに委ね、再判断しない（単一判定点）。
- `SafetyArtifactStore` trait（`PgSafetyArtifactStore` / contract test 用 `MemorySafetyArtifactStore`）。
- `build_safety_orchestrator` / `build_safety_scan_service`: `SystemScanClock` + `UuidEventIdGenerator` + provider 群での構築境界。**未知 provider 名は `required` に依らず Err / emit 有効で署名鍵なしは Err / provider 未構成は `Ok(None)`（service を作らず ingest を起動しない）** の fail-closed。mock provider は `safety-mock-provider` feature でのみ解決。

### cn-core（新規 `trust_inputs.rs`）
- `list_trust_risk_inputs()`: risk signal を ADR 0026 §2.7 に従い category で **絶対成分**（Csam/Cse/Grooming）/ **相対成分**（nsfw/spam 等）へ振り分けて返す。expiry 失効を除外、appeal を反映（`Cleared`=寄与除外 / `Disputed`=据え置き、§6.2）、basis/confidence/visibility を必ず同伴（断定ラベルにしない）。#415 の read surface がこれを消費する契約を contract test で固定。

### cn-indexer
- `IngestPipeline` を `Arc<SafetyScanService>` 経由に差し替え。verdict gate / de-index / fail-closed カウントは不変（#404 の領域は侵さない）。
- runtime / config に構築境界を結線（`COMMUNITY_NODE_SAFETY_PROVIDER_*` / `_SIGNING_KEY` / `_EMIT_SIGNED_EVENTS` env）。ingest loop の起動は本番 provider（#391）と fail-closed indexing 本体（#404）待ちのまま。

## スコープ境界
- trust/relation の read surface 本体・スコアリング・HTTP endpoint は **#415**（本 PR は入力供給 API + contract 固定まで）。
- ingest loop 起動・search/discovery 除外は **#404 / #391**。

## テスト
- `cargo test -p kukuri-cn-safety-runtime -p kukuri-cn-core -p kukuri-cn-indexer`（DB 不要）全 green。
- `KUKURI_CN_RUN_INTEGRATION_TESTS=1 cargo test -p kukuri-cn-core --test safety_events`（実 Postgres）全 green。scan_and_record の Pg 永続化と trust 入力の絶対/相対振り分けを end-to-end で確認。
- `cargo clippy -p kukuri-cn-core -p kukuri-cn-indexer --all-targets -- -D warnings` クリーン。
- `cargo build --workspace` 成功。

受け入れ条件「trustness / relation に risk signal を反映できる（runtime 結線部分）」を満たす。

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@