### PR TITLE
[contract] renderHook 共通ハーネス + useDesktopShellViewModels の characterization (WP-S5 T3)

### DIFF
--- a/apps/desktop/src/shell/testSupport/renderShellHook.tsx
+++ b/apps/desktop/src/shell/testSupport/renderShellHook.tsx
@@ -1,0 +1,93 @@
+/**
+ * WP-S5: shell フック characterization テスト用の renderHook 共通ハーネス。
+ *
+ * shell の大型フック(viewModels / data / actions / routing)を renderHook で
+ * 単体マウントするための store 生成 + Provider wrapper を提供する。
+ * WP-H6(store スライス化・selector 化)の安全網となるテスト群が共用する。
+ *
+ * 契約(T4-T7 が依存するため変更しないこと):
+ * - `setWindowHash(hash)` / `resetWindowHash()`: window.history.replaceState の薄いラッパ。
+ * - `createShellHookHarness({ hash, router })`:
+ *   hash 指定時は store 生成【前】に setWindowHash する。
+ *   `createInitialShellState` が window.location.hash を直読するため、この順序が契約。
+ *   `router: true` で Provider の内側に HashRouter を重ねる(useDesktopShellRouting 用。
+ *   MemoryRouter は不可 — routes.ts が window.location.hash を直読するため URL と乖離する)。
+ * - `actPatchState(store, partial)`: レンダー済みフックの外から store を書き換える時の
+ *   act ラッパ(React 19 では store 外部操作も act で包む必要がある)。
+ */
+import { act } from '@testing-library/react';
+import type { ComponentType, ReactNode } from 'react';
+import { HashRouter } from 'react-router-dom';
+
+import {
+  createDesktopShellStore,
+  DesktopShellStoreContext,
+  type DesktopShellState,
+  type DesktopShellStateValue,
+} from '@/shell/store';
+
+export type ShellHookHarnessOptions = {
+  /** '#/timeline?...' または '/timeline?...' 形式。store 生成前に window.location.hash に反映される。 */
+  hash?: string;
+  /** true で Provider の内側に HashRouter を重ねる(useDesktopShellRouting 用)。 */
+  router?: boolean;
+};
+
+export type ShellHookHarness = {
+  store: ReturnType<typeof createDesktopShellStore>;
+  wrapper: ComponentType<{ children: ReactNode }>;
+};
+
+/**
+ * window.location.hash を設定する。先頭の '#' は省略可
+ * (`setWindowHash('#/timeline?topic=x')` と `setWindowHash('/timeline?topic=x')` は等価)。
+ */
+export function setWindowHash(hash: string): void {
+  const normalized = hash.startsWith('#') ? hash : `#${hash}`;
+  window.history.replaceState(null, '', `/${normalized}`);
+}
+
+/** URL を '/'(hash なし)へ戻す。各テストの beforeEach で呼ぶこと。 */
+export function resetWindowHash(): void {
+  window.history.replaceState(null, '', '/');
+}
+
+/**
+ * shell フック用の store + wrapper を作る。
+ * hash 指定時は store 生成前に setWindowHash してから createDesktopShellStore を呼ぶ
+ * (createInitialShellState が window.location.hash から初期 state を組み立てるため)。
+ */
+export function createShellHookHarness(options?: ShellHookHarnessOptions): ShellHookHarness {
+  if (options?.hash !== undefined) {
+    setWindowHash(options.hash);
+  }
+  const store = createDesktopShellStore();
+  const withRouter = options?.router === true;
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <DesktopShellStoreContext.Provider value={store}>
+      {withRouter ? <HashRouter>{children}</HashRouter> : children}
+    </DesktopShellStoreContext.Provider>
+  );
+  return { store, wrapper };
+}
+
+/** レンダー済みフックの外から store.patchState を呼ぶための act ラッパ。 */
+export function actPatchState(
+  store: ShellHookHarness['store'],
+  partial: Partial<DesktopShellState>
+): void {
+  act(() => {
+    store.getState().patchState(partial);
+  });
+}
+
+/** 追加ヘルパ: レンダー済みフックの外から store.setField を呼ぶための act ラッパ。 */
+export function actSetField<K extends keyof DesktopShellState>(
+  store: ShellHookHarness['store'],
+  key: K,
+  value: DesktopShellStateValue<K>
+): void {
+  act(() => {
+    store.getState().setField(key, value);
+  });
+}

--- a/apps/desktop/src/shell/useDesktopShellViewModels.test.tsx
+++ b/apps/desktop/src/shell/useDesktopShellViewModels.test.tsx
@@ -1,0 +1,573 @@
+/**
+ * WP-S5: useDesktopShellViewModels の characterization テスト。
+ *
+ * 後続 WP-H6(shell store のスライス化・selector 化・prop drilling 除去)の
+ * 安全網として「現時点で観測した挙動」をそのまま固定する。
+ * このテストが落ちた場合、疑うべきは加えた変更でありテストではない。
+ *
+ * 方針:
+ * - t / translate は key をそのまま返す stub を注入し、locale リソースの変更で
+ *   割れないよう文言ではなくキー/構造で assert する。
+ * - 返り値 52 キーの全量比較・snapshot・参照同一性 assert は書かない
+ *   (H6 のリファクタで無意味に割れるため)。キー/フィールド単位の値のみ固定する。
+ */
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import type {
+  AuthorSocialView,
+  DirectMessageConversationView,
+  DirectMessageStatusView,
+  JoinedPrivateChannelView,
+  PostView,
+  TopicSyncStatus,
+} from '@/lib/api';
+import type { DesktopShellState } from '@/shell/store';
+import { useDesktopShellViewModels } from '@/shell/useDesktopShellViewModels';
+import {
+  actPatchState,
+  createShellHookHarness,
+  resetWindowHash,
+} from '@/shell/testSupport/renderShellHook';
+
+const SELF_PUBKEY = 'f'.repeat(64);
+const AUTHOR_A_PUBKEY = 'a'.repeat(64);
+const AUTHOR_B_PUBKEY = 'b'.repeat(64);
+const DM_PEER_PUBKEY = 'd'.repeat(64);
+const UNKNOWN_PEER_PUBKEY = 'e'.repeat(64);
+
+// key をそのまま返す stub。文言 assert を locale リソースから切り離す。
+const stubTranslate = (key: string) => key;
+
+function buildPost(overrides: Partial<PostView> = {}): PostView {
+  return {
+    object_id: 'post-1',
+    envelope_id: 'envelope-post-1',
+    author_pubkey: AUTHOR_A_PUBKEY,
+    author_name: null,
+    author_display_name: null,
+    following: false,
+    followed_by: false,
+    mutual: false,
+    friend_of_friend: false,
+    object_kind: 'post',
+    is_threadable: true,
+    content: 'hello world',
+    content_status: 'Available',
+    attachments: [],
+    created_at: 1,
+    reply_to: null,
+    root_id: 'post-1',
+    channel_id: null,
+    audience_label: 'Public',
+    ...overrides,
+  };
+}
+
+function buildAuthor(
+  pubkey: string,
+  overrides: Partial<AuthorSocialView> = {}
+): AuthorSocialView {
+  return {
+    author_pubkey: pubkey,
+    name: null,
+    display_name: null,
+    about: null,
+    picture: null,
+    picture_asset: null,
+    updated_at: null,
+    following: false,
+    followed_by: false,
+    mutual: false,
+    friend_of_friend: false,
+    friend_of_friend_via_pubkeys: [],
+    muted: false,
+    ...overrides,
+  };
+}
+
+function buildJoinedChannel(
+  channelId: string,
+  label: string,
+  overrides: Partial<JoinedPrivateChannelView> = {}
+): JoinedPrivateChannelView {
+  return {
+    topic_id: 'kukuri:topic:demo',
+    channel_id: channelId,
+    label,
+    creator_pubkey: 'c'.repeat(64),
+    owner_pubkey: 'c'.repeat(64),
+    joined_via_pubkey: null,
+    audience_kind: 'invite_only',
+    is_owner: false,
+    current_epoch_id: 'epoch-1',
+    archived_epoch_ids: [],
+    sharing_state: 'open',
+    rotation_required: false,
+    participant_count: 2,
+    stale_participant_count: 0,
+    ...overrides,
+  };
+}
+
+function buildTopicDiagnostic(
+  topic: string,
+  overrides: Partial<TopicSyncStatus> = {}
+): TopicSyncStatus {
+  return {
+    topic,
+    joined: true,
+    delivery_state: 'Live',
+    peer_count: 0,
+    connected_peers: [],
+    docs_assist_peer_ids: [],
+    configured_peer_ids: [],
+    missing_peer_ids: [],
+    active_path: 'direct_p2p',
+    rendezvous_peer_ids: [],
+    fallback_peer_ids: [],
+    last_received_at: null,
+    last_docs_activity_at: null,
+    status_detail: '',
+    last_error: null,
+    ...overrides,
+  };
+}
+
+function buildDmStatus(
+  peerPubkey: string,
+  overrides: Partial<DirectMessageStatusView> = {}
+): DirectMessageStatusView {
+  return {
+    peer_pubkey: peerPubkey,
+    dm_id: 'dm-1',
+    mutual: true,
+    send_enabled: false,
+    peer_count: 1,
+    pending_outbox_count: 2,
+    ...overrides,
+  };
+}
+
+function buildConversation(
+  peerPubkey: string,
+  overrides: Partial<DirectMessageConversationView> = {}
+): DirectMessageConversationView {
+  return {
+    dm_id: 'dm-1',
+    peer_pubkey: peerPubkey,
+    peer_name: 'dave',
+    peer_display_name: 'Dave',
+    peer_picture: null,
+    peer_picture_asset: null,
+    updated_at: 10,
+    last_message_at: null,
+    last_message_id: null,
+    last_message_preview: null,
+    status: buildDmStatus(peerPubkey),
+    ...overrides,
+  };
+}
+
+// store プリセット → renderHook → 即 assert の型。preset は現在の state を受け取り
+// patch を返す(syncStatus 等ネストの深いフィールドを spread で部分更新するため)。
+function renderViewModels(
+  preset?: (current: DesktopShellState) => Partial<DesktopShellState>
+) {
+  const harness = createShellHookHarness();
+  if (preset) {
+    harness.store.getState().patchState(preset(harness.store.getState()));
+  }
+  const rendered = renderHook(
+    () =>
+      useDesktopShellViewModels({
+        t: stubTranslate,
+        translate: stubTranslate,
+        locale: 'en',
+        theme: 'dark',
+        profileAvatarPreviewUrl: null,
+      }),
+    { wrapper: harness.wrapper }
+  );
+  return { ...rendered, store: harness.store };
+}
+
+beforeEach(() => {
+  resetWindowHash();
+});
+
+describe('useDesktopShellViewModels', () => {
+  test('builds an image post card whose media state follows mediaObjectUrls availability', () => {
+    const imageHash = '1'.repeat(64);
+    const post = buildPost({
+      object_id: 'image-post-1',
+      root_id: 'image-post-1',
+      attachments: [
+        {
+          hash: imageHash,
+          mime: 'image/png',
+          bytes: 2048,
+          role: 'image_original',
+          status: 'Missing',
+        },
+        // primary image でも video 系でもない添付は extraAttachmentCount に数えられる
+        {
+          hash: '2'.repeat(64),
+          mime: 'application/pdf',
+          bytes: 512,
+          role: 'document',
+          status: 'Missing',
+        },
+      ],
+    });
+    const view = renderViewModels(() => ({
+      // 既定の activeTopic='kukuri:topic:demo' + public scope の storage key
+      timelinesByKey: { 'kukuri:topic:demo::public': [post] },
+    }));
+
+    const card = view.result.current.activeTimelinePostViews[0];
+    expect(view.result.current.activeTimelinePostViews).toHaveLength(1);
+    expect(card.media.kind).toBe('image');
+    // object url 未取得の間は loading / preview なし
+    expect(card.media.state).toBe('loading');
+    expect(card.media.imagePreviewSrc).toBeNull();
+    expect(card.media.extraAttachmentCount).toBe(1);
+    expect(card.media.metaMime).toBe('image/png');
+    // gallery は image mime のみ(video_poster 以外)。src は object url 未取得なら null
+    expect(card.media.imageGalleryItems).toEqual([
+      { hash: imageHash, src: null, mime: 'image/png' },
+    ]);
+    expect(card.media.currentImageIndex).toBe(0);
+
+    actPatchState(view.store, {
+      mediaObjectUrls: { [imageHash]: 'blob:image-preview-1' },
+    });
+
+    const readyCard = view.result.current.activeTimelinePostViews[0];
+    expect(readyCard.media.state).toBe('ready');
+    expect(readyCard.media.imagePreviewSrc).toBe('blob:image-preview-1');
+    expect(readyCard.media.imageGalleryItems).toEqual([
+      { hash: imageHash, src: 'blob:image-preview-1', mime: 'image/png' },
+    ]);
+
+    view.unmount();
+  });
+
+  test('re-targets thread navigation of a non-quote repost to the repost source', () => {
+    const repostOfBase = {
+      source_object_id: 'source-post-1',
+      source_topic_id: 'kukuri:topic:source',
+      source_author_pubkey: AUTHOR_B_PUBKEY,
+      source_author_name: 'bob',
+      source_author_display_name: 'Bob Display',
+      source_author_picture: null,
+      source_author_picture_asset: null,
+      source_object_kind: 'post',
+      content: 'original content',
+      attachments: [],
+      reply_to: null,
+      root_id: 'source-root-1',
+    };
+    const repostWithRoot = buildPost({
+      object_id: 'repost-1',
+      root_id: 'repost-1',
+      object_kind: 'repost',
+      repost_commentary: null,
+      // 実 API が is_threadable を省略した場合の fallback 分岐
+      // (non-quote repost は canReply=false)を固定する
+      is_threadable: undefined as unknown as boolean,
+      content: '',
+      repost_of: { ...repostOfBase },
+    });
+    const repostWithoutRoot = buildPost({
+      object_id: 'repost-2',
+      root_id: 'repost-2',
+      object_kind: 'repost',
+      repost_commentary: null,
+      // wire 実態の直値 false(fallback を経ない分岐)も固定する
+      is_threadable: false,
+      content: '',
+      repost_of: { ...repostOfBase, root_id: null },
+    });
+    const quoteRepost = buildPost({
+      object_id: 'repost-3',
+      root_id: null,
+      object_kind: 'repost',
+      repost_commentary: 'my take',
+      is_threadable: undefined as unknown as boolean,
+      content: 'my take',
+      repost_of: { ...repostOfBase },
+    });
+    const view = renderViewModels(() => ({
+      timelinesByKey: {
+        'kukuri:topic:demo::public': [repostWithRoot, repostWithoutRoot, quoteRepost],
+      },
+      // repost_of に picture が無い場合は knownAuthors から解決される
+      knownAuthorsByPubkey: {
+        [AUTHOR_B_PUBKEY]: buildAuthor(AUTHOR_B_PUBKEY, {
+          picture: 'https://example.com/bob.png',
+        }),
+      },
+    }));
+
+    const [withRootCard, withoutRootCard, quoteCard] =
+      view.result.current.activeTimelinePostViews;
+    // non-quote repost: thread 遷移先は repost_of.root_id、topic は source_topic_id
+    expect(withRootCard.threadTargetId).toBe('source-root-1');
+    expect(withRootCard.threadTopicId).toBe('kukuri:topic:source');
+    expect(withRootCard.canReply).toBe(false);
+    expect(withRootCard.canRepost).toBe(false);
+    expect(withRootCard.repostSourceAuthor).toEqual({
+      pubkey: AUTHOR_B_PUBKEY,
+      label: 'Bob Display',
+      picture: 'https://example.com/bob.png',
+    });
+    // repost_of.root_id が無い場合は source_object_id に fallback
+    expect(withoutRootCard.threadTargetId).toBe('source-post-1');
+    // is_threadable: false の直値はそのまま canReply=false になる
+    expect(withoutRootCard.canReply).toBe(false);
+    // quote repost は自分自身の thread に遷移し返信可能
+    expect(quoteCard.threadTargetId).toBe('repost-3');
+    expect(quoteCard.threadTopicId).toBeNull();
+    expect(quoteCard.canReply).toBe(true);
+
+    view.unmount();
+  });
+
+  test('builds topicNavItems from diagnostics and expands channels only for the active topic', () => {
+    const view = renderViewModels((current) => ({
+      syncStatus: {
+        ...current.syncStatus,
+        topic_diagnostics: [
+          buildTopicDiagnostic('kukuri:topic:demo', {
+            peer_count: 3,
+            connected_peers: ['peer-1', 'peer-2', 'peer-3'],
+          }),
+        ],
+        gossip_disabled_topics: ['kukuri:topic:iroh'],
+        gossip_disabled_channels: ['kukuri:topic:demo::channel-alpha'],
+      },
+      joinedChannelsByTopic: {
+        ...current.joinedChannelsByTopic,
+        'kukuri:topic:demo': [
+          buildJoinedChannel('channel-alpha', 'Alpha Channel'),
+          buildJoinedChannel('channel-beta', 'Beta Channel'),
+        ],
+        'kukuri:topic:iroh': [
+          buildJoinedChannel('channel-iroh', 'Iroh Channel', {
+            topic_id: 'kukuri:topic:iroh',
+          }),
+        ],
+      },
+      selectedChannelIdByTopic: {
+        ...current.selectedChannelIdByTopic,
+        'kukuri:topic:demo': 'channel-alpha',
+      },
+    }));
+
+    const items = view.result.current.topicNavItems;
+    // starter topics 4 件がそのまま nav item になる
+    expect(items.map((item) => item.topic)).toEqual([
+      'kukuri:topic:demo',
+      'kukuri:topic:iroh',
+      'kukuri:topic:nostr',
+      'kukuri:topic:operators',
+    ]);
+
+    const demoItem = items[0];
+    expect(demoItem.active).toBe(true);
+    // channel 選択中は public 行は非アクティブ
+    expect(demoItem.publicActive).toBe(false);
+    expect(demoItem.removable).toBe(true);
+    // delivery_state='Live' + direct_p2p → 'joined'
+    expect(demoItem.connectionLabel).toBe('joined');
+    expect(demoItem.peerCount).toBe(3);
+    expect(demoItem.gossipJoined).toBe(true);
+    // channels は activeTopic のみ展開。`topic::channel_id` が
+    // gossip_disabled_channels にあれば channel 単位で gossipJoined=false
+    expect(demoItem.channels).toEqual([
+      {
+        channelId: 'channel-alpha',
+        label: 'Alpha Channel',
+        audienceKind: 'invite_only',
+        active: true,
+        gossipJoined: false,
+      },
+      {
+        channelId: 'channel-beta',
+        label: 'Beta Channel',
+        audienceKind: 'invite_only',
+        active: false,
+        gossipJoined: true,
+      },
+    ]);
+
+    const irohItem = items[1];
+    expect(irohItem.active).toBe(false);
+    // diagnostic が無い topic は 'idle' / peerCount 0
+    expect(irohItem.connectionLabel).toBe('idle');
+    expect(irohItem.peerCount).toBe(0);
+    // gossip_disabled_topics に載っている topic は gossipJoined=false
+    expect(irohItem.gossipJoined).toBe(false);
+    // activeTopic でない topic は joinedChannels があっても展開しない
+    expect(irohItem.channels).toEqual([]);
+
+    view.unmount();
+  });
+
+  test('resolves compose channel/audience with priority repostTarget > replyTarget.channel_id > composeChannelByTopic', () => {
+    const view = renderViewModels((current) => ({
+      composeChannelByTopic: {
+        ...current.composeChannelByTopic,
+        'kukuri:topic:demo': {
+          kind: 'private_channel',
+          channel_id: 'channel-alpha',
+        },
+      },
+      joinedChannelsByTopic: {
+        ...current.joinedChannelsByTopic,
+        'kukuri:topic:demo': [buildJoinedChannel('channel-alpha', 'Alpha Channel')],
+      },
+      replyTarget: buildPost({
+        object_id: 'reply-target-1',
+        channel_id: 'channel-beta',
+        audience_label: 'Beta Friends',
+      }),
+      repostTarget: buildPost({ object_id: 'repost-target-1' }),
+    }));
+
+    // 1) repostTarget が最優先: 常に public + translate('common:audience.public')
+    expect(view.result.current.activeComposeChannel).toEqual({ kind: 'public' });
+    expect(view.result.current.activeComposeAudienceLabel).toBe('common:audience.public');
+
+    // 2) repostTarget が消えると replyTarget.channel_id + replyTarget.audience_label
+    actPatchState(view.store, { repostTarget: null });
+    expect(view.result.current.activeComposeChannel).toEqual({
+      kind: 'private_channel',
+      channel_id: 'channel-beta',
+    });
+    expect(view.result.current.activeComposeAudienceLabel).toBe('Beta Friends');
+
+    // 3) どちらも無ければ composeChannelByTopic + joinedChannels の label
+    actPatchState(view.store, { replyTarget: null });
+    expect(view.result.current.activeComposeChannel).toEqual({
+      kind: 'private_channel',
+      channel_id: 'channel-alpha',
+    });
+    expect(view.result.current.activeComposeAudienceLabel).toBe('Alpha Channel');
+
+    view.unmount();
+  });
+
+  test('falls back selectedDirectMessageStatus from statusByPeer to conversation.status to null', () => {
+    const view = renderViewModels(() => ({
+      directMessages: [buildConversation(DM_PEER_PUBKEY)],
+      selectedDirectMessagePeerPubkey: DM_PEER_PUBKEY,
+    }));
+
+    // statusByPeer 未取得の間は conversation.status
+    expect(view.result.current.selectedDirectMessageConversation?.dm_id).toBe('dm-1');
+    expect(view.result.current.selectedDirectMessageStatus?.send_enabled).toBe(false);
+    expect(view.result.current.selectedDirectMessageStatus?.pending_outbox_count).toBe(2);
+    // peer_display_name > peer_name の順で label 解決
+    expect(view.result.current.selectedDirectMessagePeerLabel).toBe('Dave');
+
+    // statusByPeer が入ると conversation.status より優先
+    actPatchState(view.store, {
+      directMessageStatusByPeer: {
+        [DM_PEER_PUBKEY]: buildDmStatus(DM_PEER_PUBKEY, {
+          send_enabled: true,
+          pending_outbox_count: 0,
+        }),
+      },
+    });
+    expect(view.result.current.selectedDirectMessageStatus?.send_enabled).toBe(true);
+    expect(view.result.current.selectedDirectMessageStatus?.pending_outbox_count).toBe(0);
+
+    // conversation が見つからない peer を選ぶと null に fallback
+    actPatchState(view.store, {
+      selectedDirectMessagePeerPubkey: UNKNOWN_PEER_PUBKEY,
+    });
+    expect(view.result.current.selectedDirectMessageConversation).toBeNull();
+    expect(view.result.current.selectedDirectMessageStatus).toBeNull();
+    expect(view.result.current.selectedDirectMessagePeerLabel).toBeNull();
+    expect(view.result.current.selectedDirectMessageTimeline).toEqual([]);
+
+    view.unmount();
+  });
+
+  test('merges mentionCandidates from following + knownAuthors excluding self and duplicates', () => {
+    const view = renderViewModels((current) => ({
+      syncStatus: {
+        ...current.syncStatus,
+        local_author_pubkey: SELF_PUBKEY,
+      },
+      socialConnections: {
+        following: [
+          buildAuthor(AUTHOR_A_PUBKEY, {
+            display_name: 'Alice',
+            about: 'alice about',
+            following: true,
+          }),
+          // 自分自身は following に居ても候補から除外される
+          buildAuthor(SELF_PUBKEY, { display_name: 'Me', following: true }),
+        ],
+        followed: [],
+        muted: [],
+      },
+      knownAuthorsByPubkey: {
+        // following と重複する author は following 側が勝つ(先勝ち)
+        [AUTHOR_A_PUBKEY]: buildAuthor(AUTHOR_A_PUBKEY, {
+          display_name: 'Alice Known',
+        }),
+        [AUTHOR_B_PUBKEY]: buildAuthor(AUTHOR_B_PUBKEY, {
+          name: 'bob',
+          picture: 'https://example.com/bob.png',
+        }),
+        [SELF_PUBKEY]: buildAuthor(SELF_PUBKEY, { display_name: 'Me' }),
+      },
+    }));
+
+    const candidates = view.result.current.mentionCandidates;
+    expect(candidates.map((candidate) => candidate.pubkey)).toEqual([
+      AUTHOR_A_PUBKEY,
+      AUTHOR_B_PUBKEY,
+    ]);
+    expect(candidates[0]).toEqual({
+      pubkey: AUTHOR_A_PUBKEY,
+      label: 'Alice',
+      displayName: 'Alice',
+      name: null,
+      about: 'alice about',
+      picture: null,
+    });
+    // display_name が無ければ name が label になる
+    expect(candidates[1]).toEqual({
+      pubkey: AUTHOR_B_PUBKEY,
+      label: 'bob',
+      displayName: null,
+      name: 'bob',
+      about: null,
+      picture: 'https://example.com/bob.png',
+    });
+
+    view.unmount();
+  });
+});
+
+describe('createShellHookHarness', () => {
+  // T4-T7 が依存するハーネス契約: hash は store 生成前に反映される
+  // (createInitialShellState が window.location.hash を直読するため)。
+  test('applies the hash option before creating the store so initial state is seeded from it', () => {
+    const harness = createShellHookHarness({
+      hash: '#/timeline?topic=kukuri%3Atopic%3Ademo&settings=appearance',
+    });
+
+    expect(window.location.hash).toBe(
+      '#/timeline?topic=kukuri%3Atopic%3Ademo&settings=appearance'
+    );
+    const state = harness.store.getState();
+    expect(state.shellChromeState.activeSettingsSection).toBe('appearance');
+    expect(state.shellChromeState.settingsOpen).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要
WP-S5 第 3 弾。shell フック単体テストの共通ハーネスを新設し、最大の純変換フック useDesktopShellViewModels(1138 行、返り値 52 キー)の代表挙動を固定する。

- `src/shell/testSupport/renderShellHook.tsx`(新規 93 行): createShellHookHarness(store 生成 + DesktopShellStoreContext.Provider、router: true で HashRouter を内側に重ねる)/ setWindowHash / resetWindowHash / actPatchState / actSetField。hash オプションは store 生成【前】に反映(createInitialShellState が window.location.hash を直読するため順序が契約 — テストでも固定)。
- `src/shell/useDesktopShellViewModels.test.tsx`(新規、7 テスト): (1) image 添付の media state=ready/loading と extraAttachmentCount (2) non-quote repost の threadTargetId 付け替えと canReply=false(wire 直値 false と fallback 分岐の両方) (3) topicNavItems の診断合成と activeTopic のみの channel 展開 (4) compose 優先順位 repostTarget > replyTarget.channel_id > composeChannelByTopic (5) selectedDirectMessageStatus のフォールバック連鎖 (6) mentionCandidates の合成と自分・重複除外。
- t/translate は key を返す stub(文言でなくキー/構造で assert — locale リソース変更で割れない)。52 キー全量比較・参照同一性 assert はなし(H6 耐性方針)。

**T4〜T7 はこのハーネスに依存(base を本ブランチにした stacked PR)。本 PR を先にマージしてください。**

## 種別
contract

## 挙動変更
なし(プロダクションコード変更ゼロ。export 追加なし — 必要シンボルは全て既存 export)

## 検証
- 対象ファイル vitest 3 回連続 green
- `npx vitest run --project unit` 3 回連続 green + `cargo xtask desktop-ui-check` green

## リスク
- ハーネス API は T4〜T7 と共有 — 変更時は 5 ファイルに波及する(意図的な集約)。

## 後続対応
- T4〜T7(本 PR に stack、同時提出)

🤖 Generated with [Claude Code](https://claude.com/claude-code)