### PR TITLE
[fix] migration down の可逆性を回復(20260329 補完 + 非可逆 down 3 件修正)(WP-S6 T1)

### DIFF
--- a/crates/store/migrations/20260319010000_channel_scope_projection.down.sql
+++ b/crates/store/migrations/20260319010000_channel_scope_projection.down.sql
@@ -19,3 +19,20 @@ CREATE INDEX IF NOT EXISTS idx_object_thread_cache_topic_root_created
 DROP INDEX IF EXISTS idx_object_index_cache_topic_created;
 CREATE INDEX IF NOT EXISTS idx_object_index_cache_topic_created
     ON object_index_cache(topic_id, created_at DESC, object_id DESC);
+
+-- channel 系 index を channel_id 非参照へ戻した後に、up で追加した channel_id 列を
+-- up の逆順で DROP する(WP-S6 T1: down を真の逆操作にする)。
+ALTER TABLE live_presence_cache
+    DROP COLUMN channel_id;
+
+ALTER TABLE game_room_cache
+    DROP COLUMN channel_id;
+
+ALTER TABLE live_session_cache
+    DROP COLUMN channel_id;
+
+ALTER TABLE object_thread_cache
+    DROP COLUMN channel_id;
+
+ALTER TABLE object_index_cache
+    DROP COLUMN channel_id;

--- a/crates/store/migrations/20260329000000_profile_avatar_blob_columns.down.sql
+++ b/crates/store/migrations/20260329000000_profile_avatar_blob_columns.down.sql
@@ -1,0 +1,17 @@
+ALTER TABLE profile_cache
+    DROP COLUMN picture_bytes;
+
+ALTER TABLE profile_cache
+    DROP COLUMN picture_mime;
+
+ALTER TABLE profile_cache
+    DROP COLUMN picture_blob_hash;
+
+ALTER TABLE profiles
+    DROP COLUMN picture_bytes;
+
+ALTER TABLE profiles
+    DROP COLUMN picture_mime;
+
+ALTER TABLE profiles
+    DROP COLUMN picture_blob_hash;

--- a/crates/store/migrations/20260411000000_object_projection_attachments.down.sql
+++ b/crates/store/migrations/20260411000000_object_projection_attachments.down.sql
@@ -1,1 +1,4 @@
--- SQLite down migration is intentionally a no-op for attachments_json.
+-- 旧 down の「intentionally a no-op」を WP-S6 T1 で意図的に上書きする
+-- (production に undo 経路は無く、migration round-trip テスト成立のため)。
+ALTER TABLE object_index_cache
+    DROP COLUMN attachments_json;

--- a/crates/store/migrations/20260527000000_metaverse_game_room_columns.down.sql
+++ b/crates/store/migrations/20260527000000_metaverse_game_room_columns.down.sql
@@ -1,1 +1,7 @@
 DROP INDEX IF EXISTS idx_game_room_cache_topic_kind_updated;
+
+ALTER TABLE game_room_cache
+  DROP COLUMN metaverse_json;
+
+ALTER TABLE game_room_cache
+  DROP COLUMN room_kind;

--- a/crates/store/src/tests/migrations.rs
+++ b/crates/store/src/tests/migrations.rs
@@ -187,6 +187,179 @@ async fn connect_file_migrates_pre_metaverse_game_room_fixture() {
     assert!(latest_migration);
 }
 
+// ---------------------------------------------------------------------------
+// WP-S6 T1: migration down の可逆性を固定する characterization テスト。
+// 後続 WP-H1(ProjectionStore 分割)の安全網として、
+// (1) 全世代に up/down が embed で揃うこと、
+// (2) 全適用 → undo(0) → 再適用でスキーマと migration 記録が完全復元されること
+// を固定する。期待値は観測した現挙動の生リテラル(世代数 16 など)。
+// ---------------------------------------------------------------------------
+
+/// 全 16 世代に ReversibleUp / ReversibleDown が揃っていることを固定する(DB 不要)。
+/// down が embed されていない世代は `Migrator::undo` に黙ってスキップされ、
+/// round-trip を静かに破壊するため、ここで欠落を即検出する。
+#[tokio::test]
+async fn all_generations_have_paired_down() {
+    use sqlx::migrate::MigrationType;
+    use std::collections::BTreeMap;
+
+    // version ごとに (up あり, down あり) を集計する。
+    let mut generations: BTreeMap<i64, (bool, bool)> = BTreeMap::new();
+    for migration in STORE_MIGRATOR.iter() {
+        let entry = generations
+            .entry(migration.version)
+            .or_insert((false, false));
+        match migration.migration_type {
+            MigrationType::ReversibleUp => entry.0 = true,
+            MigrationType::ReversibleDown => entry.1 = true,
+            MigrationType::Simple => panic!(
+                "store migration {} must be a reversible up/down pair, found a simple migration",
+                migration.version
+            ),
+        }
+    }
+
+    assert_eq!(
+        generations.len(),
+        16,
+        "store migrations must cover exactly 16 generations, found versions: {:?}",
+        generations.keys().collect::<Vec<_>>()
+    );
+
+    let missing_up: Vec<i64> = generations
+        .iter()
+        .filter(|(_, (has_up, _))| !has_up)
+        .map(|(version, _)| *version)
+        .collect();
+    assert!(
+        missing_up.is_empty(),
+        "store migration generations missing an up migration: {missing_up:?}"
+    );
+
+    let missing_down: Vec<i64> = generations
+        .iter()
+        .filter(|(_, (_, has_down))| !has_down)
+        .map(|(version, _)| *version)
+        .collect();
+    assert!(
+        missing_down.is_empty(),
+        "store migration generations missing a paired down migration: {missing_down:?}"
+    );
+}
+
+/// 全適用 → undo(0) → run() の full round-trip でスキーマ(全テーブルの
+/// pragma_table_info 正規化文字列)と _sqlx_migrations の version 集合が
+/// 全適用時と一致することを固定する。down の残置列・欠落 down による
+/// up スキップをまとめて検出する。
+#[tokio::test]
+async fn full_migration_round_trip() {
+    let tempdir = tempdir().expect("tempdir");
+    let db_path = tempdir.path().join("round-trip.db");
+    let store = SqliteStore::connect_file(&db_path)
+        .await
+        .expect("initialize sqlite store");
+
+    let fully_migrated_snapshot = schema_table_snapshot(store.pool())
+        .await
+        .expect("snapshot fully migrated schema");
+
+    STORE_MIGRATOR
+        .undo(store.pool(), 0)
+        .await
+        .expect("undo all store migrations");
+
+    let remaining_tables = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+          AND name != '_sqlx_migrations'
+        ORDER BY name
+        "#,
+    )
+    .fetch_all(store.pool())
+    .await
+    .expect("list tables after undo(0)");
+    assert_eq!(
+        remaining_tables,
+        Vec::<String>::new(),
+        "undo(0) must drop every store table"
+    );
+
+    STORE_MIGRATOR
+        .run(store.pool())
+        .await
+        .expect("re-run all store migrations after undo(0)");
+
+    let replayed_snapshot = schema_table_snapshot(store.pool())
+        .await
+        .expect("snapshot schema after round trip");
+    assert_eq!(
+        replayed_snapshot, fully_migrated_snapshot,
+        "schema after undo(0) + run() must match the fully migrated schema"
+    );
+
+    let applied_versions =
+        sqlx::query_scalar::<_, i64>("SELECT version FROM _sqlx_migrations ORDER BY version")
+            .fetch_all(store.pool())
+            .await
+            .expect("list applied migration versions");
+    let mut expected_versions: Vec<i64> = STORE_MIGRATOR
+        .iter()
+        .filter(|migration| !migration.migration_type.is_down_migration())
+        .map(|migration| migration.version)
+        .collect();
+    expected_versions.sort_unstable();
+    expected_versions.dedup();
+    assert_eq!(
+        applied_versions.len(),
+        16,
+        "round trip must restore all 16 migration generations"
+    );
+    assert_eq!(applied_versions, expected_versions);
+}
+
+/// 全テーブル(_sqlx_migrations / sqlite 内部テーブル除外)の pragma_table_info を
+/// 正規化した文字列 snapshot にする。index は T2(migrations_roundtrip)の範囲。
+async fn schema_table_snapshot(pool: &sqlx::Pool<sqlx::Sqlite>) -> Result<String> {
+    let table_names = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+          AND name != '_sqlx_migrations'
+        ORDER BY name
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut snapshot = String::new();
+    for table_name in &table_names {
+        snapshot.push_str("table ");
+        snapshot.push_str(table_name);
+        snapshot.push('\n');
+        let columns = sqlx::query("SELECT * FROM pragma_table_info(?1) ORDER BY cid")
+            .bind(table_name)
+            .fetch_all(pool)
+            .await?;
+        for column in &columns {
+            let cid: i64 = column.get("cid");
+            let name: String = column.get("name");
+            let column_type: String = column.get("type");
+            let notnull: i64 = column.get("notnull");
+            let default_value: Option<String> = column.get("dflt_value");
+            let pk: i64 = column.get("pk");
+            snapshot.push_str(&format!(
+                "  column cid={cid} name={name} type={column_type} notnull={notnull} default={default_value:?} pk={pk}\n"
+            ));
+        }
+    }
+    Ok(snapshot)
+}
+
 fn fixture_applied_through(fixture: &str) -> i64 {
     fixture
         .lines()


### PR DESCRIPTION
## 概要
WP-S6(store の安全網 — WP-H1 の前提)の第 1 弾。migration down を真の逆操作にする。

- `20260329000000_profile_avatar_blob_columns.down.sql` を新規追加(profiles / profile_cache の picture_blob_hash / picture_mime / picture_bytes を DROP COLUMN ×6。参照 index/trigger/view は皆無で直接 DROP 可)
- 非可逆 down 3 件を修正(追加列を戻していなかった): 20260319010000(5 テーブルの channel_id)/ 20260411(attachments_json)/ 20260527(room_kind, metaverse_json)
- failing test 先行: 全 16 世代の up/down ペア存在テスト + full round-trip(undo(0) → run() → fresh スキーマ一致)を追加

**20260411 の「intentionally a no-op」コメントは意図的に上書き**しています(由来 PR #251 に理由の記録なし。production に undo 経路は無く、T2 の世代別 round-trip 成立に必要)。

## failing 証跡(fix 前の実測)
```
FAIL tests::migrations::all_generations_have_paired_down
  store migration generations missing a paired down migration: [20260329000000]

FAIL tests::migrations::full_migration_round_trip
  schema after undo(0) + run() must match the fully migrated schema
  → round-trip 後の profiles / profile_cache に picture_* 3 列が欠落
  原因: down 欠落 → Migrator::undo が黙ってスキップ → _sqlx_migrations に行残置 → 再 run で up スキップ
```
fix 後: kukuri-store 全 19 テストが 2 回連続 green。

補足(実測で判明): 非可逆 down 3 件は full round-trip では直接赤にならない(先行世代の DROP TABLE 等が残置列ごと消すため)。これらは T2 の世代別 stepwise round-trip が検出する。既存世代の version renumber 検出(16 個の生リテラル固定)も T2 の EXPECTED_VERSIONS が担う。

## 種別
fix(failing test 先行)

## 挙動変更
なし(**up.sql は 1 バイトも不変** — sqlx の checksum は up のみ記録・検証されるため down の追加/修正は既存ユーザ DB に影響しない。production に undo 経路なし)

## 検証
- `cargo nextest run -p kukuri-store` 19/19 green ×2、clippy -D warnings green、fmt 済み
- スタック最上段(T8)で `cargo xtask rust-test` フル green

## リスク
- down はローカル開発/テスト用途のみ(production 不使用)。DROP COLUMN はデータ破棄だが down の仕様(既存 down も大半 DROP TABLE)。

## 後続対応
- T2(世代別 round-trip + スキーマ golden)が本 PR に stack

## マージ順
**WP-S6 は 8 PR の直列スタックです。本 PR(T1)から順にマージし、各マージでブランチを削除 → 次 PR の base が main に自動で切り替わったことを確認してから次をマージしてください。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)