### PR TITLE
feat(cn): Project Arachnid Shield known-CSAM provider 統合 (#391)

### DIFF
--- a/.env.community-node.example
+++ b/.env.community-node.example
@@ -50,6 +50,19 @@ COMMUNITY_NODE_CONNECTIVITY_URLS=http://127.0.0.1:13340
 # 有効化する場合は cn-user-api にも COMMUNITY_NODE_ARCADEDB_*（cn-indexer と同一値）を渡す。
 # COMMUNITY_NODE_INDEX_QUERY_ENABLED=false
 
+# safety provider（#391 Project Arachnid Shield）。public-node profile では known-CSAM
+# provider が必須。provider 名を known_csam slot に設定し、credentials を env で渡す。
+# 未設定のまま provider を指定すると cn-indexer の runtime 構築が失敗し ingest は起動しない
+# （fail-closed）。credentials は operator 自身が https://projectarachnid.com で取得する。
+# kukuri は credentials を同梱・共有・代理利用しない。値をコミットしないこと。
+# COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM=project-arachnid-shield
+# COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM_REQUIRED=true
+# PROJECT_ARACHNID_API_USERNAME=change_me
+# PROJECT_ARACHNID_API_PASSWORD=change_me
+# 任意の上書き（未設定なら既定値）:
+# PROJECT_ARACHNID_API_BASE_URL=https://shield.projectarachnid.com
+# PROJECT_ARACHNID_API_TIMEOUT_SECS=30
+
 CN_USER_API_HOST_BIND_IP=127.0.0.1
 CN_USER_API_PORT=18080
 CN_IROH_RELAY_HTTP_HOST_BIND_IP=127.0.0.1

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,15 @@ RELAY_TOPICS=kukuri:tauri:public
 RELAY_N0_LOG_LEVEL=info
 RELAY_N0_BIND_ADDRESS=0.0.0.0:11226
 RELAY_N0_TOPICS=kukuri:tauri:public
+
+# Community node safety providers (#391)
+# Project Arachnid Shield: each operator obtains their own credentials at
+# https://projectarachnid.com and configures them here. kukuri does not ship,
+# share, or proxy any credentials. Values must never be committed.
+# COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM=project-arachnid-shield
+# COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM_REQUIRED=true
+# PROJECT_ARACHNID_API_USERNAME=change_me
+# PROJECT_ARACHNID_API_PASSWORD=change_me
+# Optional overrides:
+# PROJECT_ARACHNID_API_BASE_URL=https://shield.projectarachnid.com
+# PROJECT_ARACHNID_API_TIMEOUT_SECS=30

--- a/.env.example
+++ b/.env.example
@@ -13,15 +13,3 @@ RELAY_TOPICS=kukuri:tauri:public
 RELAY_N0_LOG_LEVEL=info
 RELAY_N0_BIND_ADDRESS=0.0.0.0:11226
 RELAY_N0_TOPICS=kukuri:tauri:public
-
-# Community node safety providers (#391)
-# Project Arachnid Shield: each operator obtains their own credentials at
-# https://projectarachnid.com and configures them here. kukuri does not ship,
-# share, or proxy any credentials. Values must never be committed.
-# COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM=project-arachnid-shield
-# COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM_REQUIRED=true
-# PROJECT_ARACHNID_API_USERNAME=change_me
-# PROJECT_ARACHNID_API_PASSWORD=change_me
-# Optional overrides:
-# PROJECT_ARACHNID_API_BASE_URL=https://shield.projectarachnid.com
-# PROJECT_ARACHNID_API_TIMEOUT_SECS=30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1048,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +1874,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2936,6 +2970,7 @@ dependencies = [
  "jsonwebtoken",
  "kukuri-cn-core",
  "kukuri-cn-safety",
+ "kukuri-cn-safety-arachnid",
  "kukuri-cn-safety-runtime",
  "kukuri-core",
  "redis",
@@ -2997,6 +3032,7 @@ dependencies = [
  "anyhow",
  "clap",
  "kukuri-cn-safety",
+ "kukuri-cn-safety-arachnid",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3014,6 +3050,21 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "kukuri-cn-safety-arachnid"
+version = "0.1.2"
+dependencies = [
+ "async-trait",
+ "kukuri-cn-safety",
+ "kukuri-cn-safety-runtime",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "wiremock",
 ]
 
 [[package]]
@@ -3825,6 +3876,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4715,6 +4776,18 @@ dependencies = [
  "libc",
  "rustix",
  "windows",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -6703,7 +6776,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7128,6 +7201,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/cn-cli",
     "crates/cn-operator",
     "crates/cn-safety",
+    "crates/cn-safety-arachnid",
     "crates/cn-safety-runtime",
     "crates/cn-indexer",
 ]
@@ -74,6 +75,7 @@ tower-http = { version = "0.6.8", features = ["trace"] }
 tower_governor = "0.8.0"
 url = "2.5.8"
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
+wiremock = "0.6"
 
 [patch.crates-io]
 netwatch = { git = "https://github.com/n0-computer/net-tools", rev = "8b2d36b9be2b44281fdbf58121a9ab6a739919bc" }

--- a/crates/cn-core/Cargo.toml
+++ b/crates/cn-core/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 # provider 実装名 `mock` を runtime 構築（build_safety_orchestrator）で解決できるようにする。
 # 本番 provider（#391 / #411）実装まで、contract test / 明示 opt-in 構成でのみ使う。
 safety-mock-provider = ["kukuri-cn-safety/mock"]
+# provider 実装名 `project-arachnid-shield`（#391）を known_csam slot で解決できるようにする。
+# reqwest 依存を持ち込むため optional にし、runtime を持つ crate（cn-indexer 等）が有効化する。
+safety-arachnid-provider = ["dep:kukuri-cn-safety-arachnid"]
 
 [dependencies]
 anyhow.workspace = true
@@ -29,6 +32,7 @@ url.workspace = true
 uuid.workspace = true
 kukuri-core = { path = "../core" }
 kukuri-cn-safety = { path = "../cn-safety" }
+kukuri-cn-safety-arachnid = { path = "../cn-safety-arachnid", optional = true }
 kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 
 [dev-dependencies]
@@ -37,4 +41,4 @@ kukuri-cn-safety = { path = "../cn-safety", features = ["mock"] }
 kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 # 自分自身を feature 付き dev-dependency にすることで、tests/ から mock provider 解決を使える
 # （feature unification によりテストビルド時のみ有効になる。cn-safety と同じ流儀）。
-kukuri-cn-core = { path = ".", features = ["safety-mock-provider"] }
+kukuri-cn-core = { path = ".", features = ["safety-mock-provider", "safety-arachnid-provider"] }

--- a/crates/cn-core/src/safety_runtime.rs
+++ b/crates/cn-core/src/safety_runtime.rs
@@ -521,21 +521,51 @@ pub fn build_safety_orchestrator(
 
 /// provider 実装名を実装に解決する。
 ///
-/// 現状解決できるのは `mock`（`safety-mock-provider` feature 有効時）のみ。本番 provider
-/// 実装名（#391 Project Arachnid Shield 等）はここに match arm を追加する。未知の名前は
-/// `required` に依らず Err（fail-closed）。
+/// 解決できるのは `mock`（`safety-mock-provider` feature）と `project-arachnid-shield`
+/// （`safety-arachnid-provider` feature、#391）。未知の名前は `required` に依らず Err
+/// （fail-closed）。
 fn resolve_provider(
     slot: &'static str,
     entry: &SafetyRuntimeProviderEntry,
 ) -> Result<Arc<dyn SafetyProvider>> {
-    match entry.provider.trim() {
+    // operator-config の underscore 表記（`project_arachnid_shield`）も受理するため、
+    // hyphen へ正規化してから解決する（cn-operator readiness と同じ規則）。
+    let normalized = entry.provider.trim().replace('_', "-");
+    match normalized.as_str() {
         #[cfg(feature = "safety-mock-provider")]
         "mock" => Ok(mock_provider_for_slot(slot)),
+        #[cfg(feature = "safety-arachnid-provider")]
+        kukuri_cn_safety_arachnid::PROVIDER_NAME => arachnid_shield_provider(slot),
         other => bail!(
             "unknown safety provider `{other}` for slot `{slot}` \
-             (fail-closed; production providers are added in #391 / #411)"
+             (fail-closed; unknown-CSAM classifier providers are added in #411)"
         ),
     }
+}
+
+/// Project Arachnid Shield provider（#391）を組み立てる。
+///
+/// - known_csam slot 専用（Shield は known-match provider であり、general / unknown_csam の
+///   役割は果たさない）。他 slot に指定されたら Err（fail-closed）。
+/// - operator-owned credentials は env（既定: `PROJECT_ARACHNID_API_USERNAME` /
+///   `PROJECT_ARACHNID_API_PASSWORD`）から読む。欠落は Err = 起動失敗（fail-closed）。
+///   エラーには env の名前のみ含まれ、値は含まれない。
+/// - media fetcher は未接続（media scan pipeline 側の issue で注入する）。それまで
+///   media_hint 付き scan は provider が `Unavailable` を返し fail-closed に倒れる。
+#[cfg(feature = "safety-arachnid-provider")]
+fn arachnid_shield_provider(slot: &'static str) -> Result<Arc<dyn SafetyProvider>> {
+    use anyhow::Context;
+
+    if slot != "known_csam" {
+        bail!(
+            "safety provider `{}` only supports the `known_csam` slot (got `{slot}`); \
+             it is a known-match provider and must not be used for general / unknown-CSAM slots",
+            kukuri_cn_safety_arachnid::PROVIDER_NAME
+        );
+    }
+    let provider = kukuri_cn_safety_arachnid::ProjectArachnidShieldProvider::from_env()
+        .context("failed to configure the project-arachnid-shield safety provider")?;
+    Ok(Arc::new(provider))
 }
 
 /// slot に対応する capability を持つ mock provider を作る（test / 構成検証用）。

--- a/crates/cn-core/tests/safety_runtime.rs
+++ b/crates/cn-core/tests/safety_runtime.rs
@@ -243,6 +243,64 @@ fn build_orchestrator_rejects_unknown_provider_name() {
 }
 
 #[test]
+fn build_orchestrator_resolves_arachnid_shield_only_with_credentials() {
+    // env は process-global なため、この 1 テスト内で「欠落 → Err」と「設定 → Ok」を順に
+    // 検証する（他テストはこの env を読まない）。
+    let providers = SafetyRuntimeProvidersConfig {
+        known_csam: Some(SafetyRuntimeProviderEntry {
+            provider: "project-arachnid-shield".to_string(),
+            required: true,
+        }),
+        ..Default::default()
+    };
+
+    // credentials 欠落 → Err（起動 fail-closed）。エラーは env 名のみで値を含まない。
+    unsafe {
+        std::env::remove_var("PROJECT_ARACHNID_API_USERNAME");
+        std::env::remove_var("PROJECT_ARACHNID_API_PASSWORD");
+    }
+    let error = build_safety_orchestrator("issuer-node", &providers, None).unwrap_err();
+    let message = format!("{error:#}");
+    assert!(message.contains("project-arachnid-shield"), "{message}");
+    assert!(
+        message.contains("PROJECT_ARACHNID_API_USERNAME"),
+        "{message}"
+    );
+
+    // credentials があれば構築できる。
+    unsafe {
+        std::env::set_var("PROJECT_ARACHNID_API_USERNAME", "operator-user");
+        std::env::set_var("PROJECT_ARACHNID_API_PASSWORD", "operator-pass");
+    }
+    let result = build_safety_orchestrator("issuer-node", &providers, None);
+    unsafe {
+        std::env::remove_var("PROJECT_ARACHNID_API_USERNAME");
+        std::env::remove_var("PROJECT_ARACHNID_API_PASSWORD");
+    }
+    result.expect("orchestrator should build once credentials are configured");
+}
+
+#[test]
+fn build_orchestrator_rejects_arachnid_shield_outside_known_csam_slot() {
+    // Shield は known-match provider。general / unknown_csam slot への指定は fail-closed。
+    let providers = SafetyRuntimeProvidersConfig {
+        known_csam: mock_slot(),
+        general: Some(SafetyRuntimeProviderEntry {
+            provider: "project-arachnid-shield".to_string(),
+            required: false,
+        }),
+        ..Default::default()
+    };
+    let error = build_safety_orchestrator("issuer-node", &providers, None).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("only supports the `known_csam` slot"),
+        "{error}"
+    );
+}
+
+#[test]
 fn build_orchestrator_rejects_empty_provider_set() {
     let providers = SafetyRuntimeProvidersConfig::default();
     let error = build_safety_orchestrator("issuer-node", &providers, None).unwrap_err();

--- a/crates/cn-indexer/Cargo.toml
+++ b/crates/cn-indexer/Cargo.toml
@@ -28,10 +28,12 @@ tracing-subscriber.workspace = true
 kukuri-core = { path = "../core" }
 kukuri-docs-sync = { path = "../docs-sync" }
 kukuri-transport = { path = "../transport" }
-# safety-mock-provider: 本番 provider（#391 / #411）実装まで、runtime 構築（provider 実装名
-# `mock`）と contract test を成立させるため有効化する。mock provider は operator が env で
-# 明示指定しない限り構成されず、未知の provider 名は fail-closed で Err になる。
-kukuri-cn-core = { path = "../cn-core", features = ["safety-mock-provider"] }
+# safety-mock-provider: 本番 provider 未使用構成でも runtime 構築（provider 実装名 `mock`）と
+# contract test を成立させるため有効化する。mock provider は operator が env で明示指定しない
+# 限り構成されず、未知の provider 名は fail-closed で Err になる。
+# safety-arachnid-provider: Project Arachnid Shield（#391、provider 実装名
+# `project-arachnid-shield`）。operator-owned credentials は env から読む。
+kukuri-cn-core = { path = "../cn-core", features = ["safety-mock-provider", "safety-arachnid-provider"] }
 kukuri-cn-safety = { path = "../cn-safety" }
 kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 

--- a/crates/cn-operator/Cargo.toml
+++ b/crates/cn-operator/Cargo.toml
@@ -14,11 +14,14 @@ path = "src/main.rs"
 
 [features]
 safety-mock = ["kukuri-cn-safety/mock", "dep:tokio"]
+# `safety test-provider project-arachnid-shield`（実 API への connectivity check、#391）。
+safety-arachnid = ["dep:kukuri-cn-safety-arachnid", "dep:tokio"]
 
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
 kukuri-cn-safety = { path = "../cn-safety" }
+kukuri-cn-safety-arachnid = { path = "../cn-safety-arachnid", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/cn-operator/src/lib.rs
+++ b/crates/cn-operator/src/lib.rs
@@ -90,9 +90,10 @@ safety:
     signing_key_secret_id: kukuri-cn-safety-signing-key
   providers:
     # known_csam は public-node readiness の必須 provider。本番では実際の
-    # known-CSAM provider 名（例: project_arachnid_shield）と secret ID を設定する。
+    # known-CSAM provider 名と secret ID を設定する。`project-arachnid-shield`（#391）は
+    # operator 自身の Project Arachnid Shield credentials を env で与える。
     known_csam:
-      provider: project_arachnid_shield
+      provider: project-arachnid-shield
       required: true
       credential_secret_id: kukuri-cn-safety-known-csam
     # general / unknown_csam は任意。下記は本番値ではない placeholder。

--- a/crates/cn-operator/src/main.rs
+++ b/crates/cn-operator/src/main.rs
@@ -80,8 +80,12 @@ enum SafetyCommand {
         #[arg(long, default_value = "public-node")]
         profile: String,
     },
-    /// mock provider で scan -> route -> verdict 経路を検査する。
+    /// provider 経路を検査する。provider 名を指定すると実 API への connectivity check、
+    /// 省略すると mock provider で scan -> route -> verdict 経路を検査する。
     TestProvider {
+        /// 実 provider の connectivity check（対応: `project-arachnid-shield`）。
+        /// credentials は env から読み、値は表示しない。
+        provider: Option<String>,
         #[arg(long, default_value = "blob-test")]
         subject_id: String,
         #[arg(long, value_enum, default_value_t = TestProviderScenario::KnownMatch)]
@@ -206,10 +210,100 @@ fn run_safety(action: SafetyCommand) -> Result<ExitCode> {
             }
         }
         SafetyCommand::TestProvider {
+            provider,
             subject_id,
             scenario,
-        } => run_safety_test_provider(subject_id, scenario),
+        } => match provider
+            .as_deref()
+            .map(|name| name.trim().replace('_', "-"))
+        {
+            Some(name) if name == "project-arachnid-shield" => run_safety_test_arachnid_shield(),
+            Some(other) => {
+                eprintln!(
+                    "未対応の provider です: {other}（対応: project-arachnid-shield。\
+                     省略時は mock 経路を検査します）"
+                );
+                Ok(ExitCode::FAILURE)
+            }
+            None => run_safety_test_provider(subject_id, scenario),
+        },
     }
+}
+
+/// Project Arachnid Shield への connectivity check（#391）。
+///
+/// env（既定: `PROJECT_ARACHNID_API_USERNAME` / `PROJECT_ARACHNID_API_PASSWORD`）から
+/// operator-owned credentials を読み、合成 PDQ hash（実画像由来ではない固定値）を
+/// `POST /v1/pdq` に送って認証・接続・応答写像を確認する。credentials の値・Match Data は
+/// 表示しない。
+#[cfg(feature = "safety-arachnid")]
+fn run_safety_test_arachnid_shield() -> Result<ExitCode> {
+    use kukuri_cn_safety_arachnid::{ShieldClient, ShieldError, ShieldProviderConfig};
+
+    // 合成 PDQ hash（Shield API の期待形式 = 32 bytes の base64。実画像から計算したものではない。
+    // 2026-07-02 に実 API で形式を確認済み）。
+    const PROBE_PDQ_HASH: &str = "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=";
+
+    let config = ShieldProviderConfig::from_env()?;
+    println!("provider: project-arachnid-shield");
+    println!("api_base_url: {}", config.api_base_url);
+    println!(
+        "credentials: env {} / {}（値は表示しません）",
+        config.api_username_env, config.api_password_env
+    );
+
+    let client = match ShieldClient::from_config(&config) {
+        Ok(client) => client,
+        Err(error) => {
+            eprintln!("NG: {error}");
+            eprintln!(
+                "credentials が未設定です。operator 自身の Project Arachnid Shield account の credentials を env に設定してください。"
+            );
+            return Ok(ExitCode::FAILURE);
+        }
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("tokio runtime の作成に失敗しました")?;
+    let result = runtime.block_on(client.scan_pdq(&[PROBE_PDQ_HASH.to_string()]));
+    match result {
+        Ok(scanned) => {
+            println!("connectivity: OK（認証成功・応答を受信）");
+            match scanned.get(PROBE_PDQ_HASH) {
+                Some(scan) => println!("probe_classification: {:?}", scan.classification),
+                None => println!("probe_classification: (応答に probe hash のエントリなし)"),
+            }
+            println!(
+                "注意: `no-known-match` は安全の証明ではありません（scan 時点で既知データに一致しなかったことのみを意味します）。"
+            );
+            Ok(ExitCode::SUCCESS)
+        }
+        Err(error @ ShieldError::Unauthorized { .. }) => {
+            eprintln!("NG: {error}");
+            eprintln!(
+                "credentials が拒否されました。env {} / {} の値（表示しません）を確認してください。",
+                config.api_username_env, config.api_password_env
+            );
+            Ok(ExitCode::FAILURE)
+        }
+        Err(error) => {
+            eprintln!("NG: {error}");
+            eprintln!(
+                "fail-closed: この状態では known-CSAM scan が実行できないため、public indexing は有効化できません。"
+            );
+            Ok(ExitCode::FAILURE)
+        }
+    }
+}
+
+#[cfg(not(feature = "safety-arachnid"))]
+fn run_safety_test_arachnid_shield() -> Result<ExitCode> {
+    eprintln!(
+        "safety test-provider project-arachnid-shield は `cargo run -p kukuri-cn-operator --features safety-arachnid -- safety test-provider project-arachnid-shield` で実行してください"
+    );
+    Ok(ExitCode::FAILURE)
 }
 
 #[cfg(feature = "safety-mock")]

--- a/crates/cn-operator/src/safety_readiness.rs
+++ b/crates/cn-operator/src/safety_readiness.rs
@@ -10,10 +10,11 @@ pub const PUBLIC_NODE_PROFILE: &str = "public-node";
 /// 通常経路（`evaluate_public_node_readiness`）と safety セクション欠落経路
 /// （`missing_safety_report`）の双方が、必ずこの集合を同じ順序で網羅する。ID で機械処理する
 /// 消費側が経路ごとの差異に依存しないことを保証する（テストで固定）。
-pub const READINESS_CHECK_IDS: [&str; 12] = [
+pub const READINESS_CHECK_IDS: [&str; 13] = [
     "safety_config_present",
     "safety_profile_public_node",
     "known_csam_provider_configured",
+    "known_csam_provider_resolvable",
     "known_csam_provider_required",
     "index_before_scan_disabled",
     "scan_error_fail_closed",
@@ -121,6 +122,7 @@ pub fn evaluate_public_node_readiness(
             ),
             check_profile(safety, profile),
             check_known_provider_configured(safety),
+            check_known_provider_resolvable(safety),
             check_known_provider_required(safety),
             check_index_before_scan(safety),
             check_on_scan_error(safety),
@@ -196,6 +198,38 @@ fn check_known_provider_configured(safety: &SafetyConfig) -> ReadinessCheck {
             provider.provider
         ),
     )
+}
+
+/// runtime（`resolve_provider`、cn-core）が解決できる known_csam provider 実装名。
+///
+/// underscore 表記（`project_arachnid_shield`）は runtime と同様に hyphen へ正規化して
+/// 受理する。ここに無い実装名は runtime 構築が fail-closed で失敗するため、readiness の
+/// 段階で fail にして設定ミスを早期に検出する。
+const RESOLVABLE_KNOWN_CSAM_PROVIDERS: [&str; 2] = ["mock", "project-arachnid-shield"];
+
+fn check_known_provider_resolvable(safety: &SafetyConfig) -> ReadinessCheck {
+    let Some(provider) = known_csam_provider(safety) else {
+        return fail(
+            "known_csam_provider_resolvable",
+            "known CSAM provider is missing".to_string(),
+        );
+    };
+    let normalized = provider.provider.trim().replace('_', "-");
+    if RESOLVABLE_KNOWN_CSAM_PROVIDERS.contains(&normalized.as_str()) {
+        pass(
+            "known_csam_provider_resolvable",
+            format!("provider={normalized} is resolvable by the runtime"),
+        )
+    } else {
+        fail(
+            "known_csam_provider_resolvable",
+            format!(
+                "provider `{}` is not a known implementation (supported: {})",
+                provider.provider,
+                RESOLVABLE_KNOWN_CSAM_PROVIDERS.join(" / ")
+            ),
+        )
+    }
 }
 
 fn check_known_provider_required(safety: &SafetyConfig) -> ReadinessCheck {

--- a/crates/cn-operator/tests/safety.rs
+++ b/crates/cn-operator/tests/safety.rs
@@ -80,6 +80,11 @@ fn readiness_complete_static_config_has_unknown_runtime_checks() {
     );
     assert_check(
         &report,
+        "known_csam_provider_resolvable",
+        ReadinessStatus::Pass,
+    );
+    assert_check(
+        &report,
         "known_csam_provider_required",
         ReadinessStatus::Pass,
     );
@@ -194,7 +199,7 @@ fn safety_readiness_cli_fails_on_static_failure() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(!output.status.success(), "stdout:\n{stdout}");
     assert!(stdout.contains("static_ok=false"), "stdout:\n{stdout}");
-    assert!(stdout.contains("fail=12"), "stdout:\n{stdout}");
+    assert!(stdout.contains("fail=13"), "stdout:\n{stdout}");
 }
 
 #[test]
@@ -233,6 +238,38 @@ fn readiness_fails_without_known_csam_provider() {
         &report,
         "known_csam_credential_secret_configured",
         ReadinessStatus::Fail,
+    );
+}
+
+#[test]
+fn readiness_fails_for_unresolvable_provider_name() {
+    // runtime が解決できない実装名は readiness の段階で fail（起動時ではなく設定時に検出）。
+    let yaml = config_with_safety(&complete_safety().replace(
+        "provider: project_arachnid_shield",
+        "provider: some-future-provider",
+    ));
+    let resolved = load_and_validate(&yaml).unwrap();
+    let report = evaluate_public_node_readiness(&resolved, "public-node");
+    assert_check(
+        &report,
+        "known_csam_provider_resolvable",
+        ReadinessStatus::Fail,
+    );
+}
+
+#[test]
+fn readiness_accepts_canonical_hyphenated_provider_name() {
+    // 正規名（hyphen 表記）も underscore 表記と同様に解決可能と判定する。
+    let yaml = config_with_safety(&complete_safety().replace(
+        "provider: project_arachnid_shield",
+        "provider: project-arachnid-shield",
+    ));
+    let resolved = load_and_validate(&yaml).unwrap();
+    let report = evaluate_public_node_readiness(&resolved, "public-node");
+    assert_check(
+        &report,
+        "known_csam_provider_resolvable",
+        ReadinessStatus::Pass,
     );
 }
 

--- a/crates/cn-safety-arachnid/Cargo.toml
+++ b/crates/cn-safety-arachnid/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "kukuri-cn-safety-arachnid"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "kukuri_cn_safety_arachnid"
+path = "src/lib.rs"
+
+[dependencies]
+async-trait.workspace = true
+kukuri-cn-safety = { path = "../cn-safety" }
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
+tokio.workspace = true
+wiremock.workspace = true

--- a/crates/cn-safety-arachnid/src/client.rs
+++ b/crates/cn-safety-arachnid/src/client.rs
@@ -1,0 +1,212 @@
+//! Shield API の最小 HTTP client（#391）。
+//!
+//! OpenAPI 1.1.0（`https://shield.projectarachnid.com/openapi.json`）のうち scan に必要な
+//! `POST /v1/media`（media bytes 直送）と、connectivity check 用の `POST /v1/pdq` のみを扱う。
+//! `POST /v1/media/submit`（analyst への提出）と `POST /v1/url` は実装しない（#391 non-goal /
+//! follow-up）。
+//!
+//! **Match Data 非保持**: 応答から deserialize するのは `classification` / `match_type` のみ。
+//! `near_match_details`・一致先 sha1/sha256・timestamp は型に存在しないため、保存・log 出力の
+//! 経路が構造的に無い。エラーにも応答 body を含めない（HTTP status のみ）。
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+use kukuri_cn_safety::ScanError;
+
+use crate::config::{ShieldConfigError, ShieldCredentials, ShieldProviderConfig};
+
+/// Shield の classification。
+///
+/// 未知の値（API 側の将来拡張）は deserialize エラー → `ShieldError::Protocol` → fail-closed
+/// に倒れる（勝手に安全側でない解釈をしない）。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ShieldClassification {
+    Csam,
+    HarmfulAbusiveMaterial,
+    Test,
+    NoKnownMatch,
+}
+
+/// 一致種別。`exact` = 既知 hash 完全一致、`near` = PDQ 知覚ハッシュ近傍一致。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ShieldMatchType {
+    Exact,
+    Near,
+}
+
+/// scan 判定に使う最小の応答。Match Data（近傍一致の詳細・一致先 hash 等）は含まない。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+pub struct ShieldScanResult {
+    pub classification: ShieldClassification,
+    #[serde(default)]
+    pub match_type: Option<ShieldMatchType>,
+}
+
+/// `POST /v1/pdq` の応答（hash ごとの判定のみ）。
+#[derive(Debug, Deserialize)]
+struct PdqResponse {
+    scanned_hashes: BTreeMap<String, ShieldScanResult>,
+}
+
+/// client のエラー。応答 body・credential 値を含めない。
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum ShieldError {
+    #[error(
+        "project arachnid shield rejected the configured credentials (HTTP {status}); \
+         verify the operator account credentials"
+    )]
+    Unauthorized { status: u16 },
+    #[error("project arachnid shield returned HTTP {status}")]
+    Http { status: u16 },
+    #[error("project arachnid shield request timed out")]
+    Timeout,
+    #[error("failed to reach project arachnid shield: {detail}")]
+    Network { detail: String },
+    #[error("unexpected response from project arachnid shield: {detail}")]
+    Protocol { detail: String },
+}
+
+impl From<ShieldError> for ScanError {
+    /// fail-closed 写像。どの variant も `allow` に落ちる `ScanOutcome` へは写像されない
+    /// （`Unavailable` → `ScanOutcome::Unavailable`、`Timeout` / `Protocol` → `Failed`）。
+    fn from(error: ShieldError) -> Self {
+        match error {
+            ShieldError::Unauthorized { .. } | ShieldError::Network { .. } => {
+                ScanError::Unavailable(error.to_string())
+            }
+            // 429 / 5xx は一時的な provider 側の不調として Unavailable、その他は Protocol。
+            ShieldError::Http { status } if status == 429 || status >= 500 => {
+                ScanError::Unavailable(error.to_string())
+            }
+            ShieldError::Http { .. } => ScanError::Protocol(error.to_string()),
+            ShieldError::Timeout => ScanError::Timeout(error.to_string()),
+            ShieldError::Protocol { .. } => ScanError::Protocol(error.to_string()),
+        }
+    }
+}
+
+/// Shield API client。`Debug` は credentials を出さない。
+#[derive(Clone)]
+pub struct ShieldClient {
+    http: reqwest::Client,
+    base_url: String,
+    credentials: ShieldCredentials,
+}
+
+impl std::fmt::Debug for ShieldClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ShieldClient")
+            .field("base_url", &self.base_url)
+            .field("credentials", &self.credentials)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ShieldClient {
+    /// 設定と credentials から client を組み立てる。
+    pub fn new(
+        config: &ShieldProviderConfig,
+        credentials: ShieldCredentials,
+    ) -> Result<Self, ShieldConfigError> {
+        let http = reqwest::Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .map_err(|error| ShieldConfigError::Client {
+                detail: error.to_string(),
+            })?;
+        Ok(Self {
+            http,
+            base_url: config.api_base_url.trim_end_matches('/').to_string(),
+            credentials,
+        })
+    }
+
+    /// 設定から credentials を env 経由で読み、client を組み立てる。
+    pub fn from_config(config: &ShieldProviderConfig) -> Result<Self, ShieldConfigError> {
+        let credentials = config.load_credentials()?;
+        Self::new(config, credentials)
+    }
+
+    /// `POST /v1/media` — media bytes を直送して scan する。
+    ///
+    /// body は HTTP request としてのみ使われ、この client は保存しない。
+    pub async fn scan_media(
+        &self,
+        bytes: Vec<u8>,
+        content_type: &str,
+    ) -> Result<ShieldScanResult, ShieldError> {
+        let response = self
+            .http
+            .post(format!("{}/v1/media", self.base_url))
+            .basic_auth(&self.credentials.username, Some(&self.credentials.password))
+            .header(reqwest::header::CONTENT_TYPE, content_type)
+            .body(bytes)
+            .send()
+            .await
+            .map_err(map_transport_error)?;
+        decode_response(response).await
+    }
+
+    /// `POST /v1/pdq` — PDQ hash 群を scan する（connectivity check / hash submission 用）。
+    ///
+    /// hash は **32 bytes の PDQ hash を base64 encode した文字列**（実 API で確認済み。
+    /// hex 表現は `invalid pdq hash` の 400 になる）。
+    pub async fn scan_pdq(
+        &self,
+        hashes: &[String],
+    ) -> Result<BTreeMap<String, ShieldScanResult>, ShieldError> {
+        let response = self
+            .http
+            .post(format!("{}/v1/pdq", self.base_url))
+            .basic_auth(&self.credentials.username, Some(&self.credentials.password))
+            .json(&serde_json::json!({ "hashes": hashes }))
+            .send()
+            .await
+            .map_err(map_transport_error)?;
+        let parsed: PdqResponse = decode_response(response).await?;
+        Ok(parsed.scanned_hashes)
+    }
+}
+
+/// 応答を検査して JSON を deserialize する。
+///
+/// 非 200 は body を読まずに status のみでエラー化する（Match Data・エラー body を
+/// エラー文字列に取り込まない）。
+async fn decode_response<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T, ShieldError> {
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(ShieldError::Unauthorized {
+            status: status.as_u16(),
+        });
+    }
+    if !status.is_success() {
+        return Err(ShieldError::Http {
+            status: status.as_u16(),
+        });
+    }
+    response
+        .json::<T>()
+        .await
+        .map_err(|error| ShieldError::Protocol {
+            // reqwest の decode エラーは応答 body を含まない（serde のエラー分類のみ）。
+            // without_url で表示から URL も取り除く（表示情報の最小化）。
+            detail: format!("failed to decode scan response: {}", error.without_url()),
+        })
+}
+
+/// 送信段階の transport エラーを写像する。
+fn map_transport_error(error: reqwest::Error) -> ShieldError {
+    if error.is_timeout() {
+        return ShieldError::Timeout;
+    }
+    ShieldError::Network {
+        detail: error.without_url().to_string(),
+    }
+}

--- a/crates/cn-safety-arachnid/src/config.rs
+++ b/crates/cn-safety-arachnid/src/config.rs
@@ -1,0 +1,138 @@
+//! provider 設定と operator-owned credentials の読み込み（#391）。
+//!
+//! credentials は env（名前は設定で差し替え可能）からのみ読む。値を repository / config /
+//! log に置かない。エラーは env の**名前**だけを含み、値は決して含まない。
+
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Shield API の既定 base URL。
+pub const DEFAULT_API_BASE_URL: &str = "https://shield.projectarachnid.com";
+/// credentials username を読む env の既定名（Project Arachnid 管理ページの表記に合わせる）。
+pub const DEFAULT_API_USERNAME_ENV: &str = "PROJECT_ARACHNID_API_USERNAME";
+/// credentials password を読む env の既定名（同上）。
+pub const DEFAULT_API_PASSWORD_ENV: &str = "PROJECT_ARACHNID_API_PASSWORD";
+/// base URL を上書きする env（テスト / self-host 用。未設定なら既定 URL）。
+pub const API_BASE_URL_ENV: &str = "PROJECT_ARACHNID_API_BASE_URL";
+/// HTTP timeout（秒）を上書きする env。
+pub const API_TIMEOUT_SECS_ENV: &str = "PROJECT_ARACHNID_API_TIMEOUT_SECS";
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// 設定・credentials 読み込みのエラー。
+///
+/// env の名前のみを含む。credential の値・部分文字列を含めてはならない。
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum ShieldConfigError {
+    #[error(
+        "environment variable `{env}` is required for the project-arachnid-shield provider \
+         but is missing or empty"
+    )]
+    MissingCredential { env: String },
+    #[error("environment variable `{env}` has an invalid value: {detail}")]
+    InvalidEnv { env: String, detail: String },
+    #[error("failed to construct the project-arachnid-shield HTTP client: {detail}")]
+    Client { detail: String },
+}
+
+/// provider の実行時設定。credential の**値**は持たない（env 名のみ）。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShieldProviderConfig {
+    /// Shield API の base URL（末尾 `/` なし）。
+    pub api_base_url: String,
+    /// username を読む env 名。
+    pub api_username_env: String,
+    /// password を読む env 名。
+    pub api_password_env: String,
+    /// HTTP timeout。
+    pub timeout: Duration,
+}
+
+impl Default for ShieldProviderConfig {
+    fn default() -> Self {
+        Self {
+            api_base_url: DEFAULT_API_BASE_URL.to_string(),
+            api_username_env: DEFAULT_API_USERNAME_ENV.to_string(),
+            api_password_env: DEFAULT_API_PASSWORD_ENV.to_string(),
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+}
+
+impl ShieldProviderConfig {
+    /// env（`PROJECT_ARACHNID_API_BASE_URL` / `PROJECT_ARACHNID_API_TIMEOUT_SECS`）から
+    /// 上書き値を読み、設定を組み立てる。credentials はここでは読まない
+    /// （[`ShieldProviderConfig::load_credentials`] が読む）。
+    pub fn from_env() -> Result<Self, ShieldConfigError> {
+        let mut config = Self::default();
+        if let Some(base_url) = non_empty_env(API_BASE_URL_ENV) {
+            config.api_base_url = base_url.trim_end_matches('/').to_string();
+        }
+        if let Some(timeout) = non_empty_env(API_TIMEOUT_SECS_ENV) {
+            let secs: u64 = timeout.parse().map_err(|_| ShieldConfigError::InvalidEnv {
+                env: API_TIMEOUT_SECS_ENV.to_string(),
+                detail: "expected a positive integer (seconds)".to_string(),
+            })?;
+            if secs == 0 {
+                return Err(ShieldConfigError::InvalidEnv {
+                    env: API_TIMEOUT_SECS_ENV.to_string(),
+                    detail: "timeout must be greater than zero".to_string(),
+                });
+            }
+            config.timeout = Duration::from_secs(secs);
+        }
+        Ok(config)
+    }
+
+    /// 設定された env 名から credentials を読む。
+    ///
+    /// 欠落・空は Err（呼び出し側で起動失敗 = fail-closed）。エラーに値は含まれない。
+    pub fn load_credentials(&self) -> Result<ShieldCredentials, ShieldConfigError> {
+        let username = non_empty_env(&self.api_username_env).ok_or_else(|| {
+            ShieldConfigError::MissingCredential {
+                env: self.api_username_env.clone(),
+            }
+        })?;
+        let password = non_empty_env(&self.api_password_env).ok_or_else(|| {
+            ShieldConfigError::MissingCredential {
+                env: self.api_password_env.clone(),
+            }
+        })?;
+        Ok(ShieldCredentials { username, password })
+    }
+}
+
+/// operator-owned credentials。`Debug` は値を出さない。
+#[derive(Clone, PartialEq, Eq)]
+pub struct ShieldCredentials {
+    pub(crate) username: String,
+    pub(crate) password: String,
+}
+
+impl ShieldCredentials {
+    /// 明示的な値から組み立てる（テスト / env 以外の secret 供給経路用）。
+    pub fn new(username: impl Into<String>, password: impl Into<String>) -> Self {
+        Self {
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+}
+
+impl std::fmt::Debug for ShieldCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ShieldCredentials")
+            .field("username", &"<redacted>")
+            .field("password", &"<redacted>")
+            .finish()
+    }
+}
+
+/// 空 / 空白のみの env は未設定として扱う。
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}

--- a/crates/cn-safety-arachnid/src/lib.rs
+++ b/crates/cn-safety-arachnid/src/lib.rs
@@ -1,0 +1,35 @@
+//! Project Arachnid Shield provider（#391）。
+//!
+//! `kukuri-cn-safety` の `SafetyProvider` trait の本番実装。Project Arachnid Shield API
+//! （<https://shield.projectarachnid.com>）を叩き、既知 CSAM / harmful-abusive material への
+//! Exact / Near Match を domain verdict の入力（`ProviderScanResult`）に写像する。
+//!
+//! 設計の真実源:
+//! - Issue #391（operator-owned credentials / Match Data handling / No Known Match semantics）
+//! - `docs/adr/0027-deterministic-moderation-critical-safety.md`
+//!
+//! この crate が守る不変条件:
+//! - **operator-owned credentials**: API credentials は各 Community Node operator が自分で取得し
+//!   env（既定: `PROJECT_ARACHNID_API_USERNAME` / `PROJECT_ARACHNID_API_PASSWORD`）で与える。
+//!   credentials の値を `Debug` / `Display` / error message / log に出さない。
+//! - **Match Data 非保持**: Shield 応答のうち scan 判定に使うのは `classification` /
+//!   `match_type` のみ。`near_match_details`・一致先 sha1/sha256・timestamp は応答型に
+//!   持たない（deserialize されず、保存・転送・log 出力の経路が構造的に存在しない）。
+//! - **fail-closed**: HTTP エラー・timeout・想定外応答はすべて `ScanError` で返し、呼び出し側
+//!   （orchestrator）が `Failed` / `Unavailable` に写像して index を止める。`allow` に落ちる
+//!   写像は存在しない。
+//! - **No Known Match ≠ safe**: `no-known-match` は `ScanOutcome::NoKnownMatch`（safe の証明では
+//!   ない）にのみ写像する。「安全確認済み」相当の命名・写像を持たない。
+
+pub mod client;
+pub mod config;
+pub mod provider;
+
+pub use client::{
+    ShieldClassification, ShieldClient, ShieldError, ShieldMatchType, ShieldScanResult,
+};
+pub use config::{
+    API_BASE_URL_ENV, API_TIMEOUT_SECS_ENV, DEFAULT_API_BASE_URL, DEFAULT_API_PASSWORD_ENV,
+    DEFAULT_API_USERNAME_ENV, ShieldConfigError, ShieldCredentials, ShieldProviderConfig,
+};
+pub use provider::{PROVIDER_NAME, ProjectArachnidShieldProvider};

--- a/crates/cn-safety-arachnid/src/provider.rs
+++ b/crates/cn-safety-arachnid/src/provider.rs
@@ -1,0 +1,175 @@
+//! `SafetyProvider` 実装（#391）。
+//!
+//! Shield の scan 結果を domain の `ProviderScanResult` に写像する。写像表:
+//!
+//! | classification | match_type | 写像 |
+//! |---|---|---|
+//! | `csam` / `harmful-abusive-material` | `exact` / なし | `known_hash_match=true` + `Csam` ラベル（capability `KnownCsamHashMatch`）→ router で `Exclude` / `csam_confirmed` |
+//! | `csam` / `harmful-abusive-material` | `near` | 同上（capability は `PerceptualHashMatch`）|
+//! | `test` | 任意 | `ProviderTest` ラベル（critical でない）→ router で `Exclude` / `provider_test_match`（`csam_confirmed` と区別） |
+//! | `no-known-match` | - | `ScanOutcome::NoKnownMatch`（**safe の証明ではない**） |
+//!
+//! `harmful-abusive-material` は CSAM の法的定義に該当しない有害・虐待的既知コンテンツだが、
+//! Shield の既知リスト一致であることに変わりはないため、保守的に known match（category `Csam`）
+//! として除外する（over-exclusion 側に倒す。ADR 0027 追補に記録）。
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use kukuri_cn_safety::provider::{
+    MediaFetcher, ProviderScanRequest, ProviderScanResult, ScanError, ScanOutcome,
+};
+use kukuri_cn_safety::{SafetyCategory, SafetyLabel, SafetyProvider, SafetyProviderCapability};
+
+use crate::client::{ShieldClassification, ShieldClient, ShieldMatchType, ShieldScanResult};
+use crate::config::{ShieldConfigError, ShieldProviderConfig};
+
+/// provider の安定識別子。config（provider slot）の値・verdict の `provider` に使う。
+pub const PROVIDER_NAME: &str = "project-arachnid-shield";
+
+const CAPABILITIES: [SafetyProviderCapability; 2] = [
+    SafetyProviderCapability::KnownCsamHashMatch,
+    SafetyProviderCapability::PerceptualHashMatch,
+];
+
+/// Project Arachnid Shield を known-CSAM（child-safety known-match）provider として実装する。
+pub struct ProjectArachnidShieldProvider {
+    client: ShieldClient,
+    /// media_hint → 一時 bytes の取得手段。未構成なら media scan は `Unavailable`（fail-closed）。
+    fetcher: Option<Arc<dyn MediaFetcher>>,
+}
+
+impl std::fmt::Debug for ProjectArachnidShieldProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProjectArachnidShieldProvider")
+            .field("name", &PROVIDER_NAME)
+            .field("client", &self.client)
+            .field("fetcher_configured", &self.fetcher.is_some())
+            .finish()
+    }
+}
+
+impl ProjectArachnidShieldProvider {
+    /// 設定から provider を組み立てる。credentials は設定が指す env から読む。
+    ///
+    /// credentials 欠落は Err（呼び出し側で起動失敗 = fail-closed）。
+    pub fn new(config: &ShieldProviderConfig) -> Result<Self, ShieldConfigError> {
+        Ok(Self {
+            client: ShieldClient::from_config(config)?,
+            fetcher: None,
+        })
+    }
+
+    /// env（base URL / timeout の上書き含む）から provider を組み立てる。
+    pub fn from_env() -> Result<Self, ShieldConfigError> {
+        Self::new(&ShieldProviderConfig::from_env()?)
+    }
+
+    /// 明示的な credentials から組み立てる（テスト / env 以外の secret 供給経路用）。
+    pub fn with_credentials(
+        config: &ShieldProviderConfig,
+        credentials: crate::config::ShieldCredentials,
+    ) -> Result<Self, ShieldConfigError> {
+        Ok(Self {
+            client: ShieldClient::new(config, credentials)?,
+            fetcher: None,
+        })
+    }
+
+    /// media_hint から一時 bytes を取得する fetcher を接続する（media scan pipeline 側が注入）。
+    pub fn with_media_fetcher(mut self, fetcher: Arc<dyn MediaFetcher>) -> Self {
+        self.fetcher = Some(fetcher);
+        self
+    }
+}
+
+#[async_trait]
+impl SafetyProvider for ProjectArachnidShieldProvider {
+    fn name(&self) -> &str {
+        PROVIDER_NAME
+    }
+
+    fn capabilities(&self) -> &[SafetyProviderCapability] {
+        &CAPABILITIES
+    }
+
+    async fn scan(&self, request: &ProviderScanRequest) -> Result<ProviderScanResult, ScanError> {
+        let media_hint = request
+            .media_hint
+            .as_deref()
+            .map(str::trim)
+            .filter(|hint| !hint.is_empty());
+
+        // media の無い対象（text-only post 等）は hash 照合の対象が存在しない。
+        // NoKnownMatch（safe の証明ではない）として「known-CSAM scan を実施した」記録だけ残す。
+        let Some(media_hint) = media_hint else {
+            return Ok(base_result(ScanOutcome::NoKnownMatch));
+        };
+
+        // media_hint があるのに fetcher が未構成なら scan 不能 → fail-closed。
+        let Some(fetcher) = &self.fetcher else {
+            return Err(ScanError::Unavailable(
+                "project-arachnid-shield has no media fetcher configured; \
+                 cannot scan referenced media (fail-closed)"
+                    .to_string(),
+            ));
+        };
+
+        let media = fetcher.fetch(media_hint).await?;
+        let scan = self
+            .client
+            .scan_media(media.bytes, &media.content_type)
+            .await
+            .map_err(ScanError::from)?;
+        Ok(scan_result_from(scan))
+    }
+}
+
+/// 検知なしの素の結果。
+fn base_result(outcome: ScanOutcome) -> ProviderScanResult {
+    ProviderScanResult {
+        provider: PROVIDER_NAME.to_string(),
+        capability: SafetyProviderCapability::KnownCsamHashMatch,
+        outcome,
+        known_hash_match: false,
+        score: None,
+        labels: Vec::new(),
+    }
+}
+
+/// Shield 応答を domain の `ProviderScanResult` に写像する（module doc の写像表）。
+fn scan_result_from(scan: ShieldScanResult) -> ProviderScanResult {
+    match scan.classification {
+        ShieldClassification::Csam | ShieldClassification::HarmfulAbusiveMaterial => {
+            let capability = match scan.match_type {
+                Some(ShieldMatchType::Near) => SafetyProviderCapability::PerceptualHashMatch,
+                // exact / match_type 欠落は known hash match として扱う（保守側）。
+                _ => SafetyProviderCapability::KnownCsamHashMatch,
+            };
+            ProviderScanResult {
+                provider: PROVIDER_NAME.to_string(),
+                capability,
+                outcome: ScanOutcome::Completed,
+                known_hash_match: true,
+                score: None,
+                labels: vec![
+                    SafetyLabel::new(SafetyCategory::Csam).with_provider_capability(capability),
+                ],
+            }
+        }
+        // provider self-test データへの一致。csam_confirmed と区別する専用 route（#391）。
+        ShieldClassification::Test => ProviderScanResult {
+            provider: PROVIDER_NAME.to_string(),
+            capability: SafetyProviderCapability::KnownCsamHashMatch,
+            outcome: ScanOutcome::Completed,
+            known_hash_match: false,
+            score: None,
+            labels: vec![
+                SafetyLabel::new(SafetyCategory::ProviderTest)
+                    .with_provider_capability(SafetyProviderCapability::KnownCsamHashMatch),
+            ],
+        },
+        ShieldClassification::NoKnownMatch => base_result(ScanOutcome::NoKnownMatch),
+    }
+}

--- a/crates/cn-safety-arachnid/tests/provider_contract.rs
+++ b/crates/cn-safety-arachnid/tests/provider_contract.rs
@@ -1,0 +1,426 @@
+//! Project Arachnid Shield provider の contract テスト（#391 受け入れ条件）。
+//!
+//! wiremock で Shield API を模擬し、以下を固定する:
+//! - Exact / Near Match → `Exclude`（critical / `csam_confirmed`）
+//! - `test` classification → `Exclude` だが `provider_test_match`（`csam_confirmed` と区別）
+//! - `no-known-match` → `NoKnownMatch`（allow だが **safe の証明ではない** reason）
+//! - 401 / 5xx / timeout / fetcher 未構成 → fail-closed（`ScanError`、allow に落ちない）
+//! - credentials / Match Data（near_match_details / sha 群）が結果・Debug・エラーに出ない
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use wiremock::matchers::{basic_auth, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use kukuri_cn_safety::provider::{
+    FetchedMedia, MediaFetcher, ProviderScanRequest, ScanError, ScanOutcome, SubjectKind,
+};
+use kukuri_cn_safety::{
+    ReasonCode, SafetyAction, SafetyCategory, SafetyPolicy, SafetyProvider,
+    SafetyProviderCapability, route,
+};
+use kukuri_cn_safety_arachnid::{
+    ProjectArachnidShieldProvider, ShieldConfigError, ShieldCredentials, ShieldProviderConfig,
+};
+
+const USERNAME: &str = "shield-user";
+const PASSWORD: &str = "shield-pass";
+/// Match Data 非露出テスト用の sentinel（模擬応答の near_match_details にのみ現れる値）。
+const MATCH_DATA_SENTINEL: &str = "sentinel-sha256-0123456789abcdef";
+
+fn test_config(base_url: &str) -> ShieldProviderConfig {
+    ShieldProviderConfig {
+        api_base_url: base_url.to_string(),
+        timeout: Duration::from_millis(500),
+        ..ShieldProviderConfig::default()
+    }
+}
+
+fn provider_for(server_url: &str) -> ProjectArachnidShieldProvider {
+    ProjectArachnidShieldProvider::with_credentials(
+        &test_config(server_url),
+        ShieldCredentials::new(USERNAME, PASSWORD),
+    )
+    .expect("provider construction should succeed")
+    .with_media_fetcher(Arc::new(StaticFetcher))
+}
+
+fn media_request() -> ProviderScanRequest {
+    ProviderScanRequest::for_subject(SubjectKind::Blob, "blob-1").with_media_hint("blake3:abc123")
+}
+
+/// 固定 bytes を返すテスト用 fetcher。
+struct StaticFetcher;
+
+#[async_trait]
+impl MediaFetcher for StaticFetcher {
+    async fn fetch(&self, _media_hint: &str) -> Result<FetchedMedia, ScanError> {
+        Ok(FetchedMedia {
+            bytes: vec![0xFF, 0xD8, 0xFF, 0xE0],
+            content_type: "image/jpeg".to_string(),
+        })
+    }
+}
+
+/// Shield の `ScannedMedia` 応答（Match Data 込み。実応答と同じ形）。
+fn scanned_media_body(classification: &str, match_type: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "classification": classification,
+        "match_type": match_type,
+        "near_match_details": [{
+            "classification": "csam",
+            "sha1_base32": "sentinel-sha1-abcdefg",
+            "sha256_hex": MATCH_DATA_SENTINEL,
+            "timestamp": 1719900000.0,
+        }],
+        "sha1_base32": "sentinel-submitted-sha1",
+        "sha256_hex": "sentinel-submitted-sha256",
+        "size_bytes": 4,
+    })
+}
+
+async fn mock_media_scan(server: &MockServer, body: serde_json::Value) {
+    Mock::given(method("POST"))
+        .and(path("/v1/media"))
+        .and(basic_auth(USERNAME, PASSWORD))
+        .and(header("content-type", "image/jpeg"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn exact_match_is_known_hash_match_and_routes_to_csam_confirmed_exclude() {
+    let server = MockServer::start().await;
+    mock_media_scan(&server, scanned_media_body("csam", Some("exact"))).await;
+
+    let provider = provider_for(&server.uri());
+    let result = provider
+        .scan(&media_request())
+        .await
+        .expect("scan succeeds");
+
+    assert_eq!(result.outcome, ScanOutcome::Completed);
+    assert!(result.known_hash_match);
+    assert_eq!(
+        result.capability,
+        SafetyProviderCapability::KnownCsamHashMatch
+    );
+
+    let verdict = route(
+        std::slice::from_ref(&result),
+        &SafetyPolicy::public_node_default(),
+        "scanned-at",
+    );
+    assert_eq!(verdict.action, SafetyAction::Exclude);
+    assert_eq!(verdict.reason_code, ReasonCode::CsamConfirmed);
+    assert!(verdict.critical);
+    assert!(!verdict.is_indexable());
+}
+
+#[tokio::test]
+async fn near_match_uses_perceptual_hash_capability_and_is_excluded() {
+    let server = MockServer::start().await;
+    mock_media_scan(&server, scanned_media_body("csam", Some("near"))).await;
+
+    let provider = provider_for(&server.uri());
+    let result = provider
+        .scan(&media_request())
+        .await
+        .expect("scan succeeds");
+
+    assert!(result.known_hash_match);
+    assert_eq!(
+        result.capability,
+        SafetyProviderCapability::PerceptualHashMatch
+    );
+
+    let verdict = route(
+        std::slice::from_ref(&result),
+        &SafetyPolicy::public_node_default(),
+        "scanned-at",
+    );
+    assert_eq!(verdict.action, SafetyAction::Exclude);
+    assert!(!verdict.is_indexable());
+}
+
+#[tokio::test]
+async fn harmful_abusive_material_is_excluded_as_known_match() {
+    let server = MockServer::start().await;
+    mock_media_scan(
+        &server,
+        scanned_media_body("harmful-abusive-material", Some("exact")),
+    )
+    .await;
+
+    let provider = provider_for(&server.uri());
+    let result = provider
+        .scan(&media_request())
+        .await
+        .expect("scan succeeds");
+
+    assert!(result.known_hash_match);
+    let verdict = route(
+        std::slice::from_ref(&result),
+        &SafetyPolicy::public_node_default(),
+        "scanned-at",
+    );
+    assert_eq!(verdict.action, SafetyAction::Exclude);
+    assert!(!verdict.is_indexable());
+}
+
+#[tokio::test]
+async fn test_classification_routes_to_provider_test_match_not_csam_confirmed() {
+    let server = MockServer::start().await;
+    mock_media_scan(&server, scanned_media_body("test", Some("exact"))).await;
+
+    let provider = provider_for(&server.uri());
+    let result = provider
+        .scan(&media_request())
+        .await
+        .expect("scan succeeds");
+
+    // 実 CSAM の confirmed とは区別される（known_hash_match ではなく専用ラベル）。
+    assert!(!result.known_hash_match);
+    assert_eq!(result.labels.len(), 1);
+    assert_eq!(result.labels[0].category, SafetyCategory::ProviderTest);
+
+    let verdict = route(
+        std::slice::from_ref(&result),
+        &SafetyPolicy::public_node_default(),
+        "scanned-at",
+    );
+    // exclude + 専用扱い: index には入れないが csam_confirmed でも critical でもない。
+    assert_eq!(verdict.action, SafetyAction::Exclude);
+    assert_eq!(verdict.reason_code, ReasonCode::ProviderTestMatch);
+    assert!(!verdict.critical);
+    assert!(!verdict.is_indexable());
+}
+
+#[tokio::test]
+async fn no_known_match_is_not_treated_as_safe() {
+    let server = MockServer::start().await;
+    mock_media_scan(&server, scanned_media_body("no-known-match", None)).await;
+
+    let provider = provider_for(&server.uri());
+    let result = provider
+        .scan(&media_request())
+        .await
+        .expect("scan succeeds");
+
+    assert_eq!(result.outcome, ScanOutcome::NoKnownMatch);
+    assert!(!result.known_hash_match);
+
+    let verdict = route(
+        std::slice::from_ref(&result),
+        &SafetyPolicy::public_node_default(),
+        "scanned-at",
+    );
+    // index は許すが、reason は Clean ではなく NoKnownMatch（safe の証明ではない）。
+    assert_eq!(verdict.action, SafetyAction::Allow);
+    assert_eq!(verdict.reason_code, ReasonCode::NoKnownMatch);
+}
+
+#[tokio::test]
+async fn match_data_never_appears_in_scan_result_serialization() {
+    let server = MockServer::start().await;
+    mock_media_scan(&server, scanned_media_body("csam", Some("near"))).await;
+
+    let provider = provider_for(&server.uri());
+    let result = provider
+        .scan(&media_request())
+        .await
+        .expect("scan succeeds");
+
+    // ProviderScanResult（persist / signed event の材料）に Match Data が構造的に存在しない。
+    let serialized = serde_json::to_string(&result).expect("result serializes");
+    assert!(!serialized.contains(MATCH_DATA_SENTINEL));
+    assert!(!serialized.contains("sentinel-sha1"));
+    assert!(!serialized.contains("sentinel-submitted"));
+    assert!(!serialized.contains("near_match_details"));
+}
+
+#[tokio::test]
+async fn moderation_event_from_exact_match_contains_no_match_data() {
+    use kukuri_cn_safety_runtime::{SafetyOrchestrator, SystemScanClock, UuidEventIdGenerator};
+
+    let server = MockServer::start().await;
+    mock_media_scan(&server, scanned_media_body("csam", Some("exact"))).await;
+
+    let orchestrator = SafetyOrchestrator::builder(
+        "issuer-node",
+        Arc::new(SystemScanClock::new()),
+        Arc::new(UuidEventIdGenerator::new()),
+    )
+    .provider(Arc::new(provider_for(&server.uri())))
+    .build()
+    .expect("orchestrator builds");
+
+    let report = orchestrator.scan_subject(&media_request()).await;
+    assert_eq!(report.verdict.reason_code, ReasonCode::CsamConfirmed);
+    assert!(!report.verdict.is_indexable());
+
+    // 署名・永続化・配布の材料になる moderation event / scan report 全体に Match Data が無い。
+    let event = report
+        .moderation_event
+        .as_ref()
+        .expect("non-indexable verdict produces a moderation event");
+    let serialized_event = serde_json::to_string(event).expect("event serializes");
+    assert!(!serialized_event.contains(MATCH_DATA_SENTINEL));
+    let serialized_report = serde_json::to_string(&report).expect("report serializes");
+    assert!(!serialized_report.contains(MATCH_DATA_SENTINEL));
+    assert!(!serialized_report.contains("sentinel-sha1"));
+    assert!(!serialized_report.contains("sentinel-submitted"));
+}
+
+#[tokio::test]
+async fn unauthorized_fails_closed_without_leaking_credentials() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/media"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server.uri());
+    let error = provider
+        .scan(&media_request())
+        .await
+        .expect_err("401 must be an error (fail-closed)");
+
+    let ScanError::Unavailable(message) = &error else {
+        panic!("401 must map to ScanError::Unavailable, got {error:?}");
+    };
+    assert!(message.contains("credential"));
+    assert!(!message.contains(USERNAME));
+    assert!(!message.contains(PASSWORD));
+}
+
+#[tokio::test]
+async fn server_error_fails_closed_as_unavailable() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/media"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server.uri());
+    let error = provider
+        .scan(&media_request())
+        .await
+        .expect_err("5xx must be an error (fail-closed)");
+    assert!(matches!(error, ScanError::Unavailable(_)));
+}
+
+#[tokio::test]
+async fn timeout_fails_closed_as_timeout() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/media"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(scanned_media_body("no-known-match", None))
+                .set_delay(Duration::from_secs(5)),
+        )
+        .mount(&server)
+        .await;
+
+    let provider = provider_for(&server.uri());
+    let error = provider
+        .scan(&media_request())
+        .await
+        .expect_err("timeout must be an error (fail-closed)");
+    assert!(matches!(error, ScanError::Timeout(_)));
+}
+
+#[tokio::test]
+async fn unexpected_response_shape_fails_closed_as_protocol_error() {
+    let server = MockServer::start().await;
+    mock_media_scan(
+        &server,
+        // 未知 classification（API 将来拡張）は安全側でない解釈をせず Protocol エラーに倒す。
+        scanned_media_body("brand-new-classification", None),
+    )
+    .await;
+
+    let provider = provider_for(&server.uri());
+    let error = provider
+        .scan(&media_request())
+        .await
+        .expect_err("unknown classification must fail closed");
+    assert!(matches!(error, ScanError::Protocol(_)));
+}
+
+#[tokio::test]
+async fn media_hint_without_fetcher_fails_closed() {
+    let provider = ProjectArachnidShieldProvider::with_credentials(
+        &test_config("http://127.0.0.1:9"),
+        ShieldCredentials::new(USERNAME, PASSWORD),
+    )
+    .expect("provider construction should succeed");
+
+    let error = provider
+        .scan(&media_request())
+        .await
+        .expect_err("media scan without fetcher must fail closed");
+    assert!(matches!(error, ScanError::Unavailable(_)));
+}
+
+#[tokio::test]
+async fn request_without_media_reports_no_known_match_scan() {
+    let provider = ProjectArachnidShieldProvider::with_credentials(
+        &test_config("http://127.0.0.1:9"),
+        ShieldCredentials::new(USERNAME, PASSWORD),
+    )
+    .expect("provider construction should succeed");
+
+    let request = ProviderScanRequest::for_subject(SubjectKind::Post, "post-1");
+    let result = provider.scan(&request).await.expect("scan succeeds");
+
+    // media の無い対象は照合対象が無い = NoKnownMatch（safe の証明ではない）。
+    assert_eq!(result.outcome, ScanOutcome::NoKnownMatch);
+    assert_eq!(
+        result.capability,
+        SafetyProviderCapability::KnownCsamHashMatch
+    );
+}
+
+#[test]
+fn debug_output_redacts_credentials() {
+    let provider = ProjectArachnidShieldProvider::with_credentials(
+        &test_config("http://127.0.0.1:9"),
+        ShieldCredentials::new(USERNAME, PASSWORD),
+    )
+    .expect("provider construction should succeed");
+
+    let debug = format!("{provider:?}");
+    assert!(!debug.contains(USERNAME));
+    assert!(!debug.contains(PASSWORD));
+    assert!(debug.contains("<redacted>"));
+}
+
+#[test]
+fn missing_credential_error_names_env_without_value() {
+    let config = ShieldProviderConfig {
+        api_username_env: "KUKURI_TEST_ARACHNID_MISSING_USER".to_string(),
+        api_password_env: "KUKURI_TEST_ARACHNID_MISSING_PASSWORD".to_string(),
+        ..ShieldProviderConfig::default()
+    };
+    let error = config
+        .load_credentials()
+        .expect_err("missing env must be an error (fail-closed)");
+    assert_eq!(
+        error,
+        ShieldConfigError::MissingCredential {
+            env: "KUKURI_TEST_ARACHNID_MISSING_USER".to_string(),
+        }
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("KUKURI_TEST_ARACHNID_MISSING_USER")
+    );
+}

--- a/crates/cn-safety-runtime/src/artifacts.rs
+++ b/crates/cn-safety-runtime/src/artifacts.rs
@@ -86,6 +86,9 @@ fn primary_category(verdict: &SafetyVerdict) -> Option<SafetyCategory> {
             .iter()
             .map(|label| label.category)
             .find(|category| !category.is_critical_safety()),
+        // provider self-test 一致（#391）。非 critical だが exclude されるため、event / signal の
+        // category は専用の ProviderTest を使う（csam と混同させない）。
+        ReasonCode::ProviderTestMatch => Some(SafetyCategory::ProviderTest),
         ReasonCode::ScanFailed
         | ReasonCode::ProviderUnavailable
         | ReasonCode::Unscanned

--- a/crates/cn-safety/src/lib.rs
+++ b/crates/cn-safety/src/lib.rs
@@ -44,7 +44,8 @@ pub use event::{
 pub use mock::{MockSafetyProvider, MockSigner};
 pub use policy::{SafetyPolicy, route};
 pub use provider::{
-    ProviderScanRequest, ProviderScanResult, SafetyProvider, ScanError, ScanOutcome, SubjectKind,
+    FetchedMedia, MediaFetcher, ProviderScanRequest, ProviderScanResult, SafetyProvider, ScanError,
+    ScanOutcome, SubjectKind,
 };
 pub use signal::{AppealStatus, RiskSignalTarget, SafetyRiskSignal};
 pub use verdict::{

--- a/crates/cn-safety/src/policy.rs
+++ b/crates/cn-safety/src/policy.rs
@@ -113,7 +113,24 @@ pub fn route(
         return verdict;
     }
 
-    // 3. 未知 CSAM / CSE 疑い（critical な検知 かつ effective score >= threshold）。
+    // 3. provider self-test データ一致（Project Arachnid Shield の `test` classification 等、
+    //    #391）。実 CSAM の confirmed（規則2）とは専用 reason で区別しつつ、既知リスト一致で
+    //    あるため policy に依らず index には決して入れない（Exclude / critical=false）。
+    if let Some(result) = scan_outcomes.iter().find(|r| {
+        r.outcome == ScanOutcome::Completed
+            && r.labels
+                .iter()
+                .any(|l| l.category == SafetyCategory::ProviderTest)
+    }) {
+        let mut verdict = base(SafetyAction::Exclude, ReasonCode::ProviderTestMatch, false);
+        verdict.provider = Some(result.provider.clone());
+        verdict.provider_capability = Some(result.capability);
+        verdict.confidence = result.score;
+        verdict.labels = non_empty_labels(result, SafetyCategory::ProviderTest);
+        return verdict;
+    }
+
+    // 4. 未知 CSAM / CSE 疑い（critical な検知 かつ effective score >= threshold）。
     if let Some(result) = scan_outcomes
         .iter()
         .filter(|r| r.outcome == ScanOutcome::Completed && is_critical_detection(r))
@@ -135,7 +152,7 @@ pub fn route(
         return verdict;
     }
 
-    // 4. scan failure / provider unavailable → fail-closed（allow にしない）。
+    // 5. scan failure / provider unavailable → fail-closed（allow にしない）。
     if let Some(result) = scan_outcomes.iter().find(|r| r.outcome.is_fail_closed()) {
         let reason = match result.outcome {
             ScanOutcome::Unavailable => ReasonCode::ProviderUnavailable,
@@ -147,7 +164,7 @@ pub fn route(
         return verdict;
     }
 
-    // 5. critical な検知があるが suspected 閾値に達しなかった / score が無いものを
+    // 6. critical な検知があるが suspected 閾値に達しなかった / score が無いものを
     //    Allow に取りこぼさない（fail-closed）。critical safety を safe と断定しない。
     if let Some(result) = scan_outcomes
         .iter()
@@ -168,7 +185,7 @@ pub fn route(
         return verdict;
     }
 
-    // 6. public-node で必須の known CSAM provider 結果が無いなら fail-closed。
+    // 7. public-node で必須の known CSAM provider 結果が無いなら fail-closed。
     //    general moderation が clean / allow を返せても、known CSAM scan 欠落時は index しない。
     if policy.require_known_csam && !has_known_csam_scan_result(scan_outcomes) {
         return base(
@@ -178,7 +195,7 @@ pub fn route(
         );
     }
 
-    // 7. 一般 moderation（critical 以外のラベル）→ critical とは別 route（critical=false）。
+    // 8. 一般 moderation（critical 以外のラベル）→ critical とは別 route（critical=false）。
     if let Some((result, category)) = scan_outcomes
         .iter()
         .find_map(|r| general_category(r).map(|category| (r, category)))
@@ -192,7 +209,7 @@ pub fn route(
         return verdict;
     }
 
-    // 8. 検知なし。既知一致なし（NoKnownMatch）は safe と断定しない。
+    // 9. 検知なし。既知一致なし（NoKnownMatch）は safe と断定しない。
     //    すべて Completed かつラベル無しのときのみ Clean とする。
     let has_no_known_match = scan_outcomes
         .iter()
@@ -289,6 +306,9 @@ fn general_action(policy: &SafetyPolicy, category: SafetyCategory) -> SafetyActi
     match category {
         SafetyCategory::Spam => policy.on_spam,
         SafetyCategory::Malware | SafetyCategory::Phishing => policy.on_malware_phishing,
+        // provider self-test 一致は route() 規則3で先に処理されるが、万一ここへ落ちても
+        // policy に依らず exclude（index に入れない）に倒す（防御の重ね）。
+        SafetyCategory::ProviderTest => SafetyAction::Exclude,
         // nsfw / その他一般。
         _ => policy.on_high_confidence_nsfw,
     }

--- a/crates/cn-safety/src/provider.rs
+++ b/crates/cn-safety/src/provider.rs
@@ -140,6 +140,36 @@ pub enum ScanError {
     Protocol(String),
 }
 
+/// scan 用に一時取得した media 本体。
+///
+/// community node は blob 本体を恒久保存しない前提のため、scan のための一時 fetch に限定して
+/// 使い、scan 後は破棄する。`Debug` は bytes を出力しない（media 本体を log に出さない）。
+#[derive(Clone, PartialEq, Eq)]
+pub struct FetchedMedia {
+    pub bytes: Vec<u8>,
+    /// provider へ渡す MIME type（例: `image/jpeg` / `video/mp4`）。
+    pub content_type: String,
+}
+
+impl std::fmt::Debug for FetchedMedia {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FetchedMedia")
+            .field("bytes_len", &self.bytes.len())
+            .field("content_type", &self.content_type)
+            .finish()
+    }
+}
+
+/// `media_hint`（hash / CID 等）から scan 用に media 本体を一時取得する抽象。
+///
+/// 本番実装は blob store / iroh-blobs からの一時 fetch（恒久保存しない）。fetch 失敗は
+/// `ScanError` で返し、呼び出し側が fail-closed に写像する。fetcher が未構成の場合、media を
+/// 要する provider は `ScanError::Unavailable` を返して fail-closed に倒す（#391）。
+#[async_trait]
+pub trait MediaFetcher: Send + Sync {
+    async fn fetch(&self, media_hint: &str) -> Result<FetchedMedia, ScanError>;
+}
+
 /// safety / moderation provider の抽象。
 ///
 /// 実装例: mock provider（本 crate）、#391 Project Arachnid Shield、一般 moderation provider。

--- a/crates/cn-safety/src/verdict.rs
+++ b/crates/cn-safety/src/verdict.rs
@@ -55,6 +55,10 @@ pub enum SafetyCategory {
     Spam,
     Malware,
     Phishing,
+    /// provider の self-test データへの一致（例: Project Arachnid Shield の `test`
+    /// classification。#391）。実 CSAM ではないため critical ではないが、既知リスト一致で
+    /// あることに変わりはなく index には決して入れない（router が常に `Exclude` に写像する）。
+    ProviderTest,
 }
 
 impl SafetyCategory {
@@ -128,6 +132,10 @@ pub enum ReasonCode {
     ProviderUnavailable,
     /// scan 要求がそもそも無い（unscanned。fail-closed の根拠）。
     Unscanned,
+    /// provider の self-test データに一致した（例: Project Arachnid Shield の `test`
+    /// classification。#391）。`csam_confirmed` と明確に区別するための専用 reason。
+    /// 実 CSAM の confirmed ではないが index には入れない（action は `Exclude`）。
+    ProviderTestMatch,
     /// 既知 hash には一致しなかった（**safe の証明ではない**）。
     NoKnownMatch,
     /// 明示的に clean と判定できた（全 capability で問題なし）。

--- a/docs/adr/0027-deterministic-moderation-critical-safety.md
+++ b/docs/adr/0027-deterministic-moderation-critical-safety.md
@@ -150,7 +150,7 @@ public-node profile が public indexing を有効化する前に満たすべき�
 
 ## 4. Out of scope（後続 / 別 ADR・Issue）
 - classifier ベース非決定論的検知の詳細（#411）。
-- 本番 provider 統合の実装詳細（#391）。
+- 本番 provider 統合の実装詳細（#391。→ §7 追補で確定）。
 - fail-closed indexing 本体の DB 実装（#404）。
 - runtime 結線・trust/relation 反映（#406）。
 
@@ -166,3 +166,44 @@ public-node profile が public indexing を有効化する前に満たすべき�
 - 本 ADR を決定論 moderation の **decision record（authoritative）** とする。
 - 旧 `docs/safety/community-node-critical-safety.md`（+ `_ja`）と `docs/architecture/moderation-event-trust-semantics.md` は、normative な内容を本 ADR（trust/relation reflection は ADR 0026）へ集約し、「設計ドキュメントを ADR と誤認する」混乱を避けるため **本 PR で削除**した。
 - 旧ドキュメントを参照していた code doc-comment / README / runbook / 他 ADR は本 ADR（trust/relation は ADR 0026）へ張り替えた。progress 記録・migration など過去時点の記録は歴史的記録として据え置き（デッドリンクは許容）。
+
+## 7. 追補: Project Arachnid Shield provider（#391、2026-07-02）
+
+本節は #391 の実装（`crates/cn-safety-arachnid`）で確定した decision を記録する。
+
+### 7.1 classification → domain の写像
+
+| Shield classification | match_type | ProviderScanResult | router 出力 |
+|---|---|---|---|
+| `csam` | `exact` / 欠落 | `known_hash_match=true`、capability `KnownCsamHashMatch`、label `csam` | `exclude` / `csam_confirmed` / critical |
+| `csam` | `near` | 同上（capability `PerceptualHashMatch`）| 同上 |
+| `harmful-abusive-material` | 任意 | `csam` と同じ（下記 7.2） | 同上 |
+| `test` | 任意 | `known_hash_match=false`、label `provider_test`（非 critical） | `exclude` / `provider_test_match` / 非 critical |
+| `no-known-match` | - | `ScanOutcome::NoKnownMatch` | `allow` / `no_known_match`（safe の証明ではない） |
+| 未知の値（将来拡張） | - | deserialize 失敗 → `ScanError::Protocol` | fail-closed（`hold` / `scan_failed`） |
+
+### 7.2 保守的写像（over-exclusion 側に倒す）
+
+- `harmful-abusive-material` は CSAM の法的定義に該当しない有害・虐待的既知コンテンツだが、
+  Shield 既知リストへの一致であることに変わりはないため、known match（category `csam`）として
+  除外する。専用 category の細分化が必要になったら本 ADR を改訂する。
+- `test`（C3P のテストデータ一致）は index には決して入れないが、実運用の `csam_confirmed`
+  event と混ざらないよう専用 reason（`ReasonCode::ProviderTestMatch`、`SafetyCategory::ProviderTest`、
+  非 critical）で記録する。router 規則3（`cn-safety/src/policy.rs`）で policy 非依存に `exclude`。
+
+### 7.3 Match Data 非保持の構造的保証
+
+- Shield 応答から deserialize するのは `classification` / `match_type` のみ。`near_match_details`・
+  一致先 sha1/sha256・timestamp は応答型に**存在しない**ため、`ProviderScanResult` →
+  verdict → signed moderation event / risk signal / `cn_safety` 永続化のどこにも載り得ない
+  （contract テストで serialize 結果に Match Data が現れないことを固定）。
+- HTTP エラーは status のみでエラー化し、応答 body・credential 値をエラー文字列・log に含めない。
+
+### 7.4 operator-owned credentials
+
+- credentials は env（既定: `PROJECT_ARACHNID_API_USERNAME` / `PROJECT_ARACHNID_API_PASSWORD`。
+  Project Arachnid 管理ページの表記に合わせた命名）から読む。欠落時は runtime 構築が Err になり
+  ingest は起動しない（fail-closed）。
+- provider 実装名は `project-arachnid-shield`（operator-config の underscore 表記は正規化して受理）。
+  known_csam slot 専用で、他 slot への指定は Err。
+- 運用手順は `docs/runbooks/project-arachnid-shield.md`。

--- a/docs/progress/2026-07-02-391-project-arachnid-shield.md
+++ b/docs/progress/2026-07-02-391-project-arachnid-shield.md
@@ -25,7 +25,8 @@ ADR 0027 §7（追補: 写像表・非保持保証・operator-owned credentials�
   no-known-match の写像、401/5xx/timeout/未知 classification の fail-closed、credentials・
   Match Data の非露出、orchestrator 経由の moderation event 非汚染）。
 - **docs**: runbook（operator の credentials / Submitted Data / No Known Match semantics /
-  法的義務 disclaimer / 漏洩時手順 / Authorized Domains）、ADR 0027 §7 追補、`.env.example`。
+  法的義務 disclaimer / 漏洩時手順 / Authorized Domains）、ADR 0027 §7 追補、
+  `.env.community-node.example`。
 
 ## 実 API での確認（2026-07-02）
 

--- a/docs/progress/2026-07-02-391-project-arachnid-shield.md
+++ b/docs/progress/2026-07-02-391-project-arachnid-shield.md
@@ -1,0 +1,47 @@
+# 2026-07-02 — #391 Project Arachnid Shield 統合
+
+参照: [Issue #391](https://github.com/KingYoSun/kukuri/issues/391) /
+ADR 0027 §7（追補: 写像表・非保持保証・operator-owned credentials）/
+`docs/runbooks/project-arachnid-shield.md`（operator 手順）/
+`.claude/plans/2026-07-02-issue-391-project-arachnid-shield.md`（実装プラン）
+
+## 実装範囲
+
+- **`crates/cn-safety-arachnid`（新規）**: `ShieldClient`（HTTP Basic auth、`POST /v1/media` /
+  `POST /v1/pdq`）、`ProjectArachnidShieldProvider`（`SafetyProvider` 実装、名称
+  `project-arachnid-shield`、capability `KnownCsamHashMatch` + `PerceptualHashMatch`）、
+  `ShieldProviderConfig`（env: `PROJECT_ARACHNID_API_USERNAME` / `PROJECT_ARACHNID_API_PASSWORD`、
+  base URL / timeout 上書き可）。
+- **domain 拡張（`cn-safety`）**: `SafetyCategory::ProviderTest` / `ReasonCode::ProviderTestMatch`
+  （Shield `test` classification の専用扱い。exclude するが `csam_confirmed` と区別）、router 規則3、
+  `MediaFetcher` / `FetchedMedia`（media 一時 fetch の seam。本 issue では未接続）。
+- **runtime 接続（`cn-core` / `cn-indexer`）**: `resolve_provider` に `project-arachnid-shield`
+  （feature `safety-arachnid-provider`、known_csam slot 専用、underscore 表記は正規化）。
+  credentials 欠落 = 構築 Err = ingest 起動せず（fail-closed）。
+- **operator CLI / readiness（`cn-operator`）**: `safety test-provider project-arachnid-shield`
+  （実 API への connectivity check。合成 PDQ hash 使用、credentials 値は非表示。feature
+  `safety-arachnid`）、readiness check `known_csam_provider_resolvable` を追加（13 項目に）。
+- **テスト**: wiremock contract テスト 15 件（exact / near / harmful-abusive / test /
+  no-known-match の写像、401/5xx/timeout/未知 classification の fail-closed、credentials・
+  Match Data の非露出、orchestrator 経由の moderation event 非汚染）。
+- **docs**: runbook（operator の credentials / Submitted Data / No Known Match semantics /
+  法的義務 disclaimer / 漏洩時手順 / Authorized Domains）、ADR 0027 §7 追補、`.env.example`。
+
+## 実 API での確認（2026-07-02）
+
+- 認証は HTTP Basic（`Www-Authenticate: Basic` を実測）。
+- `POST /v1/pdq` の hash は **32 bytes の base64**（hex は 400 `invalid pdq hash`）。
+- `safety test-provider project-arachnid-shield` が実 credentials で
+  `connectivity: OK` / `probe_classification: NoKnownMatch` を返すことを確認。
+
+## 維持した境界 / 意図的にやらないこと
+
+- media scan pipeline（blob の一時 fetch → media_hint 付き scan 発火）は未接続。media 参照付き
+  post は従来どおり `has_unscanned_media()` で fail-closed（index されない）。pipeline 実装時に
+  `MediaFetcher` を `with_media_fetcher` で注入する。
+- PDQ ローカル計算による hash submission・`POST /v1/url`（要 Authorized Domains）・
+  `POST /v1/media/submit`（analyst 提出）は follow-up。
+- Match Data（`near_match_details` / sha 群）は応答型に持たず、保存・P2P 配布・AI 入力の経路が
+  構造的に存在しない。
+- credentials は operator-owned。kukuri は同梱・共有・代理利用しない。値は log / error /
+  Debug に出さない。

--- a/docs/runbooks/project-arachnid-shield.md
+++ b/docs/runbooks/project-arachnid-shield.md
@@ -1,0 +1,132 @@
+# Project Arachnid Shield Integration (Community Node Operator)
+
+最終更新日: 2026-07-02
+
+## 目的
+
+Community Node operator が **自分の** Project Arachnid Shield account / API credentials を使って、
+kukuri の known-CSAM safety provider（`project-arachnid-shield`、Issue #391）を設定・検証・運用する
+ための手順。
+
+kukuri can be configured by operators to integrate with Project Arachnid Shield using their own
+credentials. kukuri 本体は credentials を同梱・共有・代理利用しない。
+
+> 注意: この runbook は法的助言ではない。CSAM への対応は各国法上の削除・通報義務を伴う。
+> Shield の利用はそれらの義務や、IHC / 警察等への通報フロー整備を**代替しない**。通報フローは
+> operator が自身の管轄法に基づき別途整備すること。
+
+## 前提と責任分界
+
+- **credentials は operator 所有**: 各 operator が [projectarachnid.com](https://projectarachnid.com)
+  で自分の account を取得する。kukuri 公式は shared / demo key を提供しない。hosted facilitator が
+  third-party operator の key を代理利用することも禁止。
+- **Shield API の利用は operator 自身の責任**で、Project Arachnid の Terms and Conditions of Use に
+  従う。
+- 自分のサービスで Shield を利用中であることを**公表する場合**は、Project Arachnid Terms の
+  public statement 条項に従い、必要に応じて指定文言または事前承認を使う。kukuri の docs / UI では
+  `certified` / `approved` / `officially supported` / `protected by` 等の表現を使わない。
+
+## Shield へ送信されるデータ（Submitted Data）
+
+| 経路 | 送信内容 | 使用箇所 |
+|---|---|---|
+| `POST /v1/media` | media 本体（bytes）| runtime の media scan（media fetcher 接続後） |
+| `POST /v1/pdq` | PDQ hash（32 bytes の base64。media 本体ではない） | `safety test-provider` の connectivity check |
+| `POST /v1/url` | media を指す URL | **未実装**（将来。account の Authorized Domains 登録が必要） |
+
+- Community Node は blob 本体を恒久保存しない（`safety.storage.permanent_blob_storage=false`）。
+  scan のための fetch は一時的で、scan 後に破棄される。
+- URL submission を将来使う場合、media を配信する domain を Project Arachnid の設定画面で
+  **Authorized Domains** に登録する必要がある（DNS / domain 所有確認を伴う）。media bytes 直送
+  （既定）では不要。
+
+## Shield から返るデータ（Match Data）の扱い
+
+Shield の応答（Match Data）は kukuri 内部の critical safety decision の入力としてのみ使う。
+
+- 実装は応答から `classification` / `match_type` **のみ**を読み取り、`near_match_details`・
+  一致先 sha1/sha256・timestamp は型に存在しないため保存・転送・log 出力の経路が無い
+  （`crates/cn-safety-arachnid`）。
+- 公開・共有される moderation event には provider の生結果ではなく、kukuri 側の抽象化された
+  判断（`exclude` / reason code 等）だけが載る。
+- Match Data を P2P network / 他 operator へ流さない。LLM / AI moderation pipeline の入力や
+  training / evaluation dataset にも使わない。
+
+## `No Known Match` の意味
+
+`no-known-match` は「**scan 時点で** Project Arachnid Shield の既知 Exact / Near Match に
+該当しなかった」ことだけを意味する。
+
+- **安全証明ではない**。未知の CSAM は known-match scan では検出できない。
+- kukuri 内部でも `no_known_match` という reason code のまま扱い、`safe` / `clean` / `verified`
+  相当の命名・表示に変換しない。
+
+## 設定手順
+
+1. Project Arachnid Shield account を取得し、API username / password を発行する。
+2. credentials を env / secret manager に設定する（**repository / config ファイルに値を書かない**）:
+
+   ```bash
+   # .env（コミットしない）または Secret Manager からの注入
+   PROJECT_ARACHNID_API_USERNAME=...   # 値は Project Arachnid 管理ページの表記に合わせた env 名
+   PROJECT_ARACHNID_API_PASSWORD=...
+   ```
+
+   任意の上書き:
+
+   ```bash
+   PROJECT_ARACHNID_API_BASE_URL=https://shield.projectarachnid.com  # 既定値
+   PROJECT_ARACHNID_API_TIMEOUT_SECS=30                              # 既定値
+   ```
+
+3. provider を known-CSAM slot に設定する:
+
+   ```bash
+   COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM=project-arachnid-shield
+   COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM_REQUIRED=true
+   ```
+
+   `operator-config.yaml` では:
+
+   ```yaml
+   safety:
+     profile: public-node
+     providers:
+       known_csam:
+         provider: project-arachnid-shield   # underscore 表記も受理される
+         required: true
+         credential_secret_id: <secret-manager-id>
+   ```
+
+4. 検証する:
+
+   ```bash
+   # 実 API への connectivity check（credentials の値は表示されない）
+   cargo run -p kukuri-cn-operator --features safety-arachnid -- \
+     safety test-provider project-arachnid-shield
+
+   # 静的 readiness check（public-node profile）
+   cargo run -p kukuri-cn-operator -- safety readiness --config operator-config.yaml
+   ```
+
+## fail-closed 動作（public-node profile）
+
+- credentials 未設定のまま provider を指定すると **runtime 構築が失敗**し、ingest は起動しない。
+- Shield unavailable / timeout / 想定外応答の間、対象 content は index されない（`hold`）。
+- Exact / Near Match は `exclude`（critical）として index / discovery / recommendation から除外される。
+- `test` classification（C3P のテストデータ）は index されないが、`csam_confirmed` とは別の
+  `provider_test_match` として記録される（統合検証で実運用イベントを汚さない）。
+
+## credentials 漏洩時の手順
+
+1. Project Arachnid の管理ページで該当 API credentials を無効化（rotate）する。
+2. 新しい credentials を env / secret manager に再設定する。
+3. node を再起動し、`safety test-provider project-arachnid-shield` で新 credentials を確認する。
+4. 漏洩範囲（log / shell history / CI 変数等）を確認する。kukuri は credentials を log に出さないが、
+   `.env` の共有・コミット等の運用ミスは operator 側で監査すること。
+
+## 関連
+
+- Issue #391 / #353、ADR 0027（`docs/adr/0027-deterministic-moderation-critical-safety.md`）
+- `crates/cn-safety-arachnid`（provider 実装）
+- `docs/runbooks/community-node-operator-docs.md`（operator-config / readiness 全般）


### PR DESCRIPTION
## 概要

Issue #391 の実装。known-CSAM safety provider として Project Arachnid Shield を実装し、`resolve_provider` / operator CLI / readiness check / operator docs に接続する。各 Community Node operator が自分の credentials を設定して使う方式で、kukuri 本体は credentials を同梱・共有・代理利用しない。

Closes #391

## 変更内容

### 新規 crate `crates/cn-safety-arachnid`
- **`ShieldClient`**: HTTP Basic auth、`POST /v1/media`(media scan)/`POST /v1/pdq`(connectivity check)。応答から読むのは `classification` / `match_type` のみで、**Match Data**(`near_match_details`・一致先 sha1/sha256・timestamp)は型に存在せず、保存・P2P 配布・log 露出の経路が構造的に無い。HTTP エラーは status のみでエラー化し body・credential を含めない。
- **`ProjectArachnidShieldProvider`**(`SafetyProvider` 実装、`project-arachnid-shield`、capability `KnownCsamHashMatch` + `PerceptualHashMatch`)。
- **`ShieldProviderConfig`**: credentials は env `PROJECT_ARACHNID_API_USERNAME` / `PROJECT_ARACHNID_API_PASSWORD`(Project Arachnid 管理ページ表記)から読む。`Debug` / error / log に値を出さない。

### classification → domain verdict の写像
| Shield | 写像 |
|---|---|
| `csam` / `harmful-abusive-material` (exact) | `known_hash_match` → `Exclude` / `csam_confirmed` / critical |
| 同上 (near) | 同上(capability `PerceptualHashMatch`) |
| `test` | `Exclude` + `provider_test_match`(`csam_confirmed` と区別、非 critical) |
| `no-known-match` | `NoKnownMatch`(**safe の証明ではない**) |
| 未知の値 | deserialize 失敗 → fail-closed |

- domain 拡張: `SafetyCategory::ProviderTest` / `ReasonCode::ProviderTestMatch`、`MediaFetcher` / `FetchedMedia`(media 一時 fetch の seam。本 PR では未接続)。

### runtime / CLI / readiness
- `resolve_provider`(cn-core、feature `safety-arachnid-provider`)に `project-arachnid-shield` を追加。known_csam slot 専用、credentials 欠落 = 起動 Err = fail-closed。
- `cn-operator safety test-provider project-arachnid-shield`(実 API connectivity check、feature `safety-arachnid`、credentials 値は非表示)。
- readiness check `known_csam_provider_resolvable` を追加(全 13 項目)。

### docs
- `docs/runbooks/project-arachnid-shield.md`(credentials / Submitted Data / No Known Match semantics / 法的義務 disclaimer / 漏洩時手順 / Authorized Domains)
- ADR 0027 §7 追補、progress doc

## テスト
- wiremock contract テスト(写像・fail-closed・credentials/Match Data 非露出・orchestrator 経由の moderation event 非汚染)。
- `cargo xtask check`(fmt / clippy / lint / typecheck)通過、`cargo xtask test`(Rust workspace 全 crate + desktop 305 テスト)通過。

## レビュアー向けメモ
- **実 API で connectivity check 成功を確認済み**(credentials は非表示)。
- Shield API の PDQ hash は仕様書に無い **base64(32 bytes)** 形式(hex は 400)。実装・docs に反映済み。
- **DNS(Authorized Domains)作業は不要**: media bytes 直送 + PDQ hash 送信では domain 登録は要らない(URL submission を将来使う場合のみ)。
- media scan pipeline(blob 一時 fetch → scan 発火)は follow-up。media 付き post は従来どおり `has_unscanned_media()` で fail-closed。
- DB schema 変更は無いため DB integration テスト(`KUKURI_CN_RUN_INTEGRATION_TESTS=1`)は未実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
