### PR TITLE
[contract] rendezvous / replica / gossip id 派生の golden テスト (WP-S3 T4)

### DIFF
--- a/crates/core/src/tests/derivation_golden.rs
+++ b/crates/core/src/tests/derivation_golden.rs
@@ -1,0 +1,43 @@
+//! rendezvous / topic id 派生の golden テスト(WP-S3 T4)。
+//!
+//! rendezvous key はクライアント間で一致して初めて機能する wire 契約
+//! (community-node はキーを opaque に扱い再導出しない)。ドメイン文字列・
+//! 区切りバイト・ハッシュ構成のいずれの変更もネットワーク分断になる。
+//! fail した場合はテストでなく変更側(コード・依存更新)を疑うこと。
+
+use crate::{
+    TopicId, author_profile_topic_id, private_topic_rendezvous_key_hex_secret,
+    public_topic_rendezvous_key,
+};
+
+#[test]
+fn public_topic_rendezvous_key_matches_golden() {
+    // blake3("kukuri:rendezvous:public-topic:v1" || 0x00 || topic)
+    assert_eq!(
+        public_topic_rendezvous_key(&TopicId::new("kukuri:topic:golden")),
+        "7f7f9902af85354eeadf44b6b953f31d0ec8fe39def5235b1f9a9ff0e1209e7e"
+    );
+}
+
+#[test]
+fn private_topic_rendezvous_key_matches_golden() {
+    // HMAC-SHA256(namespace_secret, "kukuri:rendezvous:private-topic:v1" || 0x00 || topic)
+    let key = private_topic_rendezvous_key_hex_secret(
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        &TopicId::new("kukuri:topic:golden"),
+    )
+    .expect("private rendezvous key");
+    assert_eq!(
+        key,
+        "72d34635686d4a3f177b033941879fa4dfc01c3c881abd92fe3eeb18561e63f7"
+    );
+}
+
+#[test]
+fn author_profile_topic_id_matches_golden() {
+    assert_eq!(
+        author_profile_topic_id("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+            .as_str(),
+        "kukuri:topic:profile:79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    );
+}

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod derivation_golden;
 mod direct_messages;
 mod envelope;
 mod media_live_game;

--- a/crates/docs-sync/src/tests/mod.rs
+++ b/crates/docs-sync/src/tests/mod.rs
@@ -3,3 +3,4 @@ mod iroh_sync;
 mod memory;
 mod node;
 mod relay;
+mod replicas;

--- a/crates/docs-sync/src/tests/replicas.rs
+++ b/crates/docs-sync/src/tests/replicas.rs
@@ -1,0 +1,53 @@
+//! replica 命名・namespace 派生の golden テスト(WP-S3 T4)。
+//!
+//! replica id とその blake3 派生 namespace はネットワーク全体の rendezvous を
+//! 決める凍結境界(1 文字の変更で既存ピアと同じ replica を発見できなくなる)。
+//! fail した場合はテストでなく変更側を疑うこと。
+
+use kukuri_core::ReplicaId;
+
+use crate::replicas::{
+    author_replica_id, device_replica_id, private_channel_epoch_replica_id,
+    private_channel_hint_topic, private_channel_replica_id, public_replica_secret, stable_key,
+    topic_replica_id,
+};
+
+#[test]
+fn replica_id_helpers_match_golden() {
+    assert_eq!(topic_replica_id("demo").as_str(), "topic::demo");
+    assert_eq!(
+        private_channel_replica_id("chan-1").as_str(),
+        "channel::chan-1"
+    );
+    assert_eq!(
+        private_channel_epoch_replica_id("chan-1", "epoch-2").as_str(),
+        "channel::chan-1::epoch::epoch-2"
+    );
+    assert_eq!(
+        private_channel_hint_topic("chan-1").as_str(),
+        "private/chan-1"
+    );
+    assert_eq!(author_replica_id("pubkey-a").as_str(), "author::pubkey-a");
+    assert_eq!(
+        device_replica_id("pubkey-a", "device-1").as_str(),
+        "device::pubkey-a::device-1"
+    );
+    assert_eq!(stable_key("objects", "obj-1/state"), "objects/obj-1/state");
+}
+
+#[test]
+fn public_replica_namespace_secret_matches_golden_digest() {
+    // blake3("kukuri-docs:" || replica_id) がそのまま NamespaceSecret になる。
+    let secret =
+        public_replica_secret(&ReplicaId::new("topic::demo")).expect("public replica secret");
+    assert_eq!(
+        hex::encode(secret.to_bytes()),
+        "ebd5f493d3f598727ea4b7b14bb42e5cec7d7b19adef0a3629586be201cddee1"
+    );
+}
+
+#[test]
+fn private_channel_replicas_never_get_public_namespace_secret() {
+    assert!(public_replica_secret(&ReplicaId::new("channel::chan-1")).is_none());
+    assert!(public_replica_secret(&ReplicaId::new("channel::chan-1::epoch::epoch-2")).is_none());
+}

--- a/crates/transport/src/iroh/topics.rs
+++ b/crates/transport/src/iroh/topics.rs
@@ -482,6 +482,18 @@ impl IrohGossipTransport {
 mod tests {
     use super::*;
 
+    // gossip topic id 派生の golden(WP-S3 T4)。blake3(topic 文字列)が
+    // on-wire の gossip 識別子そのもの。変更はネットワーク分断になる。
+    #[test]
+    fn topic_to_gossip_id_matches_golden() {
+        let id = topic_to_gossip_id(&kukuri_core::TopicId::new("kukuri:topic:golden"));
+        let expected = blake3::Hash::from_hex(
+            "65994b46e778ead0264f20707efc571bfc4bdf510f97add9ebd81c8ad507dc80",
+        )
+        .expect("expected hex parses");
+        assert_eq!(id.as_bytes(), expected.as_bytes());
+    }
+
     #[test]
     fn topic_warmup_retry_delay_backs_off_and_caps() {
         assert_eq!(


### PR DESCRIPTION
## 概要

凍結境界 §3.1-2(rendezvous 派生文字列・replica 命名・gossip topic id)の決定的派生関数を hex 直書き golden で固定する。

## 種別

`contract`(プロダクションコード変更なし)

## 挙動変更

なし。

## 検証

- core +3 / docs-sync +3(tests/replicas.rs 新設)/ transport +1、全 green
- 期待 hex は一時生成器で実測した値の直書き(生成手順はテストコメント)
- clippy --all-targets -D warnings / fmt green

## リスク

なし(テスト追加のみ)。blake3/hmac/hkdf の依存更新でこれらが fail した場合はネットワーク互換の破壊を意味する(検出が目的)

## 後続対応

- T5(wire 定数集約)がこの golden を「値不変」の安全網として使う

🤖 Generated with [Claude Code](https://claude.com/claude-code)