### PR TITLE
[contract] useRouteSynchronization / useSyncRoute の characterization (WP-S5 T5)

### DIFF
--- a/apps/desktop/src/shell/routing/useRouteSynchronization.test.tsx
+++ b/apps/desktop/src/shell/routing/useRouteSynchronization.test.tsx
@@ -1,0 +1,487 @@
+/**
+ * WP-S5: routing/useRouteSynchronization の characterization テスト。
+ *
+ * 後続 WP-H6(shell store のスライス化・selector 化・prop drilling 除去)の
+ * 安全網として「現時点で観測した挙動」をそのまま固定する。
+ * このテストが落ちた場合、疑うべきは加えた変更でありテストではない。
+ *
+ * 方針:
+ * - 全 13 依存が引数注入のため wrapper 不要。navigate / openThread / openAuthorDetail /
+ *   openDirectMessagePane / syncRoute / loadTopics は vi.fn、scheduleAnimationFrame は
+ *   即時実行 stub を注入する。normalize の rAF 連鎖は syncRoute / navigate を vi.fn に
+ *   することで断つ(実 navigate は渡さない)。
+ * - state は手渡しスナップショットであり、effect 内の setField では自動再レンダー
+ *   されない。そのため「route 変化 1 回分の 1 ステップ挙動」を 1 テストで固定し、
+ *   多段遷移は rerender で次のスナップショットを渡して観測する。
+ * - 固定するのは注入コールバックの呼び出し引数(toHaveBeenCalledWith)と store の
+ *   状態遷移(キー/フィールド単位)のみ。返り値やオブジェクト全量の snapshot・
+ *   参照同一性は assert しない(H6 のリファクタで無意味に割れるため)。
+ */
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { JoinedPrivateChannelView, PostView } from '@/lib/api';
+import { useRouteSynchronization } from '@/shell/routing/useRouteSynchronization';
+import { createDesktopShellStore, type DesktopShellStoreApi } from '@/shell/store';
+import { resetWindowHash } from '@/shell/testSupport/renderShellHook';
+
+const DM_PEER_PUBKEY = 'd'.repeat(64);
+
+type RouteSynchronizationArgs = Parameters<typeof useRouteSynchronization>[0];
+
+/**
+ * 引数一式を生成する。state は storeApi の「現時点のスナップショット」なので、
+ * store をプリセットしてから呼ぶこと(プリセット後の値が effect に渡る)。
+ */
+function createHookArgs(
+  storeApi: DesktopShellStoreApi,
+  overrides: Partial<RouteSynchronizationArgs> = {}
+): RouteSynchronizationArgs {
+  return {
+    loadTopics: vi.fn(() => Promise.resolve()),
+    lastObservedRouteUrlRef: { current: '' },
+    navigate: vi.fn(),
+    openAuthorDetail: vi.fn(() => Promise.resolve()),
+    openDirectMessagePane: vi.fn(() => Promise.resolve()),
+    openThread: vi.fn(() => Promise.resolve()),
+    pendingRouteUrlRef: { current: null },
+    resolvedRouteLocation: { pathname: '/timeline', search: '?topic=kukuri%3Atopic%3Ademo' },
+    routeSection: 'timeline',
+    scheduleAnimationFrame: (callback: () => void) => callback(),
+    state: storeApi.getState(),
+    storeApi,
+    syncRoute: vi.fn(),
+    ...overrides,
+  };
+}
+
+function buildPost(overrides: Partial<PostView> = {}): PostView {
+  return {
+    object_id: 'post-1',
+    envelope_id: 'envelope-post-1',
+    author_pubkey: 'a'.repeat(64),
+    author_name: null,
+    author_display_name: null,
+    following: false,
+    followed_by: false,
+    mutual: false,
+    friend_of_friend: false,
+    object_kind: 'post',
+    is_threadable: true,
+    content: 'hello world',
+    content_status: 'Available',
+    attachments: [],
+    created_at: 1,
+    reply_to: null,
+    root_id: 'post-1',
+    channel_id: null,
+    audience_label: 'Public',
+    ...overrides,
+  };
+}
+
+function buildJoinedChannel(
+  channelId: string,
+  label: string,
+  overrides: Partial<JoinedPrivateChannelView> = {}
+): JoinedPrivateChannelView {
+  return {
+    topic_id: 'kukuri:topic:demo',
+    channel_id: channelId,
+    label,
+    creator_pubkey: 'c'.repeat(64),
+    owner_pubkey: 'c'.repeat(64),
+    joined_via_pubkey: null,
+    audience_kind: 'invite_only',
+    is_owner: false,
+    current_epoch_id: 'epoch-1',
+    archived_epoch_ids: [],
+    sharing_state: 'open',
+    rotation_required: false,
+    participant_count: 2,
+    stale_participant_count: 0,
+    ...overrides,
+  };
+}
+
+describe('useRouteSynchronization', () => {
+  beforeEach(() => {
+    resetWindowHash();
+  });
+
+  describe('unknown pathname', () => {
+    test('redirects to /timeline preserving the search via replace navigation', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi, {
+        resolvedRouteLocation: { pathname: '/channels', search: '?topic=kukuri%3Atopic%3Ademo' },
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      expect(args.navigate).toHaveBeenCalledTimes(1);
+      expect(args.navigate).toHaveBeenCalledWith('/timeline?topic=kukuri%3Atopic%3Ademo', {
+        replace: true,
+      });
+      // リダイレクト判定より前に lastNonNotificationsRoute へ現 URL が記録される(観測挙動)
+      expect(storeApi.getState().lastNonNotificationsRoute).toBe(
+        '/channels?topic=kukuri%3Atopic%3Ademo'
+      );
+      expect(args.syncRoute).not.toHaveBeenCalled();
+      expect(args.loadTopics).not.toHaveBeenCalled();
+      view.unmount();
+    });
+  });
+
+  describe('topic param', () => {
+    test('switches activeTopic and reloads when the topic param is a tracked topic', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi, {
+        resolvedRouteLocation: { pathname: '/timeline', search: '?topic=kukuri%3Atopic%3Airoh' },
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      expect(storeApi.getState().activeTopic).toBe('kukuri:topic:iroh');
+      expect(args.loadTopics).toHaveBeenCalledTimes(1);
+      expect(args.loadTopics).toHaveBeenCalledWith(
+        ['kukuri:topic:demo', 'kukuri:topic:iroh', 'kukuri:topic:nostr', 'kukuri:topic:operators'],
+        'kukuri:topic:iroh',
+        null
+      );
+      expect(args.syncRoute).not.toHaveBeenCalled();
+      expect(args.navigate).not.toHaveBeenCalled();
+      view.unmount();
+    });
+
+    test('passes the requested threadId to loadTopics when a tracked-topic switch combines with thread context', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi, {
+        resolvedRouteLocation: {
+          pathname: '/timeline',
+          search: '?topic=kukuri%3Atopic%3Airoh&context=thread&threadId=post-9',
+        },
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      expect(storeApi.getState().activeTopic).toBe('kukuri:topic:iroh');
+      // topic 切替(shouldReload)× context=thread の複合では loadTopics の第 3 引数に
+      // requestedThreadId がそのまま渡る(useRouteSynchronization.ts L827-833)。
+      expect(args.loadTopics).toHaveBeenCalledTimes(1);
+      expect(args.loadTopics).toHaveBeenCalledWith(
+        ['kukuri:topic:demo', 'kukuri:topic:iroh', 'kukuri:topic:nostr', 'kukuri:topic:operators'],
+        'kukuri:topic:iroh',
+        'post-9'
+      );
+      // thread のオープン自体は openThread 側へ配線される(threadId が selectedThread と異なるため)。
+      expect(args.openThread).toHaveBeenCalledTimes(1);
+      expect(args.openThread).toHaveBeenCalledWith('post-9', {
+        focusObjectId: null,
+        historyMode: 'replace',
+        normalizeOnEmpty: true,
+        topic: 'kukuri:topic:iroh',
+      });
+      expect(args.syncRoute).not.toHaveBeenCalled();
+      view.unmount();
+    });
+
+    test('normalizes an untracked topic param via syncRoute replace without changing activeTopic', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi, {
+        resolvedRouteLocation: {
+          pathname: '/timeline',
+          search: '?topic=kukuri%3Atopic%3Aunknown',
+        },
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      // activeTopic は現状維持のまま、URL 側だけを replace で正規化する
+      expect(storeApi.getState().activeTopic).toBe('kukuri:topic:demo');
+      expect(args.loadTopics).not.toHaveBeenCalled();
+      expect(args.navigate).not.toHaveBeenCalled();
+      expect(args.syncRoute).toHaveBeenCalledTimes(1);
+      expect(args.syncRoute).toHaveBeenCalledWith('replace', {
+        activeTopic: 'kukuri:topic:demo',
+        composeTarget: { kind: 'public' },
+        focusedObjectId: null,
+        primarySection: 'timeline',
+        profileConnectionsView: 'following',
+        profileMode: 'overview',
+        selectedAuthorPubkey: null,
+        selectedDirectMessagePeerPubkey: null,
+        selectedGameRoomId: null,
+        selectedLiveSessionId: null,
+        selectedThread: null,
+        settingsOpen: false,
+        settingsSection: 'connectivity',
+        timelineScope: { kind: 'public' },
+        timelineView: 'feed',
+      });
+      view.unmount();
+    });
+  });
+
+  describe('channel param', () => {
+    test('normalizes the channel param to null when the channel panel is ready and the channel is not joined', () => {
+      const storeApi = createDesktopShellStore();
+      const initial = storeApi.getState();
+      storeApi.getState().patchState({
+        channelPanelStateByTopic: {
+          ...initial.channelPanelStateByTopic,
+          'kukuri:topic:demo': { status: 'ready', error: null },
+        },
+      });
+      const args = createHookArgs(storeApi, {
+        resolvedRouteLocation: {
+          pathname: '/timeline',
+          search: '?topic=kukuri%3Atopic%3Ademo&channel=chan-1',
+        },
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      // この assert は「store が書き換えられない(現状維持)」ことの確認。デフォルト値も
+      // null であり、current===next===null のため map は書かれない
+      // (useRouteSynchronization.ts L249-266)。実質的な normalize の固定は
+      // 直後の syncRoute 引数 assert が担う。
+      expect(storeApi.getState().selectedChannelIdByTopic['kukuri:topic:demo']).toBeNull();
+      expect(args.loadTopics).not.toHaveBeenCalled();
+      expect(args.syncRoute).toHaveBeenCalledTimes(1);
+      // channel は落とされ public scope / public compose target へ正規化される
+      expect(args.syncRoute).toHaveBeenCalledWith('replace', {
+        activeTopic: 'kukuri:topic:demo',
+        composeTarget: { kind: 'public' },
+        focusedObjectId: null,
+        primarySection: 'timeline',
+        profileConnectionsView: 'following',
+        profileMode: 'overview',
+        selectedAuthorPubkey: null,
+        selectedDirectMessagePeerPubkey: null,
+        selectedGameRoomId: null,
+        selectedLiveSessionId: null,
+        selectedThread: null,
+        settingsOpen: false,
+        settingsSection: 'connectivity',
+        timelineScope: { kind: 'public' },
+        timelineView: 'feed',
+      });
+      view.unmount();
+    });
+
+    test('keeps the channel param pending while the channel panel is not ready yet', () => {
+      // channelPanelStateByTopic はデフォルトで status='loading'(未 ready)
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi, {
+        resolvedRouteLocation: {
+          pathname: '/timeline',
+          search: '?topic=kukuri%3Atopic%3Ademo&channel=chan-1',
+        },
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      // pending validation 中は store も URL も書き換えない(channel は保持される)
+      expect(args.syncRoute).not.toHaveBeenCalled();
+      expect(args.navigate).not.toHaveBeenCalled();
+      expect(args.loadTopics).not.toHaveBeenCalled();
+      expect(storeApi.getState().selectedChannelIdByTopic['kukuri:topic:demo']).toBeNull();
+      expect(storeApi.getState().timelineScopeByTopic['kukuri:topic:demo']).toEqual({
+        kind: 'public',
+      });
+      view.unmount();
+    });
+
+    test('adopts a joined channel param into selection, scope and compose target then reloads', () => {
+      const storeApi = createDesktopShellStore();
+      const initial = storeApi.getState();
+      storeApi.getState().patchState({
+        channelPanelStateByTopic: {
+          ...initial.channelPanelStateByTopic,
+          'kukuri:topic:demo': { status: 'ready', error: null },
+        },
+        joinedChannelsByTopic: {
+          ...initial.joinedChannelsByTopic,
+          'kukuri:topic:demo': [buildJoinedChannel('chan-1', 'General')],
+        },
+      });
+      const args = createHookArgs(storeApi, {
+        resolvedRouteLocation: {
+          pathname: '/timeline',
+          search: '?topic=kukuri%3Atopic%3Ademo&channel=chan-1',
+        },
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      const state = storeApi.getState();
+      expect(state.selectedChannelIdByTopic['kukuri:topic:demo']).toBe('chan-1');
+      expect(state.timelineScopeByTopic['kukuri:topic:demo']).toEqual({
+        kind: 'channel',
+        channel_id: 'chan-1',
+      });
+      expect(state.composeChannelByTopic['kukuri:topic:demo']).toEqual({
+        kind: 'private_channel',
+        channel_id: 'chan-1',
+      });
+      expect(args.loadTopics).toHaveBeenCalledTimes(1);
+      expect(args.loadTopics).toHaveBeenCalledWith(
+        ['kukuri:topic:demo', 'kukuri:topic:iroh', 'kukuri:topic:nostr', 'kukuri:topic:operators'],
+        'kukuri:topic:demo',
+        null
+      );
+      expect(args.syncRoute).not.toHaveBeenCalled();
+      view.unmount();
+    });
+  });
+
+  describe('thread context', () => {
+    test('opens the thread once when threadId differs and does not re-open after the snapshot catches up', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi, {
+        resolvedRouteLocation: {
+          pathname: '/timeline',
+          search: '?topic=kukuri%3Atopic%3Ademo&context=thread&threadId=post-1',
+        },
+      });
+
+      const view = renderHook(
+        (props: RouteSynchronizationArgs) => useRouteSynchronization(props),
+        { initialProps: args }
+      );
+
+      expect(args.openThread).toHaveBeenCalledTimes(1);
+      expect(args.openThread).toHaveBeenCalledWith('post-1', {
+        focusObjectId: null,
+        historyMode: 'replace',
+        normalizeOnEmpty: true,
+        topic: 'kukuri:topic:demo',
+      });
+      expect(args.syncRoute).not.toHaveBeenCalled();
+
+      // openThread 完了相当の store 更新を模し、次のスナップショットで effect を再実行する
+      act(() => {
+        storeApi.getState().patchState({
+          selectedThread: 'post-1',
+          thread: [buildPost({ object_id: 'post-1' })],
+        });
+      });
+      view.rerender({ ...args, state: storeApi.getState() });
+
+      // threadId が selectedThread と一致し thread が読み込み済みなら再オープンしない
+      expect(args.openThread).toHaveBeenCalledTimes(1);
+      expect(args.syncRoute).not.toHaveBeenCalled();
+      view.unmount();
+    });
+  });
+
+  describe('messages peerPubkey', () => {
+    test('opens the direct message pane for a hex64 peerPubkey on the messages section', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi, {
+        resolvedRouteLocation: {
+          pathname: '/messages',
+          search: `?topic=kukuri%3Atopic%3Ademo&peerPubkey=${DM_PEER_PUBKEY}`,
+        },
+        routeSection: 'messages',
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      expect(storeApi.getState().directMessagePaneOpen).toBe(true);
+      expect(args.openDirectMessagePane).toHaveBeenCalledTimes(1);
+      expect(args.openDirectMessagePane).toHaveBeenCalledWith(DM_PEER_PUBKEY, {
+        historyMode: 'replace',
+        normalizeOnError: true,
+        preserveAuthorPane: false,
+        preservedAuthorPubkey: null,
+      });
+      expect(args.syncRoute).not.toHaveBeenCalled();
+      expect(args.navigate).not.toHaveBeenCalled();
+      view.unmount();
+    });
+
+    test('normalizes a non-hex64 peerPubkey to null without opening a conversation', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi, {
+        resolvedRouteLocation: {
+          pathname: '/messages',
+          search: '?topic=kukuri%3Atopic%3Ademo&peerPubkey=not-a-key',
+        },
+        routeSection: 'messages',
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      expect(args.openDirectMessagePane).not.toHaveBeenCalled();
+      // ペイン自体は開かれる(観測挙動)が、peer は URL から落とされる
+      expect(storeApi.getState().directMessagePaneOpen).toBe(true);
+      expect(args.syncRoute).toHaveBeenCalledTimes(1);
+      expect(args.syncRoute).toHaveBeenCalledWith('replace', {
+        activeTopic: 'kukuri:topic:demo',
+        composeTarget: { kind: 'public' },
+        focusedObjectId: null,
+        primarySection: 'messages',
+        profileConnectionsView: 'following',
+        profileMode: 'overview',
+        selectedAuthorPubkey: null,
+        selectedDirectMessagePeerPubkey: null,
+        selectedGameRoomId: null,
+        selectedLiveSessionId: null,
+        selectedThread: null,
+        settingsOpen: false,
+        settingsSection: 'connectivity',
+        timelineScope: { kind: 'public' },
+        timelineView: 'feed',
+      });
+      view.unmount();
+    });
+  });
+
+  describe('route observation gate', () => {
+    test('skips processing while a pending route url has not been observed and the route did not change', () => {
+      const storeApi = createDesktopShellStore();
+      // 未追跡 topic(本来なら normalize される URL)でも、pending 未観測なら何もしない
+      const args = createHookArgs(storeApi, {
+        lastObservedRouteUrlRef: { current: '/timeline?topic=kukuri%3Atopic%3Aunknown' },
+        pendingRouteUrlRef: { current: '/timeline?topic=kukuri%3Atopic%3Ademo' },
+        resolvedRouteLocation: {
+          pathname: '/timeline',
+          search: '?topic=kukuri%3Atopic%3Aunknown',
+        },
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      expect(args.syncRoute).not.toHaveBeenCalled();
+      expect(args.navigate).not.toHaveBeenCalled();
+      expect(args.loadTopics).not.toHaveBeenCalled();
+      expect(args.pendingRouteUrlRef.current).toBe('/timeline?topic=kukuri%3Atopic%3Ademo');
+      expect(storeApi.getState().lastNonNotificationsRoute).toBeNull();
+      view.unmount();
+    });
+
+    test('clears the pending route url and resumes processing when the route changed', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi, {
+        lastObservedRouteUrlRef: { current: '/timeline?topic=kukuri%3Atopic%3Ademo' },
+        pendingRouteUrlRef: { current: '/timeline?topic=kukuri%3Atopic%3Ademo' },
+        resolvedRouteLocation: {
+          pathname: '/timeline',
+          search: '?topic=kukuri%3Atopic%3Aunknown',
+        },
+      });
+
+      const view = renderHook(() => useRouteSynchronization(args));
+
+      expect(args.pendingRouteUrlRef.current).toBeNull();
+      expect(args.lastObservedRouteUrlRef.current).toBe('/timeline?topic=kukuri%3Atopic%3Aunknown');
+      expect(storeApi.getState().lastNonNotificationsRoute).toBe(
+        '/timeline?topic=kukuri%3Atopic%3Aunknown'
+      );
+      // 未追跡 topic の normalize が通常どおり走る
+      expect(args.syncRoute).toHaveBeenCalledTimes(1);
+      view.unmount();
+    });
+  });
+});

--- a/apps/desktop/src/shell/routing/useSyncRoute.test.tsx
+++ b/apps/desktop/src/shell/routing/useSyncRoute.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * WP-S5: routing/useSyncRoute の characterization テスト。
+ *
+ * 後続 WP-H6(shell store のスライス化・selector 化・prop drilling 除去)の
+ * 安全網として「現時点で観測した挙動」をそのまま固定する。
+ * このテストが落ちた場合、疑うべきは加えた変更でありテストではない。
+ *
+ * 方針:
+ * - 依存 4 つ(navigate / pendingRouteUrlRef / resolvedRouteLocation / storeApi)は
+ *   全て引数注入のため wrapper 不要。navigate は vi.fn を渡す。
+ * - overrides の Object.prototype.hasOwnProperty 判定(キー省略 = store の現状維持 /
+ *   null 指定 = クリア / キーを明示して undefined を渡した場合も `?? null` によりクリア扱い。
+ *   観測挙動として固定する)が適用されるのは、nullable フィールド群(selectedThread /
+ *   focusedObjectId / selectedAuthorPubkey / selectedDirectMessagePeerPubkey /
+ *   selectedLiveSessionId / selectedGameRoomId)と composeTarget / timelineScope /
+ *   settingsOpen(こちらは `?? false`)のみ(useSyncRoute.ts L38-58, L63-73)。
+ *   activeTopic / primarySection / timelineView / profileMode / profileConnectionsView /
+ *   settingsSection は素の `??` 判定で、明示 undefined はキー省略と同じ現状維持になる
+ *   (useSyncRoute.ts L29-37, L59-60)。
+ * - 生成 URL が現 URL と同一なら navigate せず pendingRouteUrlRef を null に戻し、
+ *   異なれば pendingRouteUrlRef に次 URL を記録してから navigate する。
+ * - 固定するのは navigate の呼び出し引数と pendingRouteUrlRef の値のみ。
+ */
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useSyncRoute } from '@/shell/routing/useSyncRoute';
+import { createDesktopShellStore, type DesktopShellStoreApi } from '@/shell/store';
+import { resetWindowHash } from '@/shell/testSupport/renderShellHook';
+
+type SyncRouteArgs = Parameters<typeof useSyncRoute>[0];
+
+/**
+ * 引数一式を生成する。resolvedRouteLocation の既定は search なしの '/timeline' で、
+ * buildShellUrl の出力(常に ?topic= を含む)とは一致しないため navigate が発火する。
+ */
+function createHookArgs(
+  storeApi: DesktopShellStoreApi,
+  overrides: Partial<SyncRouteArgs> = {}
+): SyncRouteArgs {
+  return {
+    navigate: vi.fn(),
+    pendingRouteUrlRef: { current: null },
+    resolvedRouteLocation: { pathname: '/timeline', search: '' },
+    storeApi,
+    ...overrides,
+  };
+}
+
+describe('useSyncRoute', () => {
+  beforeEach(() => {
+    resetWindowHash();
+  });
+
+  describe('overrides own-property semantics', () => {
+    test('keeps current store selections in the url when override keys are omitted', () => {
+      const storeApi = createDesktopShellStore();
+      storeApi.getState().patchState({ selectedThread: 'post-1', focusedObjectId: 'obj-1' });
+      const args = createHookArgs(storeApi);
+      const view = renderHook(() => useSyncRoute(args));
+
+      view.result.current('push');
+
+      expect(args.navigate).toHaveBeenCalledTimes(1);
+      expect(args.navigate).toHaveBeenCalledWith(
+        '/timeline?topic=kukuri%3Atopic%3Ademo&context=thread&threadId=post-1&focusObjectId=obj-1',
+        { replace: false }
+      );
+      expect(args.pendingRouteUrlRef.current).toBe(
+        '/timeline?topic=kukuri%3Atopic%3Ademo&context=thread&threadId=post-1&focusObjectId=obj-1'
+      );
+      view.unmount();
+    });
+
+    test('clears selections in the url when overrides pass null explicitly', () => {
+      const storeApi = createDesktopShellStore();
+      storeApi.getState().patchState({ selectedThread: 'post-1', focusedObjectId: 'obj-1' });
+      const args = createHookArgs(storeApi);
+      const view = renderHook(() => useSyncRoute(args));
+
+      view.result.current('replace', { focusedObjectId: null, selectedThread: null });
+
+      expect(args.navigate).toHaveBeenCalledTimes(1);
+      expect(args.navigate).toHaveBeenCalledWith('/timeline?topic=kukuri%3Atopic%3Ademo', {
+        replace: true,
+      });
+      view.unmount();
+    });
+
+    test('treats an explicitly-passed undefined override the same as null via hasOwnProperty', () => {
+      const storeApi = createDesktopShellStore();
+      storeApi.getState().patchState({ selectedThread: 'post-1' });
+      const args = createHookArgs(storeApi);
+      const view = renderHook(() => useSyncRoute(args));
+
+      // キーが存在する時点で hasOwnProperty は true になり、undefined ?? null → null(クリア)
+      view.result.current('replace', { selectedThread: undefined });
+
+      expect(args.navigate).toHaveBeenCalledTimes(1);
+      expect(args.navigate).toHaveBeenCalledWith('/timeline?topic=kukuri%3Atopic%3Ademo', {
+        replace: true,
+      });
+      view.unmount();
+    });
+  });
+
+  describe('url comparison and pendingRouteUrlRef', () => {
+    test('does not navigate and resets pendingRouteUrlRef to null when the built url equals the current url', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi, {
+        pendingRouteUrlRef: { current: '/timeline?topic=stale' },
+        resolvedRouteLocation: { pathname: '/timeline', search: '?topic=kukuri%3Atopic%3Ademo' },
+      });
+      const view = renderHook(() => useSyncRoute(args));
+
+      view.result.current('replace');
+
+      expect(args.navigate).not.toHaveBeenCalled();
+      expect(args.pendingRouteUrlRef.current).toBeNull();
+      view.unmount();
+    });
+
+    test('records the next url into pendingRouteUrlRef and navigates with replace by default', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi);
+      const view = renderHook(() => useSyncRoute(args));
+
+      // mode 省略時は 'replace'
+      view.result.current();
+
+      expect(args.pendingRouteUrlRef.current).toBe('/timeline?topic=kukuri%3Atopic%3Ademo');
+      expect(args.navigate).toHaveBeenCalledTimes(1);
+      expect(args.navigate).toHaveBeenCalledWith('/timeline?topic=kukuri%3Atopic%3Ademo', {
+        replace: true,
+      });
+      view.unmount();
+    });
+
+    test('navigates with replace=false when mode is push', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi);
+      const view = renderHook(() => useSyncRoute(args));
+
+      view.result.current('push');
+
+      expect(args.navigate).toHaveBeenCalledWith('/timeline?topic=kukuri%3Atopic%3Ademo', {
+        replace: false,
+      });
+      view.unmount();
+    });
+  });
+
+  describe('channel selection overrides', () => {
+    test('derives the channel param from a composeTarget override', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi);
+      const view = renderHook(() => useSyncRoute(args));
+
+      view.result.current('replace', {
+        composeTarget: { kind: 'private_channel', channel_id: 'chan-9' },
+      });
+
+      expect(args.navigate).toHaveBeenCalledWith(
+        '/timeline?topic=kukuri%3Atopic%3Ademo&channel=chan-9',
+        { replace: true }
+      );
+      view.unmount();
+    });
+
+    test('derives the channel param from a timelineScope override when composeTarget is absent', () => {
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi);
+      const view = renderHook(() => useSyncRoute(args));
+
+      view.result.current('replace', {
+        timelineScope: { kind: 'channel', channel_id: 'chan-7' },
+      });
+
+      expect(args.navigate).toHaveBeenCalledWith(
+        '/timeline?topic=kukuri%3Atopic%3Ademo&channel=chan-7',
+        { replace: true }
+      );
+      view.unmount();
+    });
+
+    test('a public composeTarget override drops the channel param even when the store has a selected channel', () => {
+      const storeApi = createDesktopShellStore();
+      const initial = storeApi.getState();
+      storeApi.getState().patchState({
+        selectedChannelIdByTopic: {
+          ...initial.selectedChannelIdByTopic,
+          'kukuri:topic:demo': 'chan-1',
+        },
+      });
+      const args = createHookArgs(storeApi);
+      const view = renderHook(() => useSyncRoute(args));
+
+      // override なしでは store の選択 channel が URL に載る
+      view.result.current('push');
+      expect(args.navigate).toHaveBeenNthCalledWith(
+        1,
+        '/timeline?topic=kukuri%3Atopic%3Ademo&channel=chan-1',
+        { replace: false }
+      );
+
+      // public composeTarget を明示すると channel が落ちる
+      view.result.current('replace', { composeTarget: { kind: 'public' } });
+      expect(args.navigate).toHaveBeenNthCalledWith(2, '/timeline?topic=kukuri%3Atopic%3Ademo', {
+        replace: true,
+      });
+      view.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## 概要
WP-S5 第 5 弾。URL→store 反映規則(H6 で最も壊しやすい暗黙契約)を固定する(21 テスト)。

- `routing/useRouteSynchronization.test.tsx`(12 テスト): 全 13 依存が引数のため wrapper 不要 — navigate / openThread / syncRoute / loadTopics は vi.fn、scheduleAnimationFrame は即時実行 stub、state は手渡しスナップショットで「route 変化 1 回分の 1 ステップ挙動」を rerender 駆動で固定。(1) 未知 pathname → /timeline へ replace (2) tracked topic 切替 + loadTopics(threadId 伝搬の複合ケース込み) (3) 未追跡 topic の normalize (4) channel param の ready/未 ready/参加済み受理 3 態 (5) thread context → openThread(historyMode:'replace', normalizeOnEmpty:true) (6) messages + hex64 → openDirectMessagePane、非 hex64 → normalize + route observation gate 2 本
- `routing/useSyncRoute.test.tsx`(9 テスト): overrides セマンティクス(キー省略=現状維持 / null=クリア / 明示 undefined=hasOwnProperty 対象フィールドではクリア)、URL 同一時は navigate せず pendingRouteUrlRef=null、channel param の composeTarget / timelineScope / public 由来の導出。

固定した現挙動: 非 hex64 peerPubkey でも directMessagePaneOpen は true になる(ペインは開き peer のみ normalize)。hasOwnProperty 判定は nullable フィールド群 + composeTarget / timelineScope / settingsOpen のみ(ヘッダコメントに正確な限定を記載)。

## マージ順の注意
base は T3 ブランチ(#452)。**#452 を先にマージ(head ブランチ削除)** → base が main に切り替わったのを確認してからマージしてください。

## 種別
contract

## 挙動変更
なし(プロダクションコード変更ゼロ — diff は新規テスト 2 ファイルのみ)

## 検証
- 対象ファイル vitest 3 回連続 green(21/21)
- `npx vitest run --project unit` 3 回連続 green + `cargo xtask desktop-ui-check` green

## リスク
- 特になし(全依存 vi.fn 注入のため実装の内部構造にはほぼ非依存。assert は呼び出し引数と store 遷移のみ)

## 後続対応
- WP-S5 T6〜T7(同時提出)

🤖 Generated with [Claude Code](https://claude.com/claude-code)