### PR TITLE
[contract] GossipHint / posts の wire serde snapshot (WP-S3 T2)

### DIFF
--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -5,3 +5,4 @@ mod posts;
 mod private_channels;
 mod profile;
 mod reactions;
+mod wire_snapshot;

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -5,5 +5,5 @@ mod posts;
 mod private_channels;
 mod profile;
 mod reactions;
-mod wire_snapshot;
 mod signing_canonical;
+mod wire_snapshot;

--- a/crates/core/src/tests/wire_snapshot.rs
+++ b/crates/core/src/tests/wire_snapshot.rs
@@ -1,0 +1,292 @@
+//! wire serde 形式の凍結テスト(WP-S3 T2)。
+//!
+//! GossipHint は serde_json のまま iroh gossip に流れ、KukuriPostEnvelopeContentV1
+//! (payload_ref 含む)は署名済み content と SQLite projection の両方に永続される。
+//! つまりここでの JSON 形(externally-tagged のタグ名 = variant 名 PascalCase、
+//! フィールド名、null/省略の扱い)はネットワーク・ストレージ契約そのものである。
+//!
+//! - これらのテストが fail したら、テストではなく変更側(rename・serde 属性・
+//!   依存更新)の互換影響を評価すること。受信側(transport)はデコード失敗を
+//!   黙殺するため、GossipHint の形式変更は実行時エラーにならず静かに機能停止
+//!   する — この snapshot が唯一の検出手段。
+//! - PayloadRef のタグが PascalCase、ObjectVisibility 等が snake_case という
+//!   混在は「意図的な凍結」である。統一リファクタは 1 バイト互換破壊になる。
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::{
+    BlobHash, ChannelId, ChannelRef, DirectMessageAckV1, EnvelopeId, GossipHint, HintObjectRef,
+    KukuriEnvelope, KukuriPostEnvelopeContentV1, ObjectStatus, ObjectVisibility, PayloadRef,
+    Pubkey, TimelineScope, TopicId,
+};
+
+const PUBKEY_A: &str = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const PUBKEY_B: &str = "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+
+/// serialize が期待 JSON(生リテラル)と一致し、期待 JSON から元の値へ
+/// デシリアライズできること(round-trip)を両方向で固定する。
+fn assert_wire<T>(value: &T, expected: &str)
+where
+    T: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug,
+{
+    assert_eq!(
+        serde_json::to_string(value).expect("serialize"),
+        expected,
+        "serialized form drifted from frozen wire snapshot"
+    );
+    let parsed: T = serde_json::from_str(expected).expect("frozen wire snapshot deserializes");
+    assert_eq!(&parsed, value, "deserialized value drifted");
+}
+
+fn demo_topic() -> TopicId {
+    TopicId::new("kukuri:topic:demo")
+}
+
+fn author() -> Pubkey {
+    Pubkey::from(PUBKEY_A)
+}
+
+#[test]
+fn gossip_hint_topic_objects_changed_snapshot() {
+    assert_wire(
+        &GossipHint::TopicObjectsChanged {
+            topic_id: demo_topic(),
+            objects: vec![HintObjectRef {
+                object_id: "obj-1".to_string(),
+                object_kind: "post".to_string(),
+            }],
+        },
+        r#"{"TopicObjectsChanged":{"topic_id":"kukuri:topic:demo","objects":[{"object_id":"obj-1","object_kind":"post"}]}}"#,
+    );
+}
+
+#[test]
+fn gossip_hint_thread_updated_snapshot() {
+    assert_wire(
+        &GossipHint::ThreadUpdated {
+            root_id: EnvelopeId("root-1".to_string()),
+            object_ids: vec![
+                EnvelopeId("obj-1".to_string()),
+                EnvelopeId("obj-2".to_string()),
+            ],
+        },
+        r#"{"ThreadUpdated":{"root_id":"root-1","object_ids":["obj-1","obj-2"]}}"#,
+    );
+}
+
+#[test]
+fn gossip_hint_profile_updated_snapshot() {
+    assert_wire(
+        &GossipHint::ProfileUpdated { author: author() },
+        r#"{"ProfileUpdated":{"author":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"}}"#,
+    );
+}
+
+#[test]
+fn gossip_hint_presence_snapshot() {
+    assert_wire(
+        &GossipHint::Presence {
+            topic_id: demo_topic(),
+            author: author(),
+            ttl_ms: 30000,
+        },
+        r#"{"Presence":{"topic_id":"kukuri:topic:demo","author":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","ttl_ms":30000}}"#,
+    );
+}
+
+#[test]
+fn gossip_hint_typing_snapshot_with_and_without_root() {
+    assert_wire(
+        &GossipHint::Typing {
+            topic_id: demo_topic(),
+            root_id: Some(EnvelopeId("root-1".to_string())),
+            author: author(),
+            ttl_ms: 5000,
+        },
+        r#"{"Typing":{"topic_id":"kukuri:topic:demo","root_id":"root-1","author":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","ttl_ms":5000}}"#,
+    );
+    // None は省略ではなく null として出力される(古いピアとの互換もこの形)。
+    assert_wire(
+        &GossipHint::Typing {
+            topic_id: demo_topic(),
+            root_id: None,
+            author: author(),
+            ttl_ms: 5000,
+        },
+        r#"{"Typing":{"topic_id":"kukuri:topic:demo","root_id":null,"author":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","ttl_ms":5000}}"#,
+    );
+}
+
+#[test]
+fn gossip_hint_session_changed_snapshot() {
+    assert_wire(
+        &GossipHint::SessionChanged {
+            topic_id: demo_topic(),
+            session_id: "session-1".to_string(),
+            object_kind: "live_session".to_string(),
+        },
+        r#"{"SessionChanged":{"topic_id":"kukuri:topic:demo","session_id":"session-1","object_kind":"live_session"}}"#,
+    );
+}
+
+#[test]
+fn gossip_hint_live_presence_snapshot() {
+    assert_wire(
+        &GossipHint::LivePresence {
+            topic_id: demo_topic(),
+            session_id: "session-1".to_string(),
+            author: author(),
+            ttl_ms: 15000,
+        },
+        r#"{"LivePresence":{"topic_id":"kukuri:topic:demo","session_id":"session-1","author":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","ttl_ms":15000}}"#,
+    );
+}
+
+#[test]
+fn gossip_hint_metaverse_room_event_snapshot() {
+    assert_wire(
+        &GossipHint::MetaverseRoomEvent {
+            topic_id: demo_topic(),
+            room_id: "room-1".to_string(),
+            event: Box::new(KukuriEnvelope {
+                id: EnvelopeId("id-1".to_string()),
+                pubkey: author(),
+                created_at: 1_700_000_000,
+                kind: "kukuri:metaverse-room-event".to_string(),
+                tags: vec![vec!["room".to_string(), "room-1".to_string()]],
+                content: "{}".to_string(),
+                sig: "sig-1".to_string(),
+            }),
+        },
+        r#"{"MetaverseRoomEvent":{"topic_id":"kukuri:topic:demo","room_id":"room-1","event":{"id":"id-1","pubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","created_at":1700000000,"kind":"kukuri:metaverse-room-event","tags":[["room","room-1"]],"content":"{}","sig":"sig-1"}}}"#,
+    );
+}
+
+#[test]
+fn gossip_hint_direct_message_frame_snapshot() {
+    assert_wire(
+        &GossipHint::DirectMessageFrame {
+            topic_id: TopicId::new("kukuri:dm:abc"),
+            dm_id: "dm-1".to_string(),
+            message_id: "msg-1".to_string(),
+            frame_hash: BlobHash::new("hash-1"),
+        },
+        r#"{"DirectMessageFrame":{"topic_id":"kukuri:dm:abc","dm_id":"dm-1","message_id":"msg-1","frame_hash":"hash-1"}}"#,
+    );
+}
+
+#[test]
+fn gossip_hint_direct_message_ack_snapshot() {
+    assert_wire(
+        &GossipHint::DirectMessageAck {
+            topic_id: TopicId::new("kukuri:dm:abc"),
+            ack: DirectMessageAckV1 {
+                dm_id: "dm-1".to_string(),
+                message_id: "msg-1".to_string(),
+                sender: author(),
+                recipient: Pubkey::from(PUBKEY_B),
+                acked_at: 1_700_000_100,
+                signature: "sig-1".to_string(),
+            },
+        },
+        r#"{"DirectMessageAck":{"topic_id":"kukuri:dm:abc","ack":{"dm_id":"dm-1","message_id":"msg-1","sender":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","recipient":"c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5","acked_at":1700000100,"signature":"sig-1"}}}"#,
+    );
+}
+
+#[test]
+fn payload_ref_snapshot_is_intentionally_pascal_case() {
+    // PayloadRef のタグ(InlineText / BlobText)は周囲の snake_case enum と
+    // 異なる PascalCase のまま署名済み content と SQLite に永続済み。
+    // 「snake_case に統一」する変更は既存データ・既存署名を全て壊す。
+    assert_wire(
+        &PayloadRef::InlineText {
+            text: "hello".to_string(),
+        },
+        r#"{"InlineText":{"text":"hello"}}"#,
+    );
+    assert_wire(
+        &PayloadRef::BlobText {
+            hash: BlobHash::new("blake3-hash"),
+            mime: "text/markdown".to_string(),
+            bytes: 1234,
+        },
+        r#"{"BlobText":{"hash":"blake3-hash","mime":"text/markdown","bytes":1234}}"#,
+    );
+}
+
+#[test]
+fn object_enums_snapshot_snake_case() {
+    assert_wire(
+        &vec![
+            ObjectVisibility::Public,
+            ObjectVisibility::Community,
+            ObjectVisibility::Room,
+            ObjectVisibility::Private,
+        ],
+        r#"["public","community","room","private"]"#,
+    );
+    assert_wire(
+        &vec![
+            ObjectStatus::Active,
+            ObjectStatus::Edited,
+            ObjectStatus::Deleted,
+            ObjectStatus::Tombstoned,
+        ],
+        r#"["active","edited","deleted","tombstoned"]"#,
+    );
+}
+
+#[test]
+fn channel_ref_and_timeline_scope_snapshot_internally_tagged() {
+    assert_wire(&ChannelRef::Public, r#"{"kind":"public"}"#);
+    assert_wire(
+        &ChannelRef::PrivateChannel {
+            channel_id: ChannelId::new("chan-1"),
+        },
+        r#"{"kind":"private_channel","channel_id":"chan-1"}"#,
+    );
+    assert_wire(&TimelineScope::Public, r#"{"kind":"public"}"#);
+    assert_wire(&TimelineScope::AllJoined, r#"{"kind":"all_joined"}"#);
+    assert_wire(
+        &TimelineScope::Channel {
+            channel_id: ChannelId::new("chan-1"),
+        },
+        r#"{"kind":"channel","channel_id":"chan-1"}"#,
+    );
+}
+
+#[test]
+fn post_envelope_content_snapshot() {
+    assert_wire(
+        &KukuriPostEnvelopeContentV1 {
+            object_kind: "post".to_string(),
+            topic_id: demo_topic(),
+            channel_id: None,
+            payload_ref: PayloadRef::InlineText {
+                text: "hello".to_string(),
+            },
+            attachments: vec![],
+            media_manifest_refs: vec![],
+            visibility: ObjectVisibility::Public,
+            reply_to: None,
+            root_id: None,
+            repost_of: None,
+        },
+        r#"{"object_kind":"post","topic_id":"kukuri:topic:demo","channel_id":null,"payload_ref":{"InlineText":{"text":"hello"}},"attachments":[],"media_manifest_refs":[],"visibility":"public","reply_to":null,"root_id":null,"repost_of":null}"#,
+    );
+}
+
+#[test]
+fn post_envelope_content_accepts_legacy_json_without_defaulted_fields() {
+    // #[serde(default)] フィールドを持たない古い署名済み content が
+    // 読み続けられること(後方互換)の凍結。
+    let legacy = r#"{"object_kind":"post","topic_id":"kukuri:topic:demo","payload_ref":{"InlineText":{"text":"hello"}},"reply_to":null,"root_id":null}"#;
+    let parsed: KukuriPostEnvelopeContentV1 =
+        serde_json::from_str(legacy).expect("legacy content deserializes");
+    assert_eq!(parsed.channel_id, None);
+    assert_eq!(parsed.attachments, vec![]);
+    assert_eq!(parsed.media_manifest_refs, Vec::<String>::new());
+    assert_eq!(parsed.visibility, ObjectVisibility::Public);
+    assert_eq!(parsed.repost_of, None);
+}


### PR DESCRIPTION
## 概要

凍結境界 §3.1-3/4(serde フィールド名・variant 名 = wire 契約、PayloadRef の PascalCase)を両方向 snapshot(serialize 一致 + deserialize round-trip)で固定する。

## 種別

`contract`(プロダクションコード変更なし)

## 挙動変更

なし。

## 検証

- `cargo test -p kukuri-core` 47/47(新規 15 本: GossipHint 10 variant + posts 系 5 本)
- 期待 JSON はすべて生リテラル直書き(実装関数を期待値側に使わない)
- clippy --all-targets -D warnings / fmt green

## リスク

- GossipHint の rename・serde 属性追加・依存更新で fail するのが目的(受信側は失敗黙殺のため実行時に検出不能)
- 古いピア/データとの互換は「defaulted フィールド欠落 JSON のデシリアライズ」テストが担保

## 後続対応

- T5(wire 定数集約)がこの snapshot を安全網として使う

🤖 Generated with [Claude Code](https://claude.com/claude-code)