### PR TITLE
[contract] timelineMerge / routes 純関数の characterization テスト (WP-S5 T1)

### DIFF
--- a/apps/desktop/src/shell/data/timelineMerge.test.ts
+++ b/apps/desktop/src/shell/data/timelineMerge.test.ts
@@ -1,0 +1,319 @@
+/**
+ * WP-S5: timelineMerge.ts(純関数 5 本)の characterization テスト。
+ *
+ * 後続 WP-H6(shell の store スライス化・selector 化・prop drilling 除去)の
+ * 安全網として「観測した現挙動」をそのまま固定する。このテストが落ちた場合に
+ * 疑うべきは直近の変更でありテストではない。期待値は生リテラルで書き、
+ * 実装側の定数・関数から期待値を生成しない。
+ */
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import type { PostView } from '@/lib/api';
+
+import { buildPaginatedPost } from '../DesktopShellPage.testHelpers';
+import {
+  hasLoadedOlderAuthoritativePosts,
+  mergeRefreshedVisiblePosts,
+  mergeUniquePosts,
+  postIdentityKey,
+  uniquePostsByIdentity,
+} from './timelineMerge';
+
+// 各テストを独立させる(setup.ts は hash を掃除しない)。
+beforeEach(() => {
+  window.history.replaceState(null, '', '/');
+});
+
+// object_id だけ差し替えた PostView fixture(検証はフィールド単位で行う)。
+function post(objectId: string, overrides: Partial<PostView> = {}): PostView {
+  return buildPaginatedPost(1, { object_id: objectId, ...overrides });
+}
+
+function ids(posts: PostView[]): string[] {
+  return posts.map((entry) => entry.object_id);
+}
+
+describe('postIdentityKey', () => {
+  const cases: Array<{
+    name: string;
+    input: Pick<PostView, 'object_id' | 'server_object_id'>;
+    expected: string;
+  }> = [
+    {
+      name: 'prefers server_object_id when present',
+      input: { object_id: 'local-1', server_object_id: 'server-1' },
+      expected: 'server-1',
+    },
+    {
+      name: 'falls back to object_id when server_object_id is null',
+      input: { object_id: 'local-1', server_object_id: null },
+      expected: 'local-1',
+    },
+    {
+      name: 'falls back to object_id when server_object_id is undefined',
+      input: { object_id: 'local-1' },
+      expected: 'local-1',
+    },
+  ];
+
+  test.each(cases)('$name', ({ input, expected }) => {
+    expect(postIdentityKey(input)).toBe(expected);
+  });
+});
+
+describe('uniquePostsByIdentity', () => {
+  test('returns an empty array for empty input', () => {
+    expect(uniquePostsByIdentity([])).toEqual([]);
+  });
+
+  test('keeps the first occurrence when the same object_id appears twice', () => {
+    const first = post('post-a', { created_at: 111 });
+    const duplicate = post('post-a', { created_at: 222 });
+
+    const result = uniquePostsByIdentity([first, post('post-b'), duplicate]);
+
+    expect(ids(result)).toEqual(['post-a', 'post-b']);
+    // 先勝ち: 最初のインスタンスが残る。
+    expect(result[0]?.created_at).toBe(111);
+  });
+
+  test('dedupes a local post and its authoritative echo via server_object_id', () => {
+    const localPost = post('local-1', {
+      local_state: 'syncing',
+      server_object_id: 'server-1',
+    });
+    const authoritativeEcho = post('server-1');
+
+    const result = uniquePostsByIdentity([localPost, authoritativeEcho]);
+
+    // identity key はどちらも 'server-1' → 先勝ちで local 側が残る。
+    expect(ids(result)).toEqual(['local-1']);
+    expect(result[0]?.local_state).toBe('syncing');
+  });
+});
+
+describe('mergeUniquePosts', () => {
+  test('appends only incoming posts whose object_id is not in current', () => {
+    const currentB = post('post-b', { created_at: 111 });
+    const incomingB = post('post-b', { created_at: 222 });
+
+    const result = mergeUniquePosts(
+      [post('post-a'), currentB],
+      [incomingB, post('post-c')]
+    );
+
+    expect(ids(result)).toEqual(['post-a', 'post-b', 'post-c']);
+    // 重複時は current 側のインスタンスが残る。
+    expect(result[1]?.created_at).toBe(111);
+  });
+
+  test('dedupes by object_id only and ignores server_object_id', () => {
+    // 現挙動の固定: postIdentityKey による同一視はせず object_id のみで比較する。
+    const localPost = post('local-1', {
+      local_state: 'syncing',
+      server_object_id: 'server-1',
+    });
+
+    const result = mergeUniquePosts([localPost], [post('server-1')]);
+
+    expect(ids(result)).toEqual(['local-1', 'server-1']);
+  });
+
+  test('keeps duplicates that appear only within incoming', () => {
+    // 現挙動の固定: seen は current 側からのみ構築され incoming 内の重複は除去されない。
+    const result = mergeUniquePosts(
+      [post('post-a')],
+      [post('post-b', { created_at: 111 }), post('post-b', { created_at: 222 })]
+    );
+
+    expect(ids(result)).toEqual(['post-a', 'post-b', 'post-b']);
+  });
+});
+
+describe('hasLoadedOlderAuthoritativePosts', () => {
+  function authoritativePosts(count: number): PostView[] {
+    return Array.from({ length: count }, (_, index) => post(`auth-${index}`));
+  }
+
+  const cases: Array<{
+    name: string;
+    currentAuthoritativeCount: number;
+    incomingCount: number;
+    expected: boolean;
+  }> = [
+    {
+      name: 'returns false when authoritative count equals incoming length',
+      currentAuthoritativeCount: 2,
+      incomingCount: 2,
+      expected: false,
+    },
+    {
+      name: 'returns true when authoritative count exceeds incoming length by one',
+      currentAuthoritativeCount: 3,
+      incomingCount: 2,
+      expected: true,
+    },
+    {
+      name: 'returns false when authoritative count is one below incoming length',
+      currentAuthoritativeCount: 1,
+      incomingCount: 2,
+      expected: false,
+    },
+  ];
+
+  test.each(cases)('$name', ({ currentAuthoritativeCount, incomingCount, expected }) => {
+    expect(
+      hasLoadedOlderAuthoritativePosts(
+        authoritativePosts(currentAuthoritativeCount),
+        authoritativePosts(incomingCount)
+      )
+    ).toBe(expected);
+  });
+
+  test('excludes local-state posts from the authoritative count', () => {
+    const current = [
+      post('local-1', { local_state: 'pending' }),
+      post('local-2', { local_state: 'failed' }),
+      post('auth-1'),
+    ];
+
+    // authoritative は auth-1 の 1 件のみ → incoming 1 件と同数なので false。
+    expect(hasLoadedOlderAuthoritativePosts(current, [post('new-1')])).toBe(false);
+    // incoming 0 件なら 1 > 0 で true。
+    expect(hasLoadedOlderAuthoritativePosts(current, [])).toBe(true);
+  });
+
+  test('treats local_state null as authoritative', () => {
+    expect(
+      hasLoadedOlderAuthoritativePosts([post('auth-1', { local_state: null })], [])
+    ).toBe(true);
+  });
+
+  test('compares against the raw incoming length without filtering incoming local-state posts', () => {
+    const current = [post('auth-1'), post('auth-2')];
+    const incomingAllLocal = [
+      post('local-1', { local_state: 'pending' }),
+      post('local-2', { local_state: 'syncing' }),
+    ];
+
+    // quirk の固定: local_state で filter されるのは current 側だけで、incoming は
+    // 生の length と比較される。incoming 2 件が全て local_state 付きでも件数に数えられ
+    // 2 > 2 → false(incoming 側も filter されるなら 2 > 0 → true になるはず)。
+    expect(hasLoadedOlderAuthoritativePosts(current, incomingAllLocal)).toBe(false);
+  });
+});
+
+describe('mergeRefreshedVisiblePosts', () => {
+  // preserveOlderPages 真偽 × optimistic post(local_state 付き)の保持 ×
+  // server_object_id による同一視(postIdentityKey)の組合せ表。
+  const cases: Array<{
+    name: string;
+    current: PostView[];
+    incoming: PostView[];
+    preserveOlderPages: boolean;
+    expectedIds: string[];
+  }> = [
+    {
+      name: 'replaces authoritative posts with incoming when preserveOlderPages is false',
+      current: [post('old-1'), post('old-2')],
+      incoming: [post('new-1')],
+      preserveOlderPages: false,
+      expectedIds: ['new-1'],
+    },
+    {
+      name: 'appends older authoritative pages after incoming when preserveOlderPages is true',
+      current: [post('old-1'), post('old-2')],
+      incoming: [post('new-1')],
+      preserveOlderPages: true,
+      expectedIds: ['new-1', 'old-1', 'old-2'],
+    },
+    {
+      name: 'keeps a pending optimistic post ahead of incoming when preserveOlderPages is false',
+      current: [post('local-1', { local_state: 'pending' }), post('old-1')],
+      incoming: [post('new-1')],
+      preserveOlderPages: false,
+      expectedIds: ['local-1', 'new-1'],
+    },
+    {
+      name: 'keeps a pending optimistic post ahead of incoming and older pages when preserveOlderPages is true',
+      current: [post('local-1', { local_state: 'pending' }), post('old-1')],
+      incoming: [post('new-1')],
+      preserveOlderPages: true,
+      expectedIds: ['local-1', 'new-1', 'old-1'],
+    },
+    {
+      name: 'drops an optimistic post whose server_object_id is echoed by incoming',
+      current: [
+        post('local-2', { local_state: 'syncing', server_object_id: 'server-2' }),
+        post('old-1'),
+      ],
+      incoming: [post('server-2')],
+      preserveOlderPages: false,
+      expectedIds: ['server-2'],
+    },
+    {
+      name: 'keeps an optimistic post whose server_object_id is not echoed by incoming',
+      current: [post('local-2', { local_state: 'syncing', server_object_id: 'server-9' })],
+      incoming: [post('new-1')],
+      preserveOlderPages: false,
+      expectedIds: ['local-2', 'new-1'],
+    },
+    {
+      name: 'does not duplicate an older page already present in incoming when preserveOlderPages is true',
+      current: [post('server-2'), post('old-1')],
+      incoming: [post('server-2', { created_at: 999 })],
+      preserveOlderPages: true,
+      expectedIds: ['server-2', 'old-1'],
+    },
+    {
+      name: 'matches older pages against incoming via server_object_id when preserveOlderPages is true',
+      current: [post('page-1', { server_object_id: 'server-3' })],
+      incoming: [post('server-3')],
+      preserveOlderPages: true,
+      expectedIds: ['server-3'],
+    },
+  ];
+
+  test.each(cases)('$name', ({ current, incoming, preserveOlderPages, expectedIds }) => {
+    expect(ids(mergeRefreshedVisiblePosts(current, incoming, preserveOlderPages))).toEqual(
+      expectedIds
+    );
+  });
+
+  test('replaces the optimistic instance with the authoritative incoming instance', () => {
+    const optimistic = post('local-2', {
+      created_at: 111,
+      local_state: 'syncing',
+      server_object_id: 'server-2',
+    });
+    const authoritative = post('server-2', { created_at: 999 });
+
+    const result = mergeRefreshedVisiblePosts([optimistic], [authoritative], false);
+
+    expect(ids(result)).toEqual(['server-2']);
+    // 生き残るのは incoming 側のインスタンス。
+    expect(result[0]?.created_at).toBe(999);
+  });
+
+  test('prefers the incoming instance when the same id exists in current and incoming', () => {
+    const result = mergeRefreshedVisiblePosts(
+      [post('server-2', { created_at: 111 }), post('old-1')],
+      [post('server-2', { created_at: 999 })],
+      true
+    );
+
+    expect(ids(result)).toEqual(['server-2', 'old-1']);
+    expect(result[0]?.created_at).toBe(999);
+  });
+
+  test('dedupes duplicate identities within incoming keeping the first', () => {
+    const result = mergeRefreshedVisiblePosts(
+      [],
+      [post('new-1', { created_at: 111 }), post('new-1', { created_at: 222 }), post('new-2')],
+      false
+    );
+
+    expect(ids(result)).toEqual(['new-1', 'new-2']);
+    expect(result[0]?.created_at).toBe(111);
+  });
+});

--- a/apps/desktop/src/shell/routes.unit.test.ts
+++ b/apps/desktop/src/shell/routes.unit.test.ts
@@ -1,0 +1,342 @@
+/**
+ * WP-S5: routes.ts 関数単位の characterization テスト。
+ *
+ * 後続 WP-H6(shell の store スライス化・selector 化・prop drilling 除去)の
+ * 安全網として「観測した現挙動」をそのまま固定する。このテストが落ちた場合に
+ * 疑うべきは直近の変更でありテストではない。期待値は生リテラルで書き、
+ * 実装側の定数・関数から期待値を生成しない。
+ *
+ * URL 復元シナリオ(App 統合)は既存 routes.test.tsx に任せ、ここでは
+ * 関数入出力のみを固定する。
+ */
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  buildShellUrl,
+  isProfileConnectionsView,
+  isSettingsSection,
+  parseHashRouteLocation,
+  parseLegacyRequestedChannel,
+  parsePrimarySectionPath,
+  type BuildShellUrlOptions,
+} from './routes';
+
+// 各テストを独立させる(setup.ts は hash を掃除しない)。
+beforeEach(() => {
+  window.history.replaceState(null, '', '/');
+});
+
+describe('isSettingsSection', () => {
+  test.each([
+    'about',
+    'appearance',
+    'connectivity',
+    'discovery',
+    'community-node',
+    'reactions',
+    'release',
+  ])('returns true for "%s"', (value) => {
+    expect(isSettingsSection(value)).toBe(true);
+  });
+
+  test.each([null, '', 'settings', 'About', 'community_node'])(
+    'returns false for %j',
+    (value) => {
+      expect(isSettingsSection(value)).toBe(false);
+    }
+  );
+});
+
+describe('isProfileConnectionsView', () => {
+  test.each(['following', 'followed', 'muted'])('returns true for "%s"', (value) => {
+    expect(isProfileConnectionsView(value)).toBe(true);
+  });
+
+  test.each([null, '', 'follower', 'Following'])('returns false for %j', (value) => {
+    expect(isProfileConnectionsView(value)).toBe(false);
+  });
+});
+
+describe('parsePrimarySectionPath', () => {
+  const cases: Array<{ name: string; pathname: string; expected: string | null }> = [
+    { name: 'normalizes "/" to the timeline section', pathname: '/', expected: 'timeline' },
+    { name: 'resolves /timeline', pathname: '/timeline', expected: 'timeline' },
+    { name: 'resolves /live', pathname: '/live', expected: 'live' },
+    { name: 'resolves /game', pathname: '/game', expected: 'game' },
+    { name: 'resolves /messages', pathname: '/messages', expected: 'messages' },
+    { name: 'resolves /profile', pathname: '/profile', expected: 'profile' },
+    { name: 'resolves /notifications', pathname: '/notifications', expected: 'notifications' },
+    { name: 'returns null for the excluded /channels path', pathname: '/channels', expected: null },
+    { name: 'returns null for an unknown path', pathname: '/unknown', expected: null },
+    { name: 'does not normalize a trailing slash', pathname: '/timeline/', expected: null },
+    { name: 'returns null without a leading slash', pathname: 'timeline', expected: null },
+  ];
+
+  test.each(cases)('$name', ({ pathname, expected }) => {
+    expect(parsePrimarySectionPath(pathname)).toBe(expected);
+  });
+});
+
+describe('parseHashRouteLocation', () => {
+  const cases: Array<{
+    name: string;
+    hash: string;
+    expected: { pathname: string; search: string };
+  }> = [
+    {
+      name: 'returns the root location for an empty hash',
+      hash: '',
+      expected: { pathname: '/', search: '' },
+    },
+    {
+      name: 'returns the root location for a bare "#"',
+      hash: '#',
+      expected: { pathname: '/', search: '' },
+    },
+    {
+      name: 'parses a hash with a pathname only',
+      hash: '#/timeline',
+      expected: { pathname: '/timeline', search: '' },
+    },
+    {
+      name: 'splits pathname and query at the first "?"',
+      hash: '#/timeline?topic=kukuri%3Atopic%3Ademo&settings=about',
+      expected: {
+        pathname: '/timeline',
+        search: '?topic=kukuri%3Atopic%3Ademo&settings=about',
+      },
+    },
+    {
+      name: 'accepts a hash without the leading "#"',
+      hash: '/messages?peerPubkey=peer-1',
+      expected: { pathname: '/messages', search: '?peerPubkey=peer-1' },
+    },
+    {
+      name: 'falls back to the root pathname when the hash starts with a query',
+      hash: '#?settings=about',
+      expected: { pathname: '/', search: '?settings=about' },
+    },
+    {
+      name: 'preserves a trailing empty query marker',
+      hash: '#/messages?',
+      expected: { pathname: '/messages', search: '?' },
+    },
+  ];
+
+  test.each(cases)('$name', ({ hash, expected }) => {
+    expect(parseHashRouteLocation(hash)).toEqual(expected);
+  });
+});
+
+describe('parseLegacyRequestedChannel', () => {
+  // 引数順は (timelineScope, composeTarget)。compose target 側が優先される。
+  const cases: Array<{
+    name: string;
+    scope: string | null;
+    compose: string | null;
+    expected: string | null;
+  }> = [
+    {
+      name: 'returns null when both values are null',
+      scope: null,
+      compose: null,
+      expected: null,
+    },
+    {
+      name: 'prefers the compose target channel over the timeline scope channel',
+      scope: 'channel:scope-channel',
+      compose: 'channel:compose-channel',
+      expected: 'compose-channel',
+    },
+    {
+      name: 'reads the channel from the timeline scope when the compose target is null',
+      scope: 'channel:scope-channel',
+      compose: null,
+      expected: 'scope-channel',
+    },
+    {
+      name: 'reads the channel from the compose target when the timeline scope is null',
+      scope: null,
+      compose: 'channel:compose-channel',
+      expected: 'compose-channel',
+    },
+    {
+      name: 'falls through a non-channel compose target to the scope channel',
+      scope: 'channel:scope-channel',
+      compose: 'following',
+      expected: 'scope-channel',
+    },
+    {
+      name: 'returns null when neither value has a channel prefix',
+      scope: 'global',
+      compose: 'home',
+      expected: null,
+    },
+    {
+      // 現挙動の固定: prefix のみの値は空文字列の channel id になる。
+      name: 'returns an empty string for a bare channel prefix',
+      scope: 'channel:',
+      compose: null,
+      expected: '',
+    },
+  ];
+
+  test.each(cases)('$name', ({ scope, compose, expected }) => {
+    expect(parseLegacyRequestedChannel(scope, compose)).toBe(expected);
+  });
+});
+
+describe('buildShellUrl', () => {
+  // 全フィールド必須のため fixture でデフォルトを埋め、期待 URL は生リテラルで固定する。
+  function buildOptions(overrides: Partial<BuildShellUrlOptions> = {}): BuildShellUrlOptions {
+    return {
+      activeTopic: 'kukuri:topic:demo',
+      primarySection: 'timeline',
+      timelineView: 'feed',
+      profileMode: 'overview',
+      profileConnectionsView: 'following',
+      selectedThread: null,
+      focusedObjectId: null,
+      selectedAuthorPubkey: null,
+      selectedDirectMessagePeerPubkey: null,
+      settingsOpen: false,
+      settingsSection: 'connectivity',
+      selectedChannelId: null,
+      selectedLiveSessionId: null,
+      selectedGameRoomId: null,
+      ...overrides,
+    };
+  }
+
+  const cases: Array<{
+    name: string;
+    overrides: Partial<BuildShellUrlOptions>;
+    expected: string;
+  }> = [
+    {
+      name: 'builds the timeline url with only the encoded topic by default',
+      overrides: {},
+      expected: '/timeline?topic=kukuri%3Atopic%3Ademo',
+    },
+    {
+      name: 'includes the channel on the timeline feed view',
+      overrides: { selectedChannelId: 'channel-1' },
+      expected: '/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1',
+    },
+    {
+      name: 'drops the channel and adds timelineView on the bookmarks view',
+      overrides: { timelineView: 'bookmarks', selectedChannelId: 'channel-1' },
+      expected: '/timeline?topic=kukuri%3Atopic%3Ademo&timelineView=bookmarks',
+    },
+    {
+      name: 'includes the channel on non-timeline sections such as game',
+      overrides: { primarySection: 'game', selectedChannelId: 'channel-1' },
+      expected: '/game?topic=kukuri%3Atopic%3Ademo&channel=channel-1',
+    },
+    {
+      name: 'drops the channel and emits peer and author pubkeys on messages',
+      overrides: {
+        primarySection: 'messages',
+        selectedChannelId: 'channel-1',
+        selectedDirectMessagePeerPubkey: 'peer-1',
+        selectedAuthorPubkey: 'author-1',
+      },
+      expected: '/messages?topic=kukuri%3Atopic%3Ademo&peerPubkey=peer-1&authorPubkey=author-1',
+    },
+    {
+      name: 'suppresses the thread context on messages',
+      overrides: { primarySection: 'messages', selectedThread: 'thread-1' },
+      expected: '/messages?topic=kukuri%3Atopic%3Ademo',
+    },
+    {
+      name: 'drops channel, thread, author, and peer on notifications',
+      overrides: {
+        primarySection: 'notifications',
+        selectedChannelId: 'channel-1',
+        selectedThread: 'thread-1',
+        selectedAuthorPubkey: 'author-1',
+        selectedDirectMessagePeerPubkey: 'peer-1',
+      },
+      expected: '/notifications?topic=kukuri%3Atopic%3Ademo',
+    },
+    {
+      name: 'emits the thread context with focus and author on the timeline',
+      overrides: {
+        selectedThread: 'thread-1',
+        focusedObjectId: 'focus-1',
+        selectedAuthorPubkey: 'author-1',
+      },
+      expected:
+        '/timeline?topic=kukuri%3Atopic%3Ademo&context=thread&threadId=thread-1&focusObjectId=focus-1&authorPubkey=author-1',
+    },
+    {
+      name: 'emits the author context when only an author is selected',
+      overrides: { selectedAuthorPubkey: 'author-1' },
+      expected: '/timeline?topic=kukuri%3Atopic%3Ademo&context=author&authorPubkey=author-1',
+    },
+    {
+      name: 'combines channel and thread context on the timeline feed view',
+      overrides: { selectedChannelId: 'channel-1', selectedThread: 'thread-1' },
+      expected:
+        '/timeline?topic=kukuri%3Atopic%3Ademo&channel=channel-1&context=thread&threadId=thread-1',
+    },
+    {
+      name: 'emits profileMode=edit on the profile section',
+      overrides: { primarySection: 'profile', profileMode: 'edit' },
+      expected: '/profile?topic=kukuri%3Atopic%3Ademo&profileMode=edit',
+    },
+    {
+      name: 'emits profileMode=connections with the connections view on the profile section',
+      overrides: {
+        primarySection: 'profile',
+        profileMode: 'connections',
+        profileConnectionsView: 'muted',
+      },
+      expected: '/profile?topic=kukuri%3Atopic%3Ademo&profileMode=connections&connectionsView=muted',
+    },
+    {
+      name: 'omits profileMode for the profile overview mode',
+      overrides: { primarySection: 'profile' },
+      expected: '/profile?topic=kukuri%3Atopic%3Ademo',
+    },
+    {
+      name: 'omits profileMode outside the profile section',
+      overrides: { primarySection: 'game', profileMode: 'edit' },
+      expected: '/game?topic=kukuri%3Atopic%3Ademo',
+    },
+    {
+      name: 'emits the settings section while the settings drawer is open',
+      overrides: { settingsOpen: true, settingsSection: 'appearance' },
+      expected: '/timeline?topic=kukuri%3Atopic%3Ademo&settings=appearance',
+    },
+    {
+      name: 'omits the settings section while the settings drawer is closed',
+      overrides: { settingsOpen: false, settingsSection: 'appearance' },
+      expected: '/timeline?topic=kukuri%3Atopic%3Ademo',
+    },
+    {
+      name: 'emits sessionId only on the live section',
+      overrides: { primarySection: 'live', selectedLiveSessionId: 'session-1' },
+      expected: '/live?topic=kukuri%3Atopic%3Ademo&sessionId=session-1',
+    },
+    {
+      name: 'omits roomId on the live section',
+      overrides: { primarySection: 'live', selectedGameRoomId: 'room-1' },
+      expected: '/live?topic=kukuri%3Atopic%3Ademo',
+    },
+    {
+      name: 'emits roomId only on the game section',
+      overrides: { primarySection: 'game', selectedGameRoomId: 'room-1' },
+      expected: '/game?topic=kukuri%3Atopic%3Ademo&roomId=room-1',
+    },
+    {
+      name: 'omits sessionId on the game section',
+      overrides: { primarySection: 'game', selectedLiveSessionId: 'session-1' },
+      expected: '/game?topic=kukuri%3Atopic%3Ademo',
+    },
+  ];
+
+  test.each(cases)('$name', ({ overrides, expected }) => {
+    expect(buildShellUrl(buildOptions(overrides))).toBe(expected);
+  });
+});


### PR DESCRIPTION
## 概要
WP-S5(shell フックの characterization テスト — WP-H6 store スライス化・selector 化の安全網)の第 1 弾。純関数群を table-driven の入出力テストで固定する。

- `src/shell/data/timelineMerge.test.ts`(新規): timelineMerge.ts の全 5 関数(postIdentityKey / uniquePostsByIdentity / mergeUniquePosts / hasLoadedOlderAuthoritativePosts / mergeRefreshedVisiblePosts)。mergeRefreshedVisiblePosts は preserveOlderPages × optimistic 保持 × server_object_id 同一視の組合せ表。
- `src/shell/routes.unit.test.ts`(新規): buildShellUrl / parseHashRouteLocation / parsePrimarySectionPath / parseLegacyRequestedChannel / isSettingsSection / isProfileConnectionsView の関数単位(既存 routes.test.tsx の App 統合 15 本とは役割分離)。
- 実行 90 ケース(test.each 展開)。期待値は全て観測した現挙動の生リテラル。

固定した現挙動の quirk(バグ修正ではなく現状凍結):
- mergeUniquePosts は object_id のみで dedupe(server_object_id 同一視をしない)/ incoming 内部の重複は除去しない
- hasLoadedOlderAuthoritativePosts は incoming 側を local_state で filter しない
- parseLegacyRequestedChannel は 'channel:'(prefix のみ)で空文字列を返す

## 種別
contract

## 挙動変更
なし(プロダクションコード変更ゼロ — diff は新規テスト 2 ファイルのみ)

## 検証
- 対象ファイル vitest 3 回連続 green(90/90)
- `npx vitest run --project unit` 3 回連続 green(414 tests、並列 lane で安定)
- `cargo xtask desktop-ui-check` green(eslint / tsc / vitest 全 lane / Playwright smoke 10 本)

## リスク
- buildShellUrl はクエリパラメータの挿入順まで full-string で固定(URL は hash に永続化される契約のため意図的)。無害な順序変更でも赤くなる — その際は期待値更新で追随する。

## 後続対応
- WP-S5 T2〜T7(同時提出)

🤖 Generated with [Claude Code](https://claude.com/claude-code)