### PR TITLE
feat(cn): community node trust / relation foundation (CommunityLocalTrust read surface) (#415)

### DIFF
--- a/.env.community-node.example
+++ b/.env.community-node.example
@@ -50,6 +50,17 @@ COMMUNITY_NODE_CONNECTIVITY_URLS=http://127.0.0.1:13340
 # 有効化する場合は cn-user-api にも COMMUNITY_NODE_ARCADEDB_*（cn-indexer と同一値）を渡す。
 # COMMUNITY_NODE_INDEX_QUERY_ENABLED=false
 
+# trust / relation read surface（#415: GET /v1/trust/*, /v1/relation/*。ADR 0026）を公開するか。
+# 既定 false（CommunityLocalTrust capability が Planned の間は無効のまま。無効時は 404）。
+# 有効化する場合は cn-user-api に COMMUNITY_NODE_ARCADEDB_*（relation graph。cn-indexer と同一値）
+# を渡し、relation graph は `cn-cli relation analyze`（batch・非常駐）で構築する。
+# COMMUNITY_NODE_TRUST_READ_ENABLED=false
+# trust 合成の operator 可変パラメータ（ADR 0026 §6.2。未設定は初期決め打ち値）:
+# w_abs（絶対成分マイナス時の重み。既定 2.0）/ w_abs（0 以上時。既定 1.0）/ 相対成分の半減期（日。既定 30）。
+# COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE=2.0
+# COMMUNITY_NODE_TRUST_W_ABS_POSITIVE=1.0
+# COMMUNITY_NODE_TRUST_RELATIVE_HALF_LIFE_DAYS=30
+
 # safety provider（#391 Project Arachnid Shield）。public-node profile では known-CSAM
 # provider が必須。provider 名を known_csam slot に設定し、credentials を env で渡す。
 # 未設定のまま provider を指定すると cn-indexer の runtime 構築が失敗し ingest は起動しない

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,6 +2952,7 @@ dependencies = [
  "chrono",
  "clap",
  "kukuri-cn-core",
+ "kukuri-cn-indexer",
  "serde_json",
  "sqlx",
  "tokio",
@@ -2972,6 +2973,7 @@ dependencies = [
  "kukuri-cn-safety",
  "kukuri-cn-safety-arachnid",
  "kukuri-cn-safety-runtime",
+ "kukuri-cn-trust",
  "kukuri-core",
  "redis",
  "secp256k1",
@@ -2998,6 +3000,7 @@ dependencies = [
  "kukuri-cn-core",
  "kukuri-cn-safety",
  "kukuri-cn-safety-runtime",
+ "kukuri-cn-trust",
  "kukuri-core",
  "kukuri-docs-sync",
  "kukuri-transport",
@@ -3086,6 +3089,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kukuri-cn-trust"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "kukuri-cn-safety",
+ "kukuri-cn-trust",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "kukuri-cn-user-api"
 version = "0.1.2"
 dependencies = [
@@ -3097,6 +3113,7 @@ dependencies = [
  "kukuri-cn-indexer",
  "kukuri-cn-operator",
  "kukuri-cn-safety",
+ "kukuri-cn-trust",
  "kukuri-core",
  "redis",
  "reqwest 0.13.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/cn-safety",
     "crates/cn-safety-arachnid",
     "crates/cn-safety-runtime",
+    "crates/cn-trust",
     "crates/cn-indexer",
 ]
 exclude = [

--- a/crates/cn-cli/Cargo.toml
+++ b/crates/cn-cli/Cargo.toml
@@ -16,3 +16,4 @@ serde_json.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
 kukuri-cn-core = { path = "../cn-core" }
+kukuri-cn-indexer = { path = "../cn-indexer" }

--- a/crates/cn-cli/src/main.rs
+++ b/crates/cn-cli/src/main.rs
@@ -3,14 +3,15 @@ use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand, ValueEnum};
 use kukuri_cn_core::{
     AdmissionMode, AuthMode, AuthRolloutConfig, COMMUNITY_NODE_AUTH_SERVICE_NAME, IndexScopeKind,
-    IndexingRequestStatus, add_allowlist, add_supported_topic, approve_indexing_request,
-    ban_subscriber, connect_postgres, get_community_node_report, initialize_database,
-    issue_invite_code, list_allowlist, list_banned, list_community_node_reports,
-    list_indexing_requests, list_invite_codes, list_supported_topics, load_admission_config,
-    migrate_postgres, reject_indexing_request, remove_allowlist, remove_supported_topic,
-    revoke_invite_code, seed_default_policies, set_admission_mode, store_auth_rollout,
-    unban_subscriber,
+    IndexingRequestStatus, PgCoParticipationSource, add_allowlist, add_supported_topic,
+    approve_indexing_request, ban_subscriber, connect_postgres, get_community_node_report,
+    initialize_database, issue_invite_code, list_allowlist, list_banned,
+    list_community_node_reports, list_indexing_requests, list_invite_codes, list_supported_topics,
+    load_admission_config, migrate_postgres, reject_indexing_request, remove_allowlist,
+    remove_supported_topic, revoke_invite_code, seed_default_policies, set_admission_mode,
+    store_auth_rollout, unban_subscriber,
 };
+use kukuri_cn_indexer::{ArcadeDbConfig, ArcadeDbRelationGraph, analyze_relations};
 
 #[derive(Debug, Parser)]
 struct Cli {
@@ -56,6 +57,24 @@ enum Command {
     IndexingRequest {
         #[command(subcommand)]
         action: IndexingRequestAction,
+    },
+    /// relation graph（trust / relation foundation, #415）を運用する。
+    Relation {
+        #[command(subcommand)]
+        action: RelationAction,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum RelationAction {
+    /// index 真実源の co-participation 集計から relation graph を batch 解析する（非常駐、冪等）。
+    ///
+    /// 書き込み先は ArcadeDB の relation graph（`COMMUNITY_NODE_ARCADEDB_*` env）のみ。
+    /// social graph canonical / index 真実源は改変しない（ADR 0026 §2.2）。
+    Analyze {
+        /// 読み込む集計行の上限（有界化）。
+        #[arg(long, default_value_t = kukuri_cn_indexer::DEFAULT_ANALYSIS_LIMIT)]
+        limit: usize,
     },
 }
 
@@ -363,8 +382,31 @@ async fn main() -> Result<()> {
         Command::IndexingRequest { action } => {
             run_indexing_request(&pool, action).await?;
         }
+        Command::Relation { action } => {
+            run_relation(&pool, action).await?;
+        }
     }
 
+    Ok(())
+}
+
+async fn run_relation(pool: &sqlx::PgPool, action: RelationAction) -> Result<()> {
+    match action {
+        RelationAction::Analyze { limit } => {
+            let source = PgCoParticipationSource::new(pool.clone());
+            let graph = ArcadeDbRelationGraph::new(ArcadeDbConfig::from_env())
+                .context("failed to build ArcadeDB relation graph client")?;
+            graph
+                .ensure_schema()
+                .await
+                .context("failed to ensure relation graph schema")?;
+            let report = analyze_relations(&source, &graph, limit).await?;
+            println!(
+                "relation analysis done: {} edge(s) upserted, {} cluster(s) assigned",
+                report.edges_upserted, report.clusters_assigned
+            );
+        }
+    }
     Ok(())
 }
 

--- a/crates/cn-core/Cargo.toml
+++ b/crates/cn-core/Cargo.toml
@@ -34,6 +34,7 @@ kukuri-core = { path = "../core" }
 kukuri-cn-safety = { path = "../cn-safety" }
 kukuri-cn-safety-arachnid = { path = "../cn-safety-arachnid", optional = true }
 kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
+kukuri-cn-trust = { path = "../cn-trust" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/cn-core/migrations/202607020002_trust_relation.sql
+++ b/crates/cn-core/migrations/202607020002_trust_relation.sql
@@ -1,0 +1,20 @@
+-- #415: community node trust / relation foundation（ADR 0026）。
+--
+-- relation の「見えない」opt-out（§2.6 / §6.3 Decision）を保持する。user は自分を
+-- (a) 他者の discovery / surfacing、(b) 他者から見た relation read の双方から外せる。
+-- node-local な選択であり、可逆（行の削除で解除）。social graph canonical の削除ではなく、
+-- trust には影響しない（troll 判定回避の手段にしない — trust read は本テーブルを見ない）。
+--
+-- trust / relation の scoring 状態はここに持たない: trust は risk signal（cn_safety.risk_signals）
+-- からの再計算、relation graph は ArcadeDB（derived projection、index 投影に相乗り）であり、
+-- どちらも再構築可能な derived state（ADR 0026 Feature Data Classification）。
+
+CREATE SCHEMA IF NOT EXISTS cn_trust;
+
+-- relation opt-out（「見えない」選択）の真実源。
+CREATE TABLE cn_trust.relation_optouts (
+    -- opt-out した user の pubkey（正規化済み hex）。
+    pubkey TEXT PRIMARY KEY,
+    -- opt-out した時刻（説明可能性: いつから見えなくなったか）。
+    opted_out_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/crates/cn-core/src/co_participation.rs
+++ b/crates/cn-core/src/co_participation.rs
@@ -1,0 +1,230 @@
+//! relation feature の観測元 = index 真実源からの co-participation 集計（ADR 0026 §2.4, #415）。
+//!
+//! `cn_index.index_entries`（#404 の fail-closed 真実源）から author 間の共起を集計する。
+//! 真実源には `allow` verdict の entry しか存在しない（DB 制約）ため、集計結果も自動的に
+//! fail-closed 済みの観測になる。
+//!
+//! **private channel 由来は集計しない**（ADR 0026 §6.3 / プラン Assumption 5, fail-closed）:
+//! `scope_kind = public_topic` のみを対象にし、private channel の co-participation が
+//! public relation に混ざらないことを構造的に保証する
+//! （`relation_private_channel_signal_stays_local_and_scoped` の入力側）。
+//! channel メンバー可視の relation は後続 Issue。
+//!
+//! 集計セマンティクス（Pg / in-memory で同一）:
+//! - `shared_topics`: 両 author が entry を持つ supported topic の数。
+//! - `co_participation_events`: 共有 topic ごとの `min(entries_a, entries_b)` の総和
+//!   （どちらか一方が大量投稿しても共起強度が過大評価されない有界化）。
+//! - dominant topic: author が最も多く entry を持つ topic（cluster_of の初期実装の入力。
+//!   同数は scope_id 辞書順で決定論化）。
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use sqlx::PgPool;
+use sqlx::Row;
+
+use crate::index_entries::MemoryIndexEntryStore;
+use crate::index_scope::IndexScopeKind;
+
+/// author ペアの co-participation 集計 1 件（`author_a < author_b` の正規化済みペア）。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CoParticipationPair {
+    pub author_a: String,
+    pub author_b: String,
+    /// 両者が entry を持つ supported topic の数。
+    pub shared_topics: i64,
+    /// 共有 topic ごとの min(entries_a, entries_b) の総和。
+    pub co_participation_events: i64,
+}
+
+/// author の dominant topic（最多 entry の topic。cluster 帰属の初期入力）。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthorDominantTopic {
+    pub author_pubkey: String,
+    pub topic_id: String,
+    pub entries: i64,
+}
+
+/// co-participation 集計の read 抽象。
+///
+/// 本番は Postgres（index 真実源への集計クエリ）、contract test は in-memory
+/// （`MemoryIndexEntryStore` のスナップショットへ同一セマンティクスを適用）。
+/// relation 解析 worker（`cn-indexer`）はこの trait 越しに観測を読む。
+#[async_trait]
+pub trait CoParticipationSource: Send + Sync {
+    /// author ペアの共起集計（shared_topics 降順 → events 降順 → pubkey 辞書順、最大 limit 件）。
+    async fn list_co_participation_pairs(&self, limit: usize) -> Result<Vec<CoParticipationPair>>;
+
+    /// author ごとの dominant topic（author_pubkey 辞書順、最大 limit 件）。
+    async fn list_author_dominant_topics(&self, limit: usize) -> Result<Vec<AuthorDominantTopic>>;
+}
+
+/// Postgres 実装。
+#[derive(Clone, Debug)]
+pub struct PgCoParticipationSource {
+    pool: PgPool,
+}
+
+impl PgCoParticipationSource {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl CoParticipationSource for PgCoParticipationSource {
+    async fn list_co_participation_pairs(&self, limit: usize) -> Result<Vec<CoParticipationPair>> {
+        let rows = sqlx::query(
+            "WITH participation AS (
+                 SELECT scope_id, author_pubkey, COUNT(*) AS entries
+                 FROM cn_index.index_entries
+                 WHERE scope_kind = 'public_topic'
+                 GROUP BY scope_id, author_pubkey
+             )
+             SELECT p1.author_pubkey AS author_a,
+                    p2.author_pubkey AS author_b,
+                    COUNT(*)::BIGINT AS shared_topics,
+                    SUM(LEAST(p1.entries, p2.entries))::BIGINT AS co_participation_events
+             FROM participation p1
+             JOIN participation p2
+               ON p1.scope_id = p2.scope_id
+              AND p1.author_pubkey < p2.author_pubkey
+             GROUP BY p1.author_pubkey, p2.author_pubkey
+             ORDER BY shared_topics DESC, co_participation_events DESC, author_a, author_b
+             LIMIT $1",
+        )
+        .bind(i64::try_from(limit)?)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.iter()
+            .map(|row| {
+                Ok(CoParticipationPair {
+                    author_a: row.try_get("author_a")?,
+                    author_b: row.try_get("author_b")?,
+                    shared_topics: row.try_get("shared_topics")?,
+                    co_participation_events: row.try_get("co_participation_events")?,
+                })
+            })
+            .collect()
+    }
+
+    async fn list_author_dominant_topics(&self, limit: usize) -> Result<Vec<AuthorDominantTopic>> {
+        let rows = sqlx::query(
+            "SELECT DISTINCT ON (author_pubkey)
+                    author_pubkey,
+                    scope_id AS topic_id,
+                    COUNT(*)::BIGINT AS entries
+             FROM cn_index.index_entries
+             WHERE scope_kind = 'public_topic'
+             GROUP BY author_pubkey, scope_id
+             ORDER BY author_pubkey, COUNT(*) DESC, scope_id
+             LIMIT $1",
+        )
+        .bind(i64::try_from(limit)?)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.iter()
+            .map(|row| {
+                Ok(AuthorDominantTopic {
+                    author_pubkey: row.try_get("author_pubkey")?,
+                    topic_id: row.try_get("topic_id")?,
+                    entries: row.try_get("entries")?,
+                })
+            })
+            .collect()
+    }
+}
+
+/// (scope_id, author) → entry 数の集計（public_topic のみ）。
+fn participation_counts(store: &MemoryIndexEntryStore) -> HashMap<(String, String), i64> {
+    let mut counts: HashMap<(String, String), i64> = HashMap::new();
+    for entry in store.entries_snapshot() {
+        // private channel 由来は relation の観測に混ぜない（fail-closed。Pg 実装の WHERE と同一）。
+        if entry.scope_kind != IndexScopeKind::PublicTopic {
+            continue;
+        }
+        *counts
+            .entry((entry.scope_id.clone(), entry.author_pubkey.clone()))
+            .or_default() += 1;
+    }
+    counts
+}
+
+#[async_trait]
+impl CoParticipationSource for MemoryIndexEntryStore {
+    async fn list_co_participation_pairs(&self, limit: usize) -> Result<Vec<CoParticipationPair>> {
+        // scope ごとの author → entries に組み替える。
+        let mut by_scope: HashMap<String, Vec<(String, i64)>> = HashMap::new();
+        for ((scope_id, author), entries) in participation_counts(self) {
+            by_scope
+                .entry(scope_id)
+                .or_default()
+                .push((author, entries));
+        }
+
+        let mut pairs: HashMap<(String, String), (i64, i64)> = HashMap::new();
+        for authors in by_scope.values_mut() {
+            authors.sort();
+            for i in 0..authors.len() {
+                for j in (i + 1)..authors.len() {
+                    let (a, ea) = &authors[i];
+                    let (b, eb) = &authors[j];
+                    let slot = pairs.entry((a.clone(), b.clone())).or_default();
+                    slot.0 += 1; // shared_topics
+                    slot.1 += (*ea).min(*eb); // co_participation_events
+                }
+            }
+        }
+
+        let mut result: Vec<CoParticipationPair> = pairs
+            .into_iter()
+            .map(
+                |((author_a, author_b), (shared_topics, events))| CoParticipationPair {
+                    author_a,
+                    author_b,
+                    shared_topics,
+                    co_participation_events: events,
+                },
+            )
+            .collect();
+        result.sort_by(|x, y| {
+            y.shared_topics
+                .cmp(&x.shared_topics)
+                .then(y.co_participation_events.cmp(&x.co_participation_events))
+                .then(x.author_a.cmp(&y.author_a))
+                .then(x.author_b.cmp(&y.author_b))
+        });
+        result.truncate(limit);
+        Ok(result)
+    }
+
+    async fn list_author_dominant_topics(&self, limit: usize) -> Result<Vec<AuthorDominantTopic>> {
+        let mut by_author: HashMap<String, Vec<(String, i64)>> = HashMap::new();
+        for ((scope_id, author), entries) in participation_counts(self) {
+            by_author
+                .entry(author)
+                .or_default()
+                .push((scope_id, entries));
+        }
+        let mut result: Vec<AuthorDominantTopic> = by_author
+            .into_iter()
+            .map(|(author_pubkey, mut topics)| {
+                // 最多 entry、同数は scope_id 辞書順（Pg 実装の DISTINCT ON と同じ決定論）。
+                topics.sort_by(|(sa, ea), (sb, eb)| eb.cmp(ea).then(sa.cmp(sb)));
+                let (topic_id, entries) = topics
+                    .into_iter()
+                    .next()
+                    .expect("non-empty by construction");
+                AuthorDominantTopic {
+                    author_pubkey,
+                    topic_id,
+                    entries,
+                }
+            })
+            .collect();
+        result.sort_by(|a, b| a.author_pubkey.cmp(&b.author_pubkey));
+        result.truncate(limit);
+        Ok(result)
+    }
+}

--- a/crates/cn-core/src/database.rs
+++ b/crates/cn-core/src/database.rs
@@ -58,6 +58,7 @@ pub async fn ensure_database_ready(pool: &PgPool) -> Result<()> {
         ("cn_index", "indexing_requests"),
         ("cn_index", "channel_secrets"),
         ("cn_index", "index_entries"),
+        ("cn_trust", "relation_optouts"),
     ] {
         let exists = sqlx::query_scalar::<_, bool>(
             "SELECT EXISTS (

--- a/crates/cn-core/src/index_entries.rs
+++ b/crates/cn-core/src/index_entries.rs
@@ -296,6 +296,16 @@ impl MemoryIndexEntryStore {
         }
     }
 
+    /// 現在の entry 一覧のスナップショット（co-participation 集計の in-memory 実装が使う）。
+    pub fn entries_snapshot(&self) -> Vec<NewIndexEntry> {
+        self.entries
+            .lock()
+            .expect("entries mutex poisoned")
+            .values()
+            .cloned()
+            .collect()
+    }
+
     /// entry が真実源に存在するか（テスト用の read ヘルパ）。
     pub fn contains(&self, scope_kind: IndexScopeKind, scope_id: &str, object_id: &str) -> bool {
         self.entries

--- a/crates/cn-core/src/lib.rs
+++ b/crates/cn-core/src/lib.rs
@@ -1,6 +1,7 @@
 mod admission;
 mod auth;
 mod bootstrap;
+mod co_participation;
 mod config;
 mod consents;
 mod database;
@@ -10,6 +11,7 @@ mod index_entries;
 mod index_scope;
 mod models;
 mod normalize;
+mod relation_optouts;
 mod rendezvous;
 mod reports;
 mod rollout;
@@ -33,6 +35,9 @@ pub use auth::{
 pub use bootstrap::{
     load_bootstrap_nodes, load_bootstrap_seed_peers, refresh_bootstrap_peer_registration,
     upsert_bootstrap_node,
+};
+pub use co_participation::{
+    AuthorDominantTopic, CoParticipationPair, CoParticipationSource, PgCoParticipationSource,
 };
 pub use config::{
     AUTH_CHALLENGE_TTL_SECONDS, AUTH_ENVELOPE_KIND, AUTH_EVENT_MAX_SKEW_SECONDS, AuthMode,
@@ -69,6 +74,10 @@ pub use models::{
 pub use normalize::{
     first_tag_value, normalize_http_url, normalize_http_url_list, normalize_pubkey,
     normalize_ws_url, parse_auth_envelope, parse_socket_addr_env, verify_auth_envelope,
+};
+pub use relation_optouts::{
+    clear_relation_optout, filter_relation_visible, get_relation_optout, is_relation_opted_out,
+    set_relation_optout,
 };
 pub use rendezvous::{
     TopicRendezvousCandidate, TopicRendezvousHeartbeat, TopicRendezvousHeartbeatResponse,

--- a/crates/cn-core/src/relation_optouts.rs
+++ b/crates/cn-core/src/relation_optouts.rs
@@ -1,0 +1,75 @@
+//! relation の「見えない」opt-out（ADR 0026 §2.6 / §6.3 Decision, #415）。
+//!
+//! user は自分を (a) 他者の discovery / surfacing、(b) 他者から見た relation read の双方から
+//! 外せる。node-local な選択であり **可逆**（解除 = 行の削除）。social graph canonical の
+//! 削除ではない。**trust には影響しない**（troll 判定回避の手段にしない — trust read は
+//! 本 module を参照しない）。
+//!
+//! 適用点は read surface（`cn-user-api`）: relation read / neighbors（discovery）の結果から
+//! opt-out 済み pubkey を落とす。relation graph（ArcadeDB）からの物理削除はしない
+//! （derived state であり、opt-out 解除で即座に見え直せる = 可逆性の実装）。
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+
+use crate::normalize::normalize_pubkey;
+
+/// opt-out を登録する（冪等。既に opt-out 済みなら何もしない = opted_out_at は初回を保持）。
+pub async fn set_relation_optout(pool: &PgPool, pubkey: &str) -> Result<()> {
+    let pubkey = normalize_pubkey(pubkey)?;
+    sqlx::query(
+        "INSERT INTO cn_trust.relation_optouts (pubkey) VALUES ($1)
+         ON CONFLICT (pubkey) DO NOTHING",
+    )
+    .bind(&pubkey)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// opt-out を解除する（冪等。可逆性の実装 = 行の削除）。
+pub async fn clear_relation_optout(pool: &PgPool, pubkey: &str) -> Result<()> {
+    let pubkey = normalize_pubkey(pubkey)?;
+    sqlx::query("DELETE FROM cn_trust.relation_optouts WHERE pubkey = $1")
+        .bind(&pubkey)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// opt-out 状態の read（説明可能性: いつから見えなくなったかを返す）。
+pub async fn get_relation_optout(pool: &PgPool, pubkey: &str) -> Result<Option<DateTime<Utc>>> {
+    let pubkey = normalize_pubkey(pubkey)?;
+    let row: Option<(DateTime<Utc>,)> =
+        sqlx::query_as("SELECT opted_out_at FROM cn_trust.relation_optouts WHERE pubkey = $1")
+            .bind(&pubkey)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.map(|(at,)| at))
+}
+
+/// opt-out 済みか。
+pub async fn is_relation_opted_out(pool: &PgPool, pubkey: &str) -> Result<bool> {
+    Ok(get_relation_optout(pool, pubkey).await?.is_some())
+}
+
+/// 候補 pubkey 列のうち opt-out **していない** ものだけを返す（neighbors / discovery の
+/// 結果 filter 用。順序は入力を保つ）。
+pub async fn filter_relation_visible(pool: &PgPool, pubkeys: &[String]) -> Result<Vec<String>> {
+    if pubkeys.is_empty() {
+        return Ok(Vec::new());
+    }
+    let opted_out: Vec<(String,)> =
+        sqlx::query_as("SELECT pubkey FROM cn_trust.relation_optouts WHERE pubkey = ANY($1)")
+            .bind(pubkeys)
+            .fetch_all(pool)
+            .await?;
+    let opted_out: std::collections::HashSet<String> =
+        opted_out.into_iter().map(|(p,)| p).collect();
+    Ok(pubkeys
+        .iter()
+        .filter(|p| !opted_out.contains(*p))
+        .cloned()
+        .collect())
+}

--- a/crates/cn-core/src/trust_inputs.rs
+++ b/crates/cn-core/src/trust_inputs.rs
@@ -21,79 +21,18 @@
 //! - `None`: 確定寄与（ADR の `rejected` 相当を含む、異議が立っていない状態）。
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use chrono::DateTime;
 use sqlx::PgPool;
 
-use kukuri_cn_safety::{
-    AppealStatus, Basis, RiskSignalTarget, SafetyCategory, Severity, Visibility,
+use kukuri_cn_safety::{AppealStatus, RiskSignalTarget};
+// 型（TrustComponentKind / TrustRiskInput / TrustRiskInputs / trust_component_for）は
+// pure domain の cn-trust（#415）へ移した。本 module は永続化 risk signal からの組み立て
+// （供給契約）のみを担い、既存利用箇所のため型を再エクスポートする。
+pub use kukuri_cn_trust::{
+    TrustComponentKind, TrustRiskInput, TrustRiskInputs, trust_component_for,
 };
 
 use crate::safety_events::{StoredRiskSignal, list_risk_signals_for_target};
-
-/// risk signal category の trust 成分振り分け先（ADR 0026 §2.7）。
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TrustComponentKind {
-    /// 絶対成分: critical safety（CSAM / CSE / grooming）。relation で重み付けせず、
-    /// 通報数で動かない（report-bomb 不動）。時間減衰もしない（§6.2、scoring は #415）。
-    Absolute,
-    /// 相対成分: nsfw / spam 等の community / 文化圏依存の指標。relation で重み付けし、
-    /// viewer / cluster 相対で扱う。半減期減衰する（§6.2、scoring は #415）。
-    Relative,
-}
-
-/// category → trust 成分の振り分け（初期規則。operator 可変化は #415）。
-///
-/// critical safety（`SafetyCategory::is_critical_safety()` = Csam / Cse / Grooming）は絶対成分、
-/// それ以外（nsfw / spam / malware / phishing 等）は相対成分（ADR 0026 §2.7）。
-pub fn trust_component_for(category: SafetyCategory) -> TrustComponentKind {
-    if category.is_critical_safety() {
-        TrustComponentKind::Absolute
-    } else {
-        TrustComponentKind::Relative
-    }
-}
-
-/// trust / relation read への入力 1 件（根拠つき advisory）。
-///
-/// 断定ラベルではない。basis / confidence / visibility / expiry / appeal を必ず同伴し、
-/// 消費側（#415）が issuer / 根拠 / 有効期限を説明できる状態を保つ。
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TrustRiskInput {
-    /// 永続化側が採番した risk signal id。
-    pub signal_id: String,
-    /// この signal を発行した issuer node。
-    pub issuer_node_id: String,
-    /// 振り分け先の trust 成分。
-    pub component: TrustComponentKind,
-    pub category: SafetyCategory,
-    pub severity: Severity,
-    pub basis: Basis,
-    pub confidence: Option<u8>,
-    /// cross-node 開示の判定材料（§6.3。開示判定は消費側の責務）。
-    pub visibility: Visibility,
-    /// `Disputed`（= pending）は寄与据え置きのまま含まれる。消費側が状態を説明できるよう同伴する。
-    pub appeal_status: AppealStatus,
-    pub expires_at: Option<String>,
-    pub persisted_at: DateTime<Utc>,
-}
-
-/// 対象 1 つ分の trust 入力（絶対 / 相対に振り分け済み）。
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct TrustRiskInputs {
-    /// 絶対成分への入力（critical safety）。
-    pub absolute: Vec<TrustRiskInput>,
-    /// 相対成分への入力（relation 重み付けの対象）。
-    pub relative: Vec<TrustRiskInput>,
-}
-
-impl TrustRiskInputs {
-    /// 入力が 1 件も無いか。
-    pub fn is_empty(&self) -> bool {
-        self.absolute.is_empty() && self.relative.is_empty()
-    }
-}
 
 /// 永続化済み risk signal 列から trust 入力を組み立てる純関数。
 ///

--- a/crates/cn-core/tests/co_participation.rs
+++ b/crates/cn-core/tests/co_participation.rs
@@ -1,0 +1,180 @@
+//! co-participation 集計（relation feature の観測元、ADR 0026 §2.4 / #415）の contract テスト。
+//!
+//! - in-memory（DB 不要、常時実行）: 集計セマンティクスと private channel 除外
+//!   （`relation_private_channel_signal_stays_local_and_scoped` の入力側）を固定する。
+//! - Postgres（`KUKURI_CN_RUN_INTEGRATION_TESTS=1`）: Pg 実装が in-memory と同一の
+//!   セマンティクスを返すことを同一シードで検証する（実装間 drift の防止）。
+
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use kukuri_cn_core::{
+    CoParticipationPair, CoParticipationSource, IndexEntryStore, IndexScopeKind,
+    MemoryIndexEntryStore, MemorySafetyArtifactStore, NewIndexEntry, PgCoParticipationSource,
+    SafetyArtifactStore, TestDatabase, connect_postgres, initialize_database, upsert_index_entry,
+    upsert_scan_verdict,
+};
+use kukuri_cn_safety::provider::SubjectKind;
+use kukuri_cn_safety::{ReasonCode, SafetyAction, SafetyVerdict};
+
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+
+fn integration_test_admin_database_url() -> Option<String> {
+    let enabled = std::env::var("KUKURI_CN_RUN_INTEGRATION_TESTS")
+        .ok()
+        .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+    Some(
+        std::env::var("COMMUNITY_NODE_DATABASE_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_ADMIN_DATABASE_URL.to_string()),
+    )
+}
+
+fn allow_verdict() -> SafetyVerdict {
+    SafetyVerdict {
+        action: SafetyAction::Allow,
+        labels: Vec::new(),
+        critical: false,
+        reason_code: ReasonCode::NoKnownMatch,
+        confidence: None,
+        provider: Some("mock-known-csam".to_string()),
+        provider_capability: None,
+        policy_version: "policy-v1-test".to_string(),
+        scanned_at: "2026-07-02T09:00:00Z".to_string(),
+    }
+}
+
+fn entry(
+    scope_kind: IndexScopeKind,
+    scope_id: &str,
+    object_id: &str,
+    author: &str,
+    verdict_id: &str,
+) -> NewIndexEntry {
+    NewIndexEntry {
+        scope_kind,
+        scope_id: scope_id.to_string(),
+        object_id: object_id.to_string(),
+        author_pubkey: author.to_string(),
+        created_at: 1_700_000_000,
+        source_replica_id: format!("replica::{scope_id}"),
+        verdict_id: verdict_id.to_string(),
+        verdict_action: "allow".to_string(),
+        critical: false,
+    }
+}
+
+/// テストシード: topic-a に A×2 + B×1、topic-b に A×1 + B×1、private channel chan-x に
+/// A×1 + C×1（→ private 由来は集計に出ないこと）。
+///
+/// 期待値:
+/// - ペアは (A, B) のみ: shared_topics = 2、co_participation_events = min(2,1) + min(1,1) = 2。
+/// - (A, C) は private channel のみの共起なので **存在しない**。
+/// - dominant topic: A → topic-a（2 entries）、B → topic-a（1 entry、同数 tie は辞書順）。
+///   C は public 参加が無いので出ない。
+struct Seed {
+    /// (scope_kind, scope_id, object_id, author)
+    entries: Vec<(IndexScopeKind, &'static str, &'static str, &'static str)>,
+}
+
+fn seed() -> Seed {
+    use IndexScopeKind::{PrivateChannel, PublicTopic};
+    Seed {
+        entries: vec![
+            (PublicTopic, "topic-a", "post-1", "author-a"),
+            (PublicTopic, "topic-a", "post-2", "author-a"),
+            (PublicTopic, "topic-a", "post-3", "author-b"),
+            (PublicTopic, "topic-b", "post-4", "author-a"),
+            (PublicTopic, "topic-b", "post-5", "author-b"),
+            (PrivateChannel, "chan-x", "post-6", "author-a"),
+            (PrivateChannel, "chan-x", "post-7", "author-c"),
+        ],
+    }
+}
+
+async fn assert_co_participation_contracts(source: &dyn CoParticipationSource) -> Result<()> {
+    let pairs = source.list_co_participation_pairs(100).await?;
+    assert_eq!(
+        pairs,
+        vec![CoParticipationPair {
+            author_a: "author-a".to_string(),
+            author_b: "author-b".to_string(),
+            shared_topics: 2,
+            co_participation_events: 2,
+        }],
+        "public topic の共起のみが集計され、private channel 由来の (A, C) ペアは出ないこと"
+    );
+
+    let dominant = source.list_author_dominant_topics(100).await?;
+    assert_eq!(dominant.len(), 2, "public 参加の無い author-c は出ない");
+    assert_eq!(dominant[0].author_pubkey, "author-a");
+    assert_eq!(dominant[0].topic_id, "topic-a");
+    assert_eq!(dominant[0].entries, 2);
+    assert_eq!(dominant[1].author_pubkey, "author-b");
+    // B は topic-a / topic-b とも 1 entry。tie は scope_id 辞書順で決定論化。
+    assert_eq!(dominant[1].topic_id, "topic-a");
+
+    // limit の有界化。
+    let limited = source.list_co_participation_pairs(0).await?;
+    assert!(limited.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn co_participation_pairs_from_public_topics_only_memory() -> Result<()> {
+    let verdicts = Arc::new(MemorySafetyArtifactStore::new());
+    let store = MemoryIndexEntryStore::new(verdicts.clone());
+    for (i, (scope_kind, scope_id, object_id, author)) in seed().entries.iter().enumerate() {
+        let verdict_id = verdicts
+            .persist_verdict(SubjectKind::Post, &format!("subject-{i}"), &allow_verdict())
+            .await?;
+        store
+            .upsert_entry(&entry(
+                *scope_kind,
+                scope_id,
+                object_id,
+                author,
+                &verdict_id,
+            ))
+            .await?;
+    }
+    assert_co_participation_contracts(&store).await
+}
+
+#[tokio::test]
+async fn co_participation_pairs_from_public_topics_only_postgres() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core co_participation test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_co_participation").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    let result = async {
+        initialize_database(&pool).await?;
+        for (i, (scope_kind, scope_id, object_id, author)) in seed().entries.iter().enumerate() {
+            let stored = upsert_scan_verdict(
+                &pool,
+                SubjectKind::Post,
+                &format!("subject-{i}"),
+                &allow_verdict(),
+            )
+            .await?;
+            upsert_index_entry(
+                &pool,
+                &entry(*scope_kind, scope_id, object_id, author, &stored.id),
+            )
+            .await?;
+        }
+        let source = PgCoParticipationSource::new(pool.clone());
+        assert_co_participation_contracts(&source).await
+    }
+    .await;
+    database.cleanup().await?;
+    result
+}

--- a/crates/cn-core/tests/relation_optouts.rs
+++ b/crates/cn-core/tests/relation_optouts.rs
@@ -1,0 +1,133 @@
+//! relation opt-out「見えない」（ADR 0026 §2.6 / §6.3, #415）の Postgres integration テスト。
+//!
+//! `KUKURI_CN_RUN_INTEGRATION_TESTS=1` のときだけ実 DB に接続して実行する。
+//! - `relation_visibility_choice_is_user_controlled_and_reversible`: set → clear の往復・冪等性。
+//! - opt-out は trust 入力（`list_trust_risk_inputs`）へ影響しない（troll 判定回避の手段にしない）。
+
+use anyhow::Result;
+
+use kukuri_cn_core::{
+    TestDatabase, clear_relation_optout, connect_postgres, filter_relation_visible,
+    get_relation_optout, initialize_database, is_relation_opted_out, list_trust_risk_inputs,
+    persist_risk_signal, set_relation_optout,
+};
+use kukuri_cn_safety::{
+    Basis, RiskSignalTarget, SafetyCategory, SafetyRiskSignal, Severity, Visibility,
+};
+
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+
+fn integration_test_admin_database_url() -> Option<String> {
+    let enabled = std::env::var("KUKURI_CN_RUN_INTEGRATION_TESTS")
+        .ok()
+        .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+    Some(
+        std::env::var("COMMUNITY_NODE_DATABASE_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_ADMIN_DATABASE_URL.to_string()),
+    )
+}
+
+const PUBKEY_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const PUBKEY_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+#[tokio::test]
+async fn relation_visibility_choice_is_user_controlled_and_reversible() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core relation optout test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_relation_optouts").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    let result = async {
+        initialize_database(&pool).await?;
+
+        // 既定は opt-out していない（既定で隠さない, §2.6）。
+        assert!(!is_relation_opted_out(&pool, PUBKEY_A).await?);
+
+        // set は冪等で、opted_out_at（いつから見えないか）を説明できる。
+        set_relation_optout(&pool, PUBKEY_A).await?;
+        set_relation_optout(&pool, PUBKEY_A).await?;
+        assert!(is_relation_opted_out(&pool, PUBKEY_A).await?);
+        assert!(get_relation_optout(&pool, PUBKEY_A).await?.is_some());
+
+        // discovery / relation read の候補 filter から opt-out 済みが落ちる。
+        let visible =
+            filter_relation_visible(&pool, &[PUBKEY_A.to_string(), PUBKEY_B.to_string()]).await?;
+        assert_eq!(visible, vec![PUBKEY_B.to_string()]);
+
+        // 可逆: clear で見え直す（canonical 削除ではなく node-local な選択の解除）。
+        clear_relation_optout(&pool, PUBKEY_A).await?;
+        clear_relation_optout(&pool, PUBKEY_A).await?; // 冪等
+        assert!(!is_relation_opted_out(&pool, PUBKEY_A).await?);
+        let visible =
+            filter_relation_visible(&pool, &[PUBKEY_A.to_string(), PUBKEY_B.to_string()]).await?;
+        assert_eq!(visible.len(), 2);
+
+        // 不正 pubkey は拒否（黙って通さない）。
+        assert!(set_relation_optout(&pool, "not-a-pubkey").await.is_err());
+        anyhow::Ok(())
+    }
+    .await;
+    database.cleanup().await?;
+    result
+}
+
+#[tokio::test]
+async fn relation_optout_does_not_affect_trust_inputs() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-core relation optout test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_optout_trust").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    let result = async {
+        initialize_database(&pool).await?;
+
+        persist_risk_signal(
+            &pool,
+            "issuer-node",
+            &SafetyRiskSignal {
+                target: RiskSignalTarget::UserPubkey,
+                target_id: PUBKEY_A.to_string(),
+                category: SafetyCategory::Spam,
+                severity: Severity::Medium,
+                basis: Basis::ClassifierScore,
+                confidence: Some(80),
+                visibility: Visibility::Local,
+                expires_at: None,
+                appeal_status: None,
+            },
+        )
+        .await?;
+
+        let before = list_trust_risk_inputs(
+            &pool,
+            RiskSignalTarget::UserPubkey,
+            PUBKEY_A,
+            "2026-07-02T09:00:00Z",
+        )
+        .await?;
+        assert_eq!(before.relative.len(), 1);
+
+        // opt-out しても trust 入力は 1 件も減らない（troll 判定回避の手段にしない, §6.3）。
+        set_relation_optout(&pool, PUBKEY_A).await?;
+        let after = list_trust_risk_inputs(
+            &pool,
+            RiskSignalTarget::UserPubkey,
+            PUBKEY_A,
+            "2026-07-02T09:00:00Z",
+        )
+        .await?;
+        assert_eq!(before, after);
+        anyhow::Ok(())
+    }
+    .await;
+    database.cleanup().await?;
+    result
+}

--- a/crates/cn-indexer/Cargo.toml
+++ b/crates/cn-indexer/Cargo.toml
@@ -36,7 +36,10 @@ kukuri-transport = { path = "../transport" }
 kukuri-cn-core = { path = "../cn-core", features = ["safety-mock-provider", "safety-arachnid-provider"] }
 kukuri-cn-safety = { path = "../cn-safety" }
 kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
+kukuri-cn-trust = { path = "../cn-trust" }
 
 [dev-dependencies]
 kukuri-cn-safety = { path = "../cn-safety", features = ["mock"] }
+# relation graph（ArcadeDB / in-memory）へ同一 contract を課す共有スイート。
+kukuri-cn-trust = { path = "../cn-trust", features = ["testing"] }
 tempfile.workspace = true

--- a/crates/cn-indexer/src/arcadedb.rs
+++ b/crates/cn-indexer/src/arcadedb.rs
@@ -26,18 +26,74 @@ const ENTRY_TYPE: &str = "IndexedEntry";
 const ENTRY_COLUMNS: &str = "scope_kind, scope_id, object_id, author_pubkey, text, created_at, \
      source_replica_id";
 
-/// ArcadeDB HTTP client 越しの index 投影。
-pub struct ArcadeDbProjection {
+/// ArcadeDB HTTP command client（`/api/v1/command/<database>`）。
+///
+/// index 投影（本 module）と relation graph（`relation_graph`、ADR 0026 §6.1）が同じ
+/// ArcadeDB インスタンスに相乗りするため、接続と command 発行をここで共有する。
+#[derive(Clone)]
+pub struct ArcadeDbClient {
     client: Client,
     config: ArcadeDbConfig,
 }
 
-impl ArcadeDbProjection {
+impl ArcadeDbClient {
     pub fn new(config: ArcadeDbConfig) -> Result<Self> {
         let client = Client::builder()
             .build()
             .context("failed to build ArcadeDB HTTP client")?;
         Ok(Self { client, config })
+    }
+
+    /// ArcadeDB `/api/v1/command/<database>` を叩く。
+    pub(crate) async fn command(&self, language: &str, command: &str) -> Result<Value> {
+        self.command_with_params(language, command, json!({})).await
+    }
+
+    pub(crate) async fn command_with_params(
+        &self,
+        language: &str,
+        command: &str,
+        params: Value,
+    ) -> Result<Value> {
+        let url = format!(
+            "{}/api/v1/command/{}",
+            self.config.base_url.trim_end_matches('/'),
+            self.config.database
+        );
+        let response = self
+            .client
+            .post(&url)
+            .basic_auth(&self.config.username, Some(&self.config.password))
+            .json(&json!({
+                "language": language,
+                "command": command,
+                "params": params,
+            }))
+            .send()
+            .await
+            .context("failed to send ArcadeDB command")?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("ArcadeDB command failed ({status}): {body}");
+        }
+        response
+            .json::<Value>()
+            .await
+            .context("failed to decode ArcadeDB response")
+    }
+}
+
+/// ArcadeDB HTTP client 越しの index 投影。
+pub struct ArcadeDbProjection {
+    client: ArcadeDbClient,
+}
+
+impl ArcadeDbProjection {
+    pub fn new(config: ArcadeDbConfig) -> Result<Self> {
+        Ok(Self {
+            client: ArcadeDbClient::new(config)?,
+        })
     }
 
     /// index 投影 schema（document type + unique index）を用意する。
@@ -82,9 +138,9 @@ impl ArcadeDbProjection {
         Ok(())
     }
 
-    /// ArcadeDB `/api/v1/command/<database>` を叩く。
+    /// ArcadeDB `/api/v1/command/<database>` を叩く（共有 client へ委譲）。
     async fn command(&self, language: &str, command: &str) -> Result<Value> {
-        self.command_with_params(language, command, json!({})).await
+        self.client.command(language, command).await
     }
 
     async fn command_with_params(
@@ -93,32 +149,9 @@ impl ArcadeDbProjection {
         command: &str,
         params: Value,
     ) -> Result<Value> {
-        let url = format!(
-            "{}/api/v1/command/{}",
-            self.config.base_url.trim_end_matches('/'),
-            self.config.database
-        );
-        let response = self
-            .client
-            .post(&url)
-            .basic_auth(&self.config.username, Some(&self.config.password))
-            .json(&json!({
-                "language": language,
-                "command": command,
-                "params": params,
-            }))
-            .send()
+        self.client
+            .command_with_params(language, command, params)
             .await
-            .context("failed to send ArcadeDB command")?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            bail!("ArcadeDB command failed ({status}): {body}");
-        }
-        response
-            .json::<Value>()
-            .await
-            .context("failed to decode ArcadeDB response")
     }
 
     fn scope_kind_str(scope_kind: IndexScopeKind) -> &'static str {

--- a/crates/cn-indexer/src/lib.rs
+++ b/crates/cn-indexer/src/lib.rs
@@ -23,6 +23,8 @@ pub mod ingest;
 pub mod participant;
 pub mod projection;
 pub mod query;
+pub mod relation_graph;
+pub mod relation_worker;
 pub mod runtime;
 
 pub use arcadedb::ArcadeDbProjection;
@@ -31,4 +33,8 @@ pub use ingest::{IngestPipeline, IngestSummary};
 pub use participant::{IndexerParticipant, ScopeReplica};
 pub use projection::{IndexProjection, IndexedEntry, MemoryIndexProjection};
 pub use query::{FailClosedIndexQuery, IndexQuery, MAX_QUERY_LIMIT, clamp_query_limit};
+pub use relation_graph::ArcadeDbRelationGraph;
+pub use relation_worker::{
+    DEFAULT_ANALYSIS_LIMIT, RelationAnalysisReport, analyze_relations, topic_cluster,
+};
 pub use runtime::run_from_env;

--- a/crates/cn-indexer/src/relation_graph.rs
+++ b/crates/cn-indexer/src/relation_graph.rs
@@ -1,0 +1,214 @@
+//! relation graph の ArcadeDB 実装（ADR 0026 §6.1, #415）。
+//!
+//! `cn-trust` の `RelationStore` trait（graph-store 抽象境界）を、index 投影と同じ ArcadeDB
+//! インスタンスに相乗りする graph で実装する。クエリは **Cypher**（ArcadeDB の opencypher
+//! サポート）で書き、scale path の neo4j（Cypher 互換）へ backend を差し替えても同じクエリ形が
+//! 使えることを担保する。schema 定義（型 / index 作成）のみ ArcadeDB SQL（`IF NOT EXISTS` が
+//! 必要なため。neo4j では相当する constraint 作成に置き換える）。
+//!
+//! - vertex `TrustUser { pubkey, cluster }`: relation の観測対象 user（社会グラフの canonical
+//!   ではなく node-local overlay。この graph への書き込みは canonical に一切触れない）。
+//! - edge `RelatesTo { features_json }`: pairwise の feature（`shared_topics` 等）。feature は
+//!   JSON 文字列 1 property に格納する（neo4j も map property を持たないため、この表現は
+//!   backend 間で可搬）。proximity の合成は backend 非依存の
+//!   [`proximity_from_features`] で行い、in-memory 実装と同一の score を返す。
+//! - edge は正規化ペア（辞書順 (小, 大)）で 1 本だけ張り、読みは無向 match（`-[r]-`）で
+//!   双方向から同じ feature が見える（対称性 contract）。
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use kukuri_cn_trust::{
+    ClusterRef, EdgeFeatures, Proximity, RelationStore, proximity_from_features,
+};
+
+use crate::arcadedb::ArcadeDbClient;
+use crate::config::ArcadeDbConfig;
+
+/// relation graph の vertex type 名。
+const USER_TYPE: &str = "TrustUser";
+/// relation graph の edge type 名。
+const EDGE_TYPE: &str = "RelatesTo";
+
+/// ArcadeDB 上の relation graph。
+pub struct ArcadeDbRelationGraph {
+    client: ArcadeDbClient,
+}
+
+impl ArcadeDbRelationGraph {
+    pub fn new(config: ArcadeDbConfig) -> Result<Self> {
+        Ok(Self {
+            client: ArcadeDbClient::new(config)?,
+        })
+    }
+
+    /// relation graph の schema（vertex / edge type + unique index）を冪等に用意する。
+    pub async fn ensure_schema(&self) -> Result<()> {
+        self.client
+            .command(
+                "sql",
+                &format!("CREATE VERTEX TYPE {USER_TYPE} IF NOT EXISTS"),
+            )
+            .await?;
+        for property in ["pubkey STRING", "cluster STRING"] {
+            self.client
+                .command(
+                    "sql",
+                    &format!("CREATE PROPERTY {USER_TYPE}.{property} IF NOT EXISTS"),
+                )
+                .await?;
+        }
+        self.client
+            .command(
+                "sql",
+                &format!("CREATE INDEX IF NOT EXISTS ON {USER_TYPE} (pubkey) UNIQUE"),
+            )
+            .await?;
+        self.client
+            .command(
+                "sql",
+                &format!("CREATE EDGE TYPE {EDGE_TYPE} IF NOT EXISTS"),
+            )
+            .await?;
+        self.client
+            .command(
+                "sql",
+                &format!("CREATE PROPERTY {EDGE_TYPE}.features_json STRING IF NOT EXISTS"),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+/// 正規化ペア（辞書順）。foundation の feature は対称なので edge は 1 本に正規化する。
+fn normalized_pair<'a>(a: &'a str, b: &'a str) -> (&'a str, &'a str) {
+    if a <= b { (a, b) } else { (b, a) }
+}
+
+/// Cypher の応答行から文字列カラムを読む。
+fn string_column(row: &Value, column: &str) -> Option<String> {
+    row.get(column).and_then(Value::as_str).map(str::to_string)
+}
+
+/// 応答の `result` 配列。
+fn result_rows(value: &Value) -> Vec<Value> {
+    value
+        .get("result")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// `features_json` 文字列（edge property）を `EdgeFeatures` に戻す。
+fn features_from_json(raw: &str) -> Result<EdgeFeatures> {
+    serde_json::from_str(raw).context("failed to decode RelatesTo.features_json")
+}
+
+#[async_trait]
+impl RelationStore for ArcadeDbRelationGraph {
+    async fn upsert_edge(&self, from: &str, to: &str, features: &EdgeFeatures) -> Result<()> {
+        let (a, b) = normalized_pair(from, to);
+        let features_json =
+            serde_json::to_string(features).context("failed to encode edge features")?;
+        // MERGE は vertex / edge とも冪等（存在しなければ作り、あれば再利用）。
+        self.client
+            .command_with_params(
+                "cypher",
+                &format!(
+                    "MERGE (a:{USER_TYPE} {{pubkey: $a}}) \
+                     MERGE (b:{USER_TYPE} {{pubkey: $b}}) \
+                     MERGE (a)-[r:{EDGE_TYPE}]->(b) \
+                     SET r.features_json = $features_json"
+                ),
+                json!({ "a": a, "b": b, "features_json": features_json }),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn pairwise_proximity(&self, viewer: &str, target: &str) -> Result<Option<Proximity>> {
+        // 無向 match（-[r]-）: 正規化ペアで張った 1 本の edge が双方向から見える（対称性）。
+        let value = self
+            .client
+            .command_with_params(
+                "cypher",
+                &format!(
+                    "MATCH (a:{USER_TYPE} {{pubkey: $a}})-[r:{EDGE_TYPE}]-(b:{USER_TYPE} {{pubkey: $b}}) \
+                     RETURN r.features_json AS features_json LIMIT 1"
+                ),
+                json!({ "a": viewer, "b": target }),
+            )
+            .await?;
+        let rows = result_rows(&value);
+        let Some(raw) = rows
+            .first()
+            .and_then(|row| string_column(row, "features_json"))
+        else {
+            return Ok(None);
+        };
+        // score の合成は backend 非依存の純関数（in-memory 実装と同一の値を返す contract）。
+        Ok(Some(proximity_from_features(&features_from_json(&raw)?)))
+    }
+
+    async fn neighbors(&self, viewer: &str, k: usize) -> Result<Vec<String>> {
+        let value = self
+            .client
+            .command_with_params(
+                "cypher",
+                &format!(
+                    "MATCH (a:{USER_TYPE} {{pubkey: $viewer}})-[r:{EDGE_TYPE}]-(b:{USER_TYPE}) \
+                     RETURN b.pubkey AS pubkey, r.features_json AS features_json"
+                ),
+                json!({ "viewer": viewer }),
+            )
+            .await?;
+        let mut scored = Vec::new();
+        for row in result_rows(&value) {
+            let (Some(pubkey), Some(raw)) = (
+                string_column(&row, "pubkey"),
+                string_column(&row, "features_json"),
+            ) else {
+                continue;
+            };
+            let score = proximity_from_features(&features_from_json(&raw)?).score;
+            scored.push((score, pubkey));
+        }
+        // proximity 降順・同点は pubkey 辞書順（in-memory 実装と同じ決定論的な並び）。
+        scored.sort_by(|(sa, pa), (sb, pb)| {
+            sb.partial_cmp(sa)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| pa.cmp(pb))
+        });
+        Ok(scored.into_iter().take(k).map(|(_, p)| p).collect())
+    }
+
+    async fn cluster_of(&self, pubkey: &str) -> Result<Option<ClusterRef>> {
+        let value = self
+            .client
+            .command_with_params(
+                "cypher",
+                &format!(
+                    "MATCH (u:{USER_TYPE} {{pubkey: $pubkey}}) RETURN u.cluster AS cluster LIMIT 1"
+                ),
+                json!({ "pubkey": pubkey }),
+            )
+            .await?;
+        let rows = result_rows(&value);
+        Ok(rows
+            .first()
+            .and_then(|row| string_column(row, "cluster"))
+            .map(ClusterRef))
+    }
+
+    async fn set_cluster(&self, pubkey: &str, cluster: &ClusterRef) -> Result<()> {
+        self.client
+            .command_with_params(
+                "cypher",
+                &format!("MERGE (u:{USER_TYPE} {{pubkey: $pubkey}}) SET u.cluster = $cluster"),
+                json!({ "pubkey": pubkey, "cluster": cluster.0 }),
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/cn-indexer/src/relation_worker.rs
+++ b/crates/cn-indexer/src/relation_worker.rs
@@ -1,0 +1,71 @@
+//! relation 解析 worker（batch・非常駐, ADR 0026 §6.1, #415）。
+//!
+//! index 真実源の co-participation 集計（`CoParticipationSource`、public topic のみ =
+//! private channel 由来は観測に入らない）を feature に点数化し、relation graph
+//! （`RelationStore`）へ upsert する。あわせて cluster 帰属の初期実装
+//! （dominant shared topic = 最多 entry の topic への帰属。プラン Assumption 6）を書き込む。
+//!
+//! - **非常駐**: `CommunityLocalTrust` capability が `Availability::Planned` の間は
+//!   `cn-cli relation analyze` からの手動 batch 実行のみ（capability 昇格判断に紐づけて
+//!   常駐化を判断する。#404 の ingest loop と同じ扱い）。
+//! - **canonical 非改変**: 書き込み先は relation graph（node-local derived overlay）のみ。
+//!   social graph / user identity / index 真実源への書き込み口を持たない
+//!   （`relation_does_not_mutate_social_graph_canonical`）。
+//! - clustering の高度化（community detection / 重み実測）は ADR 0026 §4 の後続 Issue。
+
+use anyhow::Result;
+
+use kukuri_cn_core::CoParticipationSource;
+use kukuri_cn_trust::{
+    ClusterRef, EdgeFeatures, FEATURE_CO_PARTICIPATION_EVENTS, FEATURE_SHARED_TOPICS, RelationStore,
+};
+
+/// 1 回の解析で読む集計行の上限（有界化）。
+pub const DEFAULT_ANALYSIS_LIMIT: usize = 10_000;
+
+/// dominant topic 由来の cluster 名。
+pub fn topic_cluster(topic_id: &str) -> ClusterRef {
+    ClusterRef(format!("topic:{topic_id}"))
+}
+
+/// 解析結果の要約（CLI 出力・テスト検証用）。
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RelationAnalysisReport {
+    /// upsert した pairwise edge 数。
+    pub edges_upserted: usize,
+    /// 割り当てた cluster 帰属数。
+    pub clusters_assigned: usize,
+}
+
+/// co-participation 集計 → relation graph の batch 解析。
+///
+/// 冪等: 同じ観測に対して何度実行しても同じ graph 状態に収束する（edge / cluster とも upsert）。
+pub async fn analyze_relations(
+    source: &dyn CoParticipationSource,
+    store: &dyn RelationStore,
+    limit: usize,
+) -> Result<RelationAnalysisReport> {
+    let mut report = RelationAnalysisReport::default();
+
+    for pair in source.list_co_participation_pairs(limit).await? {
+        let features = EdgeFeatures::new()
+            .with(FEATURE_SHARED_TOPICS, pair.shared_topics as f64)
+            .with(
+                FEATURE_CO_PARTICIPATION_EVENTS,
+                pair.co_participation_events as f64,
+            );
+        store
+            .upsert_edge(&pair.author_a, &pair.author_b, &features)
+            .await?;
+        report.edges_upserted += 1;
+    }
+
+    for dominant in source.list_author_dominant_topics(limit).await? {
+        store
+            .set_cluster(&dominant.author_pubkey, &topic_cluster(&dominant.topic_id))
+            .await?;
+        report.clusters_assigned += 1;
+    }
+
+    Ok(report)
+}

--- a/crates/cn-indexer/tests/relation_contracts.rs
+++ b/crates/cn-indexer/tests/relation_contracts.rs
@@ -1,0 +1,177 @@
+//! relation graph / 解析 worker の contract テスト（ADR 0026 §6.1, #415）。
+//!
+//! - 解析 worker（in-memory、常時実行）: co-participation 集計 → feature 点数化 → graph 反映と
+//!   cluster 帰属（dominant shared topic）を固定する。private channel 由来が relation に
+//!   混ざらないこと・index 真実源を改変しないことも固定する。
+//! - ArcadeDB（`KUKURI_CN_RUN_ARCADEDB_TESTS=1`、要 live ArcadeDB）: in-memory と同一の
+//!   共有 contract スイート（`relation_testing`）を実行し、backend 間の drift を防ぐ。
+
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use kukuri_cn_core::{
+    IndexEntryStore, IndexScopeKind, MemoryIndexEntryStore, MemorySafetyArtifactStore,
+    NewIndexEntry, SafetyArtifactStore,
+};
+use kukuri_cn_indexer::{ArcadeDbConfig, ArcadeDbRelationGraph, analyze_relations, topic_cluster};
+use kukuri_cn_safety::provider::SubjectKind;
+use kukuri_cn_safety::{ReasonCode, SafetyAction, SafetyVerdict};
+use kukuri_cn_trust::relation_testing::assert_relation_store_contracts;
+use kukuri_cn_trust::{
+    FEATURE_CO_PARTICIPATION_EVENTS, FEATURE_SHARED_TOPICS, MemoryRelationStore, RelationStore,
+};
+
+fn allow_verdict() -> SafetyVerdict {
+    SafetyVerdict {
+        action: SafetyAction::Allow,
+        labels: Vec::new(),
+        critical: false,
+        reason_code: ReasonCode::NoKnownMatch,
+        confidence: None,
+        provider: Some("mock-known-csam".to_string()),
+        provider_capability: None,
+        policy_version: "policy-v1-test".to_string(),
+        scanned_at: "2026-07-02T09:00:00Z".to_string(),
+    }
+}
+
+/// cn-core の co_participation テストと同じシード:
+/// topic-a = A×2 + B×1、topic-b = A×1 + B×1、private channel chan-x = A×1 + C×1。
+async fn seeded_entries() -> Result<MemoryIndexEntryStore> {
+    let verdicts = Arc::new(MemorySafetyArtifactStore::new());
+    let store = MemoryIndexEntryStore::new(verdicts.clone());
+    let seed = [
+        (IndexScopeKind::PublicTopic, "topic-a", "post-1", "author-a"),
+        (IndexScopeKind::PublicTopic, "topic-a", "post-2", "author-a"),
+        (IndexScopeKind::PublicTopic, "topic-a", "post-3", "author-b"),
+        (IndexScopeKind::PublicTopic, "topic-b", "post-4", "author-a"),
+        (IndexScopeKind::PublicTopic, "topic-b", "post-5", "author-b"),
+        (
+            IndexScopeKind::PrivateChannel,
+            "chan-x",
+            "post-6",
+            "author-a",
+        ),
+        (
+            IndexScopeKind::PrivateChannel,
+            "chan-x",
+            "post-7",
+            "author-c",
+        ),
+    ];
+    for (i, (scope_kind, scope_id, object_id, author)) in seed.iter().enumerate() {
+        let verdict_id = verdicts
+            .persist_verdict(SubjectKind::Post, &format!("subject-{i}"), &allow_verdict())
+            .await?;
+        store
+            .upsert_entry(&NewIndexEntry {
+                scope_kind: *scope_kind,
+                scope_id: scope_id.to_string(),
+                object_id: object_id.to_string(),
+                author_pubkey: author.to_string(),
+                created_at: 1_700_000_000,
+                source_replica_id: format!("replica::{scope_id}"),
+                verdict_id,
+                verdict_action: "allow".to_string(),
+                critical: false,
+            })
+            .await?;
+    }
+    Ok(store)
+}
+
+#[tokio::test]
+async fn relation_worker_builds_pairwise_proximity_from_co_participation() -> Result<()> {
+    let entries = seeded_entries().await?;
+    let graph = MemoryRelationStore::new();
+
+    let report = analyze_relations(&entries, &graph, 1000).await?;
+    assert_eq!(report.edges_upserted, 1, "(A, B) の 1 ペアのみ");
+    assert_eq!(report.clusters_assigned, 2, "public 参加のある A / B のみ");
+
+    // 同一 cluster で共起の濃い A, B は proximity が根拠つきで返る。
+    let proximity = graph
+        .pairwise_proximity("author-a", "author-b")
+        .await?
+        .expect("co-participating pair has proximity");
+    assert!(proximity.score > 0.0);
+    let shared = proximity
+        .basis
+        .iter()
+        .find(|e| e.feature == FEATURE_SHARED_TOPICS)
+        .expect("shared_topics feature in basis");
+    assert_eq!(shared.value, 2.0);
+    let events = proximity
+        .basis
+        .iter()
+        .find(|e| e.feature == FEATURE_CO_PARTICIPATION_EVENTS)
+        .expect("co_participation_events feature in basis");
+    assert_eq!(events.value, 2.0);
+
+    // private channel でしか共起しない (A, C) は relation に出ない
+    // （relation_private_channel_signal_stays_local_and_scoped の graph 側）。
+    assert!(
+        graph
+            .pairwise_proximity("author-a", "author-c")
+            .await?
+            .is_none()
+    );
+
+    // cluster 帰属 = dominant shared topic（初期実装）。
+    assert_eq!(
+        graph.cluster_of("author-a").await?,
+        Some(topic_cluster("topic-a"))
+    );
+    // public 参加の無い C は帰属しない。
+    assert!(graph.cluster_of("author-c").await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn relation_worker_is_idempotent_and_does_not_mutate_index_source() -> Result<()> {
+    let entries = seeded_entries().await?;
+    let graph = MemoryRelationStore::new();
+
+    let before = entries.entries_snapshot().len();
+    let first = analyze_relations(&entries, &graph, 1000).await?;
+    let proximity_first = graph.pairwise_proximity("author-a", "author-b").await?;
+    let second = analyze_relations(&entries, &graph, 1000).await?;
+    let proximity_second = graph.pairwise_proximity("author-a", "author-b").await?;
+
+    // 冪等: 再実行しても graph は同じ状態に収束する。
+    assert_eq!(first, second);
+    assert_eq!(proximity_first, proximity_second);
+
+    // worker は観測元（index 真実源）を読むだけで改変しない（canonical 非改変の overlay 境界。
+    // social graph canonical への書き込み口はそもそも存在しない）。
+    assert_eq!(entries.entries_snapshot().len(), before);
+    Ok(())
+}
+
+/// ArcadeDB backend への共有 contract スイート実行。
+///
+/// `KUKURI_CN_RUN_ARCADEDB_TESTS=1` かつ live ArcadeDB（`COMMUNITY_NODE_ARCADEDB_*`）が
+/// あるときのみ実行する（他の integration テストと同じ env-gate 流儀）。
+#[tokio::test]
+async fn arcadedb_relation_store_satisfies_shared_contracts() -> Result<()> {
+    let enabled = std::env::var("KUKURI_CN_RUN_ARCADEDB_TESTS")
+        .ok()
+        .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false);
+    if !enabled {
+        eprintln!("skipping ArcadeDB relation test; set KUKURI_CN_RUN_ARCADEDB_TESTS=1");
+        return Ok(());
+    }
+    let graph = ArcadeDbRelationGraph::new(ArcadeDbConfig::from_env())?;
+    graph.ensure_schema().await?;
+    // 走行間の残留データと衝突しない一意 prefix（in-memory と同一スイート）。
+    let prefix = format!(
+        "cntest-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos()
+    );
+    assert_relation_store_contracts(&graph, &prefix).await?;
+    Ok(())
+}

--- a/crates/cn-trust/Cargo.toml
+++ b/crates/cn-trust/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "kukuri-cn-trust"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "kukuri_cn_trust"
+path = "src/lib.rs"
+
+[features]
+# RelationStore 実装（in-memory / ArcadeDB / 将来の neo4j）へ同一 contract を課す共有テスト
+# スイート。production の既定 API には含めない。
+testing = []
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+serde.workspace = true
+kukuri-cn-safety = { path = "../cn-safety" }
+
+[dev-dependencies]
+# 自分自身を testing feature 付き dev-dependency にすることで、tests/ から共有スイートを使える
+# （feature unification によりテストビルド時のみ有効になる。cn-safety の mock と同じ流儀）。
+kukuri-cn-trust = { path = ".", features = ["testing"] }
+tokio.workspace = true

--- a/crates/cn-trust/src/disclosure.rs
+++ b/crates/cn-trust/src/disclosure.rs
@@ -1,0 +1,98 @@
+//! cross-node pull への開示境界（ADR 0026 §6.3 Decision, #415）。
+//!
+//! read は pull 型: 他 node がこの CN に問い合わせると、この CN の視点の signal が返る。
+//! cross-node pull に対しては **confirmed（basis = known-hash / provider-verdict）な絶対成分
+//! のみ**を根拠つき（issuer / basis / confidence / expiry）で応答する。
+//!
+//! - **相対成分は返さない**（文化依存の指標を node 外へ拡散しない）。
+//! - **suspected（classifier / local-policy 由来）は返さない**（誤検知を拡散しない）。
+//! - `visibility` は pull へのアクセス範囲: `Local` は決して返さず（既定）、
+//!   `SubscribedNodes` は subscriber と認証できた要求者のみ、`Public` は誰でも。
+//! - relation は本 module に開示口が **存在しない**（`Local` 固定、
+//!   `relation_defaults_local_and_not_cross_node_pullable` の構造的保証）。
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use kukuri_cn_safety::{Basis, Visibility};
+
+use crate::inputs::{TrustComponentKind, TrustRiskInput, TrustRiskInputs};
+use crate::params::TrustParams;
+use crate::read::{TrustBasisEntry, build_trust_read};
+use crate::score::UniformRelationWeight;
+
+/// cross-node pull の要求者区分。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PullAudience {
+    /// 匿名 / 未認証の要求者（`Public` visibility のみ見える）。
+    Public,
+    /// この CN の subscriber として認証済みの要求者（`SubscribedNodes` 以上が見える）。
+    SubscribedNodes,
+}
+
+/// cross-node pull への応答（confirmed 絶対成分のみ、根拠つき）。
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CrossNodeTrustDisclosure {
+    pub target_id: String,
+    /// 開示可能な入力のみから再計算した絶対成分（`[-1, 1]`）。開示対象外の signal の
+    /// 存在が値から推測できないよう、全量からではなく開示分から計算する。
+    pub absolute: f64,
+    /// 計算時刻（RFC3339）。
+    pub computed_at: String,
+    /// 開示した signal の根拠（issuer / basis / confidence / expiry を同伴）。
+    pub basis: Vec<TrustBasisEntry>,
+}
+
+/// 入力 1 件が `audience` へ開示可能か（§6.3 の全条件）。
+fn disclosable(input: &TrustRiskInput, audience: PullAudience) -> bool {
+    // 絶対成分のみ（相対成分・relation は node-local に閉じる）。
+    if input.component != TrustComponentKind::Absolute {
+        return false;
+    }
+    // confirmed のみ（classifier / local-policy 由来の suspected は拡散しない）。
+    if !matches!(input.basis, Basis::KnownHashMatch | Basis::ProviderVerdict) {
+        return false;
+    }
+    // visibility = pull へのアクセス範囲。
+    match input.visibility {
+        Visibility::Local => false,
+        Visibility::SubscribedNodes => audience == PullAudience::SubscribedNodes,
+        Visibility::Public => true,
+    }
+}
+
+/// cross-node pull への開示を組み立てる純関数。
+///
+/// 開示可能な入力だけで絶対成分を再計算する（開示不可の signal が値に影響しない =
+/// `Local` signal の存在を pull 応答から推測させない）。相対成分・合成 trust は含めない。
+pub fn cross_node_trust_disclosure(
+    target_id: &str,
+    inputs: &TrustRiskInputs,
+    audience: PullAudience,
+    now: DateTime<Utc>,
+) -> CrossNodeTrustDisclosure {
+    let disclosed = TrustRiskInputs {
+        absolute: inputs
+            .absolute
+            .iter()
+            .filter(|input| disclosable(input, audience))
+            .cloned()
+            .collect(),
+        relative: Vec::new(),
+    };
+    // 絶対成分は decay / relation 重み / params 非依存なので、view の absolute / basis を
+    // そのまま開示に使える（trust / relative は使わない）。
+    let view = build_trust_read(
+        target_id,
+        &disclosed,
+        now,
+        &TrustParams::default(),
+        &UniformRelationWeight::default(),
+    );
+    CrossNodeTrustDisclosure {
+        target_id: view.target_id,
+        absolute: view.absolute,
+        computed_at: view.computed_at,
+        basis: view.basis,
+    }
+}

--- a/crates/cn-trust/src/inputs.rs
+++ b/crates/cn-trust/src/inputs.rs
@@ -1,0 +1,98 @@
+//! trust read への入力型（#406 の供給契約が生成し、本 crate の scoring が消費する）。
+//!
+//! 型はここ（pure domain）に置き、永続化 risk signal からの組み立て
+//! （`trust_risk_inputs_from` / `list_trust_risk_inputs`）は `cn-core` が担う。
+//! ADR 0026 §2.7 に従い、signal の category で trust の **絶対成分**（CSAM 等 critical safety。
+//! relation 非依存・report-bomb 不動）と **相対成分**（nsfw / spam 等。relation 重み付け・
+//! viewer 相対）へ振り分ける。
+//!
+//! 断定ラベルにしない（ADR 0026 §2.5 / trust-semantics）: 入力は必ず basis / confidence /
+//! visibility / expiry / appeal を同伴し、read surface が説明可能性を落とせない形にする。
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use kukuri_cn_safety::{AppealStatus, Basis, SafetyCategory, Severity, Visibility};
+
+/// risk signal category の trust 成分振り分け先（ADR 0026 §2.7）。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustComponentKind {
+    /// 絶対成分: critical safety（CSAM / CSE / grooming）。relation で重み付けせず、
+    /// 通報数で動かない（report-bomb 不動）。時間減衰もしない（§6.2）。
+    Absolute,
+    /// 相対成分: nsfw / spam 等の community / 文化圏依存の指標。relation で重み付けし、
+    /// viewer / cluster 相対で扱う。半減期減衰する（§6.2）。
+    Relative,
+}
+
+/// category → trust 成分の振り分け（初期規則）。
+///
+/// critical safety（`SafetyCategory::is_critical_safety()` = Csam / Cse / Grooming）は絶対成分、
+/// それ以外（nsfw / spam / malware / phishing 等）は相対成分（ADR 0026 §2.7）。
+pub fn trust_component_for(category: SafetyCategory) -> TrustComponentKind {
+    if category.is_critical_safety() {
+        TrustComponentKind::Absolute
+    } else {
+        TrustComponentKind::Relative
+    }
+}
+
+/// trust / relation read への入力 1 件（根拠つき advisory）。
+///
+/// 断定ラベルではない。basis / confidence / visibility / expiry / appeal を必ず同伴し、
+/// 消費側が issuer / 根拠 / 有効期限を説明できる状態を保つ。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TrustRiskInput {
+    /// 永続化側が採番した risk signal id。
+    pub signal_id: String,
+    /// この signal を発行した issuer node。
+    pub issuer_node_id: String,
+    /// 振り分け先の trust 成分。
+    pub component: TrustComponentKind,
+    pub category: SafetyCategory,
+    pub severity: Severity,
+    pub basis: Basis,
+    pub confidence: Option<u8>,
+    /// cross-node 開示の判定材料（§6.3。開示判定は消費側の責務）。
+    pub visibility: Visibility,
+    /// `Disputed`（= pending）は寄与据え置きのまま含まれる。消費側が状態を説明できるよう同伴する。
+    pub appeal_status: AppealStatus,
+    pub expires_at: Option<String>,
+    pub persisted_at: DateTime<Utc>,
+}
+
+/// 対象 1 つ分の trust 入力（絶対 / 相対に振り分け済み）。
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TrustRiskInputs {
+    /// 絶対成分への入力（critical safety）。
+    pub absolute: Vec<TrustRiskInput>,
+    /// 相対成分への入力（relation 重み付けの対象）。
+    pub relative: Vec<TrustRiskInput>,
+}
+
+impl TrustRiskInputs {
+    /// 入力が 1 件も無いか。
+    pub fn is_empty(&self) -> bool {
+        self.absolute.is_empty() && self.relative.is_empty()
+    }
+}
+
+/// 観測者つき node-local 観測の seam（ADR 0026 §2.3 相対成分の将来入力）。
+///
+/// 相対成分は本来「非決定論 moderation + node-local 観測を relation で重み付け」した値だが、
+/// 観測者（observer）を持つ観測の producer は非決定論的 moderation（ADR 0028 / #420 系）の
+/// 実装まで存在しない。本型はその接続点のみを固定する: 観測者 pubkey を持つことで、
+/// 消費側が observer↔viewer / observer↔target の relation（cluster 近接度）で重み付けでき、
+/// 特定 cluster からの大量観測が raw count として効かない（report-bombing 耐性、§2.3）。
+///
+/// 通報（`cn_admin.reports`, #370）は reporter identity を保持しないため本型の producer に
+/// **ならない**（raw count を trust に入れない構造的保証）。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObservedSignal {
+    /// 観測者（relation 重み付けの対象となる pubkey）。
+    pub observer_pubkey: String,
+    pub category: SafetyCategory,
+    pub severity: Severity,
+    pub observed_at: DateTime<Utc>,
+}

--- a/crates/cn-trust/src/lib.rs
+++ b/crates/cn-trust/src/lib.rs
@@ -1,0 +1,49 @@
+//! kukuri community node の trust / relation foundation の **pure domain 層**（#415）。
+//!
+//! この crate は DB / network / credential に依存しない。trust の合成式（ADR 0026 §6.2）・
+//! 成分算出（絶対 / 相対）・根拠つき read view・relation の graph-store 抽象（§6.1）と
+//! in-memory 実装を提供し、deterministic な単体テストで ADR 0026 の contract を固定する。
+//!
+//! 設計の真実源: `docs/adr/0026-community-node-trust-relation-foundation.md`
+//! - §2.3 絶対指標と相対指標の分離（report-bombing 耐性）
+//! - §2.7 risk signal category による絶対 / 相対振り分け（#406 の供給契約が上流）
+//! - §6.1 graph-store 抽象境界（ArcadeDB 最小 / neo4j scale、Cypher 互換）
+//! - §6.2 合成式・最終クランプ `[-1, 1]`・相対成分の半減期減衰・appeal 反映
+//! - §6.3 cross-node 開示（confirmed 絶対成分のみ）・viewer 相対 read の認証
+//!
+//! スコープ境界（本 crate に含まないもの）:
+//! - risk signal の永続化・供給（`cn-core` の `trust_risk_inputs_from` / `list_trust_risk_inputs`）
+//! - relation graph の ArcadeDB 実装・解析 worker（`cn-indexer`）
+//! - read エンドポイント / viewer 認証 / cross-node pull の HTTP 境界（`cn-user-api`）
+//!
+//! trust / relation は node-local **advisory** であり、network-wide command でも canonical でも
+//! ない（ADR 0027 §2.1）。user identity / profile / social graph の canonical を所有・改変しない。
+
+pub mod disclosure;
+pub mod inputs;
+pub mod memory;
+pub mod params;
+pub mod read;
+pub mod relation;
+pub mod score;
+
+/// `RelationStore` 実装への共有 contract スイート。`testing` feature でのみ有効
+/// （in-memory / ArcadeDB / 将来の neo4j に同一契約を課し、drift を防ぐ）。
+#[cfg(feature = "testing")]
+pub mod relation_testing;
+
+pub use disclosure::{CrossNodeTrustDisclosure, PullAudience, cross_node_trust_disclosure};
+pub use inputs::{
+    ObservedSignal, TrustComponentKind, TrustRiskInput, TrustRiskInputs, trust_component_for,
+};
+pub use memory::MemoryRelationStore;
+pub use params::TrustParams;
+pub use read::{TrustBasisEntry, TrustReadView, build_trust_read};
+pub use relation::{
+    ClusterRef, EdgeFeatures, FEATURE_CO_PARTICIPATION_EVENTS, FEATURE_FOLLOW_PROJECTION,
+    FEATURE_SHARED_TOPICS, Proximity, ProximityBasisEntry, RelationStore, proximity_from_features,
+};
+pub use score::{
+    ComposedTrust, RelationWeighting, UniformRelationWeight, compose_trust, decay_factor,
+    signal_contribution,
+};

--- a/crates/cn-trust/src/memory.rs
+++ b/crates/cn-trust/src/memory.rs
@@ -1,0 +1,87 @@
+//! in-memory `RelationStore`（テスト / 単体検証用）。
+//!
+//! ArcadeDB 実装（`cn-indexer`）と同じ contract テストを両実装に対して実行するための
+//! 参照実装。proximity の合成は backend 非依存の [`proximity_from_features`] を使う。
+
+use std::collections::BTreeMap;
+use std::sync::RwLock;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::relation::{
+    ClusterRef, EdgeFeatures, Proximity, RelationStore, proximity_from_features,
+};
+
+/// 対称 edge の正規化 key（辞書順で (小, 大)）。
+fn edge_key(a: &str, b: &str) -> (String, String) {
+    if a <= b {
+        (a.to_string(), b.to_string())
+    } else {
+        (b.to_string(), a.to_string())
+    }
+}
+
+/// in-memory relation graph。
+#[derive(Debug, Default)]
+pub struct MemoryRelationStore {
+    edges: RwLock<BTreeMap<(String, String), EdgeFeatures>>,
+    clusters: RwLock<BTreeMap<String, ClusterRef>>,
+}
+
+impl MemoryRelationStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl RelationStore for MemoryRelationStore {
+    async fn upsert_edge(&self, from: &str, to: &str, features: &EdgeFeatures) -> Result<()> {
+        let mut edges = self.edges.write().expect("edges lock poisoned");
+        edges.insert(edge_key(from, to), features.clone());
+        Ok(())
+    }
+
+    async fn pairwise_proximity(&self, viewer: &str, target: &str) -> Result<Option<Proximity>> {
+        let edges = self.edges.read().expect("edges lock poisoned");
+        Ok(edges
+            .get(&edge_key(viewer, target))
+            .map(proximity_from_features))
+    }
+
+    async fn neighbors(&self, viewer: &str, k: usize) -> Result<Vec<String>> {
+        let edges = self.edges.read().expect("edges lock poisoned");
+        let mut scored: Vec<(f64, String)> = edges
+            .iter()
+            .filter_map(|((a, b), features)| {
+                let other = if a == viewer {
+                    Some(b)
+                } else if b == viewer {
+                    Some(a)
+                } else {
+                    None
+                }?;
+                Some((proximity_from_features(features).score, other.clone()))
+            })
+            .collect();
+        // proximity 降順・同点は pubkey 辞書順（決定論的な並び）。
+        scored.sort_by(|(sa, pa), (sb, pb)| {
+            sb.partial_cmp(sa)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| pa.cmp(pb))
+        });
+        Ok(scored.into_iter().take(k).map(|(_, p)| p).collect())
+    }
+
+    async fn cluster_of(&self, pubkey: &str) -> Result<Option<ClusterRef>> {
+        let clusters = self.clusters.read().expect("clusters lock poisoned");
+        Ok(clusters.get(pubkey).cloned())
+    }
+
+    async fn set_cluster(&self, pubkey: &str, cluster: &ClusterRef) -> Result<()> {
+        let mut clusters = self.clusters.write().expect("clusters lock poisoned");
+        clusters.insert(pubkey.to_string(), cluster.clone());
+        Ok(())
+    }
+}

--- a/crates/cn-trust/src/params.rs
+++ b/crates/cn-trust/src/params.rs
@@ -1,0 +1,92 @@
+//! operator 可変な trust scoring パラメータ（ADR 0026 §6.2）。
+//!
+//! 合成式の重み（`w_abs`）と相対成分の半減期は **operator が変更できる**ことが contract
+//! （`trust_composition_weights_are_operator_tunable`）。env（`COMMUNITY_NODE_TRUST_*`）から
+//! 供給し、未設定は ADR 0026 §6.2 の初期決め打ち値に倒す。cn-operator config への正式節追加は
+//! capability 昇格判断時（プラン Assumption 9）。
+//!
+//! 断定閾値は置かない（§6.2 Decision）: read は連続値 advisory のまま返し、バケット化が
+//! 必要になった場合も operator 可変パラメータとして本型に足す（本 foundation では持たない）。
+
+use anyhow::{Result, bail};
+
+/// `w_abs`（絶対成分がマイナスのとき）の env 変数名。
+pub const ENV_W_ABS_NEGATIVE: &str = "COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE";
+/// `w_abs`（絶対成分が 0 以上のとき）の env 変数名。
+pub const ENV_W_ABS_POSITIVE: &str = "COMMUNITY_NODE_TRUST_W_ABS_POSITIVE";
+/// 相対成分の半減期（日）の env 変数名。
+pub const ENV_RELATIVE_HALF_LIFE_DAYS: &str = "COMMUNITY_NODE_TRUST_RELATIVE_HALF_LIFE_DAYS";
+
+/// trust 合成のパラメータ（operator 可変, ADR 0026 §6.2）。
+#[derive(Clone, Debug, PartialEq)]
+pub struct TrustParams {
+    /// 絶対成分がマイナス（CSAM など確定的に排除すべき）のときの重み。distrust を支配的にし、
+    /// 相対指標（文化依存）が良好でも薄まらないようにする。初期値 2.0。
+    pub w_abs_negative: f64,
+    /// 絶対成分が 0 以上のときの重み。初期値 1.0。
+    pub w_abs_positive: f64,
+    /// 相対成分・node-local 観測の半減期（日）。絶対成分は evidence / 検知ベースのため
+    /// 減衰させない（§6.2）。初期値 30 日。
+    pub relative_half_life_days: f64,
+}
+
+impl Default for TrustParams {
+    fn default() -> Self {
+        Self {
+            w_abs_negative: 2.0,
+            w_abs_positive: 1.0,
+            relative_half_life_days: 30.0,
+        }
+    }
+}
+
+impl TrustParams {
+    /// パラメータの妥当性検証。重みは正の有限値、半減期は正の有限値のみ許す
+    /// （0 や負・NaN は合成式 / decay を壊すため拒否する）。
+    pub fn validate(&self) -> Result<()> {
+        for (name, value) in [
+            (ENV_W_ABS_NEGATIVE, self.w_abs_negative),
+            (ENV_W_ABS_POSITIVE, self.w_abs_positive),
+            (ENV_RELATIVE_HALF_LIFE_DAYS, self.relative_half_life_days),
+        ] {
+            if !value.is_finite() || value <= 0.0 {
+                bail!("trust param {name} must be a positive finite number, got {value}");
+            }
+        }
+        Ok(())
+    }
+
+    /// 任意の lookup（env 相当）からパラメータを組み立てる。未設定キーは既定値。
+    ///
+    /// 不正値（数値でない / 非正 / 非有限）は黙って既定値に倒さず Err にする
+    /// （operator の設定ミスを起動時に検出する。fail-closed な設定検証の既存流儀に合わせる）。
+    pub fn from_lookup(lookup: impl Fn(&str) -> Option<String>) -> Result<Self> {
+        let mut params = Self::default();
+        for (name, slot) in [
+            (ENV_W_ABS_NEGATIVE, &mut params.w_abs_negative),
+            (ENV_W_ABS_POSITIVE, &mut params.w_abs_positive),
+            (
+                ENV_RELATIVE_HALF_LIFE_DAYS,
+                &mut params.relative_half_life_days,
+            ),
+        ] {
+            if let Some(raw) = lookup(name) {
+                let trimmed = raw.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let parsed: f64 = trimmed
+                    .parse()
+                    .map_err(|_| anyhow::anyhow!("trust param {name} is not a number: `{raw}`"))?;
+                *slot = parsed;
+            }
+        }
+        params.validate()?;
+        Ok(params)
+    }
+
+    /// プロセス env（`COMMUNITY_NODE_TRUST_*`）からパラメータを組み立てる。
+    pub fn from_env() -> Result<Self> {
+        Self::from_lookup(|name| std::env::var(name).ok())
+    }
+}

--- a/crates/cn-trust/src/read.rs
+++ b/crates/cn-trust/src/read.rs
@@ -1,0 +1,138 @@
+//! 根拠つき trust read view（ADR 0026 §2.5 / trust-semantics §4）。
+//!
+//! read は断定ラベルではなく **根拠つき advisory**: 絶対 / 相対成分を分離して返し
+//! （`trust_is_not_single_absolute_scalar` / `trust_separates_absolute_and_relative_indicators`）、
+//! 寄与 signal ごとに issuer / basis / confidence / visibility / expiry / appeal と
+//! 実効寄与（decay / relation 重み込み）を説明できる形にする
+//! （`trust_read_is_explainable_with_basis`）。
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use kukuri_cn_safety::{AppealStatus, Basis, SafetyCategory, Severity, Visibility};
+
+use crate::inputs::{TrustComponentKind, TrustRiskInput, TrustRiskInputs};
+use crate::params::TrustParams;
+use crate::score::{
+    RelationWeighting, clamp_unit, compose_trust, contributes, decay_factor, signal_contribution,
+};
+
+/// 寄与 signal 1 件の説明（basis entry）。
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TrustBasisEntry {
+    pub signal_id: String,
+    pub issuer_node_id: String,
+    pub component: TrustComponentKind,
+    pub category: SafetyCategory,
+    pub severity: Severity,
+    pub basis: Basis,
+    pub confidence: Option<u8>,
+    pub visibility: Visibility,
+    pub appeal_status: AppealStatus,
+    pub expires_at: Option<String>,
+    /// 生寄与（severity × confidence。decay / relation 重み前）。
+    pub raw_contribution: f64,
+    /// 適用された時間減衰係数（絶対成分は常に 1.0 = 減衰しない）。
+    pub decay_factor: f64,
+    /// 適用された relation 重み（絶対成分は常に 1.0 = relation 非依存）。
+    pub relation_weight: f64,
+    /// 実効寄与（raw × decay × relation 重み）。
+    pub contribution: f64,
+}
+
+/// trust read の応答形（node-local advisory）。
+///
+/// 単一の絶対スカラーではなく、絶対成分（viewer 非依存）+ 相対成分（viewer / cluster 依存）+
+/// 合成値を根拠つきで返す。「このユーザーは troll」等の断定ラベルは持たない（§6.2 Decision:
+/// 断定閾値を置かない）。
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TrustReadView {
+    /// 対象 pubkey。
+    pub target_id: String,
+    /// 絶対成分（`[-1, 1]`。relation 非依存・減衰なし・viewer 非依存）。
+    pub absolute: f64,
+    /// 相対成分（`[-1, 1]`。relation 重み付け・半減期減衰・viewer / cluster 相対）。
+    pub relative: f64,
+    /// 合成 trust（`[-1, 1]` にクランプ済み）。
+    pub trust: f64,
+    /// 合成に適用された絶対成分の重み（operator 可変, §6.2）。
+    pub w_abs_applied: f64,
+    /// 計算時刻（RFC3339。相対成分の decay 基準時刻）。
+    pub computed_at: String,
+    /// 寄与 signal ごとの根拠。
+    pub basis: Vec<TrustBasisEntry>,
+}
+
+fn basis_entry(input: &TrustRiskInput, decay: f64, relation_weight: f64) -> TrustBasisEntry {
+    let raw = signal_contribution(input);
+    TrustBasisEntry {
+        signal_id: input.signal_id.clone(),
+        issuer_node_id: input.issuer_node_id.clone(),
+        component: input.component,
+        category: input.category,
+        severity: input.severity,
+        basis: input.basis,
+        confidence: input.confidence,
+        visibility: input.visibility,
+        appeal_status: input.appeal_status,
+        expires_at: input.expires_at.clone(),
+        raw_contribution: raw,
+        decay_factor: decay,
+        relation_weight,
+        contribution: raw * decay * relation_weight,
+    }
+}
+
+/// 入力（#406 供給契約）から根拠つき trust read view を組み立てる。
+///
+/// - 絶対成分: `inputs.absolute` の生寄与の総和（decay なし・relation 重みなし）を ±1 にクランプ。
+/// - 相対成分: `inputs.relative` の寄与 × 半減期減衰 × relation 重み（`[0,1]` に丸め）の総和を
+///   ±1 にクランプ。
+/// - 合成: [`compose_trust`]（§6.2 の式 + 最終クランプ）。
+/// - `AppealStatus::Cleared` は届いても寄与させない（供給層と二重の防御）。
+pub fn build_trust_read(
+    target_id: &str,
+    inputs: &TrustRiskInputs,
+    now: DateTime<Utc>,
+    params: &TrustParams,
+    relation_weighting: &dyn RelationWeighting,
+) -> TrustReadView {
+    let mut basis = Vec::new();
+
+    let mut absolute_sum = 0.0;
+    for input in &inputs.absolute {
+        if !contributes(input) || input.component != TrustComponentKind::Absolute {
+            continue;
+        }
+        // 絶対成分は relation 非依存（重み 1.0 固定）かつ減衰しない（decay 1.0 固定）。
+        let entry = basis_entry(input, 1.0, 1.0);
+        absolute_sum += entry.contribution;
+        basis.push(entry);
+    }
+
+    let mut relative_sum = 0.0;
+    for input in &inputs.relative {
+        if !contributes(input) || input.component != TrustComponentKind::Relative {
+            continue;
+        }
+        let decay = decay_factor(input.persisted_at, now, params.relative_half_life_days);
+        let weight = relation_weighting.weight_for(input).clamp(0.0, 1.0);
+        let entry = basis_entry(input, decay, weight);
+        relative_sum += entry.contribution;
+        basis.push(entry);
+    }
+
+    let absolute = clamp_unit(absolute_sum);
+    let relative = clamp_unit(relative_sum);
+    let composed = compose_trust(params, absolute, relative);
+
+    TrustReadView {
+        target_id: target_id.to_string(),
+        absolute,
+        relative,
+        trust: composed.trust,
+        w_abs_applied: composed.w_abs_applied,
+        computed_at: now.to_rfc3339(),
+        basis,
+    }
+}

--- a/crates/cn-trust/src/relation.rs
+++ b/crates/cn-trust/src/relation.rs
@@ -1,0 +1,145 @@
+//! relation（pairwise cluster proximity）のドメイン型と graph-store 抽象境界（ADR 0026 §6.1）。
+//!
+//! relation は CN が観測から導く node-local な derived overlay であり、social graph の
+//! canonical を所有・改変しない（§2.2）。出力は cluster proximity（A から見た B の近さ）で
+//! あって follow 関係でも risk ラベルでもない。
+//!
+//! graph-store 抽象境界（§6.1 Decision）: backend（最小 = ArcadeDB / scale = neo4j）を
+//! 差し替え可能にする trait を置く。クエリは **Cypher 互換**表現に落とせることを前提とし、
+//! proximity の合成（feature → score）は backend 非依存の純関数 [`proximity_from_features`]
+//! に置いて、ArcadeDB / neo4j / in-memory が同一の score を返すようにする（backend は
+//! edge property の格納と取り出しだけを担う）。
+
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// 共有 supported topic 数の feature key。
+pub const FEATURE_SHARED_TOPICS: &str = "shared_topics";
+/// co-participation イベント数（同一 scope での共起 entry 数）の feature key。
+pub const FEATURE_CO_PARTICIPATION_EVENTS: &str = "co_participation_events";
+/// follow projection（ADR 0013）由来 feature の key。
+///
+/// **seam**: CN 側に follow projection の観測実装が無いため、producer は後続
+/// （プラン Assumption 4）。key だけ固定し、値が入り次第 proximity に自然合流する。
+pub const FEATURE_FOLLOW_PROJECTION: &str = "follow_projection";
+
+/// pairwise edge に格納する feature 値（解析 worker が点数化して upsert する）。
+///
+/// key は `FEATURE_*` 定数。BTreeMap で決定論的な順序を保つ（説明・テストの安定性）。
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct EdgeFeatures(pub BTreeMap<String, f64>);
+
+impl EdgeFeatures {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with(mut self, key: &str, value: f64) -> Self {
+        self.0.insert(key.to_string(), value);
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// proximity の根拠 1 件（feature ごとの内訳）。
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProximityBasisEntry {
+    pub feature: String,
+    /// 格納されていた feature 値。
+    pub value: f64,
+    /// この feature の重み。
+    pub weight: f64,
+    /// score への寄与（正規化後）。
+    pub contribution: f64,
+}
+
+/// pairwise cluster proximity（根拠つき, ADR 0026 §6.1）。
+///
+/// `score ∈ [0, 1]`。断定ラベルではなく、feature 内訳（basis）を必ず同伴する
+/// （`relation_read_is_explainable`）。
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Proximity {
+    pub score: f64,
+    pub basis: Vec<ProximityBasisEntry>,
+}
+
+/// cluster 帰属（相対成分の重み付け入力, §6.1）。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClusterRef(pub String);
+
+/// feature の重み（初期決め打ち。チューニングは ADR 0026 §4 で後続 Issue）。
+fn feature_weight(feature: &str) -> f64 {
+    match feature {
+        FEATURE_SHARED_TOPICS => 1.0,
+        FEATURE_CO_PARTICIPATION_EVENTS => 1.0,
+        FEATURE_FOLLOW_PROJECTION => 1.0,
+        _ => 0.5,
+    }
+}
+
+/// feature 値 → proximity score の backend 非依存合成。
+///
+/// 各 feature を飽和変換 `value / (value + 1)`（逓減。回数が増えるほど寄与が鈍る）で
+/// `[0, 1)` に正規化し、重み付き平均を score とする。すべての backend（in-memory /
+/// ArcadeDB / neo4j）はこの関数で score を合成し、同一 feature には同一 score を返す。
+pub fn proximity_from_features(features: &EdgeFeatures) -> Proximity {
+    let mut basis = Vec::new();
+    let mut weighted_sum = 0.0;
+    let mut total_weight = 0.0;
+    for (feature, value) in &features.0 {
+        let weight = feature_weight(feature);
+        let normalized = if *value > 0.0 {
+            value / (value + 1.0)
+        } else {
+            0.0
+        };
+        let contribution = weight * normalized;
+        weighted_sum += contribution;
+        total_weight += weight;
+        basis.push(ProximityBasisEntry {
+            feature: feature.clone(),
+            value: *value,
+            weight,
+            contribution,
+        });
+    }
+    let score = if total_weight > 0.0 {
+        (weighted_sum / total_weight).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    Proximity { score, basis }
+}
+
+/// graph-store 抽象境界（ADR 0026 §6.1 の最小 API + cluster 書き込み）。
+///
+/// いずれも viewer / target は pubkey。クエリは Cypher 互換表現に落とせることを前提とし、
+/// ArcadeDB / neo4j 双方で同一 API を満たす。relation graph は social graph canonical とは
+/// 別物の node-local overlay であり、この trait に canonical への書き込み口は存在しない
+/// （`relation_does_not_mutate_social_graph_canonical` の構造的保証）。
+#[async_trait]
+pub trait RelationStore: Send + Sync {
+    /// co-participation / follow projection 等の feature を pairwise edge に格納する。
+    ///
+    /// foundation の feature（co-participation 系）は対称なので、実装は (from, to) と
+    /// (to, from) のどちらで読んでも同じ feature が見えることを保証する。
+    async fn upsert_edge(&self, from: &str, to: &str, features: &EdgeFeatures) -> Result<()>;
+
+    /// viewer 視点の target への近接度（根拠つき）。edge が無ければ None。
+    async fn pairwise_proximity(&self, viewer: &str, target: &str) -> Result<Option<Proximity>>;
+
+    /// discovery / surfacing 用の近接近傍（proximity 降順で最大 k 件）。
+    async fn neighbors(&self, viewer: &str, k: usize) -> Result<Vec<String>>;
+
+    /// cluster 帰属（相対成分の重み付け入力）。未割り当てなら None。
+    async fn cluster_of(&self, pubkey: &str) -> Result<Option<ClusterRef>>;
+
+    /// 解析 worker が算出した cluster 帰属を格納する（§6.1 の最小 API に加える書き込み口）。
+    async fn set_cluster(&self, pubkey: &str, cluster: &ClusterRef) -> Result<()>;
+}

--- a/crates/cn-trust/src/relation_testing.rs
+++ b/crates/cn-trust/src/relation_testing.rs
@@ -1,0 +1,173 @@
+//! `RelationStore` 実装への共有 contract スイート（`testing` feature）。
+//!
+//! in-memory（本 crate）と ArcadeDB（`cn-indexer`）、将来の neo4j が **同一の contract** を
+//! 満たすことを保証する。各実装のテストはこのスイートを呼ぶだけにし、契約の drift を防ぐ。
+//!
+//! `prefix` は pubkey の名前空間。永続 backend（ArcadeDB）に対して実行するとき、
+//! 走行間の残留データと衝突しないよう呼び出し側が一意な prefix を渡す。
+
+use anyhow::{Context, Result, ensure};
+
+use crate::relation::{
+    ClusterRef, EdgeFeatures, FEATURE_CO_PARTICIPATION_EVENTS, FEATURE_SHARED_TOPICS,
+    RelationStore, proximity_from_features,
+};
+
+fn pk(prefix: &str, name: &str) -> String {
+    format!("{prefix}-{name}")
+}
+
+/// `relation_is_pairwise_cluster_proximity`: 同一 cluster で共起の濃い 2 者は近接度が高く、
+/// 共起の無い 2 者は低い（根拠つき）。
+pub async fn assert_pairwise_cluster_proximity(
+    store: &dyn RelationStore,
+    prefix: &str,
+) -> Result<()> {
+    let (a, b, c) = (pk(prefix, "a"), pk(prefix, "b"), pk(prefix, "c"));
+    let dense = EdgeFeatures::new()
+        .with(FEATURE_SHARED_TOPICS, 4.0)
+        .with(FEATURE_CO_PARTICIPATION_EVENTS, 20.0);
+    let sparse = EdgeFeatures::new()
+        .with(FEATURE_SHARED_TOPICS, 1.0)
+        .with(FEATURE_CO_PARTICIPATION_EVENTS, 1.0);
+    store.upsert_edge(&a, &b, &dense).await?;
+    store.upsert_edge(&a, &c, &sparse).await?;
+
+    let near = store
+        .pairwise_proximity(&a, &b)
+        .await?
+        .context("proximity(a, b) should exist")?;
+    let far = store
+        .pairwise_proximity(&a, &c)
+        .await?
+        .context("proximity(a, c) should exist")?;
+    ensure!(
+        near.score > far.score,
+        "dense co-participation must yield higher proximity: near={} far={}",
+        near.score,
+        far.score
+    );
+    ensure!(
+        (0.0..=1.0).contains(&near.score) && (0.0..=1.0).contains(&far.score),
+        "proximity score must stay in [0, 1]"
+    );
+    // edge の無い 2 者には proximity が無い（勝手に作らない）。
+    let none = store
+        .pairwise_proximity(&b, &pk(prefix, "stranger"))
+        .await?;
+    ensure!(none.is_none(), "no edge must mean no proximity");
+    Ok(())
+}
+
+/// `relation_read_is_explainable`: proximity は feature 内訳（basis）を必ず同伴し、
+/// backend 非依存の合成（`proximity_from_features`）と一致する。
+pub async fn assert_proximity_is_explainable(
+    store: &dyn RelationStore,
+    prefix: &str,
+) -> Result<()> {
+    let (a, b) = (pk(prefix, "xa"), pk(prefix, "xb"));
+    let features = EdgeFeatures::new()
+        .with(FEATURE_SHARED_TOPICS, 2.0)
+        .with(FEATURE_CO_PARTICIPATION_EVENTS, 5.0);
+    store.upsert_edge(&a, &b, &features).await?;
+
+    let proximity = store
+        .pairwise_proximity(&a, &b)
+        .await?
+        .context("proximity should exist")?;
+    let expected = proximity_from_features(&features);
+    ensure!(
+        proximity == expected,
+        "backend must return the canonical feature composition: got {proximity:?}, want {expected:?}"
+    );
+    ensure!(
+        !proximity.basis.is_empty(),
+        "proximity basis must not be empty"
+    );
+    for entry in &proximity.basis {
+        ensure!(
+            entry.contribution.is_finite() && entry.weight.is_finite(),
+            "basis entries must carry finite weight / contribution"
+        );
+    }
+    Ok(())
+}
+
+/// 対称性: foundation の feature（co-participation 系）は対称なので、(from, to) の upsert が
+/// (to, from) の read からも同じに見える。
+pub async fn assert_symmetric_lookup(store: &dyn RelationStore, prefix: &str) -> Result<()> {
+    let (a, b) = (pk(prefix, "sa"), pk(prefix, "sb"));
+    let features = EdgeFeatures::new().with(FEATURE_SHARED_TOPICS, 3.0);
+    store.upsert_edge(&a, &b, &features).await?;
+    let forward = store.pairwise_proximity(&a, &b).await?;
+    let backward = store.pairwise_proximity(&b, &a).await?;
+    ensure!(
+        forward == backward && forward.is_some(),
+        "pairwise proximity must be readable from both directions"
+    );
+    Ok(())
+}
+
+/// `neighbors`: proximity 降順で最大 k 件。
+pub async fn assert_neighbors_ranked(store: &dyn RelationStore, prefix: &str) -> Result<()> {
+    let v = pk(prefix, "viewer");
+    let (n1, n2, n3) = (pk(prefix, "n1"), pk(prefix, "n2"), pk(prefix, "n3"));
+    store
+        .upsert_edge(
+            &v,
+            &n1,
+            &EdgeFeatures::new().with(FEATURE_SHARED_TOPICS, 9.0),
+        )
+        .await?;
+    store
+        .upsert_edge(
+            &v,
+            &n2,
+            &EdgeFeatures::new().with(FEATURE_SHARED_TOPICS, 1.0),
+        )
+        .await?;
+    store
+        .upsert_edge(
+            &v,
+            &n3,
+            &EdgeFeatures::new().with(FEATURE_SHARED_TOPICS, 4.0),
+        )
+        .await?;
+
+    let top2 = store.neighbors(&v, 2).await?;
+    ensure!(
+        top2 == vec![n1.clone(), n3.clone()],
+        "neighbors must be proximity-descending and k-limited: got {top2:?}"
+    );
+    Ok(())
+}
+
+/// `cluster_of` / `set_cluster` の往復。未割り当ては None。
+pub async fn assert_cluster_roundtrip(store: &dyn RelationStore, prefix: &str) -> Result<()> {
+    let member = pk(prefix, "member");
+    ensure!(
+        store.cluster_of(&member).await?.is_none(),
+        "unassigned pubkey must have no cluster"
+    );
+    let cluster = ClusterRef(format!("{prefix}-topic:rust"));
+    store.set_cluster(&member, &cluster).await?;
+    let read = store.cluster_of(&member).await?;
+    ensure!(
+        read == Some(cluster),
+        "cluster assignment must round-trip, got {read:?}"
+    );
+    Ok(())
+}
+
+/// 全 contract を一括実行する（各実装のテストはこれを呼ぶ）。
+pub async fn assert_relation_store_contracts(
+    store: &dyn RelationStore,
+    prefix: &str,
+) -> Result<()> {
+    assert_pairwise_cluster_proximity(store, prefix).await?;
+    assert_proximity_is_explainable(store, prefix).await?;
+    assert_symmetric_lookup(store, prefix).await?;
+    assert_neighbors_ranked(store, prefix).await?;
+    assert_cluster_roundtrip(store, prefix).await?;
+    Ok(())
+}

--- a/crates/cn-trust/src/score.rs
+++ b/crates/cn-trust/src/score.rs
@@ -1,0 +1,119 @@
+//! trust scoring の純関数群（ADR 0026 §6.2）。
+//!
+//! - 絶対成分: relation 非依存・**減衰しない**・viewer 非依存（`trust_absolute_component_does_not_decay`）。
+//! - 相対成分: relation 重み付け + 半減期減衰（`trust_relative_component_decays_over_time`）。
+//! - 合成: `w_abs = w_abs_negative if absolute < 0 else w_abs_positive`、
+//!   `trust = clamp(-1, 1, (w_abs * absolute + relative) / 2)`（`trust_is_clamped_to_unit_interval`）。
+//!
+//! risk signal は負の evidence として寄与する（severity × confidence）。正の evidence source は
+//! 現状存在しないため絶対 / 相対成分の実効値は `[-1, 0]` だが、値域契約は §6.2 どおり ±1 で扱う。
+
+use chrono::{DateTime, Utc};
+
+use kukuri_cn_safety::{AppealStatus, Severity};
+
+use crate::inputs::TrustRiskInput;
+use crate::params::TrustParams;
+
+/// 値を `[-1, 1]` にクランプする（成分・最終値の共通契約, §6.2）。
+pub fn clamp_unit(value: f64) -> f64 {
+    value.clamp(-1.0, 1.0)
+}
+
+/// severity → 寄与の大きさ（初期決め打ち mapping。プラン Assumption 8）。
+///
+/// operator 可変化は `w_abs` / 半減期を優先し、この mapping の可変化は後続に残す。
+pub fn severity_magnitude(severity: Severity) -> f64 {
+    match severity {
+        Severity::Critical => 1.0,
+        Severity::High => 0.7,
+        Severity::Medium => 0.4,
+        Severity::Low => 0.2,
+    }
+}
+
+/// confidence（0..=100）→ 係数。未申告（None）は 1.0（申告なしを理由に薄めない）。
+pub fn confidence_factor(confidence: Option<u8>) -> f64 {
+    match confidence {
+        Some(value) => f64::from(value.min(100)) / 100.0,
+        None => 1.0,
+    }
+}
+
+/// risk signal 1 件の生寄与（decay / relation 重み前）。負の evidence なので常に `<= 0`。
+pub fn signal_contribution(input: &TrustRiskInput) -> f64 {
+    -(severity_magnitude(input.severity) * confidence_factor(input.confidence))
+}
+
+/// 半減期方式の時間減衰係数（§6.2。相対成分にのみ適用する）。
+///
+/// `factor = 0.5^(age_days / half_life_days)`。`persisted_at` が未来（クロックずれ）の場合は
+/// age を 0 に切り上げ、減衰なし（1.0）とする。
+pub fn decay_factor(persisted_at: DateTime<Utc>, now: DateTime<Utc>, half_life_days: f64) -> f64 {
+    let age_seconds = (now - persisted_at).num_seconds().max(0) as f64;
+    let age_days = age_seconds / 86_400.0;
+    0.5_f64.powf(age_days / half_life_days)
+}
+
+/// 相対成分入力への relation 重み付け（ADR 0026 §2.3 / §2.7 の seam）。
+///
+/// 重みは `[0, 1]` に丸めて使う。foundation では相対成分入力は本 node の scan 由来
+/// （observer なし）のみなので production は [`UniformRelationWeight`]（= 1.0）だが、
+/// observer-attributed 観測（`ObservedSignal`）の producer が実装され次第、observer の
+/// cluster 近接度から重みを導出する実装に差し替える（report-bombing 耐性の効き先）。
+pub trait RelationWeighting {
+    fn weight_for(&self, input: &TrustRiskInput) -> f64;
+}
+
+/// 一様な relation 重み。
+#[derive(Clone, Copy, Debug)]
+pub struct UniformRelationWeight(pub f64);
+
+impl Default for UniformRelationWeight {
+    fn default() -> Self {
+        Self(1.0)
+    }
+}
+
+impl RelationWeighting for UniformRelationWeight {
+    fn weight_for(&self, _input: &TrustRiskInput) -> f64 {
+        self.0
+    }
+}
+
+/// 合成結果（適用された `w_abs` を説明のため同伴する）。
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ComposedTrust {
+    /// 適用された絶対成分の重み。
+    pub w_abs_applied: f64,
+    /// 最終 trust 値（`[-1, 1]` にクランプ済み）。
+    pub trust: f64,
+}
+
+/// §6.2 の合成式。成分はそれぞれ ±1 にクランプしてから合成し、最終値も ±1 にクランプする。
+///
+/// 絶対成分がマイナスのとき `w_abs_negative`（初期 2.0）で distrust を支配的にする
+/// （`trust_absolute_negative_is_weighted_double`）。クランプにより read 値域は対称に保たれる
+/// （`trust_is_clamped_to_unit_interval`）。
+pub fn compose_trust(params: &TrustParams, absolute: f64, relative: f64) -> ComposedTrust {
+    let absolute = clamp_unit(absolute);
+    let relative = clamp_unit(relative);
+    let w_abs = if absolute < 0.0 {
+        params.w_abs_negative
+    } else {
+        params.w_abs_positive
+    };
+    ComposedTrust {
+        w_abs_applied: w_abs,
+        trust: clamp_unit((w_abs * absolute + relative) / 2.0),
+    }
+}
+
+/// scoring 層での appeal 防御（ADR 0026 §6.2）。
+///
+/// `Cleared`（= accepted）は供給層（`trust_risk_inputs_from`）で既に除外されるが、
+/// 万一 scoring まで届いても寄与させない（defense in depth）。`Disputed`（= pending）は
+/// 寄与据え置きなので含める。
+pub(crate) fn contributes(input: &TrustRiskInput) -> bool {
+    input.appeal_status != AppealStatus::Cleared
+}

--- a/crates/cn-trust/tests/cross_node_disclosure.rs
+++ b/crates/cn-trust/tests/cross_node_disclosure.rs
@@ -1,0 +1,153 @@
+//! cross-node pull 開示境界（ADR 0026 §6.3, Issue #415）の contract テスト。DB 不要。
+
+use chrono::{DateTime, Utc};
+
+use kukuri_cn_safety::{AppealStatus, Basis, SafetyCategory, Severity, Visibility};
+use kukuri_cn_trust::{
+    PullAudience, TrustComponentKind, TrustRiskInput, TrustRiskInputs, cross_node_trust_disclosure,
+};
+
+fn now() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-07-02T09:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+fn input(
+    id: &str,
+    component: TrustComponentKind,
+    category: SafetyCategory,
+    basis: Basis,
+    visibility: Visibility,
+) -> TrustRiskInput {
+    TrustRiskInput {
+        signal_id: id.to_string(),
+        issuer_node_id: "issuer-node".to_string(),
+        component,
+        category,
+        severity: Severity::Critical,
+        basis,
+        confidence: Some(100),
+        visibility,
+        appeal_status: AppealStatus::None,
+        expires_at: Some("2026-12-31T00:00:00Z".to_string()),
+        persisted_at: now(),
+    }
+}
+
+fn disclosed_ids(inputs: &TrustRiskInputs, audience: PullAudience) -> Vec<String> {
+    cross_node_trust_disclosure("pubkey-1", inputs, audience, now())
+        .basis
+        .iter()
+        .map(|e| e.signal_id.clone())
+        .collect()
+}
+
+#[test]
+fn cross_node_pull_discloses_only_confirmed_absolute_component() {
+    let inputs = TrustRiskInputs {
+        absolute: vec![
+            // confirmed（known-hash）+ Public → 開示される唯一の signal。
+            input(
+                "abs-confirmed-public",
+                TrustComponentKind::Absolute,
+                SafetyCategory::Csam,
+                Basis::KnownHashMatch,
+                Visibility::Public,
+            ),
+            // suspected（classifier 由来）は visibility が Public でも返さない（誤検知を拡散しない）。
+            input(
+                "abs-suspected-public",
+                TrustComponentKind::Absolute,
+                SafetyCategory::Csam,
+                Basis::ClassifierScore,
+                Visibility::Public,
+            ),
+            // confirmed でも Local は返さない（既定 = 最も安全側）。
+            input(
+                "abs-confirmed-local",
+                TrustComponentKind::Absolute,
+                SafetyCategory::Csam,
+                Basis::KnownHashMatch,
+                Visibility::Local,
+            ),
+        ],
+        relative: vec![
+            // 相対成分は confirmed / Public でも決して返さない（文化依存指標を拡散しない）。
+            input(
+                "rel-confirmed-public",
+                TrustComponentKind::Relative,
+                SafetyCategory::Nsfw,
+                Basis::ProviderVerdict,
+                Visibility::Public,
+            ),
+        ],
+    };
+
+    let ids = disclosed_ids(&inputs, PullAudience::Public);
+    assert_eq!(ids, vec!["abs-confirmed-public".to_string()]);
+
+    // 開示値は開示分のみから計算する（Local signal の存在が absolute 値から漏れない）。
+    let all_public = TrustRiskInputs {
+        absolute: vec![input(
+            "abs-confirmed-public",
+            TrustComponentKind::Absolute,
+            SafetyCategory::Csam,
+            Basis::KnownHashMatch,
+            Visibility::Public,
+        )],
+        relative: Vec::new(),
+    };
+    let full = cross_node_trust_disclosure("pubkey-1", &inputs, PullAudience::Public, now());
+    let only = cross_node_trust_disclosure("pubkey-1", &all_public, PullAudience::Public, now());
+    assert_eq!(full.absolute, only.absolute);
+
+    // 根拠（issuer / basis / confidence / expiry）を同伴する。
+    let entry = &full.basis[0];
+    assert_eq!(entry.issuer_node_id, "issuer-node");
+    assert_eq!(entry.basis, Basis::KnownHashMatch);
+    assert_eq!(entry.confidence, Some(100));
+    assert_eq!(entry.expires_at, Some("2026-12-31T00:00:00Z".to_string()));
+}
+
+#[test]
+fn subscribed_nodes_visibility_requires_subscriber_audience() {
+    let inputs = TrustRiskInputs {
+        absolute: vec![input(
+            "abs-confirmed-subscribed",
+            TrustComponentKind::Absolute,
+            SafetyCategory::Csam,
+            Basis::ProviderVerdict,
+            Visibility::SubscribedNodes,
+        )],
+        relative: Vec::new(),
+    };
+    // 匿名 pull には返らない。
+    assert!(disclosed_ids(&inputs, PullAudience::Public).is_empty());
+    // subscriber 認証済み pull には返る。
+    assert_eq!(
+        disclosed_ids(&inputs, PullAudience::SubscribedNodes),
+        vec!["abs-confirmed-subscribed".to_string()]
+    );
+}
+
+#[test]
+fn relative_component_never_crosses_node_boundary() {
+    // relation そのものに開示口が無いこと（`Local` 固定）は型レベルで保証される
+    // （`cross_node_trust_disclosure` は relation を受け取らず、relative は常に落とす）。
+    let inputs = TrustRiskInputs {
+        absolute: Vec::new(),
+        relative: vec![input(
+            "rel-any",
+            TrustComponentKind::Relative,
+            SafetyCategory::Spam,
+            Basis::KnownHashMatch,
+            Visibility::Public,
+        )],
+    };
+    for audience in [PullAudience::Public, PullAudience::SubscribedNodes] {
+        let disclosure = cross_node_trust_disclosure("pubkey-1", &inputs, audience, now());
+        assert!(disclosure.basis.is_empty());
+        assert_eq!(disclosure.absolute, 0.0);
+    }
+}

--- a/crates/cn-trust/tests/relation_contracts.rs
+++ b/crates/cn-trust/tests/relation_contracts.rs
@@ -1,0 +1,66 @@
+//! relation（pairwise cluster proximity）の contract テスト（ADR 0026 §6.1, Issue #415）。
+//!
+//! 契約本体は共有スイート（`relation_testing`）にあり、in-memory 実装へ課す。
+//! ArcadeDB 実装（`cn-indexer`）も同じスイートを実行する（backend 間の drift 防止）。
+
+use kukuri_cn_trust::relation_testing::{
+    assert_cluster_roundtrip, assert_neighbors_ranked, assert_pairwise_cluster_proximity,
+    assert_proximity_is_explainable, assert_symmetric_lookup,
+};
+use kukuri_cn_trust::{
+    EdgeFeatures, FEATURE_FOLLOW_PROJECTION, FEATURE_SHARED_TOPICS, MemoryRelationStore,
+    proximity_from_features,
+};
+
+#[tokio::test]
+async fn relation_is_pairwise_cluster_proximity() {
+    let store = MemoryRelationStore::new();
+    assert_pairwise_cluster_proximity(&store, "prox")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn relation_read_is_explainable() {
+    let store = MemoryRelationStore::new();
+    assert_proximity_is_explainable(&store, "explain")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn relation_lookup_is_symmetric() {
+    let store = MemoryRelationStore::new();
+    assert_symmetric_lookup(&store, "sym").await.unwrap();
+}
+
+#[tokio::test]
+async fn relation_neighbors_are_ranked_and_limited() {
+    let store = MemoryRelationStore::new();
+    assert_neighbors_ranked(&store, "nb").await.unwrap();
+}
+
+#[tokio::test]
+async fn relation_cluster_assignment_round_trips() {
+    let store = MemoryRelationStore::new();
+    assert_cluster_roundtrip(&store, "cl").await.unwrap();
+}
+
+#[test]
+fn follow_projection_feature_is_a_seam_that_composes() {
+    // follow projection の producer は未実装（プラン Assumption 4）だが、feature key は
+    // 予約済みで、値が入り次第 proximity に自然合流する。
+    let without = proximity_from_features(&EdgeFeatures::new().with(FEATURE_SHARED_TOPICS, 2.0));
+    let with_follow = proximity_from_features(
+        &EdgeFeatures::new()
+            .with(FEATURE_SHARED_TOPICS, 2.0)
+            .with(FEATURE_FOLLOW_PROJECTION, 1.0),
+    );
+    assert_ne!(without.score, with_follow.score);
+    assert!(
+        with_follow
+            .basis
+            .iter()
+            .any(|e| e.feature == FEATURE_FOLLOW_PROJECTION)
+    );
+}

--- a/crates/cn-trust/tests/trust_scoring.rs
+++ b/crates/cn-trust/tests/trust_scoring.rs
@@ -1,0 +1,475 @@
+//! trust scoring の contract テスト（ADR 0026 §2.3 / §6.2, Issue #415）。DB 不要。
+//!
+//! テスト名は ADR 0026 の必須 contract 名に対応する。
+
+use chrono::{DateTime, Duration, Utc};
+
+use kukuri_cn_safety::{AppealStatus, Basis, SafetyCategory, Severity, Visibility};
+use kukuri_cn_trust::{
+    TrustComponentKind, TrustParams, TrustRiskInput, TrustRiskInputs, UniformRelationWeight,
+    build_trust_read, compose_trust, trust_component_for,
+};
+
+fn now() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-07-02T09:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+fn input(
+    id: &str,
+    component: TrustComponentKind,
+    category: SafetyCategory,
+    severity: Severity,
+    confidence: Option<u8>,
+    persisted_at: DateTime<Utc>,
+) -> TrustRiskInput {
+    TrustRiskInput {
+        signal_id: id.to_string(),
+        issuer_node_id: "issuer-node".to_string(),
+        component,
+        category,
+        severity,
+        basis: Basis::KnownHashMatch,
+        confidence,
+        visibility: Visibility::Local,
+        appeal_status: AppealStatus::None,
+        expires_at: None,
+        persisted_at,
+    }
+}
+
+fn csam_input(id: &str, persisted_at: DateTime<Utc>) -> TrustRiskInput {
+    input(
+        id,
+        TrustComponentKind::Absolute,
+        SafetyCategory::Csam,
+        Severity::Critical,
+        Some(100),
+        persisted_at,
+    )
+}
+
+fn nsfw_input(id: &str, persisted_at: DateTime<Utc>) -> TrustRiskInput {
+    input(
+        id,
+        TrustComponentKind::Relative,
+        SafetyCategory::Nsfw,
+        Severity::High,
+        Some(100),
+        persisted_at,
+    )
+}
+
+// --- 合成式（§6.2） ---
+
+#[test]
+fn trust_is_clamped_to_unit_interval() {
+    let params = TrustParams::default();
+    // absolute=-1, relative=-1 → 生値 (2*-1 + -1)/2 = -1.5 だが最終値は -1 で止まる。
+    let composed = compose_trust(&params, -1.0, -1.0);
+    assert_eq!(composed.trust, -1.0);
+    // 成分に範囲外の値が渡っても ±1 に丸めてから合成する。
+    let composed = compose_trust(&params, -5.0, 3.0);
+    assert!((-1.0..=1.0).contains(&composed.trust));
+}
+
+#[test]
+fn trust_absolute_negative_is_weighted_double() {
+    let params = TrustParams::default();
+    // 絶対成分がマイナスのとき重み 2 倍（distrust 支配）。相対が最良でも救済されない。
+    let negative = compose_trust(&params, -1.0, 1.0);
+    assert_eq!(negative.w_abs_applied, 2.0);
+    // §6.2 の式そのまま: (w_abs * absolute + relative) / 2 = (2.0 * (-1.0) + 1.0) / 2 = -0.5
+    assert_eq!(negative.trust, -0.5);
+    assert!(negative.trust < 0.0, "良好な相対指標で薄まってはいけない");
+    // プラスのときは 1 倍。
+    let positive = compose_trust(&params, 0.5, 0.0);
+    assert_eq!(positive.w_abs_applied, 1.0);
+    assert_eq!(positive.trust, 0.25);
+}
+
+#[test]
+fn trust_composition_weights_are_operator_tunable() {
+    // operator が w_abs を変えると合成結果が変わる。
+    let default_params = TrustParams::default();
+    let tuned = TrustParams {
+        w_abs_negative: 4.0,
+        ..TrustParams::default()
+    };
+    let a = compose_trust(&default_params, -0.4, 0.2);
+    let b = compose_trust(&tuned, -0.4, 0.2);
+    assert_ne!(a.trust, b.trust);
+    assert_eq!(b.w_abs_applied, 4.0);
+
+    // env 相当の lookup から可変（未設定キーは既定値、値は上書き）。
+    let params = TrustParams::from_lookup(|name| {
+        (name == "COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE").then(|| "3.5".to_string())
+    })
+    .unwrap();
+    assert_eq!(params.w_abs_negative, 3.5);
+    assert_eq!(params.w_abs_positive, 1.0);
+    assert_eq!(params.relative_half_life_days, 30.0);
+
+    // 不正値は黙って既定値に倒さず Err（operator の設定ミスを検出する）。
+    assert!(
+        TrustParams::from_lookup(|name| {
+            (name == "COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE").then(|| "not-a-number".to_string())
+        })
+        .is_err()
+    );
+    assert!(
+        TrustParams::from_lookup(|name| {
+            (name == "COMMUNITY_NODE_TRUST_RELATIVE_HALF_LIFE_DAYS").then(|| "0".to_string())
+        })
+        .is_err()
+    );
+}
+
+// --- 単一絶対スカラーにしない / 成分分離（§2.3） ---
+
+#[test]
+fn trust_is_not_single_absolute_scalar() {
+    let inputs = TrustRiskInputs {
+        absolute: vec![csam_input("sig-abs", now())],
+        relative: vec![nsfw_input("sig-rel", now())],
+    };
+    let view = build_trust_read(
+        "pubkey-1",
+        &inputs,
+        now(),
+        &TrustParams::default(),
+        &UniformRelationWeight::default(),
+    );
+    // read は絶対 / 相対成分を分離して返し、合成値だけの単一スカラーにしない。
+    assert_ne!(view.absolute, view.relative);
+    assert!(view.absolute < 0.0);
+    assert!(view.relative < 0.0);
+    // 断定ラベルは存在しない（連続値 + 根拠のみ）。
+    assert!(!view.basis.is_empty());
+}
+
+#[test]
+fn trust_separates_absolute_and_relative_indicators() {
+    // CSAM（critical）は絶対成分のみ、nsfw は相対成分のみに効く。
+    let absolute_only = TrustRiskInputs {
+        absolute: vec![csam_input("sig-abs", now())],
+        relative: vec![],
+    };
+    let view = build_trust_read(
+        "pubkey-1",
+        &absolute_only,
+        now(),
+        &TrustParams::default(),
+        &UniformRelationWeight::default(),
+    );
+    assert!(view.absolute < 0.0);
+    assert_eq!(view.relative, 0.0);
+
+    let relative_only = TrustRiskInputs {
+        absolute: vec![],
+        relative: vec![nsfw_input("sig-rel", now())],
+    };
+    let view = build_trust_read(
+        "pubkey-1",
+        &relative_only,
+        now(),
+        &TrustParams::default(),
+        &UniformRelationWeight::default(),
+    );
+    assert_eq!(view.absolute, 0.0);
+    assert!(view.relative < 0.0);
+}
+
+#[test]
+fn trust_reflects_risk_signals_split_by_category() {
+    // category → 成分の振り分け規則（#406 の供給契約と同じ規則を scoring 側でも公開する）。
+    for category in [
+        SafetyCategory::Csam,
+        SafetyCategory::Cse,
+        SafetyCategory::Grooming,
+    ] {
+        assert_eq!(trust_component_for(category), TrustComponentKind::Absolute);
+    }
+    for category in [
+        SafetyCategory::Nsfw,
+        SafetyCategory::Spam,
+        SafetyCategory::Malware,
+        SafetyCategory::Phishing,
+    ] {
+        assert_eq!(trust_component_for(category), TrustComponentKind::Relative);
+    }
+}
+
+// --- relation 重み付け（§2.3: 絶対は非依存、相対は依存） ---
+
+#[test]
+fn trust_absolute_indicators_not_relation_weighted() {
+    let inputs = TrustRiskInputs {
+        absolute: vec![csam_input("sig-abs", now())],
+        relative: vec![],
+    };
+    let params = TrustParams::default();
+    // relation 重みを 0 にしても絶対成分は 1 ミリも動かない（report-bomb 不動・relation 非依存）。
+    let unweighted = build_trust_read("pk", &inputs, now(), &params, &UniformRelationWeight(0.0));
+    let weighted = build_trust_read("pk", &inputs, now(), &params, &UniformRelationWeight(1.0));
+    assert_eq!(unweighted.absolute, weighted.absolute);
+    assert_eq!(unweighted.trust, weighted.trust);
+    assert_eq!(unweighted.basis[0].relation_weight, 1.0);
+}
+
+#[test]
+fn trust_relative_indicators_are_relation_weighted() {
+    let inputs = TrustRiskInputs {
+        absolute: vec![],
+        relative: vec![nsfw_input("sig-rel", now())],
+    };
+    let params = TrustParams::default();
+    let full = build_trust_read("pk", &inputs, now(), &params, &UniformRelationWeight(1.0));
+    let half = build_trust_read("pk", &inputs, now(), &params, &UniformRelationWeight(0.5));
+    let none = build_trust_read("pk", &inputs, now(), &params, &UniformRelationWeight(0.0));
+    // relation 重みが相対成分の実効寄与を変える（viewer / cluster 相対）。
+    assert!(full.relative < half.relative);
+    assert_eq!(none.relative, 0.0);
+    assert_eq!(half.basis[0].relation_weight, 0.5);
+}
+
+#[test]
+fn trust_resists_mass_report_bombing() {
+    // 特定 cluster からの大量シグナルは raw count として効かず、relation 重みで相対化される。
+    // （通報そのもの（cn_admin.reports）は reporter identity を持たず trust の入力に一切
+    //  ならない — raw count が構造的に入り得ないことが第一の防壁。本テストは第二の防壁 =
+    //  相対成分の relation 重み付けを固定する。）
+    let bombed: Vec<TrustRiskInput> = (0..100)
+        .map(|i| nsfw_input(&format!("bomb-{i}"), now()))
+        .collect();
+    let inputs = TrustRiskInputs {
+        absolute: vec![],
+        relative: bombed,
+    };
+    let params = TrustParams::default();
+
+    // 遠い cluster（重み 0.001）からの 100 件は、近い cluster の 1 件より小さい寄与に留まる。
+    let bombed_far = build_trust_read("pk", &inputs, now(), &params, &UniformRelationWeight(0.001));
+    let single_near = build_trust_read(
+        "pk",
+        &TrustRiskInputs {
+            absolute: vec![],
+            relative: vec![nsfw_input("single", now())],
+        },
+        now(),
+        &params,
+        &UniformRelationWeight(1.0),
+    );
+    assert!(
+        bombed_far.relative > single_near.relative,
+        "100 件 × 重み 0.001 ({}) は 1 件 × 重み 1.0 ({}) より寄与が小さい（マイナス幅が浅い）こと",
+        bombed_far.relative,
+        single_near.relative
+    );
+
+    // そして絶対成分は件数に関わらず不動。
+    assert_eq!(bombed_far.absolute, 0.0);
+}
+
+// --- decay（§6.2: 絶対は減衰しない / 相対は半減期） ---
+
+#[test]
+fn trust_absolute_component_does_not_decay() {
+    let old = now() - Duration::days(365);
+    let fresh_view = build_trust_read(
+        "pk",
+        &TrustRiskInputs {
+            absolute: vec![csam_input("sig", now())],
+            relative: vec![],
+        },
+        now(),
+        &TrustParams::default(),
+        &UniformRelationWeight::default(),
+    );
+    let old_view = build_trust_read(
+        "pk",
+        &TrustRiskInputs {
+            absolute: vec![csam_input("sig", old)],
+            relative: vec![],
+        },
+        now(),
+        &TrustParams::default(),
+        &UniformRelationWeight::default(),
+    );
+    // known-hash 由来の絶対成分は 1 年経っても同じ寄与（時間で薄めない）。
+    assert_eq!(fresh_view.absolute, old_view.absolute);
+    assert_eq!(old_view.basis[0].decay_factor, 1.0);
+}
+
+#[test]
+fn trust_relative_component_decays_over_time() {
+    let params = TrustParams::default(); // 半減期 30 日
+    let fresh = build_trust_read(
+        "pk",
+        &TrustRiskInputs {
+            absolute: vec![],
+            relative: vec![nsfw_input("sig", now())],
+        },
+        now(),
+        &params,
+        &UniformRelationWeight::default(),
+    );
+    let aged = build_trust_read(
+        "pk",
+        &TrustRiskInputs {
+            absolute: vec![],
+            relative: vec![nsfw_input("sig", now() - Duration::days(30))],
+        },
+        now(),
+        &params,
+        &UniformRelationWeight::default(),
+    );
+    // 1 半減期でちょうど寄与が半分になる。
+    let ratio = aged.relative / fresh.relative;
+    assert!(
+        (ratio - 0.5).abs() < 1e-9,
+        "30 日（1 半減期）で寄与が半分になること: ratio={ratio}"
+    );
+    // 半減期は operator 可変: 短くすればより速く減衰する。
+    let short = TrustParams {
+        relative_half_life_days: 7.0,
+        ..TrustParams::default()
+    };
+    let aged_short = build_trust_read(
+        "pk",
+        &TrustRiskInputs {
+            absolute: vec![],
+            relative: vec![nsfw_input("sig", now() - Duration::days(30))],
+        },
+        now(),
+        &short,
+        &UniformRelationWeight::default(),
+    );
+    assert!(
+        aged_short.relative > aged.relative,
+        "短半減期はより浅い寄与（減衰が速い）"
+    );
+}
+
+// --- appeal 反映（§6.2） ---
+
+#[test]
+fn trust_appeal_pending_holds_contribution() {
+    // pending（Disputed）は寄与据え置き: 申し立て中に勝手に緩めない。
+    let mut disputed = csam_input("sig-disputed", now());
+    disputed.appeal_status = AppealStatus::Disputed;
+    let view = build_trust_read(
+        "pk",
+        &TrustRiskInputs {
+            absolute: vec![disputed],
+            relative: vec![],
+        },
+        now(),
+        &TrustParams::default(),
+        &UniformRelationWeight::default(),
+    );
+    assert!(view.absolute < 0.0, "pending は寄与したまま");
+    assert_eq!(view.basis[0].appeal_status, AppealStatus::Disputed);
+}
+
+#[test]
+fn trust_appeal_accepted_excludes_contribution() {
+    // accepted（Cleared）は供給層で除外されるが、万一 scoring まで届いても寄与させない
+    // （defense in depth）。
+    let mut cleared = csam_input("sig-cleared", now());
+    cleared.appeal_status = AppealStatus::Cleared;
+    let view = build_trust_read(
+        "pk",
+        &TrustRiskInputs {
+            absolute: vec![cleared],
+            relative: vec![],
+        },
+        now(),
+        &TrustParams::default(),
+        &UniformRelationWeight::default(),
+    );
+    assert_eq!(view.absolute, 0.0);
+    assert!(view.basis.is_empty(), "除外された signal は根拠にも出ない");
+}
+
+// --- 根拠つき read（trust-semantics §4） ---
+
+#[test]
+fn trust_read_is_explainable_with_basis() {
+    let inputs = TrustRiskInputs {
+        absolute: vec![csam_input("sig-abs", now())],
+        relative: vec![nsfw_input("sig-rel", now() - Duration::days(30))],
+    };
+    let view = build_trust_read(
+        "pubkey-1",
+        &inputs,
+        now(),
+        &TrustParams::default(),
+        &UniformRelationWeight(0.8),
+    );
+    assert_eq!(view.target_id, "pubkey-1");
+    assert_eq!(view.basis.len(), 2);
+
+    let abs = view
+        .basis
+        .iter()
+        .find(|e| e.signal_id == "sig-abs")
+        .unwrap();
+    // issuer / basis / confidence / visibility / expiry / appeal を説明できる。
+    assert_eq!(abs.issuer_node_id, "issuer-node");
+    assert_eq!(abs.component, TrustComponentKind::Absolute);
+    assert_eq!(abs.category, SafetyCategory::Csam);
+    assert_eq!(abs.basis, Basis::KnownHashMatch);
+    assert_eq!(abs.confidence, Some(100));
+    assert_eq!(abs.visibility, Visibility::Local);
+    assert_eq!(abs.appeal_status, AppealStatus::None);
+    assert_eq!(abs.decay_factor, 1.0);
+    assert_eq!(abs.relation_weight, 1.0);
+
+    let rel = view
+        .basis
+        .iter()
+        .find(|e| e.signal_id == "sig-rel")
+        .unwrap();
+    // 実効寄与の内訳（decay / relation 重み）まで説明できる。
+    assert!((rel.decay_factor - 0.5).abs() < 1e-9);
+    assert_eq!(rel.relation_weight, 0.8);
+    assert!((rel.contribution - rel.raw_contribution * rel.decay_factor * 0.8).abs() < 1e-12);
+
+    // 合成値と成分・適用重みが view から再構成できる（説明可能性）。
+    let recomposed = compose_trust(&TrustParams::default(), view.absolute, view.relative);
+    assert_eq!(view.trust, recomposed.trust);
+    assert_eq!(view.w_abs_applied, recomposed.w_abs_applied);
+}
+
+// --- scenario: CSAM 系 risk は relation / 通報数で揺れない ---
+
+#[test]
+fn csam_absolute_component_is_immune_to_relation_and_mass_signals() {
+    let params = TrustParams::default();
+    let base = TrustRiskInputs {
+        absolute: vec![csam_input("sig-csam", now() - Duration::days(180))],
+        relative: vec![],
+    };
+    let view_alone = build_trust_read("pk", &base, now(), &params, &UniformRelationWeight(0.0));
+
+    // 大量の相対シグナルを足しても、relation 重みを変えても、絶対成分は同じ。
+    let mut with_noise = base.clone();
+    with_noise.relative = (0..50)
+        .map(|i| nsfw_input(&format!("noise-{i}"), now()))
+        .collect();
+    let view_noisy = build_trust_read(
+        "pk",
+        &with_noise,
+        now(),
+        &params,
+        &UniformRelationWeight(1.0),
+    );
+
+    assert_eq!(view_alone.absolute, view_noisy.absolute);
+    assert!(view_alone.absolute <= -1.0 + 1e-12);
+    // 絶対成分マイナスなので合成でも distrust が支配的（相対が最悪でも -1 未満に落ちない）。
+    assert!(view_noisy.trust <= -0.5);
+    assert!(view_noisy.trust >= -1.0);
+}

--- a/crates/cn-user-api/Cargo.toml
+++ b/crates/cn-user-api/Cargo.toml
@@ -24,10 +24,11 @@ url.workspace = true
 kukuri-cn-core = { path = "../cn-core" }
 kukuri-cn-indexer = { path = "../cn-indexer" }
 kukuri-cn-operator = { path = "../cn-operator" }
+kukuri-cn-safety = { path = "../cn-safety" }
+kukuri-cn-trust = { path = "../cn-trust" }
 
 [dev-dependencies]
 kukuri-core = { path = "../core" }
-kukuri-cn-safety = { path = "../cn-safety" }
 hex.workspace = true
 reqwest.workspace = true
 redis.workspace = true

--- a/crates/cn-user-api/src/lib.rs
+++ b/crates/cn-user-api/src/lib.rs
@@ -3,10 +3,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use axum::extract::{Query, State};
+use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use kukuri_cn_core::PgIndexEntryStore;
 use kukuri_cn_core::{
@@ -16,15 +16,24 @@ use kukuri_cn_core::{
     CommunityNodeBootstrapNode, CommunityNodeConsentStatus, CommunityNodeResolvedUrls,
     DatabaseInitMode, IndexScopeKind, JwtConfig, NewCommunityNodeReport, TopicRendezvousHeartbeat,
     TopicRendezvousHeartbeatResponse, TopicRendezvousStore, accept_consents, auth_required_error,
-    connect_postgres, create_auth_challenge, get_consent_status, initialize_database,
-    initialize_database_for_runtime, insert_community_node_report, insert_indexing_request,
-    load_admission_config, load_bootstrap_nodes, load_bootstrap_seed_peers, normalize_http_url,
-    normalize_http_url_list, parse_bool_env, parse_csv_env, refresh_bootstrap_peer_registration,
-    register_channel_secret, require_bearer_identity, require_bearer_pubkey, require_consents,
+    clear_relation_optout, connect_postgres, create_auth_challenge, filter_relation_visible,
+    get_consent_status, get_relation_optout, initialize_database, initialize_database_for_runtime,
+    insert_community_node_report, insert_indexing_request, is_relation_opted_out,
+    list_trust_risk_inputs, load_admission_config, load_bootstrap_nodes, load_bootstrap_seed_peers,
+    normalize_http_url, normalize_http_url_list, normalize_pubkey, parse_bool_env, parse_csv_env,
+    refresh_bootstrap_peer_registration, register_channel_secret, require_bearer_identity,
+    require_bearer_pubkey, require_consents, set_relation_optout,
     verify_auth_envelope_and_issue_token,
 };
-use kukuri_cn_indexer::{ArcadeDbConfig, ArcadeDbProjection, FailClosedIndexQuery, IndexQuery};
+use kukuri_cn_indexer::{
+    ArcadeDbConfig, ArcadeDbProjection, ArcadeDbRelationGraph, FailClosedIndexQuery, IndexQuery,
+};
 use kukuri_cn_operator::{CommunityNodeManifest, build_manifest, load_and_validate};
+use kukuri_cn_safety::RiskSignalTarget;
+use kukuri_cn_trust::{
+    PullAudience, RelationStore, TrustParams, TrustReadView, UniformRelationWeight,
+    build_trust_read, cross_node_trust_disclosure,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sqlx::postgres::PgPool;
@@ -51,6 +60,21 @@ pub struct UserApiState {
     /// None = 機能無効（`CommunityIndex` が `Availability::Planned` の既定状態）で、
     /// `/v1/index/*` は 404 を返す。
     index_query: Option<Arc<dyn IndexQuery>>,
+    /// trust / relation read surface（#415 / ADR 0026）。
+    /// None = 機能無効（`CommunityLocalTrust` が `Availability::Planned` の既定状態）で、
+    /// `/v1/trust/*` / `/v1/relation/*` は 404 を返す。
+    trust_read: Option<Arc<TrustReadState>>,
+}
+
+/// trust / relation read surface の依存一式（#415）。
+///
+/// trust の入力（risk signal）は Postgres（`UserApiState::pool`）から読み、relation は
+/// graph backend（本番 = ArcadeDB、テスト = in-memory）から読む。
+pub struct TrustReadState {
+    /// trust 合成のパラメータ（operator 可変, ADR 0026 §6.2）。
+    pub params: TrustParams,
+    /// relation graph の読み口（graph-store 抽象境界, §6.1）。
+    pub relation: Arc<dyn RelationStore>,
 }
 
 impl UserApiState {
@@ -59,6 +83,13 @@ impl UserApiState {
     /// 注入する実装は必ず fail-closed gate（`FailClosedIndexQuery`）を通したものにすること。
     pub fn with_index_query(mut self, index_query: Arc<dyn IndexQuery>) -> Self {
         self.index_query = Some(index_query);
+        self
+    }
+
+    /// trust / relation read surface を差し替える（テスト用の in-memory relation 注入、
+    /// または明示的な有効化）。
+    pub fn with_trust_read(mut self, trust_read: Arc<TrustReadState>) -> Self {
+        self.trust_read = Some(trust_read);
         self
     }
 }
@@ -90,6 +121,12 @@ pub struct UserApiConfig {
     /// 既定 false（`CommunityIndex` が `Availability::Planned` の現状と整合。`/v1/index/*` は 404）。
     /// 有効化すると ArcadeDB（`COMMUNITY_NODE_ARCADEDB_*`）へ接続する。
     pub index_query_enabled: bool,
+    /// trust / relation read surface を公開するか（#415）。
+    /// 既定 false（`CommunityLocalTrust` が `Availability::Planned` の現状と整合。
+    /// `/v1/trust/*` / `/v1/relation/*` は 404）。有効化すると relation graph の
+    /// ArcadeDB（`COMMUNITY_NODE_ARCADEDB_*`）へ接続し、trust パラメータを
+    /// `COMMUNITY_NODE_TRUST_*` env から読む。
+    pub trust_read_enabled: bool,
 }
 
 impl std::fmt::Debug for UserApiConfig {
@@ -110,6 +147,7 @@ impl std::fmt::Debug for UserApiConfig {
                 &self.channel_secret_key.as_ref().map(|_| "<redacted>"),
             )
             .field("index_query_enabled", &self.index_query_enabled)
+            .field("trust_read_enabled", &self.trust_read_enabled)
             .finish()
     }
 }
@@ -245,6 +283,7 @@ impl UserApiConfig {
             .ok()
             .filter(|value| !value.trim().is_empty());
         let index_query_enabled = parse_bool_env("COMMUNITY_NODE_INDEX_QUERY_ENABLED", false)?;
+        let trust_read_enabled = parse_bool_env("COMMUNITY_NODE_TRUST_READ_ENABLED", false)?;
         Ok(Self {
             bind_addr,
             database_url,
@@ -257,6 +296,7 @@ impl UserApiConfig {
             operator_config_path,
             channel_secret_key,
             index_query_enabled,
+            trust_read_enabled,
         })
     }
 }
@@ -390,6 +430,19 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
     } else {
         None
     };
+    // trust / relation read surface（#415）。有効時のみ trust パラメータ（operator 可変）を
+    // 検証つきで読み、relation graph（ArcadeDB。`cn-cli relation analyze` が構築する）へ接続する。
+    let trust_read: Option<Arc<TrustReadState>> = if config.trust_read_enabled {
+        let params = TrustParams::from_env().context("invalid COMMUNITY_NODE_TRUST_* params")?;
+        let relation = ArcadeDbRelationGraph::new(ArcadeDbConfig::from_env())
+            .context("failed to build ArcadeDB client for relation graph")?;
+        Some(Arc::new(TrustReadState {
+            params,
+            relation: Arc::new(relation),
+        }))
+    } else {
+        None
+    };
     Ok(UserApiState {
         pool,
         rendezvous_store,
@@ -405,6 +458,7 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
         manifest,
         channel_secret_cipher,
         index_query,
+        trust_read,
     })
 }
 
@@ -442,6 +496,14 @@ pub fn app_router(state: UserApiState) -> Router {
         .route("/v1/index/search", get(index_search))
         .route("/v1/index/discovery", get(index_discovery))
         .route("/v1/index/recommendations", get(index_recommendations))
+        .route("/v1/trust/users/{pubkey}", get(trust_user_read))
+        .route("/v1/trust/pull/{pubkey}", get(trust_pull))
+        .route("/v1/relation/users/{target}", get(relation_user_read))
+        .route("/v1/relation/neighbors", get(relation_neighbors))
+        .route(
+            "/v1/relation/optout",
+            put(relation_optout_set).delete(relation_optout_clear),
+        )
         .with_state(state);
     api.merge(manifest).layer(TraceLayer::new_for_http())
 }
@@ -924,6 +986,257 @@ async fn index_recommendations(
         .await
         .map_err(internal_error)?;
     Ok(Json(entries.into()))
+}
+
+// --- trust / relation read surface（#415 / ADR 0026） ---
+
+/// trust / relation read 共通の前処理: 機能ゲート（未構成なら 404）+ 認証 + consent。
+///
+/// `CommunityLocalTrust` capability が `Availability::Planned` の既定状態では構成されず、
+/// この node は trust / relation read を提供しない。認証は challenge への鍵署名を検証して
+/// 発行された bearer（`BearerIdentity`）であり、**viewer = bearer の pubkey に固定**される
+/// （`viewer_relative_read_requires_authenticated_viewer` / `relation_read_requires_authenticated_viewer`。
+/// 他人を viewer に指定する手段を持たない = なりすまし防止）。
+async fn require_trust_read(
+    state: &UserApiState,
+    headers: &HeaderMap,
+) -> ApiResult<(Arc<TrustReadState>, String)> {
+    let Some(trust_read) = state.trust_read.clone() else {
+        return Err(ApiError::new(
+            StatusCode::NOT_FOUND,
+            "TRUST_READ_NOT_CONFIGURED",
+            "this community node does not provide trust / relation reads",
+        ));
+    };
+    let identity = require_bearer_identity(&state.pool, &state.jwt_config, headers).await?;
+    let _ = require_consents(&state.pool, identity.pubkey.as_str()).await?;
+    Ok((trust_read, identity.pubkey))
+}
+
+fn parse_target_pubkey(raw: &str) -> Result<String, ApiError> {
+    normalize_pubkey(raw).map_err(|error| {
+        ApiError::new(
+            StatusCode::BAD_REQUEST,
+            "INVALID_TRUST_QUERY",
+            error.to_string(),
+        )
+    })
+}
+
+/// trust read の応答（node-local advisory。断定ラベルなし・根拠つき）。
+#[derive(Debug, Serialize)]
+struct TrustUserReadResponse {
+    /// この read の viewer（bearer identity の pubkey。相対成分の視点）。
+    viewer_pubkey: String,
+    #[serde(flatten)]
+    view: TrustReadView,
+}
+
+/// per-user trust read（ADR 0026 §2.3 / §6.2）。
+///
+/// 絶対成分（viewer 非依存・relation 非依存・減衰なし）+ 相対成分（viewer / cluster 相対・
+/// relation 重み付け・半減期減衰）+ 合成 trust を、寄与 signal の根拠つきで返す。
+/// 相対成分の relation 重みは observer-attributed 観測の producer（非決定論的 moderation,
+/// ADR 0028 系）実装まで一様 1.0（重み付けの seam は scoring 層で固定済み）。
+async fn trust_user_read(
+    State(state): State<UserApiState>,
+    headers: HeaderMap,
+    Path(pubkey): Path<String>,
+) -> ApiResult<Json<TrustUserReadResponse>> {
+    let (trust_read, viewer_pubkey) = require_trust_read(&state, &headers).await?;
+    let target = parse_target_pubkey(pubkey.as_str())?;
+    let now = chrono::Utc::now();
+    let inputs = list_trust_risk_inputs(
+        &state.pool,
+        RiskSignalTarget::UserPubkey,
+        target.as_str(),
+        now.to_rfc3339().as_str(),
+    )
+    .await
+    .map_err(internal_error)?;
+    let view = build_trust_read(
+        target.as_str(),
+        &inputs,
+        now,
+        &trust_read.params,
+        &UniformRelationWeight::default(),
+    );
+    Ok(Json(TrustUserReadResponse {
+        viewer_pubkey,
+        view,
+    }))
+}
+
+/// cross-node pull（ADR 0026 §6.3）。
+///
+/// **confirmed（known-hash / provider-verdict）な絶対成分のみ**を根拠つきで返す。
+/// 相対成分・relation・suspected は visibility に依らず返さない。`visibility` は
+/// アクセス範囲: `Local` は返さず（既定）、`SubscribedNodes` は bearer で subscriber と
+/// 認証できた要求者のみ、`Public` は匿名でも返す。絶対成分は viewer 非依存のため
+/// viewer 証明は要さない（bearer は audience 判定のみに使う）。
+async fn trust_pull(
+    State(state): State<UserApiState>,
+    headers: HeaderMap,
+    Path(pubkey): Path<String>,
+) -> ApiResult<Json<kukuri_cn_trust::CrossNodeTrustDisclosure>> {
+    let Some(_) = state.trust_read.clone() else {
+        return Err(ApiError::new(
+            StatusCode::NOT_FOUND,
+            "TRUST_READ_NOT_CONFIGURED",
+            "this community node does not provide trust / relation reads",
+        ));
+    };
+    // bearer が有効な subscriber なら SubscribedNodes、無ければ匿名（Public visibility のみ）。
+    let audience = match require_bearer_identity(&state.pool, &state.jwt_config, &headers).await {
+        Ok(_) => PullAudience::SubscribedNodes,
+        Err(_) => PullAudience::Public,
+    };
+    let target = parse_target_pubkey(pubkey.as_str())?;
+    let now = chrono::Utc::now();
+    let inputs = list_trust_risk_inputs(
+        &state.pool,
+        RiskSignalTarget::UserPubkey,
+        target.as_str(),
+        now.to_rfc3339().as_str(),
+    )
+    .await
+    .map_err(internal_error)?;
+    Ok(Json(cross_node_trust_disclosure(
+        target.as_str(),
+        &inputs,
+        audience,
+        now,
+    )))
+}
+
+/// relation read の応答（pairwise cluster proximity。根拠つき）。
+#[derive(Debug, Serialize)]
+struct RelationReadResponse {
+    viewer_pubkey: String,
+    target_pubkey: String,
+    #[serde(flatten)]
+    proximity: kukuri_cn_trust::Proximity,
+}
+
+/// pairwise relation read（ADR 0026 §2.4）。viewer = bearer identity。
+///
+/// target が opt-out（「見えない」）している場合は edge が無い場合と同じ 404 を返し、
+/// opt-out 状態そのものを漏らさない。relation は情報として返すのみで、index / search /
+/// discovery の結果集合をこの値で削らない（`relation_does_not_auto_suppress_cross_cluster_content`）。
+async fn relation_user_read(
+    State(state): State<UserApiState>,
+    headers: HeaderMap,
+    Path(target): Path<String>,
+) -> ApiResult<Json<RelationReadResponse>> {
+    let (trust_read, viewer_pubkey) = require_trust_read(&state, &headers).await?;
+    let target = parse_target_pubkey(target.as_str())?;
+    let not_found = || {
+        ApiError::new(
+            StatusCode::NOT_FOUND,
+            "RELATION_NOT_FOUND",
+            "no relation observed for this pair",
+        )
+    };
+    // 「見えない」opt-out: 他者から見た relation read に出さない（§6.3。可逆・trust 非影響）。
+    if is_relation_opted_out(&state.pool, target.as_str())
+        .await
+        .map_err(internal_error)?
+    {
+        return Err(not_found());
+    }
+    let proximity = trust_read
+        .relation
+        .pairwise_proximity(viewer_pubkey.as_str(), target.as_str())
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(not_found)?;
+    Ok(Json(RelationReadResponse {
+        viewer_pubkey,
+        target_pubkey: target,
+        proximity,
+    }))
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RelationNeighborsParams {
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct RelationNeighborsResponse {
+    viewer_pubkey: String,
+    neighbors: Vec<String>,
+}
+
+/// discovery / surfacing 用の近接近傍（ADR 0026 §6.1 `neighbors`）。viewer = bearer identity。
+///
+/// opt-out 済み user は結果から除外する（「見えない」= discovery に出ない, §6.3）。
+async fn relation_neighbors(
+    State(state): State<UserApiState>,
+    headers: HeaderMap,
+    Query(params): Query<RelationNeighborsParams>,
+) -> ApiResult<Json<RelationNeighborsResponse>> {
+    let (trust_read, viewer_pubkey) = require_trust_read(&state, &headers).await?;
+    let limit = params.limit.unwrap_or(20).clamp(1, 100);
+    let neighbors = trust_read
+        .relation
+        .neighbors(viewer_pubkey.as_str(), limit)
+        .await
+        .map_err(internal_error)?;
+    let neighbors = filter_relation_visible(&state.pool, neighbors.as_slice())
+        .await
+        .map_err(internal_error)?;
+    Ok(Json(RelationNeighborsResponse {
+        viewer_pubkey,
+        neighbors,
+    }))
+}
+
+#[derive(Debug, Serialize)]
+struct RelationOptoutResponse {
+    pubkey: String,
+    opted_out: bool,
+    /// opt-out した時刻（説明可能性。解除済みなら null）。
+    opted_out_at: Option<String>,
+}
+
+/// 「見えない」opt-out の設定（ADR 0026 §2.6 / §6.3）。
+///
+/// **自分自身のみ**設定できる（bearer identity に固定）。可逆（DELETE で解除）で、
+/// trust には影響しない（troll 判定回避の手段にしない）。social graph canonical の削除でもない。
+async fn relation_optout_set(
+    State(state): State<UserApiState>,
+    headers: HeaderMap,
+) -> ApiResult<Json<RelationOptoutResponse>> {
+    let (_, pubkey) = require_trust_read(&state, &headers).await?;
+    set_relation_optout(&state.pool, pubkey.as_str())
+        .await
+        .map_err(internal_error)?;
+    let opted_out_at = get_relation_optout(&state.pool, pubkey.as_str())
+        .await
+        .map_err(internal_error)?;
+    Ok(Json(RelationOptoutResponse {
+        pubkey,
+        opted_out: true,
+        opted_out_at: opted_out_at.map(|at| at.to_rfc3339()),
+    }))
+}
+
+/// 「見えない」opt-out の解除（可逆性の実装）。
+async fn relation_optout_clear(
+    State(state): State<UserApiState>,
+    headers: HeaderMap,
+) -> ApiResult<Json<RelationOptoutResponse>> {
+    let (_, pubkey) = require_trust_read(&state, &headers).await?;
+    clear_relation_optout(&state.pool, pubkey.as_str())
+        .await
+        .map_err(internal_error)?;
+    Ok(Json(RelationOptoutResponse {
+        pubkey,
+        opted_out: false,
+        opted_out_at: None,
+    }))
 }
 
 /// channel secret 登録失敗を HTTP 応答へマップする。

--- a/crates/cn-user-api/tests/contract.rs
+++ b/crates/cn-user-api/tests/contract.rs
@@ -48,6 +48,7 @@ impl TestServer {
             operator_config_path: None,
             channel_secret_key: None,
             index_query_enabled: false,
+            trust_read_enabled: false,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-user-api/tests/index_query.rs
+++ b/crates/cn-user-api/tests/index_query.rs
@@ -153,6 +153,7 @@ impl TestServer {
             operator_config_path: None,
             channel_secret_key: None,
             index_query_enabled: false,
+            trust_read_enabled: false,
         })
         .await?;
         if let Some(index) = index {

--- a/crates/cn-user-api/tests/indexing_requests.rs
+++ b/crates/cn-user-api/tests/indexing_requests.rs
@@ -49,6 +49,7 @@ impl TestServer {
             operator_config_path: None,
             channel_secret_key,
             index_query_enabled: false,
+            trust_read_enabled: false,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-user-api/tests/reports.rs
+++ b/crates/cn-user-api/tests/reports.rs
@@ -72,6 +72,7 @@ impl TestServer {
             operator_config_path: Some(operator_config.path().to_path_buf()),
             channel_secret_key: None,
             index_query_enabled: false,
+            trust_read_enabled: false,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-user-api/tests/trust_relation.rs
+++ b/crates/cn-user-api/tests/trust_relation.rs
@@ -1,0 +1,639 @@
+//! #415 trust / relation read surface（`CommunityLocalTrust`）の contract test。
+//!
+//! `GET /v1/trust/users/{pubkey}` / `GET /v1/trust/pull/{pubkey}` /
+//! `GET /v1/relation/users/{target}` / `GET /v1/relation/neighbors` /
+//! `PUT|DELETE /v1/relation/optout` を ADR 0026 の contract に沿って固定する。
+//! 機能未構成（既定。`CommunityLocalTrust` = `Availability::Planned`）の node は 404。
+//!
+//! Postgres + Redis を要するため `KUKURI_CN_RUN_INTEGRATION_TESTS=1` で gate する。
+//! relation graph は in-memory（`MemoryRelationStore`）を `with_trust_read` で注入する
+//! （proximity の合成は ArcadeDB 実装と共通の `proximity_from_features`）。
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use kukuri_cn_core::{
+    JwtConfig, NewCommunityNodeReport, TestDatabase, build_auth_envelope_json, connect_postgres,
+    insert_community_node_report, persist_risk_signal,
+};
+use kukuri_cn_safety::{
+    Basis, RiskSignalTarget, SafetyCategory, SafetyRiskSignal, Severity, Visibility,
+};
+use kukuri_cn_trust::{
+    EdgeFeatures, FEATURE_CO_PARTICIPATION_EVENTS, FEATURE_SHARED_TOPICS, MemoryRelationStore,
+    RelationStore, TrustParams,
+};
+use kukuri_cn_user_api::{TrustReadState, UserApiConfig, app_router, build_state};
+use kukuri_core::{KukuriKeys, generate_keys};
+use reqwest::{Client, StatusCode};
+
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+const DEFAULT_RENDEZVOUS_REDIS_URL: &str = "redis://127.0.0.1:16379/";
+
+fn integration_test_admin_database_url() -> Option<String> {
+    let enabled = std::env::var("KUKURI_CN_RUN_INTEGRATION_TESTS")
+        .ok()
+        .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+    Some(
+        std::env::var("COMMUNITY_NODE_DATABASE_URL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_ADMIN_DATABASE_URL.to_string()),
+    )
+}
+
+fn integration_test_rendezvous_redis_url() -> String {
+    std::env::var("COMMUNITY_NODE_RENDEZVOUS_REDIS_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_RENDEZVOUS_REDIS_URL.to_string())
+}
+
+struct TestServer {
+    task: tokio::task::JoinHandle<()>,
+    database: TestDatabase,
+    base_url: String,
+}
+
+impl TestServer {
+    /// trust / relation read（in-memory relation）を注入した user-api server を起動する。
+    /// `trust` が None の場合は機能未構成の node（`/v1/trust/*` / `/v1/relation/*` は 404）。
+    async fn spawn(
+        admin_database_url: &str,
+        prefix: &str,
+        trust: Option<Arc<TrustReadState>>,
+    ) -> Result<Self> {
+        let database = TestDatabase::create(admin_database_url, prefix).await?;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("failed to bind test trust read listener")?;
+        let addr = listener.local_addr()?;
+        let base_url = format!("http://{addr}");
+        let mut state = build_state(&UserApiConfig {
+            bind_addr: addr,
+            database_url: database.database_url.clone(),
+            rendezvous_redis_url: integration_test_rendezvous_redis_url(),
+            rendezvous_key_prefix: format!("cn:test:{prefix}"),
+            base_url: base_url.clone(),
+            public_base_url: base_url.clone(),
+            connectivity_urls: vec!["http://127.0.0.1:13340".to_string()],
+            jwt_config: JwtConfig::new("kukuri-cn-tests", "test-secret", 3600),
+            operator_config_path: None,
+            channel_secret_key: None,
+            index_query_enabled: false,
+            trust_read_enabled: false,
+        })
+        .await?;
+        if let Some(trust) = trust {
+            state = state.with_trust_read(trust);
+        }
+        let app = app_router(state);
+        let task = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("trust read server");
+        });
+        Ok(Self {
+            task,
+            database,
+            base_url,
+        })
+    }
+
+    async fn shutdown(self) -> Result<()> {
+        self.task.abort();
+        self.database.cleanup().await
+    }
+}
+
+/// 認証 + consent を通し、bearer access token を返す。
+async fn authenticate_and_consent(
+    client: &Client,
+    base_url: &str,
+    keys: &KukuriKeys,
+) -> Result<String> {
+    let pubkey = keys.public_key_hex();
+    let challenge = client
+        .post(format!("{base_url}/v1/auth/challenge"))
+        .json(&serde_json::json!({ "pubkey": pubkey }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<kukuri_cn_core::AuthChallengeResponse>()
+        .await?;
+    let auth_envelope_json =
+        build_auth_envelope_json(keys, challenge.challenge.as_str(), base_url)?;
+    let verify = client
+        .post(format!("{base_url}/v1/auth/verify"))
+        .json(&serde_json::json!({
+            "auth_envelope_json": auth_envelope_json,
+            "endpoint_id": "peer-a",
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<kukuri_cn_core::AuthVerifyResponse>()
+        .await?;
+    client
+        .post(format!("{base_url}/v1/consents"))
+        .bearer_auth(verify.access_token.as_str())
+        .json(&serde_json::json!({ "policy_slugs": [] }))
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(verify.access_token)
+}
+
+fn memory_trust_state() -> (Arc<TrustReadState>, Arc<MemoryRelationStore>) {
+    let relation = Arc::new(MemoryRelationStore::new());
+    let state = Arc::new(TrustReadState {
+        params: TrustParams::default(),
+        relation: relation.clone(),
+    });
+    (state, relation)
+}
+
+fn risk_signal(
+    target_id: &str,
+    category: SafetyCategory,
+    severity: Severity,
+    basis: Basis,
+    visibility: Visibility,
+) -> SafetyRiskSignal {
+    SafetyRiskSignal {
+        target: RiskSignalTarget::UserPubkey,
+        target_id: target_id.to_string(),
+        category,
+        severity,
+        basis,
+        confidence: Some(100),
+        visibility,
+        expires_at: None,
+        appeal_status: None,
+    }
+}
+
+#[tokio::test]
+async fn trust_read_is_not_found_when_not_configured() -> Result<()> {
+    // 既定（機能無効 = `CommunityLocalTrust` Planned 相当）の node は trust / relation read を
+    // 公開しない。
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api trust read test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn(admin_database_url.as_str(), "cn_trust_off", None).await?;
+    let client = Client::new();
+    let keys = generate_keys();
+    let token = authenticate_and_consent(&client, server.base_url.as_str(), &keys).await?;
+    let target = generate_keys().public_key_hex();
+
+    for path in [
+        format!("/v1/trust/users/{target}"),
+        format!("/v1/trust/pull/{target}"),
+        format!("/v1/relation/users/{target}"),
+        "/v1/relation/neighbors".to_string(),
+    ] {
+        let response = client
+            .get(format!("{}{path}", server.base_url))
+            .bearer_auth(token.as_str())
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{path}");
+    }
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn viewer_relative_read_requires_authenticated_viewer() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api trust read test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let (trust, _relation) = memory_trust_state();
+    let server =
+        TestServer::spawn(admin_database_url.as_str(), "cn_trust_auth", Some(trust)).await?;
+    let client = Client::new();
+    let target = generate_keys().public_key_hex();
+
+    // 未認証の viewer 相対 read（trust / relation）は拒否される。
+    for path in [
+        format!("/v1/trust/users/{target}"),
+        format!("/v1/relation/users/{target}"),
+        "/v1/relation/neighbors".to_string(),
+    ] {
+        let response = client
+            .get(format!("{}{path}", server.base_url))
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{path}");
+    }
+
+    // 認証済み read の viewer は bearer identity（鍵署名で検証済みの pubkey）に固定される:
+    // 「viewer=A」を騙って read する手段が存在しない（なりすまし防止, §6.3）。
+    let viewer_keys = generate_keys();
+    let token = authenticate_and_consent(&client, server.base_url.as_str(), &viewer_keys).await?;
+    let body: serde_json::Value = client
+        .get(format!("{}/v1/trust/users/{target}", server.base_url))
+        .bearer_auth(token.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(
+        body["viewer_pubkey"].as_str(),
+        Some(viewer_keys.public_key_hex().as_str())
+    );
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn trust_read_returns_components_with_basis_and_ignores_reports() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api trust read test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let (trust, _relation) = memory_trust_state();
+    let server =
+        TestServer::spawn(admin_database_url.as_str(), "cn_trust_read", Some(trust)).await?;
+    let pool = connect_postgres(server.database.database_url.as_str()).await?;
+    let client = Client::new();
+    let viewer_keys = generate_keys();
+    let token = authenticate_and_consent(&client, server.base_url.as_str(), &viewer_keys).await?;
+    let target = generate_keys().public_key_hex();
+
+    // CSAM（critical safety, known-hash confirmed）→ 絶対成分。nsfw → 相対成分。
+    persist_risk_signal(
+        &pool,
+        "issuer-node",
+        &risk_signal(
+            target.as_str(),
+            SafetyCategory::Csam,
+            Severity::Critical,
+            Basis::KnownHashMatch,
+            Visibility::Public,
+        ),
+    )
+    .await?;
+    persist_risk_signal(
+        &pool,
+        "issuer-node",
+        &risk_signal(
+            target.as_str(),
+            SafetyCategory::Nsfw,
+            Severity::High,
+            Basis::ClassifierScore,
+            Visibility::Local,
+        ),
+    )
+    .await?;
+
+    let read_trust = |token: String| {
+        let client = client.clone();
+        let url = format!("{}/v1/trust/users/{target}", server.base_url);
+        async move {
+            anyhow::Ok(
+                client
+                    .get(url)
+                    .bearer_auth(token)
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .json::<serde_json::Value>()
+                    .await?,
+            )
+        }
+    };
+    let body = read_trust(token.clone()).await?;
+
+    // 単一絶対スカラーではなく、絶対 / 相対成分 + 合成 + 根拠を返す。
+    let absolute = body["absolute"].as_f64().unwrap();
+    let relative = body["relative"].as_f64().unwrap();
+    let trust_value = body["trust"].as_f64().unwrap();
+    assert!(absolute <= -1.0 + 1e-9, "CSAM confirmed で絶対成分は最低値");
+    assert!(relative < 0.0);
+    assert_eq!(body["w_abs_applied"].as_f64(), Some(2.0));
+    assert!((-1.0..=1.0).contains(&trust_value), "最終クランプ");
+    assert!(trust_value <= -0.5, "絶対マイナスは相対で薄まらない");
+    let basis = body["basis"].as_array().unwrap();
+    assert_eq!(basis.len(), 2);
+    for entry in basis {
+        // 根拠つき advisory: issuer / basis / confidence / visibility を説明できる。
+        assert!(entry["issuer_node_id"].is_string());
+        assert!(entry["basis"].is_string());
+        assert!(entry["visibility"].is_string());
+        assert!(entry["contribution"].is_number());
+    }
+
+    // 通報（reporter identity を持たない, #370）は何件積まれても trust に影響しない
+    // （report-bombing 耐性の構造的保証。trust の入力は verdict / risk signal のみで、
+    //  `cn_admin.reports` から trust への経路が存在しない）。intake 経路（HTTP / 管理操作）に
+    //  依存しない性質なので、通報の真実源へ直接大量投入して固定する。
+    for i in 0..25 {
+        insert_community_node_report(
+            &pool,
+            &NewCommunityNodeReport {
+                subject_kind: "profile".to_string(),
+                subject_id: target.clone(),
+                capability: "community_index".to_string(),
+                reason: format!("mass-report-{i}"),
+                details: None,
+                reporter_contact: None,
+            },
+        )
+        .await?;
+    }
+    let after = read_trust(token.clone()).await?;
+    assert_eq!(after["absolute"], body["absolute"]);
+    assert_eq!(after["relative"], body["relative"]);
+    assert_eq!(after["trust"], body["trust"]);
+
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn cross_node_pull_discloses_only_confirmed_absolute_component() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api trust read test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let (trust, _relation) = memory_trust_state();
+    let server =
+        TestServer::spawn(admin_database_url.as_str(), "cn_trust_pull", Some(trust)).await?;
+    let pool = connect_postgres(server.database.database_url.as_str()).await?;
+    let client = Client::new();
+    let target = generate_keys().public_key_hex();
+
+    // Public + confirmed（開示される）/ Local + confirmed（返さない）/
+    // Public + suspected（返さない）/ 相対成分（返さない）/ SubscribedNodes + confirmed
+    // （subscriber 認証時のみ）。
+    let public_confirmed = persist_risk_signal(
+        &pool,
+        "issuer-node",
+        &risk_signal(
+            target.as_str(),
+            SafetyCategory::Csam,
+            Severity::Critical,
+            Basis::KnownHashMatch,
+            Visibility::Public,
+        ),
+    )
+    .await?;
+    persist_risk_signal(
+        &pool,
+        "issuer-node",
+        &risk_signal(
+            target.as_str(),
+            SafetyCategory::Cse,
+            Severity::Critical,
+            Basis::ProviderVerdict,
+            Visibility::Local,
+        ),
+    )
+    .await?;
+    persist_risk_signal(
+        &pool,
+        "issuer-node",
+        &risk_signal(
+            target.as_str(),
+            SafetyCategory::Grooming,
+            Severity::High,
+            Basis::ClassifierScore,
+            Visibility::Public,
+        ),
+    )
+    .await?;
+    persist_risk_signal(
+        &pool,
+        "issuer-node",
+        &risk_signal(
+            target.as_str(),
+            SafetyCategory::Nsfw,
+            Severity::High,
+            Basis::KnownHashMatch,
+            Visibility::Public,
+        ),
+    )
+    .await?;
+    let subscribed_confirmed = persist_risk_signal(
+        &pool,
+        "issuer-node",
+        &risk_signal(
+            target.as_str(),
+            SafetyCategory::Csam,
+            Severity::Critical,
+            Basis::ProviderVerdict,
+            Visibility::SubscribedNodes,
+        ),
+    )
+    .await?;
+
+    let pull_url = format!("{}/v1/trust/pull/{target}", server.base_url);
+    let signal_ids = |body: &serde_json::Value| -> Vec<String> {
+        body["basis"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["signal_id"].as_str().unwrap_or_default().to_string())
+            .collect()
+    };
+
+    // 匿名 pull: Public + confirmed + 絶対成分のみ。
+    let anonymous: serde_json::Value = client
+        .get(pull_url.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(signal_ids(&anonymous), vec![public_confirmed.id.clone()]);
+    assert!(anonymous.get("relative").is_none(), "相対成分は返さない");
+    assert!(anonymous.get("trust").is_none(), "合成値も返さない");
+
+    // subscriber 認証つき pull: SubscribedNodes visibility の confirmed も開示される。
+    let subscriber_keys = generate_keys();
+    let token =
+        authenticate_and_consent(&client, server.base_url.as_str(), &subscriber_keys).await?;
+    let subscribed: serde_json::Value = client
+        .get(pull_url.as_str())
+        .bearer_auth(token.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let mut ids = signal_ids(&subscribed);
+    ids.sort();
+    let mut expected = vec![public_confirmed.id, subscribed_confirmed.id];
+    expected.sort();
+    assert_eq!(ids, expected);
+
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn relation_read_optout_and_no_auto_suppression() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api trust read test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let (trust, relation) = memory_trust_state();
+    let server = TestServer::spawn(admin_database_url.as_str(), "cn_relation", Some(trust)).await?;
+    let pool = connect_postgres(server.database.database_url.as_str()).await?;
+    let client = Client::new();
+
+    let viewer_keys = generate_keys();
+    let target_keys = generate_keys();
+    let other_keys = generate_keys();
+    let viewer = viewer_keys.public_key_hex();
+    let target = target_keys.public_key_hex();
+    let other = other_keys.public_key_hex();
+    let viewer_token =
+        authenticate_and_consent(&client, server.base_url.as_str(), &viewer_keys).await?;
+    let target_token =
+        authenticate_and_consent(&client, server.base_url.as_str(), &target_keys).await?;
+
+    // relation graph を seed（解析 worker 出力と同型）。
+    relation
+        .upsert_edge(
+            viewer.as_str(),
+            target.as_str(),
+            &EdgeFeatures::new()
+                .with(FEATURE_SHARED_TOPICS, 3.0)
+                .with(FEATURE_CO_PARTICIPATION_EVENTS, 10.0),
+        )
+        .await?;
+    relation
+        .upsert_edge(
+            viewer.as_str(),
+            other.as_str(),
+            &EdgeFeatures::new().with(FEATURE_SHARED_TOPICS, 1.0),
+        )
+        .await?;
+
+    // pairwise read: 根拠つき proximity が返る。
+    let relation_url = format!("{}/v1/relation/users/{target}", server.base_url);
+    let body: serde_json::Value = client
+        .get(relation_url.as_str())
+        .bearer_auth(viewer_token.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert!(body["score"].as_f64().unwrap() > 0.0);
+    assert!(!body["basis"].as_array().unwrap().is_empty(), "根拠つき");
+
+    // neighbors: proximity 降順で返る。
+    let neighbors_url = format!("{}/v1/relation/neighbors", server.base_url);
+    let neighbors: serde_json::Value = client
+        .get(neighbors_url.as_str())
+        .bearer_auth(viewer_token.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(
+        neighbors["neighbors"].as_array().unwrap().len(),
+        2,
+        "opt-out 前は両方見える"
+    );
+
+    // target が「見えない」を選ぶ（自分自身のみ・user-controlled）。
+    let optout: serde_json::Value = client
+        .put(format!("{}/v1/relation/optout", server.base_url))
+        .bearer_auth(target_token.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(optout["opted_out"].as_bool(), Some(true));
+    assert_eq!(optout["pubkey"].as_str(), Some(target.as_str()));
+
+    // 他者から見た relation read / neighbors（discovery）の双方から消える。
+    let hidden = client
+        .get(relation_url.as_str())
+        .bearer_auth(viewer_token.as_str())
+        .send()
+        .await?;
+    assert_eq!(hidden.status(), StatusCode::NOT_FOUND);
+    let neighbors_after: serde_json::Value = client
+        .get(neighbors_url.as_str())
+        .bearer_auth(viewer_token.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let visible: Vec<&str> = neighbors_after["neighbors"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert_eq!(visible, vec![other.as_str()]);
+
+    // opt-out は trust には影響しない（troll 判定回避の手段にしない）: opt-out した target の
+    // trust read は変わらず取得でき、risk signal の寄与も変わらない。
+    persist_risk_signal(
+        &pool,
+        "issuer-node",
+        &risk_signal(
+            target.as_str(),
+            SafetyCategory::Spam,
+            Severity::Medium,
+            Basis::ClassifierScore,
+            Visibility::Local,
+        ),
+    )
+    .await?;
+    let trust_body: serde_json::Value = client
+        .get(format!("{}/v1/trust/users/{target}", server.base_url))
+        .bearer_auth(viewer_token.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert!(trust_body["relative"].as_f64().unwrap() < 0.0);
+
+    // 可逆: 解除すれば見え直す（canonical 削除ではない node-local の選択）。
+    client
+        .delete(format!("{}/v1/relation/optout", server.base_url))
+        .bearer_auth(target_token.as_str())
+        .send()
+        .await?
+        .error_for_status()?;
+    let restored = client
+        .get(relation_url.as_str())
+        .bearer_auth(viewer_token.as_str())
+        .send()
+        .await?;
+    assert_eq!(restored.status(), StatusCode::OK);
+
+    // cross-cluster content の自動抑制をしない: relation read は近接度の情報を返すだけで、
+    // どのエンドポイントの結果集合も relation 値で削らない（本 server の index query は
+    // relation state と独立に構成され、relation の有無・opt-out が index 応答を変えない
+    // ことは `/v1/index/*` が relation state を参照しない構造で保証される）。
+    // edge の無い相手（cross-cluster 相当）への read は 404 = 「情報なし」であり、
+    // 抑制指示ではない。
+    let stranger = generate_keys().public_key_hex();
+    let cross = client
+        .get(format!("{}/v1/relation/users/{stranger}", server.base_url))
+        .bearer_auth(viewer_token.as_str())
+        .send()
+        .await?;
+    assert_eq!(cross.status(), StatusCode::NOT_FOUND);
+
+    server.shutdown().await
+}

--- a/crates/harness/src/runtime.rs
+++ b/crates/harness/src/runtime.rs
@@ -103,6 +103,7 @@ impl CommunityNodeStack {
             operator_config_path: None,
             channel_secret_key: None,
             index_query_enabled: false,
+            trust_read_enabled: false,
         })
         .await
         .context("failed to build community-node user-api state")?;

--- a/docs/progress/2026-07-02-415-trust-relation-foundation.md
+++ b/docs/progress/2026-07-02-415-trust-relation-foundation.md
@@ -1,0 +1,125 @@
+# 2026-07-02 #415 community node trust / relation foundation（CommunityLocalTrust read surface）
+
+参照: `docs/adr/0026-community-node-trust-relation-foundation.md`（§2 Decision / §6 #416 Decision）、
+`.claude/plans/2026-07-02-issue-415-trust-relation-foundation.md`、
+`docs/progress/2026-07-02-404-fail-closed-community-indexing.md`（index 真実源 = co-participation 観測元）
+
+## 実装した範囲
+
+`CommunityLocalTrust` capability の中身 = **trust（per-user 信頼度）+ relation（pairwise cluster
+proximity）の 2 read** を foundation として実装した。trust / relation とも node-local **advisory**
+であり、canonical（user identity / social graph）を所有・改変しない overlay。
+
+- **`cn-trust`（新 crate。pure domain、DB / network 非依存）**
+  - `TrustParams`: operator 可変パラメータ（`COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE` 既定 2.0 /
+    `..._W_ABS_POSITIVE` 既定 1.0 / `..._RELATIVE_HALF_LIFE_DAYS` 既定 30）。不正値は起動時 Err。
+  - scoring（§6.2）: `trust = clamp(-1, 1, (w_abs*absolute + relative) / 2)`。絶対成分 =
+    critical safety risk signal（減衰なし・relation 非依存・viewer 非依存）、相対成分 = 非 critical
+    risk signal（半減期減衰 + relation 重み seam `RelationWeighting`）。appeal は供給層
+    （#406 `trust_risk_inputs_from`）+ scoring 層の二重防御（pending 据え置き / accepted 除外）。
+  - `TrustReadView`: 絶対 / 相対 / 合成 + 寄与 signal ごとの根拠（issuer / basis / confidence /
+    visibility / expiry / appeal / decay / relation 重み / 実効寄与）。断定ラベル・閾値は持たない。
+  - relation（§6.1）: graph-store 抽象 `RelationStore`（`upsert_edge` / `pairwise_proximity` /
+    `neighbors` / `cluster_of` + `set_cluster`）、backend 非依存の proximity 合成
+    `proximity_from_features`（feature 内訳つき）、in-memory 実装、共有 contract スイート
+    （`testing` feature。in-memory / ArcadeDB に同一契約を課す）。
+  - cross-node 開示（§6.3）: `cross_node_trust_disclosure` = **confirmed（known-hash /
+    provider-verdict）な絶対成分のみ**。suspected / 相対成分 / relation は返さない。開示値は
+    開示可能な signal のみから再計算（Local signal の存在を漏らさない）。
+  - seam: `ObservedSignal`（観測者つき node-local 観測）は**型のみ**。producer は非決定論的
+    moderation（ADR 0028 系）実装まで存在しない。`FEATURE_FOLLOW_PROJECTION` も key 予約のみ。
+- **`cn-core`** — migration `202607020002_trust_relation.sql`
+  - `cn_trust.relation_optouts`: 「見えない」opt-out の真実源（可逆 = 行削除、冪等）。
+    **trust には影響しない**（trust read は本テーブルを見ない）。
+  - `co_participation.rs`: index 真実源（`cn_index.index_entries`、allow verdict のみ）からの
+    共起集計。`CoParticipationSource` trait（Pg / in-memory 同一セマンティクス）。
+    **`public_topic` scope のみ**を集計し、private channel 由来は構造的に relation へ入らない。
+  - `trust_inputs.rs` の型（`TrustRiskInput` 等）は cn-trust へ移動し再エクスポート（互換維持）。
+- **`cn-indexer`**
+  - `ArcadeDbRelationGraph`: `RelationStore` の ArcadeDB 実装。index 投影と同じインスタンスに
+    相乗り（#413 方針）。クエリは **Cypher**（neo4j 互換の scale path、§6.1）。edge feature は
+    `features_json` 文字列 property（neo4j も map property を持たないため可搬）。
+  - `relation_worker.rs`: co-participation 集計 → feature 点数化（共有 topic 数 / 共起 events）→
+    `upsert_edge` + cluster 帰属（**dominant shared topic** の初期実装）。batch・冪等・**非常駐**。
+- **`cn-cli`**: `relation analyze`（`--limit`）。schema 冪等作成 + batch 解析の手動実行。
+- **`cn-user-api`** — すべて `COMMUNITY_NODE_TRUST_READ_ENABLED`（**既定 false = 404**）で gate:
+  - `GET /v1/trust/users/{pubkey}`: viewer 相対 trust read。**viewer = bearer identity に固定**
+    （challenge への鍵署名で検証済み。他人視点を騙る手段が無い）。認証 + consent + rate limit。
+  - `GET /v1/trust/pull/{pubkey}`: cross-node pull。匿名 = `Public` visibility のみ、bearer で
+    subscriber 認証済み = `SubscribedNodes` も。confirmed 絶対成分のみ根拠つき。
+  - `GET /v1/relation/users/{target}` / `GET /v1/relation/neighbors`: pairwise proximity（根拠つき）
+    と近接近傍。opt-out 済み user は双方から消える（opt-out 状態自体は 404 で漏らさない）。
+  - `PUT /v1/relation/optout` / `DELETE /v1/relation/optout`: 自分自身のみ・可逆。
+  - relation を使って index / search / discovery の結果集合を削る経路は**存在しない**
+    （auto-suppression しない。relation read は情報を返すだけ）。
+
+## ADR 0026 contract ↔ テスト対応
+
+| contract | テスト |
+|---|---|
+| `trust_is_not_single_absolute_scalar` | cn-trust `tests/trust_scoring.rs` 同名 |
+| `trust_separates_absolute_and_relative_indicators` | 同上 同名 |
+| `trust_absolute_indicators_not_relation_weighted` | 同上 同名 |
+| `trust_relative_indicators_are_relation_weighted` | 同上 同名 |
+| `trust_resists_mass_report_bombing` | 同上 同名 + cn-user-api `trust_read_returns_components_with_basis_and_ignores_reports`（通報は入力にならない構造的保証） |
+| `trust_absolute_negative_is_weighted_double` | 同上 同名 |
+| `trust_composition_weights_are_operator_tunable` | 同上 同名 |
+| `trust_reflects_risk_signals_split_by_category` | 同上 同名 + cn-core `tests/trust_inputs.rs`（#406） |
+| `trust_does_not_own_or_mutate_user_identity` | read-only surface（書き込み口は opt-out のみ、canonical 非接触）。cn-indexer `relation_worker_is_idempotent_and_does_not_mutate_index_source` |
+| `trust_read_is_explainable_with_basis` | cn-trust 同名 + cn-user-api（basis の issuer / basis / visibility を assert） |
+| `trust_is_clamped_to_unit_interval` | cn-trust 同名 |
+| `trust_absolute_component_does_not_decay` | cn-trust 同名 |
+| `trust_relative_component_decays_over_time` | cn-trust 同名 |
+| `trust_appeal_pending_holds_contribution` | cn-trust 同名 + cn-core `disputed_appeal_holds_contribution` |
+| `trust_appeal_accepted_excludes_contribution` | cn-trust 同名 + cn-core `cleared_appeal_excludes_contribution` |
+| `cross_node_pull_discloses_only_confirmed_absolute_component` | cn-trust `tests/cross_node_disclosure.rs` 同名 + cn-user-api 同名 |
+| `viewer_relative_read_requires_authenticated_viewer` | cn-user-api `viewer_relative_read_requires_authenticated_viewer` |
+| `relation_is_pairwise_cluster_proximity` | cn-trust `tests/relation_contracts.rs` 同名（共有スイート、ArcadeDB 実装にも `cn-indexer tests/relation_contracts.rs` で適用） |
+| `relation_does_not_mutate_social_graph_canonical` | `RelationStore` に canonical への書き込み口が無い（型レベル）+ cn-indexer `relation_worker_is_idempotent_and_does_not_mutate_index_source` |
+| `relation_read_is_explainable` | cn-trust `relation_read_is_explainable` + cn-user-api（basis assert） |
+| `relation_visibility_choice_is_user_controlled_and_reversible` | cn-core `tests/relation_optouts.rs` 同名 + cn-user-api `relation_read_optout_and_no_auto_suppression` |
+| `relation_does_not_auto_suppress_cross_cluster_content` | cn-user-api 同上（relation が index 応答へ介在しない構造 + edge 無し = 404 は情報なしであって抑制でない） |
+| `relation_read_requires_authenticated_viewer` | cn-user-api `viewer_relative_read_requires_authenticated_viewer` |
+| `relation_opt_out_hides_from_others_relation_and_discovery` | cn-user-api `relation_read_optout_and_no_auto_suppression`（relation read + neighbors 双方） |
+| `relation_defaults_local_and_not_cross_node_pullable` | relation の cross-node endpoint が存在しない（構造）+ cn-trust `relative_component_never_crosses_node_boundary` |
+| `relation_private_channel_signal_stays_local_and_scoped` | cn-core `co_participation_pairs_from_public_topics_only_*`（集計が channel scope を除外）+ cn-indexer worker テスト（private のみの共起ペアが graph に無い） |
+
+opt-out が trust に影響しないこと: cn-core `relation_optout_does_not_affect_trust_inputs` +
+cn-user-api（opt-out 後も trust read が変わらない）。
+
+## デプロイ順序（重要）
+
+`ensure_database_ready`（`RequireReady`）が新テーブル `cn_trust.relation_optouts` の存在を要求する。
+**新バイナリの RequireReady 起動より前に migration（Prepare / migrate 手順）を適用**すること
+（#405 / #413 / #404 と同じ fail-closed 運用）。
+
+新 env（`.env.community-node.example` に追記済み）:
+- `COMMUNITY_NODE_TRUST_READ_ENABLED`（cn-user-api、**既定 false**）。有効化する場合は
+  `COMMUNITY_NODE_ARCADEDB_*`（relation graph。cn-indexer と同一値）も渡し、
+  `cn-cli relation analyze` で relation graph を構築しておく。
+- `COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE` / `..._W_ABS_POSITIVE` / `..._RELATIVE_HALF_LIFE_DAYS`
+  （operator 可変。未設定は ADR 0026 §6.2 の初期値）。
+
+## 維持した境界（本 PR に含まない）
+
+- `CommunityLocalTrust` の `Availability::Planned` → 昇格（issue 記載どおり実装・テスト後に別途判断）。
+  read flag の既定有効化・relation 解析 worker の常駐化も同判断に紐づけて据え置き。
+- 相対成分の入力は**非決定論的 moderation（ADR 0028 / #420 系）実装まで** risk signal のみ。
+  観測者つき観測（`ObservedSignal`）と relation 重みの実運用値はその時点で結線する
+  （seam は scoring 層でテスト済み）。
+- follow projection（ADR 0013）の CN 側観測 = `FEATURE_FOLLOW_PROJECTION` の producer。
+- private channel の channel メンバー可視 relation（foundation では graph に入れない fail-closed）。
+- clustering の高度化（community detection / 重み実測 / pairwise 計算・保存コスト最適化、ADR 0026 §4）。
+- neo4j adapter 本体（Cypher 互換のクエリ形と `RelationStore` trait までが本 issue）。
+- P2P 層での cross-node pull 実配信（HTTP read 境界まで）。client UI。
+
+## 検証
+
+- `cargo test -p kukuri-cn-trust`（scoring 15 / relation 6 / cross-node 3）: pass。
+- `cargo test -p kukuri-cn-indexer --test relation_contracts`: pass（ArcadeDB は
+  `KUKURI_CN_RUN_ARCADEDB_TESTS=1` + live ArcadeDB で共有スイートを実行）。
+- `cargo clippy`（cn-trust / cn-core / cn-indexer / cn-user-api / cn-cli, all-targets,
+  `-D warnings`）: clean。`cargo fmt --check`: clean。
+- `cargo xtask cn-check`: pass。
+- `cargo xtask cn-test`（Postgres + Redis harness, `KUKURI_CN_RUN_INTEGRATION_TESTS=1`）: pass
+  （cn-core relation_optouts / co_participation、cn-user-api trust_relation の integration 含む）。

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
-const CN_PACKAGES: [&str; 8] = [
+const CN_PACKAGES: [&str; 9] = [
     "kukuri-cn-core",
     "kukuri-cn-user-api",
     "kukuri-cn-iroh-relay",
@@ -14,6 +14,7 @@ const CN_PACKAGES: [&str; 8] = [
     "kukuri-cn-operator",
     "kukuri-cn-safety",
     "kukuri-cn-safety-runtime",
+    "kukuri-cn-trust",
     "kukuri-cn-indexer",
 ];
 const SERIAL_RUST_PACKAGE: &str = "kukuri-harness";


### PR DESCRIPTION
Closes #415

## 概要

ADR 0026(`docs/adr/0026-community-node-trust-relation-foundation.md`)の foundation 実装。`CommunityLocalTrust` capability の中身 = **trust(per-user 信頼度)+ relation(pairwise cluster proximity)の 2 read** を node-local advisory として実装する。実装プランは `.claude/plans/2026-07-02-issue-415-trust-relation-foundation.md`、実装記録と contract↔テスト対応表は `docs/progress/2026-07-02-415-trust-relation-foundation.md`。

## 変更内容

### `cn-trust`(新 crate。pure domain、DB / network 非依存)
- **trust scoring(§6.2)**: `trust = clamp(-1, 1, (w_abs*absolute + relative) / 2)`。`w_abs`(絶対マイナス時 2.0 / それ以外 1.0)と相対成分の半減期(30 日)は `COMMUNITY_NODE_TRUST_*` env で operator 可変、不正値は起動時 Err。
- 絶対成分 = critical safety risk signal(**減衰なし・relation 非依存・report-bomb 不動**)、相対成分 = 非 critical risk signal(**半減期減衰 + relation 重み seam**)。appeal は供給層(#406)+ scoring 層の二重防御。
- `TrustReadView`: 絶対 / 相対 / 合成 + 寄与 signal ごとの根拠(issuer / basis / confidence / visibility / expiry / appeal / decay / relation 重み)。断定ラベル・閾値なし。
- **relation(§6.1)**: graph-store 抽象 `RelationStore`(`upsert_edge` / `pairwise_proximity` / `neighbors` / `cluster_of`)+ backend 非依存の proximity 合成 + in-memory 実装 + **共有 contract スイート**(`testing` feature。in-memory / ArcadeDB に同一契約を課し drift を防ぐ)。
- **cross-node 開示(§6.3)**: confirmed(known-hash / provider-verdict)な絶対成分のみ。開示値は開示可能な signal だけから再計算し、`Local` signal の存在を漏らさない。

### `cn-core`
- migration `202607020002_trust_relation.sql`: `cn_trust.relation_optouts`(「見えない」opt-out。可逆 = 行削除・**trust 非影響**)。
- co-participation 集計(`CoParticipationSource`、Pg / in-memory 同一セマンティクス)。**`public_topic` scope のみ** = private channel 由来は構造的に relation へ入らない(fail-closed)。
- `TrustRiskInput` 等の型を cn-trust へ移動し再エクスポート(既存 API 互換)。

### `cn-indexer` / `cn-cli`
- `ArcadeDbRelationGraph`: index 投影と同じ ArcadeDB に相乗り(#413 方針)。クエリは **Cypher**(scale path の neo4j 互換、§6.1)。
- relation 解析 worker: co-participation → feature 点数化 → edge upsert + cluster 帰属(dominant shared topic の初期実装)。**batch・冪等・非常駐**。`cn-cli relation analyze` で手動実行。

### `cn-user-api`(すべて `COMMUNITY_NODE_TRUST_READ_ENABLED` 既定 false = 404 で gate)
- `GET /v1/trust/users/{pubkey}`: viewer 相対 trust read。**viewer = bearer identity(challenge への鍵署名で検証済み)に固定** = 他人視点を騙る手段が無い。
- `GET /v1/trust/pull/{pubkey}`: cross-node pull。匿名 = `Public` のみ、subscriber 認証済み = `SubscribedNodes` も。
- `GET /v1/relation/users/{target}` / `GET /v1/relation/neighbors`: 根拠つき proximity / 近接近傍。opt-out 済み user は双方から消える(opt-out 状態自体は 404 で漏らさない)。
- `PUT|DELETE /v1/relation/optout`: 自分自身のみ・可逆。
- relation で index / search / discovery の結果集合を削る経路は**存在しない**(auto-suppression しない)。

## 受け入れ条件

Issue #415 のチェックボックス(trust 10 + relation 5)+ ADR 0026 §6 追加 contract(clamp / decay / appeal / cross-node 開示 / viewer 認証 / opt-out 範囲 / Local 既定 / private channel)すべてにテスト名 1:1 対応(progress doc に対応表)。

## 維持した境界

- `CommunityLocalTrust` は `Availability::Planned` のまま(昇格は実装・テスト後に別途判断。read flag 既定無効・worker 非常駐も同判断に紐づく)。
- 相対成分の入力は**非決定論的 moderation(ADR 0028 / #420 系)実装まで** risk signal のみ(`ObservedSignal` は型 seam)。
- follow projection の CN 側観測(feature key 予約のみ)/ channel メンバー可視 relation / clustering チューニング / neo4j adapter 本体 / P2P 実配信 / client UI。

## デプロイ順序(重要)

`ensure_database_ready`(`RequireReady`)が `cn_trust.relation_optouts` を要求する。**新バイナリの RequireReady 起動より前に migration を適用**(#405 / #413 / #404 と同運用)。新 env は `.env.community-node.example` 参照。

## 検証

- `cargo xtask cn-check` / `cargo xtask cn-test`(Docker Postgres + Redis、`KUKURI_CN_RUN_INTEGRATION_TESTS=1`、CN 9 crate): pass
- `cargo clippy --all-targets --all-features -- -D warnings`(cn-trust / cn-core / cn-indexer / cn-user-api / cn-cli): clean、`cargo fmt --check`: clean
- ArcadeDB backend への共有 contract スイートは `KUKURI_CN_RUN_ARCADEDB_TESTS=1` + live ArcadeDB で実行可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)