### PR TITLE
[refactor:extract] wire prefix を core::wire へ集約 (WP-S3 T5)

### DIFF
--- a/crates/app-api/src/service/attachment_support.rs
+++ b/crates/app-api/src/service/attachment_support.rs
@@ -212,7 +212,7 @@ pub(crate) async fn direct_message_topic_peer_count(
     topic: &TopicId,
 ) -> Result<usize> {
     let snapshot = transport.peers().await?;
-    let hint_topic = format!("hint/{}", topic.as_str());
+    let hint_topic = kukuri_core::wire::hint_topic_id(topic).0;
     let topic_peer_count = snapshot
         .topic_diagnostics
         .iter()
@@ -363,9 +363,11 @@ pub(crate) fn short_id_suffix(author_pubkey: &str) -> &str {
 
 pub(crate) fn normalize_topic_name(topic: String) -> Option<String> {
     let normalized = topic
-        .strip_prefix("hint/")
+        .strip_prefix(kukuri_core::wire::HINT_TOPIC_PREFIX)
         .map_or(topic.clone(), ToOwned::to_owned);
-    if normalized.starts_with("private/") || normalized.starts_with("kukuri:dm:") {
+    if normalized.starts_with(kukuri_core::wire::PRIVATE_CHANNEL_TOPIC_PREFIX)
+        || normalized.starts_with(kukuri_core::wire::DM_TOPIC_PREFIX)
+    {
         None
     } else {
         Some(normalized)

--- a/crates/app-api/src/service/direct_messages_subscription_support.rs
+++ b/crates/app-api/src/service/direct_messages_subscription_support.rs
@@ -312,7 +312,7 @@ impl AppService {
         let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
         let topic =
             derive_direct_message_topic(self.keys.as_ref(), &Pubkey::from(peer_pubkey.as_str()))?;
-        let hint_topic = format!("hint/{}", topic.as_str());
+        let hint_topic = kukuri_core::wire::hint_topic_id(&topic).0;
         Ok(self
             .transport
             .peers()

--- a/crates/app-api/src/tests/mod.rs
+++ b/crates/app-api/src/tests/mod.rs
@@ -31,6 +31,7 @@ mod reactions;
 mod social;
 mod sync;
 mod timeline;
+mod topic_normalization;
 
 mod support;
 use support::*;

--- a/crates/app-api/src/tests/topic_normalization.rs
+++ b/crates/app-api/src/tests/topic_normalization.rs
@@ -1,0 +1,51 @@
+//! 診断 topic 正規化の凍結テスト(WP-S3 T5)。
+//!
+//! hint/ の strip と private/・kukuri:dm: の除外は診断表示の契約。
+//! 期待値の prefix は生リテラル(core::wire の定数を期待値側に使わない)。
+
+use super::*;
+
+#[test]
+fn normalize_topic_name_strips_hint_prefix() {
+    assert_eq!(
+        normalize_topic_name("hint/kukuri:topic:demo".to_string()),
+        Some("kukuri:topic:demo".to_string())
+    );
+}
+
+#[test]
+fn normalize_topic_name_passes_plain_topics_through() {
+    assert_eq!(
+        normalize_topic_name("kukuri:topic:demo".to_string()),
+        Some("kukuri:topic:demo".to_string())
+    );
+}
+
+#[test]
+fn normalize_topic_name_excludes_private_channel_and_dm_topics() {
+    assert_eq!(normalize_topic_name("private/chan-1".to_string()), None);
+    assert_eq!(normalize_topic_name("kukuri:dm:abc123".to_string()), None);
+    // hint/ を剥がした後に private/・kukuri:dm: 判定が効くことも契約。
+    assert_eq!(
+        normalize_topic_name("hint/private/chan-1".to_string()),
+        None
+    );
+    assert_eq!(
+        normalize_topic_name("hint/kukuri:dm:abc123".to_string()),
+        None
+    );
+}
+
+#[test]
+fn normalize_topics_dedupes_and_preserves_order() {
+    let normalized = normalize_topics(vec![
+        "hint/kukuri:topic:a".to_string(),
+        "kukuri:topic:a".to_string(),
+        "private/chan-1".to_string(),
+        "kukuri:topic:b".to_string(),
+    ]);
+    assert_eq!(
+        normalized,
+        vec!["kukuri:topic:a".to_string(), "kukuri:topic:b".to_string()]
+    );
+}

--- a/crates/core/src/direct_messages.rs
+++ b/crates/core/src/direct_messages.rs
@@ -181,7 +181,8 @@ pub fn derive_direct_message_topic(
     hkdf.expand(b"kukuri:direct-message:pairwise-topic", &mut topic_key)
         .map_err(|_| anyhow!("failed to derive direct message topic"))?;
     Ok(TopicId::new(format!(
-        "kukuri:dm:{}",
+        "{}{}",
+        crate::wire::DM_TOPIC_PREFIX,
         hex::encode(topic_key)
     )))
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ mod private_channels;
 mod profile;
 mod reactions;
 mod rendezvous;
+pub mod wire;
 
 #[cfg(test)]
 mod tests;

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -6,3 +6,4 @@ mod posts;
 mod private_channels;
 mod profile;
 mod reactions;
+mod wire_constants;

--- a/crates/core/src/tests/wire_constants.rs
+++ b/crates/core/src/tests/wire_constants.rs
@@ -1,0 +1,24 @@
+//! wire prefix 定数の値凍結テスト(WP-S3 T5)。
+//!
+//! 期待値は生リテラル直書き(wire モジュールの定数を期待値側に使うと、
+//! 定数と一緒に書き換えられて凍結の意味が失われる)。
+
+use crate::TopicId;
+use crate::wire::{
+    DM_TOPIC_PREFIX, HINT_TOPIC_PREFIX, PRIVATE_CHANNEL_TOPIC_PREFIX, hint_topic_id,
+};
+
+#[test]
+fn wire_prefixes_match_frozen_literals() {
+    assert_eq!(HINT_TOPIC_PREFIX, "hint/");
+    assert_eq!(PRIVATE_CHANNEL_TOPIC_PREFIX, "private/");
+    assert_eq!(DM_TOPIC_PREFIX, "kukuri:dm:");
+}
+
+#[test]
+fn hint_topic_id_prepends_frozen_prefix() {
+    assert_eq!(
+        hint_topic_id(&TopicId::new("kukuri:topic:demo")).as_str(),
+        "hint/kukuri:topic:demo"
+    );
+}

--- a/crates/core/src/wire.rs
+++ b/crates/core/src/wire.rs
@@ -1,0 +1,26 @@
+//! wire prefix 定数(凍結境界)。
+//!
+//! これらの値は gossip topic 名・診断表示・topic 除外判定として複数 crate に
+//! またがる契約であり、変更はネットワーク分断・診断不一致になる。
+//! 値そのものの凍結は src/tests/wire_constants.rs が生リテラル比較で担う
+//! (このモジュールを参照せずに固定するのが目的なので、テスト側の期待値を
+//! この定数に置き換えてはならない)。
+
+use crate::TopicId;
+
+/// gossip hint 配送 topic の prefix。実 topic 名の前置により hint 用の
+/// 並行 gossip スワームを分離する。
+pub const HINT_TOPIC_PREFIX: &str = "hint/";
+
+/// private channel の hint topic prefix(docs-sync の replica 命名と対)。
+/// 診断表示からの除外判定にも使われる。
+pub const PRIVATE_CHANNEL_TOPIC_PREFIX: &str = "private/";
+
+/// pairwise DM topic の prefix(HKDF 派生 hex 64 桁が続く)。
+/// 診断表示からの除外判定にも使われる。
+pub const DM_TOPIC_PREFIX: &str = "kukuri:dm:";
+
+/// topic に対応する gossip hint topic id を返す。
+pub fn hint_topic_id(topic: &TopicId) -> TopicId {
+    TopicId::new(format!("{HINT_TOPIC_PREFIX}{}", topic.as_str()))
+}

--- a/crates/docs-sync/src/replicas.rs
+++ b/crates/docs-sync/src/replicas.rs
@@ -22,7 +22,10 @@ pub fn private_channel_epoch_replica_id(channel_id: &str, epoch_id: &str) -> Rep
 }
 
 pub fn private_channel_hint_topic(channel_id: &str) -> TopicId {
-    TopicId::new(format!("private/{channel_id}"))
+    TopicId::new(format!(
+        "{}{channel_id}",
+        kukuri_core::wire::PRIVATE_CHANNEL_TOPIC_PREFIX
+    ))
 }
 
 pub fn author_replica_id(author_pubkey: &str) -> ReplicaId {

--- a/crates/transport/src/fake.rs
+++ b/crates/transport/src/fake.rs
@@ -244,7 +244,7 @@ impl Transport for FakeTransport {
 #[async_trait]
 impl HintTransport for FakeTransport {
     async fn subscribe_hints(&self, topic: &TopicId) -> Result<HintStream> {
-        let hint_topic = TopicId::new(format!("hint/{}", topic.as_str()));
+        let hint_topic = kukuri_core::wire::hint_topic_id(topic);
         self.subscribed_topics
             .lock()
             .await
@@ -263,7 +263,7 @@ impl HintTransport for FakeTransport {
     }
 
     async fn unsubscribe_hints(&self, topic: &TopicId) -> Result<()> {
-        let hint_topic = TopicId::new(format!("hint/{}", topic.as_str()));
+        let hint_topic = kukuri_core::wire::hint_topic_id(topic);
         self.subscribed_topics
             .lock()
             .await

--- a/crates/transport/src/iroh/topics.rs
+++ b/crates/transport/src/iroh/topics.rs
@@ -442,13 +442,13 @@ impl IrohGossipTransport {
     }
 
     pub(crate) async fn hint_subscribe_hints_impl(&self, topic: &TopicId) -> Result<HintStream> {
-        let hint_topic = TopicId::new(format!("hint/{}", topic.as_str()));
+        let hint_topic = kukuri_core::wire::hint_topic_id(topic);
         let sender = self.ensure_hint_topic(&hint_topic).await?;
         Ok(Self::stream_from_sender(&sender))
     }
 
     pub(crate) async fn hint_unsubscribe_hints_impl(&self, topic: &TopicId) -> Result<()> {
-        let hint_topic = TopicId::new(format!("hint/{}", topic.as_str()));
+        let hint_topic = kukuri_core::wire::hint_topic_id(topic);
         self.remove_topic_state(hint_topic.as_str()).await;
         Ok(())
     }
@@ -458,7 +458,7 @@ impl IrohGossipTransport {
         topic: &TopicId,
         hint: GossipHint,
     ) -> Result<()> {
-        let hint_topic = TopicId::new(format!("hint/{}", topic.as_str()));
+        let hint_topic = kukuri_core::wire::hint_topic_id(topic);
         let _ = self.ensure_hint_topic(&hint_topic).await?;
         let states = self.topic_states.lock().await;
         let state = states


### PR DESCRIPTION
## 概要

複数 crate に重複していた wire prefix リテラル(`hint/`×8、`private/`×2、`kukuri:dm:`×2)を `kukuri_core::wire` に集約する。**base は T4(#439)** — 派生 golden を「値不変」の安全網として使うため。

## 種別

`refactor:extract` + `contract`(定数の値凍結テストと normalize の契約テストを同梱 — 集約と値固定は一体)

## 挙動変更

なし(値・出力完全不変)。TS 側の `hint/${topic}`(MetaverseRoomPanel.tsx)は Rust 定数を共有できないため対象外(実装プラン Non-goals)。

## 検証

- 値凍結テスト新設(期待値は生リテラル — 定数と一緒に書き換えられない設計)
- 既存の hint/ 文字列比較テスト群(transport 統合 37 本等)と T4 派生 golden が置換後も全 green = 値不変の証明
- normalize_topic_name/topics の unit テスト 4 本新設(従来カバレッジゼロの穴)
- clippy --all-targets -D warnings / fmt(4 crate)green

## リスク

- 今後 prefix を触る変更は定数 1 箇所 + 凍結テストの両方に現れる(意図した摩擦)

## 後続対応

- T7(REFACTORING.md 凍結境界章)で core::wire をアンカーとして参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)