### PR TITLE
[contract] migration の世代別 round-trip + 全適用後スキーマ golden (WP-S6 T2)

### DIFF
--- a/crates/store/fixtures/schema/store_schema_full.txt
+++ b/crates/store/fixtures/schema/store_schema_full.txt
@@ -1,0 +1,458 @@
+table author_relationship_cache
+  column cid=0 name=local_author_pubkey type=TEXT notnull=1 default=None pk=1
+  column cid=1 name=author_pubkey type=TEXT notnull=1 default=None pk=2
+  column cid=2 name=following type=INTEGER notnull=1 default=None pk=0
+  column cid=3 name=followed_by type=INTEGER notnull=1 default=None pk=0
+  column cid=4 name=mutual type=INTEGER notnull=1 default=None pk=0
+  column cid=5 name=friend_of_friend type=INTEGER notnull=1 default=None pk=0
+  column cid=6 name=friend_of_friend_via_pubkeys_json type=TEXT notnull=1 default=None pk=0
+  column cid=7 name=derived_at type=INTEGER notnull=1 default=None pk=0
+table blob_objects
+  column cid=0 name=blob_hash type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=status type=TEXT notnull=1 default=None pk=0
+table bookmarked_custom_reactions
+  column cid=0 name=asset_id type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=owner_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=2 name=blob_hash type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=mime type=TEXT notnull=1 default=None pk=0
+  column cid=4 name=bytes type=INTEGER notnull=1 default=None pk=0
+  column cid=5 name=width type=INTEGER notnull=1 default=None pk=0
+  column cid=6 name=height type=INTEGER notnull=1 default=None pk=0
+  column cid=7 name=bookmarked_at type=INTEGER notnull=1 default=None pk=0
+  column cid=8 name=search_key type=TEXT notnull=1 default=Some("''") pk=0
+table bookmarked_posts
+  column cid=0 name=source_object_id type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=source_envelope_id type=TEXT notnull=1 default=None pk=0
+  column cid=2 name=source_replica_id type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=topic_id type=TEXT notnull=1 default=None pk=0
+  column cid=4 name=channel_id type=TEXT notnull=1 default=None pk=0
+  column cid=5 name=author_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=6 name=created_at type=INTEGER notnull=1 default=None pk=0
+  column cid=7 name=object_kind type=TEXT notnull=1 default=None pk=0
+  column cid=8 name=payload_ref_json type=TEXT notnull=1 default=None pk=0
+  column cid=9 name=content type=TEXT notnull=0 default=None pk=0
+  column cid=10 name=attachments_json type=TEXT notnull=1 default=None pk=0
+  column cid=11 name=reply_to_object_id type=TEXT notnull=0 default=None pk=0
+  column cid=12 name=root_object_id type=TEXT notnull=0 default=None pk=0
+  column cid=13 name=repost_of_json type=TEXT notnull=0 default=None pk=0
+  column cid=14 name=bookmarked_at type=INTEGER notnull=1 default=None pk=0
+table dm_conversations
+  column cid=0 name=dm_id type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=peer_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=2 name=updated_at type=INTEGER notnull=1 default=None pk=0
+  column cid=3 name=last_message_at type=INTEGER notnull=0 default=None pk=0
+  column cid=4 name=last_message_id type=TEXT notnull=0 default=None pk=0
+  column cid=5 name=last_message_preview type=TEXT notnull=0 default=None pk=0
+table dm_message_tombstones
+  column cid=0 name=dm_id type=TEXT notnull=1 default=None pk=1
+  column cid=1 name=message_id type=TEXT notnull=1 default=None pk=2
+  column cid=2 name=deleted_at type=INTEGER notnull=1 default=None pk=0
+table dm_messages
+  column cid=0 name=dm_id type=TEXT notnull=1 default=None pk=1
+  column cid=1 name=message_id type=TEXT notnull=1 default=None pk=2
+  column cid=2 name=sender_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=recipient_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=4 name=created_at type=INTEGER notnull=1 default=None pk=0
+  column cid=5 name=text type=TEXT notnull=0 default=None pk=0
+  column cid=6 name=reply_to_message_id type=TEXT notnull=0 default=None pk=0
+  column cid=7 name=attachment_manifest_json type=TEXT notnull=0 default=None pk=0
+  column cid=8 name=outgoing type=INTEGER notnull=1 default=Some("0") pk=0
+  column cid=9 name=acked_at type=INTEGER notnull=0 default=None pk=0
+table dm_outbox
+  column cid=0 name=dm_id type=TEXT notnull=1 default=None pk=1
+  column cid=1 name=message_id type=TEXT notnull=1 default=None pk=2
+  column cid=2 name=peer_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=frame_blob_hash type=TEXT notnull=1 default=None pk=0
+  column cid=4 name=created_at type=INTEGER notnull=1 default=None pk=0
+  column cid=5 name=last_attempt_at type=INTEGER notnull=0 default=None pk=0
+table download_jobs
+  column cid=0 name=blob_hash type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=status type=TEXT notnull=1 default=None pk=0
+table envelopes
+  column cid=0 name=envelope_id type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=2 name=created_at type=INTEGER notnull=1 default=None pk=0
+  column cid=3 name=kind type=TEXT notnull=1 default=None pk=0
+  column cid=4 name=content type=TEXT notnull=1 default=None pk=0
+  column cid=5 name=tags_json type=TEXT notnull=1 default=None pk=0
+  column cid=6 name=sig type=TEXT notnull=1 default=None pk=0
+table follow_edges
+  column cid=0 name=subject_pubkey type=TEXT notnull=1 default=None pk=1
+  column cid=1 name=target_pubkey type=TEXT notnull=1 default=None pk=2
+  column cid=2 name=status type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=updated_at type=INTEGER notnull=1 default=None pk=0
+  column cid=4 name=source_envelope_id type=TEXT notnull=1 default=None pk=0
+table game_room_cache
+  column cid=0 name=room_id type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=topic_id type=TEXT notnull=1 default=None pk=0
+  column cid=2 name=host_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=title type=TEXT notnull=1 default=None pk=0
+  column cid=4 name=description type=TEXT notnull=1 default=None pk=0
+  column cid=5 name=status type=TEXT notnull=1 default=None pk=0
+  column cid=6 name=phase_label type=TEXT notnull=0 default=None pk=0
+  column cid=7 name=scores_json type=TEXT notnull=1 default=None pk=0
+  column cid=8 name=updated_at type=INTEGER notnull=1 default=None pk=0
+  column cid=9 name=source_replica_id type=TEXT notnull=1 default=None pk=0
+  column cid=10 name=source_key type=TEXT notnull=1 default=None pk=0
+  column cid=11 name=manifest_blob_hash type=TEXT notnull=1 default=None pk=0
+  column cid=12 name=derived_at type=INTEGER notnull=1 default=None pk=0
+  column cid=13 name=projection_version type=INTEGER notnull=1 default=None pk=0
+  column cid=14 name=channel_id type=TEXT notnull=1 default=Some("'public'") pk=0
+  column cid=15 name=room_kind type=TEXT notnull=1 default=Some("'score_game'") pk=0
+  column cid=16 name=metaverse_json type=TEXT notnull=0 default=None pk=0
+table live_presence_cache
+  column cid=0 name=topic_id type=TEXT notnull=1 default=None pk=1
+  column cid=1 name=session_id type=TEXT notnull=1 default=None pk=2
+  column cid=2 name=author_pubkey type=TEXT notnull=1 default=None pk=3
+  column cid=3 name=expires_at type=INTEGER notnull=1 default=None pk=0
+  column cid=4 name=updated_at type=INTEGER notnull=1 default=None pk=0
+  column cid=5 name=channel_id type=TEXT notnull=1 default=Some("'public'") pk=0
+table live_session_cache
+  column cid=0 name=session_id type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=topic_id type=TEXT notnull=1 default=None pk=0
+  column cid=2 name=host_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=title type=TEXT notnull=1 default=None pk=0
+  column cid=4 name=description type=TEXT notnull=1 default=None pk=0
+  column cid=5 name=status type=TEXT notnull=1 default=None pk=0
+  column cid=6 name=started_at type=INTEGER notnull=1 default=None pk=0
+  column cid=7 name=ended_at type=INTEGER notnull=0 default=None pk=0
+  column cid=8 name=updated_at type=INTEGER notnull=1 default=None pk=0
+  column cid=9 name=source_replica_id type=TEXT notnull=1 default=None pk=0
+  column cid=10 name=source_key type=TEXT notnull=1 default=None pk=0
+  column cid=11 name=manifest_blob_hash type=TEXT notnull=1 default=None pk=0
+  column cid=12 name=derived_at type=INTEGER notnull=1 default=None pk=0
+  column cid=13 name=projection_version type=INTEGER notnull=1 default=None pk=0
+  column cid=14 name=channel_id type=TEXT notnull=1 default=Some("'public'") pk=0
+table muted_authors
+  column cid=0 name=author_pubkey type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=muted_at type=INTEGER notnull=1 default=None pk=0
+table notifications
+  column cid=0 name=notification_id type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=recipient_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=2 name=kind type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=actor_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=4 name=source_envelope_id type=TEXT notnull=0 default=None pk=0
+  column cid=5 name=source_replica_id type=TEXT notnull=0 default=None pk=0
+  column cid=6 name=topic_id type=TEXT notnull=0 default=None pk=0
+  column cid=7 name=channel_id type=TEXT notnull=0 default=None pk=0
+  column cid=8 name=object_id type=TEXT notnull=0 default=None pk=0
+  column cid=9 name=dm_id type=TEXT notnull=0 default=None pk=0
+  column cid=10 name=message_id type=TEXT notnull=0 default=None pk=0
+  column cid=11 name=preview_text type=TEXT notnull=0 default=None pk=0
+  column cid=12 name=created_at type=INTEGER notnull=1 default=None pk=0
+  column cid=13 name=received_at type=INTEGER notnull=1 default=None pk=0
+  column cid=14 name=read_at type=INTEGER notnull=0 default=None pk=0
+table object_index_cache
+  column cid=0 name=object_id type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=topic_id type=TEXT notnull=1 default=None pk=0
+  column cid=2 name=author_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=created_at type=INTEGER notnull=1 default=None pk=0
+  column cid=4 name=root_object_id type=TEXT notnull=0 default=None pk=0
+  column cid=5 name=reply_to_object_id type=TEXT notnull=0 default=None pk=0
+  column cid=6 name=payload_ref_json type=TEXT notnull=1 default=None pk=0
+  column cid=7 name=content type=TEXT notnull=0 default=None pk=0
+  column cid=8 name=source_replica_id type=TEXT notnull=1 default=None pk=0
+  column cid=9 name=source_key type=TEXT notnull=1 default=None pk=0
+  column cid=10 name=source_envelope_id type=TEXT notnull=1 default=None pk=0
+  column cid=11 name=source_blob_hash type=TEXT notnull=0 default=None pk=0
+  column cid=12 name=derived_at type=INTEGER notnull=1 default=None pk=0
+  column cid=13 name=projection_version type=INTEGER notnull=1 default=None pk=0
+  column cid=14 name=channel_id type=TEXT notnull=1 default=Some("'public'") pk=0
+  column cid=15 name=object_kind type=TEXT notnull=1 default=Some("'post'") pk=0
+  column cid=16 name=repost_of_json type=TEXT notnull=0 default=None pk=0
+  column cid=17 name=attachments_json type=TEXT notnull=1 default=Some("'[]'") pk=0
+table object_thread_cache
+  column cid=0 name=object_id type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=topic_id type=TEXT notnull=1 default=None pk=0
+  column cid=2 name=root_object_id type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=created_at type=INTEGER notnull=1 default=None pk=0
+  column cid=4 name=channel_id type=TEXT notnull=1 default=Some("'public'") pk=0
+table object_threads
+  column cid=0 name=topic_id type=TEXT notnull=1 default=None pk=0
+  column cid=1 name=object_id type=TEXT notnull=0 default=None pk=1
+  column cid=2 name=root_object_id type=TEXT notnull=1 default=None pk=0
+  column cid=3 name=reply_to_object_id type=TEXT notnull=0 default=None pk=0
+  column cid=4 name=created_at type=INTEGER notnull=1 default=None pk=0
+  fk id=0 seq=0 table=envelopes from=object_id to=Some("envelope_id") on_update=NO ACTION on_delete=NO ACTION match=NONE
+table profile_cache
+  column cid=0 name=pubkey type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=name type=TEXT notnull=0 default=None pk=0
+  column cid=2 name=display_name type=TEXT notnull=0 default=None pk=0
+  column cid=3 name=about type=TEXT notnull=0 default=None pk=0
+  column cid=4 name=picture type=TEXT notnull=0 default=None pk=0
+  column cid=5 name=updated_at type=INTEGER notnull=1 default=None pk=0
+  column cid=6 name=picture_blob_hash type=TEXT notnull=0 default=None pk=0
+  column cid=7 name=picture_mime type=TEXT notnull=0 default=None pk=0
+  column cid=8 name=picture_bytes type=INTEGER notnull=0 default=None pk=0
+table profiles
+  column cid=0 name=pubkey type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=name type=TEXT notnull=0 default=None pk=0
+  column cid=2 name=display_name type=TEXT notnull=0 default=None pk=0
+  column cid=3 name=about type=TEXT notnull=0 default=None pk=0
+  column cid=4 name=picture type=TEXT notnull=0 default=None pk=0
+  column cid=5 name=updated_at type=INTEGER notnull=1 default=None pk=0
+  column cid=6 name=picture_blob_hash type=TEXT notnull=0 default=None pk=0
+  column cid=7 name=picture_mime type=TEXT notnull=0 default=None pk=0
+  column cid=8 name=picture_bytes type=INTEGER notnull=0 default=None pk=0
+table reaction_cache
+  column cid=0 name=source_replica_id type=TEXT notnull=1 default=None pk=1
+  column cid=1 name=target_object_id type=TEXT notnull=1 default=None pk=2
+  column cid=2 name=reaction_id type=TEXT notnull=1 default=None pk=3
+  column cid=3 name=author_pubkey type=TEXT notnull=1 default=None pk=0
+  column cid=4 name=created_at type=INTEGER notnull=1 default=None pk=0
+  column cid=5 name=updated_at type=INTEGER notnull=1 default=None pk=0
+  column cid=6 name=reaction_key_kind type=TEXT notnull=1 default=None pk=0
+  column cid=7 name=normalized_reaction_key type=TEXT notnull=1 default=None pk=0
+  column cid=8 name=emoji type=TEXT notnull=0 default=None pk=0
+  column cid=9 name=custom_asset_id type=TEXT notnull=0 default=None pk=0
+  column cid=10 name=custom_asset_snapshot_json type=TEXT notnull=0 default=None pk=0
+  column cid=11 name=status type=TEXT notnull=1 default=None pk=0
+  column cid=12 name=source_key type=TEXT notnull=1 default=None pk=0
+  column cid=13 name=source_envelope_id type=TEXT notnull=1 default=None pk=0
+  column cid=14 name=derived_at type=INTEGER notnull=1 default=None pk=0
+  column cid=15 name=projection_version type=INTEGER notnull=1 default=None pk=0
+table replica_cursors
+  column cid=0 name=replica_id type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=cursor type=TEXT notnull=0 default=None pk=0
+table topic_objects
+  column cid=0 name=topic_id type=TEXT notnull=1 default=None pk=1
+  column cid=1 name=object_id type=TEXT notnull=1 default=None pk=2
+  column cid=2 name=created_at type=INTEGER notnull=1 default=None pk=0
+  fk id=0 seq=0 table=envelopes from=object_id to=Some("envelope_id") on_update=NO ACTION on_delete=NO ACTION match=NONE
+table ui_state
+  column cid=0 name=state_key type=TEXT notnull=0 default=None pk=1
+  column cid=1 name=value_json type=TEXT notnull=1 default=None pk=0
+index idx_author_relationship_cache_local_author table=author_relationship_cache unique=0 origin=c partial=0
+  key seqno=0 cid=0 name=Some("local_author_pubkey")
+  key seqno=1 cid=1 name=Some("author_pubkey")
+  sql=Some("CREATE INDEX idx_author_relationship_cache_local_author ON author_relationship_cache(local_author_pubkey, author_pubkey)")
+index idx_bookmarked_custom_reactions_bookmarked_at table=bookmarked_custom_reactions unique=0 origin=c partial=0
+  key seqno=0 cid=7 name=Some("bookmarked_at")
+  key seqno=1 cid=0 name=Some("asset_id")
+  sql=Some("CREATE INDEX idx_bookmarked_custom_reactions_bookmarked_at ON bookmarked_custom_reactions(bookmarked_at DESC, asset_id DESC)")
+index idx_bookmarked_posts_bookmarked_at table=bookmarked_posts unique=0 origin=c partial=0
+  key seqno=0 cid=14 name=Some("bookmarked_at")
+  key seqno=1 cid=0 name=Some("source_object_id")
+  sql=Some("CREATE INDEX idx_bookmarked_posts_bookmarked_at ON bookmarked_posts(bookmarked_at DESC, source_object_id DESC)")
+index idx_dm_conversations_updated_at table=dm_conversations unique=0 origin=c partial=0
+  key seqno=0 cid=2 name=Some("updated_at")
+  key seqno=1 cid=0 name=Some("dm_id")
+  sql=Some("CREATE INDEX idx_dm_conversations_updated_at ON dm_conversations(updated_at DESC, dm_id DESC)")
+index idx_dm_messages_timeline table=dm_messages unique=0 origin=c partial=0
+  key seqno=0 cid=0 name=Some("dm_id")
+  key seqno=1 cid=4 name=Some("created_at")
+  key seqno=2 cid=1 name=Some("message_id")
+  sql=Some("CREATE INDEX idx_dm_messages_timeline ON dm_messages(dm_id, created_at DESC, message_id DESC)")
+index idx_dm_outbox_created_at table=dm_outbox unique=0 origin=c partial=0
+  key seqno=0 cid=4 name=Some("created_at")
+  key seqno=1 cid=1 name=Some("message_id")
+  sql=Some("CREATE INDEX idx_dm_outbox_created_at ON dm_outbox(created_at ASC, message_id ASC)")
+index idx_dm_tombstones_dm_id table=dm_message_tombstones unique=0 origin=c partial=0
+  key seqno=0 cid=0 name=Some("dm_id")
+  key seqno=1 cid=2 name=Some("deleted_at")
+  key seqno=2 cid=1 name=Some("message_id")
+  sql=Some("CREATE INDEX idx_dm_tombstones_dm_id ON dm_message_tombstones(dm_id, deleted_at DESC, message_id DESC)")
+index idx_follow_edges_subject table=follow_edges unique=0 origin=c partial=0
+  key seqno=0 cid=0 name=Some("subject_pubkey")
+  key seqno=1 cid=3 name=Some("updated_at")
+  key seqno=2 cid=1 name=Some("target_pubkey")
+  sql=Some("CREATE INDEX idx_follow_edges_subject ON follow_edges(subject_pubkey, updated_at DESC, target_pubkey ASC)")
+index idx_follow_edges_target table=follow_edges unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("target_pubkey")
+  key seqno=1 cid=3 name=Some("updated_at")
+  key seqno=2 cid=0 name=Some("subject_pubkey")
+  sql=Some("CREATE INDEX idx_follow_edges_target ON follow_edges(target_pubkey, updated_at DESC, subject_pubkey ASC)")
+index idx_game_room_cache_topic_kind_updated table=game_room_cache unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("topic_id")
+  key seqno=1 cid=15 name=Some("room_kind")
+  key seqno=2 cid=8 name=Some("updated_at")
+  key seqno=3 cid=0 name=Some("room_id")
+  sql=Some("CREATE INDEX idx_game_room_cache_topic_kind_updated ON game_room_cache(topic_id, room_kind, updated_at DESC, room_id DESC)")
+index idx_game_room_cache_topic_updated table=game_room_cache unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("topic_id")
+  key seqno=1 cid=14 name=Some("channel_id")
+  key seqno=2 cid=8 name=Some("updated_at")
+  key seqno=3 cid=0 name=Some("room_id")
+  sql=Some("CREATE INDEX idx_game_room_cache_topic_updated ON game_room_cache(topic_id, channel_id, updated_at DESC, room_id DESC)")
+index idx_game_room_cache_topic_updated_all table=game_room_cache unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("topic_id")
+  key seqno=1 cid=8 name=Some("updated_at")
+  key seqno=2 cid=0 name=Some("room_id")
+  sql=Some("CREATE INDEX idx_game_room_cache_topic_updated_all ON game_room_cache(topic_id, updated_at DESC, room_id DESC)")
+index idx_live_presence_cache_expiry table=live_presence_cache unique=0 origin=c partial=0
+  key seqno=0 cid=3 name=Some("expires_at")
+  sql=Some("CREATE INDEX idx_live_presence_cache_expiry ON live_presence_cache(expires_at ASC)")
+index idx_live_presence_cache_identity table=live_presence_cache unique=1 origin=c partial=0
+  key seqno=0 cid=0 name=Some("topic_id")
+  key seqno=1 cid=5 name=Some("channel_id")
+  key seqno=2 cid=1 name=Some("session_id")
+  key seqno=3 cid=2 name=Some("author_pubkey")
+  sql=Some("CREATE UNIQUE INDEX idx_live_presence_cache_identity ON live_presence_cache(topic_id, channel_id, session_id, author_pubkey)")
+index idx_live_session_cache_topic_started table=live_session_cache unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("topic_id")
+  key seqno=1 cid=14 name=Some("channel_id")
+  key seqno=2 cid=6 name=Some("started_at")
+  key seqno=3 cid=0 name=Some("session_id")
+  sql=Some("CREATE INDEX idx_live_session_cache_topic_started ON live_session_cache(topic_id, channel_id, started_at DESC, session_id DESC)")
+index idx_live_session_cache_topic_started_all table=live_session_cache unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("topic_id")
+  key seqno=1 cid=6 name=Some("started_at")
+  key seqno=2 cid=0 name=Some("session_id")
+  sql=Some("CREATE INDEX idx_live_session_cache_topic_started_all ON live_session_cache(topic_id, started_at DESC, session_id DESC)")
+index idx_muted_authors_muted_at table=muted_authors unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("muted_at")
+  key seqno=1 cid=0 name=Some("author_pubkey")
+  sql=Some("CREATE INDEX idx_muted_authors_muted_at ON muted_authors(muted_at DESC, author_pubkey ASC)")
+index idx_notifications_dm_dedupe table=notifications unique=1 origin=c partial=1
+  key seqno=0 cid=1 name=Some("recipient_pubkey")
+  key seqno=1 cid=2 name=Some("kind")
+  key seqno=2 cid=9 name=Some("dm_id")
+  key seqno=3 cid=10 name=Some("message_id")
+  sql=Some("CREATE UNIQUE INDEX idx_notifications_dm_dedupe ON notifications(recipient_pubkey, kind, dm_id, message_id) WHERE dm_id IS NOT NULL AND message_id IS NOT NULL")
+index idx_notifications_docs_dedupe table=notifications unique=1 origin=c partial=1
+  key seqno=0 cid=1 name=Some("recipient_pubkey")
+  key seqno=1 cid=2 name=Some("kind")
+  key seqno=2 cid=4 name=Some("source_envelope_id")
+  sql=Some("CREATE UNIQUE INDEX idx_notifications_docs_dedupe ON notifications(recipient_pubkey, kind, source_envelope_id) WHERE source_envelope_id IS NOT NULL")
+index idx_notifications_inbox table=notifications unique=0 origin=c partial=0
+  key seqno=0 cid=13 name=Some("received_at")
+  key seqno=1 cid=0 name=Some("notification_id")
+  sql=Some("CREATE INDEX idx_notifications_inbox ON notifications(received_at DESC, notification_id DESC)")
+index idx_notifications_unread table=notifications unique=0 origin=c partial=1
+  key seqno=0 cid=13 name=Some("received_at")
+  key seqno=1 cid=0 name=Some("notification_id")
+  sql=Some("CREATE INDEX idx_notifications_unread ON notifications(received_at DESC, notification_id DESC) WHERE read_at IS NULL")
+index idx_object_index_cache_topic_created table=object_index_cache unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("topic_id")
+  key seqno=1 cid=14 name=Some("channel_id")
+  key seqno=2 cid=3 name=Some("created_at")
+  key seqno=3 cid=0 name=Some("object_id")
+  sql=Some("CREATE INDEX idx_object_index_cache_topic_created ON object_index_cache(topic_id, channel_id, created_at DESC, object_id DESC)")
+index idx_object_index_cache_topic_created_all table=object_index_cache unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("topic_id")
+  key seqno=1 cid=3 name=Some("created_at")
+  key seqno=2 cid=0 name=Some("object_id")
+  sql=Some("CREATE INDEX idx_object_index_cache_topic_created_all ON object_index_cache(topic_id, created_at DESC, object_id DESC)")
+index idx_object_thread_cache_topic_root_created table=object_thread_cache unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("topic_id")
+  key seqno=1 cid=4 name=Some("channel_id")
+  key seqno=2 cid=2 name=Some("root_object_id")
+  key seqno=3 cid=3 name=Some("created_at")
+  key seqno=4 cid=0 name=Some("object_id")
+  sql=Some("CREATE INDEX idx_object_thread_cache_topic_root_created ON object_thread_cache(topic_id, channel_id, root_object_id, created_at ASC, object_id ASC)")
+index idx_object_thread_cache_topic_root_created_all table=object_thread_cache unique=0 origin=c partial=0
+  key seqno=0 cid=1 name=Some("topic_id")
+  key seqno=1 cid=2 name=Some("root_object_id")
+  key seqno=2 cid=3 name=Some("created_at")
+  key seqno=3 cid=0 name=Some("object_id")
+  sql=Some("CREATE INDEX idx_object_thread_cache_topic_root_created_all ON object_thread_cache(topic_id, root_object_id, created_at ASC, object_id ASC)")
+index idx_object_threads_root table=object_threads unique=0 origin=c partial=0
+  key seqno=0 cid=0 name=Some("topic_id")
+  key seqno=1 cid=2 name=Some("root_object_id")
+  key seqno=2 cid=4 name=Some("created_at")
+  key seqno=3 cid=1 name=Some("object_id")
+  sql=Some("CREATE INDEX idx_object_threads_root ON object_threads (topic_id, root_object_id, created_at ASC, object_id ASC)")
+index idx_reaction_cache_author_updated_at table=reaction_cache unique=0 origin=c partial=0
+  key seqno=0 cid=3 name=Some("author_pubkey")
+  key seqno=1 cid=5 name=Some("updated_at")
+  key seqno=2 cid=2 name=Some("reaction_id")
+  sql=Some("CREATE INDEX idx_reaction_cache_author_updated_at ON reaction_cache(author_pubkey, updated_at DESC, reaction_id DESC)")
+index idx_reaction_cache_target table=reaction_cache unique=0 origin=c partial=0
+  key seqno=0 cid=0 name=Some("source_replica_id")
+  key seqno=1 cid=1 name=Some("target_object_id")
+  key seqno=2 cid=7 name=Some("normalized_reaction_key")
+  key seqno=3 cid=2 name=Some("reaction_id")
+  sql=Some("CREATE INDEX idx_reaction_cache_target ON reaction_cache(source_replica_id, target_object_id, normalized_reaction_key, reaction_id)")
+index idx_topic_objects_timeline table=topic_objects unique=0 origin=c partial=0
+  key seqno=0 cid=0 name=Some("topic_id")
+  key seqno=1 cid=2 name=Some("created_at")
+  key seqno=2 cid=1 name=Some("object_id")
+  sql=Some("CREATE INDEX idx_topic_objects_timeline ON topic_objects (topic_id, created_at DESC, object_id DESC)")
+index sqlite_autoindex_author_relationship_cache_1 table=author_relationship_cache unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("local_author_pubkey")
+  key seqno=1 cid=1 name=Some("author_pubkey")
+  sql=None
+index sqlite_autoindex_blob_objects_1 table=blob_objects unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("blob_hash")
+  sql=None
+index sqlite_autoindex_bookmarked_custom_reactions_1 table=bookmarked_custom_reactions unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("asset_id")
+  sql=None
+index sqlite_autoindex_bookmarked_posts_1 table=bookmarked_posts unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("source_object_id")
+  sql=None
+index sqlite_autoindex_dm_conversations_1 table=dm_conversations unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("dm_id")
+  sql=None
+index sqlite_autoindex_dm_conversations_2 table=dm_conversations unique=1 origin=u partial=0
+  key seqno=0 cid=1 name=Some("peer_pubkey")
+  sql=None
+index sqlite_autoindex_dm_message_tombstones_1 table=dm_message_tombstones unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("dm_id")
+  key seqno=1 cid=1 name=Some("message_id")
+  sql=None
+index sqlite_autoindex_dm_messages_1 table=dm_messages unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("dm_id")
+  key seqno=1 cid=1 name=Some("message_id")
+  sql=None
+index sqlite_autoindex_dm_outbox_1 table=dm_outbox unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("dm_id")
+  key seqno=1 cid=1 name=Some("message_id")
+  sql=None
+index sqlite_autoindex_download_jobs_1 table=download_jobs unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("blob_hash")
+  sql=None
+index sqlite_autoindex_envelopes_1 table=envelopes unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("envelope_id")
+  sql=None
+index sqlite_autoindex_follow_edges_1 table=follow_edges unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("subject_pubkey")
+  key seqno=1 cid=1 name=Some("target_pubkey")
+  sql=None
+index sqlite_autoindex_game_room_cache_1 table=game_room_cache unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("room_id")
+  sql=None
+index sqlite_autoindex_live_presence_cache_1 table=live_presence_cache unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("topic_id")
+  key seqno=1 cid=1 name=Some("session_id")
+  key seqno=2 cid=2 name=Some("author_pubkey")
+  sql=None
+index sqlite_autoindex_live_session_cache_1 table=live_session_cache unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("session_id")
+  sql=None
+index sqlite_autoindex_muted_authors_1 table=muted_authors unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("author_pubkey")
+  sql=None
+index sqlite_autoindex_notifications_1 table=notifications unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("notification_id")
+  sql=None
+index sqlite_autoindex_object_index_cache_1 table=object_index_cache unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("object_id")
+  sql=None
+index sqlite_autoindex_object_thread_cache_1 table=object_thread_cache unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("object_id")
+  sql=None
+index sqlite_autoindex_object_threads_1 table=object_threads unique=1 origin=pk partial=0
+  key seqno=0 cid=1 name=Some("object_id")
+  sql=None
+index sqlite_autoindex_profile_cache_1 table=profile_cache unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("pubkey")
+  sql=None
+index sqlite_autoindex_profiles_1 table=profiles unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("pubkey")
+  sql=None
+index sqlite_autoindex_reaction_cache_1 table=reaction_cache unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("source_replica_id")
+  key seqno=1 cid=1 name=Some("target_object_id")
+  key seqno=2 cid=2 name=Some("reaction_id")
+  sql=None
+index sqlite_autoindex_replica_cursors_1 table=replica_cursors unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("replica_id")
+  sql=None
+index sqlite_autoindex_topic_objects_1 table=topic_objects unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("topic_id")
+  key seqno=1 cid=1 name=Some("object_id")
+  sql=None
+index sqlite_autoindex_ui_state_1 table=ui_state unique=1 origin=pk partial=0
+  key seqno=0 cid=0 name=Some("state_key")
+  sql=None

--- a/crates/store/migrations/20260319010000_channel_scope_projection.down.sql
+++ b/crates/store/migrations/20260319010000_channel_scope_projection.down.sql
@@ -19,3 +19,20 @@ CREATE INDEX IF NOT EXISTS idx_object_thread_cache_topic_root_created
 DROP INDEX IF EXISTS idx_object_index_cache_topic_created;
 CREATE INDEX IF NOT EXISTS idx_object_index_cache_topic_created
     ON object_index_cache(topic_id, created_at DESC, object_id DESC);
+
+-- channel 系 index を channel_id 非参照へ戻した後に、up で追加した channel_id 列を
+-- up の逆順で DROP する(WP-S6 T1: down を真の逆操作にする)。
+ALTER TABLE live_presence_cache
+    DROP COLUMN channel_id;
+
+ALTER TABLE game_room_cache
+    DROP COLUMN channel_id;
+
+ALTER TABLE live_session_cache
+    DROP COLUMN channel_id;
+
+ALTER TABLE object_thread_cache
+    DROP COLUMN channel_id;
+
+ALTER TABLE object_index_cache
+    DROP COLUMN channel_id;

--- a/crates/store/migrations/20260329000000_profile_avatar_blob_columns.down.sql
+++ b/crates/store/migrations/20260329000000_profile_avatar_blob_columns.down.sql
@@ -1,0 +1,17 @@
+ALTER TABLE profile_cache
+    DROP COLUMN picture_bytes;
+
+ALTER TABLE profile_cache
+    DROP COLUMN picture_mime;
+
+ALTER TABLE profile_cache
+    DROP COLUMN picture_blob_hash;
+
+ALTER TABLE profiles
+    DROP COLUMN picture_bytes;
+
+ALTER TABLE profiles
+    DROP COLUMN picture_mime;
+
+ALTER TABLE profiles
+    DROP COLUMN picture_blob_hash;

--- a/crates/store/migrations/20260411000000_object_projection_attachments.down.sql
+++ b/crates/store/migrations/20260411000000_object_projection_attachments.down.sql
@@ -1,1 +1,4 @@
--- SQLite down migration is intentionally a no-op for attachments_json.
+-- 旧 down の「intentionally a no-op」を WP-S6 T1 で意図的に上書きする
+-- (production に undo 経路は無く、migration round-trip テスト成立のため)。
+ALTER TABLE object_index_cache
+    DROP COLUMN attachments_json;

--- a/crates/store/migrations/20260527000000_metaverse_game_room_columns.down.sql
+++ b/crates/store/migrations/20260527000000_metaverse_game_room_columns.down.sql
@@ -1,1 +1,7 @@
 DROP INDEX IF EXISTS idx_game_room_cache_topic_kind_updated;
+
+ALTER TABLE game_room_cache
+  DROP COLUMN metaverse_json;
+
+ALTER TABLE game_room_cache
+  DROP COLUMN room_kind;

--- a/crates/store/src/tests/migrations.rs
+++ b/crates/store/src/tests/migrations.rs
@@ -187,6 +187,179 @@ async fn connect_file_migrates_pre_metaverse_game_room_fixture() {
     assert!(latest_migration);
 }
 
+// ---------------------------------------------------------------------------
+// WP-S6 T1: migration down の可逆性を固定する characterization テスト。
+// 後続 WP-H1(ProjectionStore 分割)の安全網として、
+// (1) 全世代に up/down が embed で揃うこと、
+// (2) 全適用 → undo(0) → 再適用でスキーマと migration 記録が完全復元されること
+// を固定する。期待値は観測した現挙動の生リテラル(世代数 16 など)。
+// ---------------------------------------------------------------------------
+
+/// 全 16 世代に ReversibleUp / ReversibleDown が揃っていることを固定する(DB 不要)。
+/// down が embed されていない世代は `Migrator::undo` に黙ってスキップされ、
+/// round-trip を静かに破壊するため、ここで欠落を即検出する。
+#[tokio::test]
+async fn all_generations_have_paired_down() {
+    use sqlx::migrate::MigrationType;
+    use std::collections::BTreeMap;
+
+    // version ごとに (up あり, down あり) を集計する。
+    let mut generations: BTreeMap<i64, (bool, bool)> = BTreeMap::new();
+    for migration in STORE_MIGRATOR.iter() {
+        let entry = generations
+            .entry(migration.version)
+            .or_insert((false, false));
+        match migration.migration_type {
+            MigrationType::ReversibleUp => entry.0 = true,
+            MigrationType::ReversibleDown => entry.1 = true,
+            MigrationType::Simple => panic!(
+                "store migration {} must be a reversible up/down pair, found a simple migration",
+                migration.version
+            ),
+        }
+    }
+
+    assert_eq!(
+        generations.len(),
+        16,
+        "store migrations must cover exactly 16 generations, found versions: {:?}",
+        generations.keys().collect::<Vec<_>>()
+    );
+
+    let missing_up: Vec<i64> = generations
+        .iter()
+        .filter(|(_, (has_up, _))| !has_up)
+        .map(|(version, _)| *version)
+        .collect();
+    assert!(
+        missing_up.is_empty(),
+        "store migration generations missing an up migration: {missing_up:?}"
+    );
+
+    let missing_down: Vec<i64> = generations
+        .iter()
+        .filter(|(_, (_, has_down))| !has_down)
+        .map(|(version, _)| *version)
+        .collect();
+    assert!(
+        missing_down.is_empty(),
+        "store migration generations missing a paired down migration: {missing_down:?}"
+    );
+}
+
+/// 全適用 → undo(0) → run() の full round-trip でスキーマ(全テーブルの
+/// pragma_table_info 正規化文字列)と _sqlx_migrations の version 集合が
+/// 全適用時と一致することを固定する。down の残置列・欠落 down による
+/// up スキップをまとめて検出する。
+#[tokio::test]
+async fn full_migration_round_trip() {
+    let tempdir = tempdir().expect("tempdir");
+    let db_path = tempdir.path().join("round-trip.db");
+    let store = SqliteStore::connect_file(&db_path)
+        .await
+        .expect("initialize sqlite store");
+
+    let fully_migrated_snapshot = schema_table_snapshot(store.pool())
+        .await
+        .expect("snapshot fully migrated schema");
+
+    STORE_MIGRATOR
+        .undo(store.pool(), 0)
+        .await
+        .expect("undo all store migrations");
+
+    let remaining_tables = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+          AND name != '_sqlx_migrations'
+        ORDER BY name
+        "#,
+    )
+    .fetch_all(store.pool())
+    .await
+    .expect("list tables after undo(0)");
+    assert_eq!(
+        remaining_tables,
+        Vec::<String>::new(),
+        "undo(0) must drop every store table"
+    );
+
+    STORE_MIGRATOR
+        .run(store.pool())
+        .await
+        .expect("re-run all store migrations after undo(0)");
+
+    let replayed_snapshot = schema_table_snapshot(store.pool())
+        .await
+        .expect("snapshot schema after round trip");
+    assert_eq!(
+        replayed_snapshot, fully_migrated_snapshot,
+        "schema after undo(0) + run() must match the fully migrated schema"
+    );
+
+    let applied_versions =
+        sqlx::query_scalar::<_, i64>("SELECT version FROM _sqlx_migrations ORDER BY version")
+            .fetch_all(store.pool())
+            .await
+            .expect("list applied migration versions");
+    let mut expected_versions: Vec<i64> = STORE_MIGRATOR
+        .iter()
+        .filter(|migration| !migration.migration_type.is_down_migration())
+        .map(|migration| migration.version)
+        .collect();
+    expected_versions.sort_unstable();
+    expected_versions.dedup();
+    assert_eq!(
+        applied_versions.len(),
+        16,
+        "round trip must restore all 16 migration generations"
+    );
+    assert_eq!(applied_versions, expected_versions);
+}
+
+/// 全テーブル(_sqlx_migrations / sqlite 内部テーブル除外)の pragma_table_info を
+/// 正規化した文字列 snapshot にする。index は T2(migrations_roundtrip)の範囲。
+async fn schema_table_snapshot(pool: &sqlx::Pool<sqlx::Sqlite>) -> Result<String> {
+    let table_names = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+          AND name != '_sqlx_migrations'
+        ORDER BY name
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut snapshot = String::new();
+    for table_name in &table_names {
+        snapshot.push_str("table ");
+        snapshot.push_str(table_name);
+        snapshot.push('\n');
+        let columns = sqlx::query("SELECT * FROM pragma_table_info(?1) ORDER BY cid")
+            .bind(table_name)
+            .fetch_all(pool)
+            .await?;
+        for column in &columns {
+            let cid: i64 = column.get("cid");
+            let name: String = column.get("name");
+            let column_type: String = column.get("type");
+            let notnull: i64 = column.get("notnull");
+            let default_value: Option<String> = column.get("dflt_value");
+            let pk: i64 = column.get("pk");
+            snapshot.push_str(&format!(
+                "  column cid={cid} name={name} type={column_type} notnull={notnull} default={default_value:?} pk={pk}\n"
+            ));
+        }
+    }
+    Ok(snapshot)
+}
+
 fn fixture_applied_through(fixture: &str) -> i64 {
     fixture
         .lines()

--- a/crates/store/src/tests/migrations.rs
+++ b/crates/store/src/tests/migrations.rs
@@ -369,7 +369,13 @@ fn fixture_applied_through(fixture: &str) -> i64 {
         .expect("fixture applied_through version")
 }
 
-async fn materialize_sqlite_fixture(db_path: &std::path::Path, applied_through: i64) -> Result<()> {
+/// `applied_through` 世代までの up migration だけを適用した DB ファイルを合成する
+/// 共通ヘルパ(WP-S6 T2 の stepwise round-trip でも中間世代 DB の合成に使う)。
+/// `applied_through = 0` は「migration 未適用(_sqlx_migrations のみ)」を意味する。
+pub(crate) async fn materialize_sqlite_fixture(
+    db_path: &std::path::Path,
+    applied_through: i64,
+) -> Result<()> {
     let options = SqliteConnectOptions::from_str(&format!("sqlite://{}", db_path.display()))?
         .create_if_missing(true);
     let pool = SqlitePoolOptions::new()

--- a/crates/store/src/tests/migrations_roundtrip.rs
+++ b/crates/store/src/tests/migrations_roundtrip.rs
@@ -1,0 +1,344 @@
+//! WP-S6 T2: migration の per-generation stepwise round-trip と全適用後スキーマ golden。
+//!
+//! 後続 WP-H1(ProjectionStore 分割)の安全網。永続スキーマ(凍結境界)への
+//! 退行・意図しない変更を CI と PR diff の両方で可視化する。
+//!
+//! - stepwise round-trip: 各世代 k について
+//!   「全適用 → undo(V[k-1]) → V[k-1] まで適用した別 DB とスキーマ一致
+//!   → run() 再適用 → 全適用スキーマと一致」を全 16 世代で固定する。
+//! - schema golden: 全適用後スキーマの正規化 dump を
+//!   `crates/store/fixtures/schema/store_schema_full.txt` と比較して固定する。
+//!
+//! golden の再生成手順(スキーマ変更が本当に意図的な場合のみ):
+//!   `UPDATE_SCHEMA_GOLDEN=1 cargo nextest run -p kukuri-store fully_migrated_schema_matches_golden`
+//! を実行し、golden の diff をレビューのうえコミットする
+//! (app-api の views_wire_snapshot.rs の UPDATE_FIXTURES=1 と同じ流儀)。
+//!
+//! snapshot の正規化方針:
+//! - 生 sqlite_master の CREATE TABLE テキスト全体比較はしない
+//!   (ALTER TABLE ADD/DROP COLUMN の履歴でテキストが揺れるため)。
+//!   テーブルは pragma_table_info(name/type/notnull/dflt_value/pk、cid 順)、
+//!   index は pragma index_list / index_info の構造で比較する。
+//! - 外部キーは pragma_foreign_key_list(id/seq/参照先テーブル/from/to/
+//!   on_update/on_delete/match)を id・seq 順(決定的)で各テーブル直下に含める
+//!   (現行スキーマの FK は 20260310 up.sql の topic_objects / object_threads →
+//!   envelopes の 2 本のみ)。
+//! - CHECK 制約・VIEW・TRIGGER は現行スキーマに 1 つも存在しないため snapshot の
+//!   対象外(導入する場合はこの正規化への追加が必要)。
+//! - partial index の WHERE 句(notifications に 3 本)は pragma で取れないため、
+//!   index に限り sqlite_master.sql の空白正規化テキストを併用する。
+//! - テーブル・index は名前順ソート。_sqlx_migrations はスキーマ比較から除外し
+//!   (undo 由来 DB と materialize 由来 DB で installed_on が異なるため)、
+//!   version 集合を別 assert で固定する。
+
+use super::*;
+use anyhow::Result;
+use sqlx::Row;
+use std::path::PathBuf;
+
+use super::migrations::materialize_sqlite_fixture;
+
+/// 全 16 世代の up migration version(migrations/ ディレクトリのファイル名から
+/// 観測した生リテラル、昇順)。世代の追加・削除はここと golden の両方に現れる。
+const EXPECTED_VERSIONS: [i64; 16] = [
+    20260310000000,
+    20260312000000,
+    20260315000000,
+    20260319000000,
+    20260319010000,
+    20260328000000,
+    20260328010000,
+    20260329000000,
+    20260330000000,
+    20260330010000,
+    20260330020000,
+    20260331000000,
+    20260405000000,
+    20260411000000,
+    20260413000000,
+    20260527000000,
+];
+
+/// 各世代 k について「全適用 → undo(V[k-1]) → 中間世代スキーマと一致 →
+/// run() 再適用 → 全適用スキーマと一致」を固定する(k=0 は undo(0) = 全 revert)。
+/// 期待側の中間世代 DB は materialize_sqlite_fixture で up のみ順次適用して合成する。
+#[tokio::test]
+async fn per_generation_stepwise_round_trip() {
+    let tempdir = tempdir().expect("tempdir");
+    let db_path = tempdir.path().join("stepwise-round-trip.db");
+    let store = SqliteStore::connect_file(&db_path)
+        .await
+        .expect("initialize sqlite store");
+
+    let versions = migrator_up_versions();
+    assert_eq!(
+        versions, EXPECTED_VERSIONS,
+        "embedded store migration generations drifted from the observed 16 versions"
+    );
+
+    let full_snapshot = schema_snapshot(store.pool())
+        .await
+        .expect("snapshot fully migrated schema");
+    assert_eq!(
+        applied_migration_versions(store.pool())
+            .await
+            .expect("list applied versions after connect_file"),
+        EXPECTED_VERSIONS
+    );
+
+    for (k, version) in versions.iter().enumerate() {
+        let undo_target = if k == 0 { 0 } else { versions[k - 1] };
+        STORE_MIGRATOR
+            .undo(store.pool(), undo_target)
+            .await
+            .unwrap_or_else(|error| {
+                panic!("undo generation {version} down to {undo_target} (k={k}): {error}")
+            });
+
+        // 期待スキーマ: V[k-1] までの up だけを適用した別 DB(materialize で合成)。
+        let expected_db_path = tempdir
+            .path()
+            .join(format!("expected-through-{undo_target}.db"));
+        materialize_sqlite_fixture(&expected_db_path, undo_target)
+            .await
+            .expect("materialize expected intermediate db");
+        let expected_pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(&format!("sqlite://{}", expected_db_path.display()))
+            .await
+            .expect("open expected intermediate db");
+        let expected_snapshot = schema_snapshot(&expected_pool)
+            .await
+            .expect("snapshot expected intermediate schema");
+        expected_pool.close().await;
+
+        let undone_snapshot = schema_snapshot(store.pool())
+            .await
+            .expect("snapshot schema after undo");
+        assert_eq!(
+            undone_snapshot, expected_snapshot,
+            "schema after undo(generation {version}, k={k}) must match a db migrated \
+             through {undo_target} only"
+        );
+        assert_eq!(
+            applied_migration_versions(store.pool())
+                .await
+                .expect("list applied versions after undo"),
+            &versions[..k],
+            "undo(generation {version}, k={k}) must leave exactly the first {k} versions applied"
+        );
+
+        STORE_MIGRATOR
+            .run(store.pool())
+            .await
+            .unwrap_or_else(|error| {
+                panic!("re-run migrations after undoing generation {version} (k={k}): {error}")
+            });
+
+        let replayed_snapshot = schema_snapshot(store.pool())
+            .await
+            .expect("snapshot schema after re-run");
+        assert_eq!(
+            replayed_snapshot, full_snapshot,
+            "schema after undo(generation {version}, k={k}) + run() must match the fully \
+             migrated schema"
+        );
+        assert_eq!(
+            applied_migration_versions(store.pool())
+                .await
+                .expect("list applied versions after re-run"),
+            EXPECTED_VERSIONS
+        );
+    }
+
+    store.close().await;
+}
+
+/// 全適用後スキーマの正規化 dump を golden ファイルと比較して固定する。
+/// スキーマが変わる PR は必ず golden の diff として現れる(H1 の受入
+/// 「storage schema 不変」の検出装置)。再生成手順はファイル冒頭の doc コメント参照。
+#[tokio::test]
+async fn fully_migrated_schema_matches_golden() {
+    let tempdir = tempdir().expect("tempdir");
+    let db_path = tempdir.path().join("schema-golden.db");
+    let store = SqliteStore::connect_file(&db_path)
+        .await
+        .expect("initialize sqlite store");
+
+    // _sqlx_migrations は snapshot から除外しているため、version 集合を別に固定する。
+    assert_eq!(
+        migrator_up_versions(),
+        EXPECTED_VERSIONS,
+        "embedded store migration generations drifted from the observed 16 versions"
+    );
+    assert_eq!(
+        applied_migration_versions(store.pool())
+            .await
+            .expect("list applied versions"),
+        EXPECTED_VERSIONS
+    );
+
+    let snapshot = schema_snapshot(store.pool())
+        .await
+        .expect("snapshot fully migrated schema");
+    store.close().await;
+
+    let golden_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/schema/store_schema_full.txt");
+    if std::env::var_os("UPDATE_SCHEMA_GOLDEN").is_some() {
+        std::fs::create_dir_all(golden_path.parent().expect("golden dir"))
+            .expect("create golden dir");
+        std::fs::write(&golden_path, &snapshot).expect("write schema golden");
+        return;
+    }
+
+    let committed = std::fs::read_to_string(&golden_path)
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to read {} ({error}); run `UPDATE_SCHEMA_GOLDEN=1 cargo nextest run \
+                 -p kukuri-store fully_migrated_schema_matches_golden` to (re)generate the golden",
+                golden_path.display()
+            )
+        })
+        .replace("\r\n", "\n");
+    assert_eq!(
+        snapshot, committed,
+        "fully migrated store schema drifted from fixtures/schema/store_schema_full.txt; \
+         the persistent schema is a frozen boundary — if the change is truly intentional, \
+         regenerate the golden (see module doc) and review the diff"
+    );
+}
+
+/// STORE_MIGRATOR の up migration version 一覧(昇順・重複除去)。
+/// migration メタデータの列挙は契約そのものなので migrator から取得してよい。
+fn migrator_up_versions() -> Vec<i64> {
+    let mut versions: Vec<i64> = STORE_MIGRATOR
+        .iter()
+        .filter(|migration| !migration.migration_type.is_down_migration())
+        .map(|migration| migration.version)
+        .collect();
+    versions.sort_unstable();
+    versions.dedup();
+    versions
+}
+
+/// _sqlx_migrations に記録された version 一覧(昇順)。
+async fn applied_migration_versions(pool: &sqlx::Pool<sqlx::Sqlite>) -> Result<Vec<i64>> {
+    Ok(
+        sqlx::query_scalar::<_, i64>("SELECT version FROM _sqlx_migrations ORDER BY version")
+            .fetch_all(pool)
+            .await?,
+    )
+}
+
+/// スキーマの正規化 snapshot(決定的・LF・末尾改行あり)。
+/// - テーブル(名前順)ごとに pragma_table_info を cid 順で 1 行ずつ、
+///   続けて pragma_foreign_key_list を id・seq 順で 1 行ずつ。
+/// - 続けて全テーブルの index を index 名順に、pragma index_list のメタ
+///   (unique/origin/partial)+ pragma index_info のキー列(seqno 順)+
+///   sqlite_master.sql の空白正規化テキスト(自動 index は None)を 1 行ずつ。
+/// - _sqlx_migrations と sqlite 内部オブジェクトは除外。
+async fn schema_snapshot(pool: &sqlx::Pool<sqlx::Sqlite>) -> Result<String> {
+    let table_names = sqlx::query_scalar::<_, String>(
+        r#"
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name NOT LIKE 'sqlite_%'
+          AND name != '_sqlx_migrations'
+        ORDER BY name
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut snapshot = String::new();
+    for table_name in &table_names {
+        snapshot.push_str("table ");
+        snapshot.push_str(table_name);
+        snapshot.push('\n');
+        let columns = sqlx::query("SELECT * FROM pragma_table_info(?1) ORDER BY cid")
+            .bind(table_name)
+            .fetch_all(pool)
+            .await?;
+        for column in &columns {
+            let cid: i64 = column.get("cid");
+            let name: String = column.get("name");
+            let column_type: String = column.get("type");
+            let notnull: i64 = column.get("notnull");
+            let default_value: Option<String> = column.get("dflt_value");
+            let pk: i64 = column.get("pk");
+            snapshot.push_str(&format!(
+                "  column cid={cid} name={name} type={column_type} notnull={notnull} default={default_value:?} pk={pk}\n"
+            ));
+        }
+        // 外部キー(id・seq 順で決定的)。参照先カラム省略形は to が NULL → None。
+        let foreign_keys =
+            sqlx::query("SELECT * FROM pragma_foreign_key_list(?1) ORDER BY id, seq")
+                .bind(table_name)
+                .fetch_all(pool)
+                .await?;
+        for foreign_key in &foreign_keys {
+            let id: i64 = foreign_key.get("id");
+            let seq: i64 = foreign_key.get("seq");
+            let referenced_table: String = foreign_key.get("table");
+            let from: String = foreign_key.get("from");
+            let to: Option<String> = foreign_key.get("to");
+            let on_update: String = foreign_key.get("on_update");
+            let on_delete: String = foreign_key.get("on_delete");
+            let fk_match: String = foreign_key.get("match");
+            snapshot.push_str(&format!(
+                "  fk id={id} seq={seq} table={referenced_table} from={from} to={to:?} on_update={on_update} on_delete={on_delete} match={fk_match}\n"
+            ));
+        }
+    }
+
+    // (index 名, テーブル名, unique, origin, partial) を集めて index 名順にソート。
+    let mut indexes: Vec<(String, String, i64, String, i64)> = Vec::new();
+    for table_name in &table_names {
+        let index_rows = sqlx::query("SELECT * FROM pragma_index_list(?1)")
+            .bind(table_name)
+            .fetch_all(pool)
+            .await?;
+        for index_row in &index_rows {
+            indexes.push((
+                index_row.get("name"),
+                table_name.clone(),
+                index_row.get("unique"),
+                index_row.get("origin"),
+                index_row.get("partial"),
+            ));
+        }
+    }
+    indexes.sort();
+
+    for (index_name, table_name, unique, origin, partial) in &indexes {
+        snapshot.push_str(&format!(
+            "index {index_name} table={table_name} unique={unique} origin={origin} partial={partial}\n"
+        ));
+        let key_columns = sqlx::query("SELECT * FROM pragma_index_info(?1) ORDER BY seqno")
+            .bind(index_name)
+            .fetch_all(pool)
+            .await?;
+        for key_column in &key_columns {
+            let seqno: i64 = key_column.get("seqno");
+            let cid: i64 = key_column.get("cid");
+            let name: Option<String> = key_column.get("name");
+            snapshot.push_str(&format!("  key seqno={seqno} cid={cid} name={name:?}\n"));
+        }
+        // partial index の WHERE 句は pragma で取れないため sqlite_master.sql を
+        // 空白正規化して併用する(自動 index は sql が NULL → None)。
+        let raw_sql = sqlx::query_scalar::<_, Option<String>>(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?1",
+        )
+        .bind(index_name)
+        .fetch_optional(pool)
+        .await?
+        .flatten();
+        let normalized_sql =
+            raw_sql.map(|sql| sql.split_whitespace().collect::<Vec<_>>().join(" "));
+        snapshot.push_str(&format!("  sql={normalized_sql:?}\n"));
+    }
+
+    Ok(snapshot)
+}

--- a/crates/store/src/tests/mod.rs
+++ b/crates/store/src/tests/mod.rs
@@ -15,5 +15,6 @@ use tempfile::tempdir;
 
 mod direct_messages;
 mod migrations;
+mod migrations_roundtrip;
 mod sqlite_projection;
 mod sqlite_store;


### PR DESCRIPTION
## 概要
WP-S6 第 2 弾(base: #458)。永続スキーマ(凍結境界 6 項目め)の検出装置を拡充する。

- `tests/migrations_roundtrip.rs`(新規): 16 世代すべてで「全適用 → undo(V[k-1]) → 中間世代スキーマと一致 → run() 再適用 → 全適用スキーマと一致」の stepwise round-trip。既存 materialize_sqlite_fixture を pub(crate) 化して流用。
- 全適用後スキーマの golden: `fixtures/schema/store_schema_full.txt`(458 行 — pragma_table_info + index_list/index_info + **foreign_key_list** の正規化 dump、partial index の WHERE 句は index の sqlite_master.sql 併用)。**以後スキーマが変わる PR は golden の diff として可視化される**(H1 受入「storage schema 不変」の検出装置)。再生成は `UPDATE_SCHEMA_GOLDEN=1`(手順は module doc)。
- version 集合は 16 個の生リテラル(EXPECTED_VERSIONS)で凍結(renumber 検出)。
- 生の CREATE TABLE テキスト全体比較はしない(ALTER 履歴でテキストが揺れるため構造比較)。CHECK/VIEW/TRIGGER は現行スキーマに皆無のため対象外(module doc に明記)。

## golden が効くことの実証
golden の 1 箇所(notnull=1 → 0)を改変して実行 → `fully migrated store schema drifted from fixtures/schema/store_schema_full.txt; the persistent schema is a frozen boundary ...` で fail(実証後に復元し PASS 確認)。

## 種別
contract

## 挙動変更
なし(プロダクションコード変更ゼロ。migrations.rs への変更は既存ヘルパの pub(crate) 化 + doc コメントのみ)

## 検証
- `cargo nextest run -p kukuri-store` 21/21 green ×2(stepwise 16 世代通過)、clippy green、fmt 済み
- golden は LF・末尾改行(読み込み側に CRLF→LF 正規化の防御あり — Windows の autocrlf 対策)

## リスク
- 新 migration 追加のたびに golden の再生成が必要(意図した保守コスト — スキーマ変更をレビュー可視化するのが目的)

## 後続対応
- T3〜T8 が本スタックに続く

## マージ順
#458(T1)を先にマージ(ブランチ削除)→ 本 PR の base が main に切り替わったのを確認してからマージ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)