### PR TITLE
[fix] oversized-files を baseline ratchet ゲート化 (WP-S2 T2)

### DIFF
--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -120,12 +120,22 @@ PR 作成前または `main` merge 前は、可能なら `cargo xtask check` + `
 
 ## 大型ファイルポリシー
 
-`cargo xtask oversized-files` は大型の手書きファイルを報告する。
+`cargo xtask oversized-files` は大型(1000行以上)の手書きファイルを報告し、
+`xtask/oversized-baseline.json` との比較で **ratchet 方式の CI ゲート**として動作する。
+
+ゲートの判定:
+
+- baseline に無い 1000 行以上の新規ファイル → **fail**。
+- baseline 記載ファイルが記録行数を超えて成長 → **fail**。
+- 行数不変・減少 → pass(減少時は baseline 更新推奨の note を表示)。
+- baseline の更新は `cargo xtask oversized-files --update-baseline` で再生成し、
+  正当化を PR 本文に書いた上でコミットする(レビューを通すことが ratchet の意図)。
+- ファイルを分割して 1000 行未満にした場合も `--update-baseline` で baseline から除去する。
 
 ルール:
 
-- 明示的な正当化なしに、1000行を超える新規手書きファイルを追加しない。
-- 既存の大型ファイルを編集する場合は、差分を最小に保つ。
+- 明示的な正当化(= baseline 更新コミット)なしに、1000行以上の新規手書きファイルを追加しない。
+- 既存の大型ファイルを編集する場合は、差分を最小に保つ(行数を増やす変更は baseline 更新が必要になる)。
 - 大型ファイルの中で大きなロジック変更を行う場合は、先に分割計画を提案する。
 - 1500行を超えるファイルで、かつ複数責務に触る場合は、後続の分割計画を作成する。
 - formatting-only change と semantic change を混ぜない。

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -1,0 +1,52 @@
+{
+  "files": [
+    {
+      "lines": 3085,
+      "path": "apps/desktop/src/styles/shell-phase1.css"
+    },
+    {
+      "lines": 1559,
+      "path": "apps/desktop/src/mocks/desktopApiMock.ts"
+    },
+    {
+      "lines": 1355,
+      "path": "crates/cn-user-api/src/lib.rs"
+    },
+    {
+      "lines": 1207,
+      "path": "crates/cn-user-api/tests/contract.rs"
+    },
+    {
+      "lines": 1159,
+      "path": "apps/desktop/src/shell/DesktopShellPage.tsx"
+    },
+    {
+      "lines": 1155,
+      "path": "apps/desktop/src/components/extended/MetaverseRoomPanel.tsx"
+    },
+    {
+      "lines": 1141,
+      "path": "apps/desktop/src/styles/shell-phase1-legacy.css"
+    },
+    {
+      "lines": 1138,
+      "path": "apps/desktop/src/shell/useDesktopShellViewModels.ts"
+    },
+    {
+      "lines": 1133,
+      "path": "apps/desktop/src/shell/useDesktopShellData.ts"
+    },
+    {
+      "lines": 1087,
+      "path": "crates/harness/src/scenarios/community_node.rs"
+    },
+    {
+      "lines": 1028,
+      "path": "crates/app-api/src/service/private_channels_support.rs"
+    },
+    {
+      "lines": 1020,
+      "path": "crates/app-api/src/private_channels.rs"
+    }
+  ]
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -42,7 +42,17 @@ fn main() -> Result<()> {
             let tag = args.next();
             release_check(tag.as_deref())
         }
-        "oversized-files" => oversized_files(),
+        "oversized-files" => {
+            let update_baseline = match args.next().as_deref() {
+                None => false,
+                Some("--update-baseline") => true,
+                Some(flag) => {
+                    print_usage();
+                    bail!("unsupported oversized-files flag: {flag}");
+                }
+            };
+            oversized_files(update_baseline)
+        }
         "e2e-smoke" => e2e_smoke("desktop_smoke_post_persist"),
         "scenario" => {
             let name = args.next().context("scenario name is required")?;
@@ -80,6 +90,6 @@ fn doctor() -> Result<()> {
 
 fn print_usage() {
     eprintln!(
-        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-ui-check|cn-check|cn-test|desktop-package|release-check [tag]|oversized-files|e2e-smoke|scenario <name>>"
+        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-ui-check|cn-check|cn-test|desktop-package|release-check [tag]|oversized-files [--update-baseline]|e2e-smoke|scenario <name>>"
     );
 }

--- a/xtask/src/oversized.rs
+++ b/xtask/src/oversized.rs
@@ -21,6 +21,8 @@ pub(crate) const OVERSIZED_FILE_EXCLUDED_EXACT_PATHS: &[&str] = &[
     "apps/desktop/src-tauri/Cargo.lock",
 ];
 
+pub(crate) const OVERSIZED_BASELINE_PATH: &str = "xtask/oversized-baseline.json";
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct OversizedFileReport {
     path: String,
@@ -28,28 +30,172 @@ pub(crate) struct OversizedFileReport {
     category: &'static str,
 }
 
-pub(crate) fn oversized_files() -> Result<()> {
-    let reports = collect_oversized_files(&root_dir())?;
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct OversizedBaselineEntry {
+    path: String,
+    lines: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct OversizedViolation {
+    path: String,
+    lines: usize,
+    baseline_lines: Option<usize>,
+}
+
+pub(crate) fn oversized_files(update_baseline: bool) -> Result<()> {
+    let root = root_dir();
+    let reports = collect_oversized_files(&root)?;
     if reports.is_empty() {
         println!(
             "[xtask] no oversized tracked hand-written files found (threshold={} lines)",
             OVERSIZED_FILE_LINE_LIMIT
         );
+    } else {
+        eprintln!(
+            "[xtask] warning: found {} oversized tracked hand-written files (threshold={} lines)",
+            reports.len(),
+            OVERSIZED_FILE_LINE_LIMIT
+        );
+        for report in &reports {
+            println!(
+                "[xtask] warning oversized-file category={} lines={} path={}",
+                report.category, report.line_count, report.path
+            );
+        }
+    }
+
+    let baseline_path = root.join(OVERSIZED_BASELINE_PATH);
+    if update_baseline {
+        std::fs::write(&baseline_path, render_baseline(&reports))
+            .with_context(|| format!("failed to write baseline: {}", baseline_path.display()))?;
+        println!(
+            "[xtask] oversized baseline updated: {} ({} entries)",
+            OVERSIZED_BASELINE_PATH,
+            reports.len()
+        );
         return Ok(());
     }
 
-    eprintln!(
-        "[xtask] warning: found {} oversized tracked hand-written files (threshold={} lines)",
-        reports.len(),
-        OVERSIZED_FILE_LINE_LIMIT
-    );
-    for report in reports {
-        println!(
-            "[xtask] warning oversized-file category={} lines={} path={}",
-            report.category, report.line_count, report.path
-        );
+    let baseline_json = std::fs::read_to_string(&baseline_path).with_context(|| {
+        format!(
+            "failed to read {} (run `cargo xtask oversized-files --update-baseline` to create it)",
+            OVERSIZED_BASELINE_PATH
+        )
+    })?;
+    let baseline = parse_baseline(&baseline_json)
+        .with_context(|| format!("failed to parse {OVERSIZED_BASELINE_PATH}"))?;
+
+    let (violations, stale_notes) = diff_against_baseline(&reports, &baseline);
+    for note in &stale_notes {
+        println!("[xtask] note oversized-baseline {note}");
     }
-    Ok(())
+    if violations.is_empty() {
+        return Ok(());
+    }
+
+    for violation in &violations {
+        match violation.baseline_lines {
+            None => eprintln!(
+                "[xtask] error oversized-file new file exceeds {} lines: {} ({} lines)",
+                OVERSIZED_FILE_LINE_LIMIT, violation.path, violation.lines
+            ),
+            Some(baseline_lines) => eprintln!(
+                "[xtask] error oversized-file grew beyond baseline: {} ({} -> {} lines)",
+                violation.path, baseline_lines, violation.lines
+            ),
+        }
+    }
+    bail!(
+        "oversized-files: {} violation(s) against {}. Split the file, or if the growth is \
+         justified, run `cargo xtask oversized-files --update-baseline` and commit the result \
+         with the justification in the PR body (see REFACTORING.md).",
+        violations.len(),
+        OVERSIZED_BASELINE_PATH
+    )
+}
+
+pub(crate) fn parse_baseline(json: &str) -> Result<Vec<OversizedBaselineEntry>> {
+    let value: serde_json::Value = serde_json::from_str(json)?;
+    let files = value
+        .get("files")
+        .and_then(|files| files.as_array())
+        .context("baseline JSON must contain a `files` array")?;
+    let mut entries = Vec::with_capacity(files.len());
+    for file in files {
+        let path = file
+            .get("path")
+            .and_then(|path| path.as_str())
+            .context("baseline entry is missing a string `path`")?;
+        let lines = file
+            .get("lines")
+            .and_then(|lines| lines.as_u64())
+            .context("baseline entry is missing a numeric `lines`")?;
+        entries.push(OversizedBaselineEntry {
+            path: path.to_string(),
+            lines: usize::try_from(lines).context("baseline `lines` does not fit in usize")?,
+        });
+    }
+    Ok(entries)
+}
+
+pub(crate) fn render_baseline(reports: &[OversizedFileReport]) -> String {
+    let files: Vec<serde_json::Value> = reports
+        .iter()
+        .map(|report| {
+            serde_json::json!({
+                "path": report.path,
+                "lines": report.line_count,
+            })
+        })
+        .collect();
+    let value = serde_json::json!({ "files": files });
+    let mut rendered = serde_json::to_string_pretty(&value).expect("baseline JSON serializes");
+    rendered.push('\n');
+    rendered
+}
+
+pub(crate) fn diff_against_baseline(
+    current: &[OversizedFileReport],
+    baseline: &[OversizedBaselineEntry],
+) -> (Vec<OversizedViolation>, Vec<String>) {
+    let mut violations = Vec::new();
+    let mut stale_notes = Vec::new();
+
+    for report in current {
+        match baseline.iter().find(|entry| entry.path == report.path) {
+            None => violations.push(OversizedViolation {
+                path: report.path.clone(),
+                lines: report.line_count,
+                baseline_lines: None,
+            }),
+            Some(entry) if report.line_count > entry.lines => {
+                violations.push(OversizedViolation {
+                    path: report.path.clone(),
+                    lines: report.line_count,
+                    baseline_lines: Some(entry.lines),
+                });
+            }
+            Some(entry) if report.line_count < entry.lines => {
+                stale_notes.push(format!(
+                    "{} shrank ({} -> {} lines); consider `--update-baseline` to ratchet down",
+                    report.path, entry.lines, report.line_count
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+
+    for entry in baseline {
+        if !current.iter().any(|report| report.path == entry.path) {
+            stale_notes.push(format!(
+                "{} is no longer oversized; consider `--update-baseline` to remove it",
+                entry.path
+            ));
+        }
+    }
+
+    (violations, stale_notes)
 }
 
 pub(crate) fn collect_oversized_files(root: &Path) -> Result<Vec<OversizedFileReport>> {
@@ -188,5 +334,81 @@ mod tests {
             oversized_file_category("apps/desktop/src/styles/shell-phase1.css"),
             "support"
         );
+    }
+
+    fn report(path: &str, line_count: usize) -> OversizedFileReport {
+        OversizedFileReport {
+            path: path.to_string(),
+            line_count,
+            category: "production",
+        }
+    }
+
+    fn entry(path: &str, lines: usize) -> OversizedBaselineEntry {
+        OversizedBaselineEntry {
+            path: path.to_string(),
+            lines,
+        }
+    }
+
+    #[test]
+    fn baseline_diff_flags_new_oversized_file_as_violation() {
+        let (violations, notes) = diff_against_baseline(&[report("a.rs", 1200)], &[]);
+        assert_eq!(
+            violations,
+            vec![OversizedViolation {
+                path: "a.rs".to_string(),
+                lines: 1200,
+                baseline_lines: None,
+            }]
+        );
+        assert!(notes.is_empty());
+    }
+
+    #[test]
+    fn baseline_diff_flags_growth_beyond_baseline_as_violation() {
+        let (violations, notes) =
+            diff_against_baseline(&[report("a.rs", 1201)], &[entry("a.rs", 1200)]);
+        assert_eq!(
+            violations,
+            vec![OversizedViolation {
+                path: "a.rs".to_string(),
+                lines: 1201,
+                baseline_lines: Some(1200),
+            }]
+        );
+        assert!(notes.is_empty());
+    }
+
+    #[test]
+    fn baseline_diff_accepts_unchanged_baseline_entry() {
+        let (violations, notes) =
+            diff_against_baseline(&[report("a.rs", 1200)], &[entry("a.rs", 1200)]);
+        assert!(violations.is_empty());
+        assert!(notes.is_empty());
+    }
+
+    #[test]
+    fn baseline_diff_reports_shrunk_entry_as_stale_note_not_violation() {
+        let (violations, notes) =
+            diff_against_baseline(&[report("a.rs", 1100)], &[entry("a.rs", 1200)]);
+        assert!(violations.is_empty());
+        assert_eq!(notes.len(), 1);
+        assert!(notes[0].contains("shrank"));
+    }
+
+    #[test]
+    fn baseline_diff_reports_resolved_entry_as_stale_note_not_violation() {
+        let (violations, notes) = diff_against_baseline(&[], &[entry("a.rs", 1200)]);
+        assert!(violations.is_empty());
+        assert_eq!(notes.len(), 1);
+        assert!(notes[0].contains("no longer oversized"));
+    }
+
+    #[test]
+    fn baseline_render_and_parse_round_trip() {
+        let reports = vec![report("b.rs", 1500), report("a.rs", 1200)];
+        let parsed = parse_baseline(&render_baseline(&reports)).expect("round trip parses");
+        assert_eq!(parsed, vec![entry("b.rs", 1500), entry("a.rs", 1200)]);
     }
 }


### PR DESCRIPTION
## 概要

警告のみだった `cargo xtask oversized-files` を、`xtask/oversized-baseline.json`(12 ファイル収載)との比較で fail する ratchet ゲートに強化する。**base は T1(#431)** — マージ後に自動で main に retarget される。

## 種別

`fix`(ゲート挙動変更 + REFACTORING.md 運用ルール追記を同梱。ポリシーと enforcement を同時に変えるため)

## 挙動変更

oversized-files の exit code のみ: 新規 1000 行以上ファイル / baseline 超過成長で exit≠0。既存の警告出力形式・走査対象は不変。CI 側の yml 変更は不要(fast:87,495 / nightly:58 の既存ステップがそのまま fail するようになる)。

## 検証

- `cargo test -p xtask` 13/13(diff/parse/render の unit テスト 6 本追加)
- clippy --all-targets -D warnings / fmt green
- 実証: 通常 run = exit 0 / 新規 1000 行ファイル追加 = fail(メッセージに対処法) / baseline ファイル 2 行成長 = fail(1020→1022 表示) / 復元後 = exit 0
- baseline はツール自身で生成(`--update-baseline`)し、実装プラン付録 B の 12 件と一致

## リスク

- 本 PR マージ後、baseline 記載ファイルを成長させる全 PR が fail する(意図した挙動)。その場合の手順は REFACTORING.md に明記済み
- 走査は `git ls-files --cached --others` のため untracked のローカル一時ファイル(1000 行以上)があるとローカル実行が fail し得る(CI は clean checkout のため影響なし)

## 後続対応

- T3(cn-check clippy 化)を本ブランチに stack 予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)