### PR TITLE
[fix] workspace lints: clippy::unwrap_used を導入 (WP-S2 T5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,6 @@ wiremock = "0.6"
 
 [patch.crates-io]
 netwatch = { git = "https://github.com/n0-computer/net-tools", rev = "8b2d36b9be2b44281fdbf58121a9ab6a739919bc" }
+
+[workspace.lints.clippy]
+unwrap_used = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/crates/app-api/Cargo.toml
+++ b/crates/app-api/Cargo.toml
@@ -26,3 +26,6 @@ tempfile.workspace = true
 iroh-mainline-address-lookup.workspace = true
 n0-mainline.workspace = true
 iroh = { workspace = true, features = ["test-utils"] }
+
+[lints]
+workspace = true

--- a/crates/blob-service/Cargo.toml
+++ b/crates/blob-service/Cargo.toml
@@ -19,3 +19,7 @@ kukuri-transport = { path = "../transport" }
 
 [dev-dependencies]
 tempfile.workspace = true
+
+
+[lints]
+workspace = true

--- a/crates/cn-cli/Cargo.toml
+++ b/crates/cn-cli/Cargo.toml
@@ -17,3 +17,6 @@ sqlx.workspace = true
 tokio.workspace = true
 kukuri-cn-core = { path = "../cn-core" }
 kukuri-cn-indexer = { path = "../cn-indexer" }
+
+[lints]
+workspace = true

--- a/crates/cn-core/Cargo.toml
+++ b/crates/cn-core/Cargo.toml
@@ -43,3 +43,6 @@ kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 # 自分自身を feature 付き dev-dependency にすることで、tests/ から mock provider 解決を使える
 # （feature unification によりテストビルド時のみ有効になる。cn-safety と同じ流儀）。
 kukuri-cn-core = { path = ".", features = ["safety-mock-provider", "safety-arachnid-provider"] }
+
+[lints]
+workspace = true

--- a/crates/cn-core/tests/safety_events.rs
+++ b/crates/cn-core/tests/safety_events.rs
@@ -45,6 +45,7 @@ fn integration_test_admin_database_url() -> Option<String> {
     )
 }
 
+#[allow(clippy::unwrap_used)] // test fixture helper
 fn signer() -> Secp256k1ModerationEventSigner {
     Secp256k1ModerationEventSigner::from_secret(TEST_SECRET).unwrap()
 }

--- a/crates/cn-core/tests/safety_runtime.rs
+++ b/crates/cn-core/tests/safety_runtime.rs
@@ -43,10 +43,12 @@ impl EventIdGenerator for SequentialIdGenerator {
     }
 }
 
+#[allow(clippy::unwrap_used)] // test fixture helper
 fn signer() -> Secp256k1ModerationEventSigner {
     Secp256k1ModerationEventSigner::from_secret(TEST_SECRET).unwrap()
 }
 
+#[allow(clippy::unwrap_used)] // test fixture helper
 fn orchestrator(issuer: &str, provider: MockSafetyProvider) -> Arc<SafetyOrchestrator> {
     Arc::new(
         SafetyOrchestrator::builder(
@@ -61,6 +63,7 @@ fn orchestrator(issuer: &str, provider: MockSafetyProvider) -> Arc<SafetyOrchest
 }
 
 /// signer + memory store で組んだ service（本番構成と同型、DB のみ in-memory）。
+#[allow(clippy::unwrap_used)] // test fixture helper
 fn signed_service(
     provider: MockSafetyProvider,
 ) -> (SafetyScanService, Arc<MemorySafetyArtifactStore>, String) {

--- a/crates/cn-indexer/Cargo.toml
+++ b/crates/cn-indexer/Cargo.toml
@@ -43,3 +43,6 @@ kukuri-cn-safety = { path = "../cn-safety", features = ["mock"] }
 # relation graph（ArcadeDB / in-memory）へ同一 contract を課す共有スイート。
 kukuri-cn-trust = { path = "../cn-trust", features = ["testing"] }
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cn-iroh-relay/Cargo.toml
+++ b/crates/cn-iroh-relay/Cargo.toml
@@ -19,3 +19,6 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 rcgen = "0.14"
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cn-operator/Cargo.toml
+++ b/crates/cn-operator/Cargo.toml
@@ -29,3 +29,6 @@ tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cn-safety-arachnid/Cargo.toml
+++ b/crates/cn-safety-arachnid/Cargo.toml
@@ -20,3 +20,6 @@ thiserror.workspace = true
 kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 tokio.workspace = true
 wiremock.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cn-safety-runtime/Cargo.toml
+++ b/crates/cn-safety-runtime/Cargo.toml
@@ -25,3 +25,6 @@ kukuri-cn-safety = { path = "../cn-safety", features = ["mock"] }
 serde_json.workspace = true
 tokio.workspace = true
 uuid.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cn-safety/Cargo.toml
+++ b/crates/cn-safety/Cargo.toml
@@ -25,3 +25,6 @@ thiserror.workspace = true
 # （feature unification によりテストビルド時のみ mock が有効になる）。
 kukuri-cn-safety = { path = ".", features = ["mock"] }
 tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cn-trust/Cargo.toml
+++ b/crates/cn-trust/Cargo.toml
@@ -25,3 +25,6 @@ kukuri-cn-safety = { path = "../cn-safety" }
 # （feature unification によりテストビルド時のみ有効になる。cn-safety の mock と同じ流儀）。
 kukuri-cn-trust = { path = ".", features = ["testing"] }
 tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cn-trust/tests/cross_node_disclosure.rs
+++ b/crates/cn-trust/tests/cross_node_disclosure.rs
@@ -7,6 +7,7 @@ use kukuri_cn_trust::{
     PullAudience, TrustComponentKind, TrustRiskInput, TrustRiskInputs, cross_node_trust_disclosure,
 };
 
+#[allow(clippy::unwrap_used)] // test fixture helper
 fn now() -> DateTime<Utc> {
     DateTime::parse_from_rfc3339("2026-07-02T09:00:00Z")
         .unwrap()

--- a/crates/cn-trust/tests/trust_scoring.rs
+++ b/crates/cn-trust/tests/trust_scoring.rs
@@ -10,6 +10,7 @@ use kukuri_cn_trust::{
     build_trust_read, compose_trust, trust_component_for,
 };
 
+#[allow(clippy::unwrap_used)] // test fixture helper
 fn now() -> DateTime<Utc> {
     DateTime::parse_from_rfc3339("2026-07-02T09:00:00Z")
         .unwrap()

--- a/crates/cn-user-api/Cargo.toml
+++ b/crates/cn-user-api/Cargo.toml
@@ -33,3 +33,6 @@ hex.workspace = true
 reqwest.workspace = true
 redis.workspace = true
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,3 +16,6 @@ secp256k1.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+
+[lints]
+workspace = true

--- a/crates/desktop-runtime/Cargo.toml
+++ b/crates/desktop-runtime/Cargo.toml
@@ -39,3 +39,6 @@ iroh-mainline-address-lookup.workspace = true
 n0-mainline.workspace = true
 iroh = { workspace = true, features = ["test-utils"] }
 kukuri-cn-iroh-relay = { path = "../cn-iroh-relay" }
+
+[lints]
+workspace = true

--- a/crates/docs-sync/Cargo.toml
+++ b/crates/docs-sync/Cargo.toml
@@ -25,3 +25,6 @@ kukuri-transport = { path = "../transport" }
 [dev-dependencies]
 iroh = { workspace = true, features = ["test-utils"] }
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/harness/Cargo.toml
+++ b/crates/harness/Cargo.toml
@@ -21,3 +21,6 @@ kukuri-core = { path = "../core" }
 kukuri-desktop-runtime = { path = "../desktop-runtime" }
 kukuri-store = { path = "../store" }
 kukuri-transport = { path = "../transport" }
+
+[lints]
+workspace = true

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -17,3 +17,6 @@ kukuri-core = { path = "../core" }
 [dev-dependencies]
 tempfile.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -24,3 +24,6 @@ kukuri-core = { path = "../core" }
 
 [dev-dependencies]
 iroh = { workspace = true, features = ["test-utils"] }
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,3 +9,6 @@ anyhow.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 kukuri-harness = { path = "../crates/harness" }
+
+[lints]
+workspace = true


### PR DESCRIPTION
## 概要

production コードへの `.unwrap()` 追加を CI で fail させる。`[workspace.lints.clippy] unwrap_used = "warn"` + `clippy.toml` の `allow-unwrap-in-tests = true` + 19 member への `[lints] workspace = true` 追記。**base は T3(#434)** — cn-check の clippy 化が前提のため。

## 種別

`fix`(ゲート追加。実装コード変更なし — 実測で production unwrap は 0 件)

## 挙動変更

lint 判定のみ。rust-check / cn-check は -D warnings のため unwrap_used = warn が実質 deny になる。テストコードは `allow-unwrap-in-tests` で許容。統合テストのフィクスチャヘルパ 6 fn(`#[test]` fn 外のため許容が届かない)にのみ fn 単位 `#[allow(clippy::unwrap_used)]` を付与した(cn-trust×2 / cn-core×4、全て test fixture)。

## 検証

- production(crates/core)に unwrap を一時追加 → clippy 発火を実証 → 復元
- `cargo xtask rust-check` green(47s)/ `cargo xtask cn-check` green(30s)/ fmt green
- workspace 全体 --all-targets で unwrap_used 残余 0 件

## リスク

- 以後、テスト fn 外のヘルパで unwrap を書くと fail する(expect への置換か fn 単位 allow が必要 — 意図した挙動)
- expect_used は対象外(lock().expect("poisoned") 慣用 30 箇所は許容。マスタープラン Q6 の typed error 化で扱う)

## 後続対応

なし(WP-S2 の lint 系はこれで完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)