### PR TITLE
[contract] CommunityNodeManifest の round-trip / wire golden (WP-S3 T6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3165,6 +3165,7 @@ dependencies = [
  "kukuri-blob-service",
  "kukuri-cn-core",
  "kukuri-cn-iroh-relay",
+ "kukuri-cn-operator",
  "kukuri-core",
  "kukuri-docs-sync",
  "kukuri-store",

--- a/crates/cn-operator/tests/manifest_golden.rs
+++ b/crates/cn-operator/tests/manifest_golden.rs
@@ -1,0 +1,73 @@
+//! manifest wire 出力の golden テスト(WP-S3 T6)。
+//!
+//! build_manifest の JSON 出力(フィールド名・宣言順・値)は unauthenticated な
+//! 公開 endpoint(/v1/node/manifest)の wire 契約そのもの。desktop-runtime 側の
+//! round-trip テスト(manifest_support.rs、同一 fixture YAML)と対で drift を検出する。
+//! fail した場合はテストでなく変更側の互換影響(client の tolerant reader が
+//! default に落ちないか)を評価すること。後方互換な変更は optional フィールドの
+//! 追加のみ(REFACTORING.md 凍結境界)。
+use kukuri_cn_operator::{build_manifest, load_and_validate};
+
+const FIXTURE_YAML: &str = r#"server:
+  domain: golden.example
+  operator_name: Golden Operator
+  country: JP
+  cloud_provider: ExampleCloud
+  region: example-region-1
+  contact: abuse@golden.example
+  node_id: node-golden-1
+  node_name: Golden Node
+
+profile: relay-enabled
+
+features:
+  community_index: true
+  moderation: true
+  community_local_trust: true
+  report_endpoint: true
+  iroh_relay: true
+  traffic_relay_fallback: true
+  private_message_storage: false
+  blob_cache: false
+  analytics: false
+  crash_report: false
+  cloudflare_proxy: true
+
+retention:
+  connection_logs_days: 30
+  moderation_logs_days: 180
+
+safety:
+  profile: public-node
+  policy_version: 2026-06-public-node-v1
+  indexing:
+    index_before_scan: false
+    on_scan_error: hold
+  storage:
+    permanent_blob_storage: false
+  events:
+    emit_signed_moderation_events: true
+    signing_key_secret_id: kukuri-cn-safety-signing-key
+  providers:
+    known_csam:
+      provider: project-arachnid-shield
+      required: true
+      credential_secret_id: kukuri-cn-safety-known-csam
+
+manifest:
+  manifest_version: v1
+  node_role: default-onboarding-node
+
+acknowledge_planned_capabilities: true
+"#;
+
+#[test]
+fn manifest_wire_output_matches_golden() {
+    let resolved = load_and_validate(FIXTURE_YAML).expect("fixture validates");
+    let manifest = build_manifest(&resolved);
+    let expected = r##"{"node_id":"node-golden-1","node_name":"Golden Node","node_role":"default-onboarding-node","server_name":"golden.example","operator_name":"Golden Operator","operator_country":"JP","cloud_provider":"ExampleCloud","region":"example-region-1","contact":"abuse@golden.example","abuse_contact":"abuse@golden.example","report_endpoint":"https://golden.example/v1/report","terms_url":"https://golden.example/terms","privacy_url":"https://golden.example/privacy","external_transmission_url":"https://golden.example/external-transmission","moderation_policy_url":"https://golden.example/moderation-policy","abuse_policy_url":"https://golden.example/abuse-policy","manifest_version":"v1","capabilities":{"auth_consent":true,"bootstrap_assist":true,"topic_rendezvous":true,"iroh_relay":true,"traffic_relay_fallback":true,"blob_cache":false,"private_message_storage":false,"analytics":false,"crash_report":false,"cloudflare_proxy":true,"push_notification":false,"community_index":true,"moderation":true,"community_local_trust":true,"report_endpoint":true},"capability_scope":{"available_enabled":["auth_consent","bootstrap_assist","topic_rendezvous","iroh_relay","traffic_relay_fallback","cloudflare_proxy","report_endpoint"],"planned_enabled":["community_index","moderation","community_local_trust"]},"authority_scope":{"applies_to":["this_node","communities_indexed_by_this_node","moderation_events_issued_by_this_node","trust_signals_issued_by_this_node"],"does_not_apply_to":["kukuri_network_as_a_whole","third_party_nodes","user_identity","user_profile_canonical_source","user_social_graph_canonical_source"]},"p2p_boundary":{"identity_authority":false,"profile_canonical_store":false,"social_graph_canonical_store":false,"content_truth_source":false,"network_wide_authority":false},"features":{"community_index":true,"moderation":true,"trust_score":"community-local","iroh_relay":true,"iroh_relay_mode":"dedicated","traffic_relay_fallback":true,"private_message_storage":false,"blob_cache":false},"retention":{"connection_logs_days":30,"moderation_logs_days":180}}"##;
+    assert_eq!(
+        serde_json::to_string(&manifest).expect("serialize"),
+        expected
+    );
+}

--- a/crates/desktop-runtime/Cargo.toml
+++ b/crates/desktop-runtime/Cargo.toml
@@ -39,6 +39,8 @@ iroh-mainline-address-lookup.workspace = true
 n0-mainline.workspace = true
 iroh = { workspace = true, features = ["test-utils"] }
 kukuri-cn-iroh-relay = { path = "../cn-iroh-relay" }
+# WP-S3 T6: manifest round-trip contract テスト(server 実出力 -> slim 型)のため。
+kukuri-cn-operator = { path = "../cn-operator" }
 
 [lints]
 workspace = true

--- a/crates/desktop-runtime/src/community_node/manifest_support.rs
+++ b/crates/desktop-runtime/src/community_node/manifest_support.rs
@@ -203,4 +203,147 @@ mod tests {
         assert_eq!(json["status"], "absent");
         assert!(json["manifest"].is_null());
     }
+
+    // ---- WP-S3 T6: server 実出力との round-trip(rename drift 検出) ----
+    //
+    // 上の SAMPLE_MANIFEST 系テストは「手書き JSON に対する tolerant reader」
+    // (欠落 default・未知フィールド無視)を検証する。ここは役割が異なり、
+    // cn-operator の build_manifest が生成する実出力を slim 型が読めること、
+    // すなわち server/client 間のフィールド rename drift を CI で検出する。
+    // fail した場合は server 側 manifest.rs か本 slim 型の rename を疑うこと。
+
+    const ROUND_TRIP_FIXTURE_YAML: &str = r#"server:
+  domain: golden.example
+  operator_name: Golden Operator
+  country: JP
+  cloud_provider: ExampleCloud
+  region: example-region-1
+  contact: abuse@golden.example
+  node_id: node-golden-1
+  node_name: Golden Node
+
+profile: relay-enabled
+
+features:
+  community_index: true
+  moderation: true
+  community_local_trust: true
+  report_endpoint: true
+  iroh_relay: true
+  traffic_relay_fallback: true
+  private_message_storage: false
+  blob_cache: false
+  analytics: false
+  crash_report: false
+  cloudflare_proxy: true
+
+retention:
+  connection_logs_days: 30
+  moderation_logs_days: 180
+
+safety:
+  profile: public-node
+  policy_version: 2026-06-public-node-v1
+  indexing:
+    index_before_scan: false
+    on_scan_error: hold
+  storage:
+    permanent_blob_storage: false
+  events:
+    emit_signed_moderation_events: true
+    signing_key_secret_id: kukuri-cn-safety-signing-key
+  providers:
+    known_csam:
+      provider: project-arachnid-shield
+      required: true
+      credential_secret_id: kukuri-cn-safety-known-csam
+
+manifest:
+  manifest_version: v1
+  node_role: default-onboarding-node
+
+acknowledge_planned_capabilities: true
+"#;
+
+    #[test]
+    fn server_manifest_output_round_trips_into_slim_type() {
+        let resolved = kukuri_cn_operator::load_and_validate(ROUND_TRIP_FIXTURE_YAML)
+            .expect("fixture config validates");
+        let server_json = serde_json::to_value(kukuri_cn_operator::build_manifest(&resolved))
+            .expect("server manifest serializes");
+        let slim: CommunityNodeManifest =
+            serde_json::from_value(server_json.clone()).expect("slim parses server output");
+
+        let expected = CommunityNodeManifest {
+            node_id: "node-golden-1".to_string(),
+            node_name: "Golden Node".to_string(),
+            node_role: "default-onboarding-node".to_string(),
+            server_name: "golden.example".to_string(),
+            manifest_version: "v1".to_string(),
+            capability_scope: CommunityNodeCapabilityScope {
+                available_enabled: vec![
+                    "auth_consent".to_string(),
+                    "bootstrap_assist".to_string(),
+                    "topic_rendezvous".to_string(),
+                    "iroh_relay".to_string(),
+                    "traffic_relay_fallback".to_string(),
+                    "cloudflare_proxy".to_string(),
+                    "report_endpoint".to_string(),
+                ],
+                planned_enabled: vec![
+                    "community_index".to_string(),
+                    "moderation".to_string(),
+                    "community_local_trust".to_string(),
+                ],
+            },
+            authority_scope: CommunityNodeAuthorityScope {
+                applies_to: vec![
+                    "this_node".to_string(),
+                    "communities_indexed_by_this_node".to_string(),
+                    "moderation_events_issued_by_this_node".to_string(),
+                    "trust_signals_issued_by_this_node".to_string(),
+                ],
+                does_not_apply_to: vec![
+                    "kukuri_network_as_a_whole".to_string(),
+                    "third_party_nodes".to_string(),
+                    "user_identity".to_string(),
+                    "user_profile_canonical_source".to_string(),
+                    "user_social_graph_canonical_source".to_string(),
+                ],
+            },
+            p2p_boundary: CommunityNodeP2pBoundary {
+                identity_authority: false,
+                profile_canonical_store: false,
+                social_graph_canonical_store: false,
+                content_truth_source: false,
+                network_wide_authority: false,
+            },
+            abuse_contact: "abuse@golden.example".to_string(),
+            report_endpoint: "https://golden.example/v1/report".to_string(),
+            terms_url: "https://golden.example/terms".to_string(),
+            privacy_url: "https://golden.example/privacy".to_string(),
+            moderation_policy_url: "https://golden.example/moderation-policy".to_string(),
+        };
+        assert_eq!(slim, expected);
+
+        // slim が emit する全キー(nested 含む)が server 出力にも存在すること。
+        // p2p_boundary のように「全フィールドが default 値」の構造は上の
+        // assert_eq では rename drift を検出できないため、この包含が担う。
+        let slim_json = serde_json::to_value(&slim).expect("slim serializes");
+        assert_json_keys_subset(&slim_json, &server_json, "$");
+    }
+
+    fn assert_json_keys_subset(slim: &serde_json::Value, server: &serde_json::Value, path: &str) {
+        if let serde_json::Value::Object(slim_map) = slim {
+            let server_map = server
+                .as_object()
+                .unwrap_or_else(|| panic!("server value at {path} is not an object"));
+            for (key, slim_child) in slim_map {
+                let server_child = server_map.get(key).unwrap_or_else(|| {
+                    panic!("server manifest is missing key {path}.{key} that the client reads")
+                });
+                assert_json_keys_subset(slim_child, server_child, &format!("{path}.{key}"));
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 概要

凍結境界 §3.1-7(CommunityNodeManifest)の server↔client rename drift 検出。同一 fixture YAML(全 slim フィールドが非 default になるよう設計)から server 実出力 → slim 型の round-trip を desktop-runtime 側に、wire 出力全体の golden を cn-operator 側に置く。

## 種別

`contract`(+ dev-dependencies への kukuri-cn-operator 追加 — 本テストの必須構成として本文で正当化。プロダクション依存への影響なし・循環なし)

## 挙動変更

なし。

## 検証

- desktop-runtime manifest 系 7/7(round-trip 新規 1)/ cn-operator manifest_golden 1/1
- p2p_boundary(全フィールド default)の rename は値比較で検出不能のため、再帰キー包含 assert が担う設計をテストコメントに明記
- clippy --all-targets -D warnings / fmt green
- 既存の SAMPLE_MANIFEST テスト(tolerant reader = forward compatibility 検証)は無変更(役割分担を本文とコメントに明記)

## リスク

- round-trip テストは rust-test lane、golden は cn-test lane で走る。cn-operator の manifest を触る PR は両方の実行が必要(T7 で検証マトリクスに追記予定)

## 後続対応

- T7(REFACTORING.md 凍結境界章)でテストアンカーとして参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)