### PR TITLE
[refactor:extract] xtask: 純関数 seam 抽出と unit テスト拡充 (WP-S2 T6)

### DIFF
--- a/xtask/src/cn.rs
+++ b/xtask/src/cn.rs
@@ -50,21 +50,28 @@ pub(crate) fn cn_test_envs() -> Vec<(String, String)> {
 }
 
 pub(crate) fn cn_test_database_url() -> String {
-    let port = std::env::var("CN_POSTGRES_PORT")
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "15432".to_string());
+    cn_test_database_url_for(std::env::var("CN_POSTGRES_PORT").ok())
+}
+
+pub(crate) fn cn_test_database_url_for(port_env: Option<String>) -> String {
+    let port = resolve_port(port_env, "15432");
     format!("postgres://cn:cn_password@127.0.0.1:{port}/cn")
 }
 
 pub(crate) fn cn_test_rendezvous_redis_url() -> String {
-    let port = std::env::var("CN_VALKEY_PORT")
-        .ok()
+    cn_test_rendezvous_redis_url_for(std::env::var("CN_VALKEY_PORT").ok())
+}
+
+pub(crate) fn cn_test_rendezvous_redis_url_for(port_env: Option<String>) -> String {
+    let port = resolve_port(port_env, "16379");
+    format!("redis://127.0.0.1:{port}/")
+}
+
+fn resolve_port(port_env: Option<String>, default: &str) -> String {
+    port_env
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| "16379".to_string());
-    format!("redis://127.0.0.1:{port}/")
+        .unwrap_or_else(|| default.to_string())
 }
 
 pub(crate) fn with_cn_postgres<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
@@ -125,5 +132,34 @@ pub(crate) fn with_cn_postgres<T>(operation: impl FnOnce() -> Result<T>) -> Resu
         (Err(operation_error), Err(shutdown_error)) => Err(operation_error.context(format!(
             "failed to tear down cn-postgres after error: {shutdown_error:#}"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cn_test_urls_use_documented_default_ports() {
+        assert_eq!(
+            cn_test_database_url_for(None),
+            "postgres://cn:cn_password@127.0.0.1:15432/cn"
+        );
+        assert_eq!(
+            cn_test_rendezvous_redis_url_for(None),
+            "redis://127.0.0.1:16379/"
+        );
+    }
+
+    #[test]
+    fn cn_test_urls_respect_port_overrides_and_ignore_blank_values() {
+        assert_eq!(
+            cn_test_database_url_for(Some(" 25432 ".to_string())),
+            "postgres://cn:cn_password@127.0.0.1:25432/cn"
+        );
+        assert_eq!(
+            cn_test_rendezvous_redis_url_for(Some(String::new())),
+            "redis://127.0.0.1:16379/"
+        );
     }
 }

--- a/xtask/src/exec.rs
+++ b/xtask/src/exec.rs
@@ -290,4 +290,13 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn format_duration_covers_ms_seconds_and_minutes() {
+        assert_eq!(format_duration(Duration::from_millis(999)), "999ms");
+        assert_eq!(format_duration(Duration::from_millis(1000)), "1.0s");
+        assert_eq!(format_duration(Duration::from_secs(59)), "59.0s");
+        assert_eq!(format_duration(Duration::from_secs(60)), "1m00s");
+        assert_eq!(format_duration(Duration::from_secs(605)), "10m05s");
+    }
 }

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -35,20 +35,25 @@ pub(crate) fn release_check(tag: Option<&str>) -> Result<()> {
     }
 
     if let Some(tag) = tag {
-        let expected = format!("v{workspace_version}-preview.");
-        if !tag.starts_with(&expected) {
-            bail!("release tag must start with {expected} and include a preview number, got {tag}");
-        }
-        let suffix = &tag[expected.len()..];
-        if suffix.is_empty() || !suffix.chars().all(|value| value.is_ascii_digit()) {
-            bail!("release tag preview suffix must be numeric, got {tag}");
-        }
+        validate_release_tag(&workspace_version, tag)?;
     }
 
     println!(
         "[xtask] release version ok: workspace={workspace_version} channel=preview tag={}",
         tag.unwrap_or("<not checked>")
     );
+    Ok(())
+}
+
+pub(crate) fn validate_release_tag(workspace_version: &str, tag: &str) -> Result<()> {
+    let expected = format!("v{workspace_version}-preview.");
+    if !tag.starts_with(&expected) {
+        bail!("release tag must start with {expected} and include a preview number, got {tag}");
+    }
+    let suffix = &tag[expected.len()..];
+    if suffix.is_empty() || !suffix.chars().all(|value| value.is_ascii_digit()) {
+        bail!("release tag preview suffix must be numeric, got {tag}");
+    }
     Ok(())
 }
 
@@ -95,4 +100,33 @@ pub(crate) fn read_json_version(path: &Path) -> Result<String> {
         .and_then(Value::as_str)
         .map(str::to_string)
         .with_context(|| format!("version was not found in {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_tag_accepts_preview_tag_matching_workspace_version() {
+        assert!(validate_release_tag("0.1.2", "v0.1.2-preview.1").is_ok());
+        assert!(validate_release_tag("0.1.2", "v0.1.2-preview.12").is_ok());
+    }
+
+    #[test]
+    fn release_tag_rejects_version_mismatch_and_bad_suffixes() {
+        assert!(validate_release_tag("0.1.2", "v0.1.3-preview.1").is_err());
+        assert!(validate_release_tag("0.1.2", "v0.1.2-preview.").is_err());
+        assert!(validate_release_tag("0.1.2", "v0.1.2-preview.1a").is_err());
+        assert!(validate_release_tag("0.1.2", "v0.1.2").is_err());
+    }
+
+    #[test]
+    fn parse_toml_string_value_extracts_quoted_values_only() {
+        assert_eq!(
+            parse_toml_string_value("version = \"0.1.2\"").unwrap(),
+            "0.1.2"
+        );
+        assert!(parse_toml_string_value("version = 3").is_err());
+        assert!(parse_toml_string_value("no equals sign").is_err());
+    }
 }

--- a/xtask/src/rust.rs
+++ b/xtask/src/rust.rs
@@ -181,4 +181,18 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn cargo_package_args_prefixes_command_and_expands_packages() {
+        assert_eq!(
+            cargo_package_args("clippy", &CN_PACKAGES[..2]),
+            vec![
+                "clippy".to_string(),
+                "-p".to_string(),
+                CN_PACKAGES[0].to_string(),
+                "-p".to_string(),
+                CN_PACKAGES[1].to_string(),
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## 概要

CI ゲートのオーケストレータである xtask に回帰検出力を付ける。release タグ検証と cn テスト URL 構築を純関数として抽出し、unit テストを 7 → 14 本に拡充。**base は T1(#431)**。

## 種別

`refactor:extract`(外部挙動変更なし)

## 挙動変更

なし。release-check の有効タグ / 不正タグ / タグ省略の 3 経路が抽出前と同一挙動であることを実行確認済み。cn URL の既定ポート(15432/16379)・env override・空白無視も従来ロジックの等価分離。

## 検証

- `cargo test -p xtask` 14/14
- clippy --all-targets -D warnings / fmt green
- `cargo xtask release-check v0.1.2-preview.1`(ok)/ `v9.9.9-preview.1`(従来と同文言で fail)/ タグ省略(ok)

## リスク

なし(pub(crate) 関数の追加と委譲のみ)

## 後続対応

なし(WP-S2 の xtask 系はこれで完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)