### PR TITLE
[fix] desktop-lint に no-console ルールを追加 (WP-S2 T4)

### DIFF
--- a/apps/desktop/eslint.config.js
+++ b/apps/desktop/eslint.config.js
@@ -35,6 +35,9 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       'react-hooks/set-state-in-effect': 'off',
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      // AGENTS.md: console.error は使わない。log/debug も禁止し、
+      // 意図的なログは warn / info のみ許可する。
+      'no-console': ['error', { allow: ['warn', 'info'] }],
     },
   },
   {


### PR DESCRIPTION
## 概要

AGENTS.md:45「`console.error` は使わない」をレビュー規約から eslint ゲートに昇格する。`'no-console': ['error', { allow: ['warn', 'info'] }]` を ts/tsx ブロックに追加。

## 種別

`fix`(ゲート追加。プロダクション挙動変更なし)

## 挙動変更

desktop-lint の判定のみ: console.log / console.error / console.debug の新規追加が fail になる。既存コード(console.info×2, console.warn×1)は無修正で green。

## 検証

- `cargo xtask desktop-lint` 相当(eslint --max-warnings 0 + tsc)green
- `console.error(...)` を一時追加 → no-console エラーで fail することを実証 → 復元後 green

## リスク

なし(設定 1 ルールの追加のみ。allow に error を含めないことで AGENTS.md と整合)

## 後続対応

WP-S2 の他ゲート(oversized ratchet / cn clippy / workspace lints)は別 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)