### PR TITLE
[scenario] 視覚回帰 spec + Playwright/xtask/CI 基盤配線(baseline なし)(WP-S7 T1)

### DIFF
--- a/.github/workflows/kukuri-visual-baseline.yml
+++ b/.github/workflows/kukuri-visual-baseline.yml
@@ -1,0 +1,62 @@
+name: Kukuri Visual Baseline
+
+# 視覚回帰 baseline（Linux/Chromium）を生成し artifact として吐き出す（WP-S7 T1）。
+# CI 環境では process.env.CI が自動設定され playwright.config の ignoreSnapshots が false に
+# なるため、--update-snapshots で __screenshots__/ を生成できる。手動 dispatch 専用。
+# kukuri-fast.yml の必須ジョブには一切手を入れない（step 追加は T2）。
+on:
+  workflow_dispatch:
+
+jobs:
+  generate-baseline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux system dependencies
+        run: >
+          sudo apt-get update &&
+          sudo apt-get install -y
+          pkg-config
+          libdbus-1-dev
+          libglib2.0-dev
+          libgtk-3-dev
+          libwebkit2gtk-4.1-dev
+          libayatana-appindicator3-dev
+          librsvg2-dev
+          patchelf
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/desktop/pnpm-lock.yaml
+
+      - name: Install desktop dependencies
+        working-directory: apps/desktop
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        working-directory: apps/desktop
+        run: pnpm exec playwright install chromium
+
+      - name: Generate visual baseline
+        working-directory: apps/desktop
+        run: pnpm test:e2e:visual --update-snapshots
+
+      - name: Upload visual baseline
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kukuri-desktop-visual-baseline
+          path: apps/desktop/tests/playwright/__screenshots__/
+          if-no-files-found: warn

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
-    "test:e2e:browser": "playwright test",
+    "test:e2e:browser": "playwright test --project=chromium",
+    "test:e2e:visual": "playwright test --project=visual",
     "tauri": "node ./scripts/tauri-cli.mjs",
     "tauri:dev": "node ./scripts/tauri-cli.mjs dev",
     "tauri:build": "node ./scripts/tauri-cli.mjs build"

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -6,18 +6,46 @@ const port = 4176;
 const host = '127.0.0.1';
 const baseURL = `http://${host}:${port}`;
 
+// 視覚回帰 spec のファイル名。機能 e2e project からは testIgnore で除外し、
+// 視覚 project からは testMatch で拾う。両者を 1 ファイル名で一元管理する。
+const VISUAL_SPEC = '**/visual.spec.ts';
+
 export default defineConfig({
   testDir: './tests/playwright',
   fullyParallel: true,
   reporter: 'list',
+  // baseline は Linux CI 生成に一本化する（@font-face 非同梱でシステムフォント依存のため
+  // Windows 開発機との pixel 一致は構造的に不可能）。CI 以外では比較を skip し、視覚 spec は
+  // 到達操作の smoke として流れる。cargo xtask desktop-ui-check は従来どおり green のまま。
+  ignoreSnapshots: !process.env.CI,
+  // プラットフォーム suffix を付けない（Linux 固定運用で -win32 混入事故を防ぐ）。
+  snapshotPathTemplate: '{testDir}/__screenshots__/{testFileName}/{arg}{ext}',
   use: {
     baseURL,
     locale: 'en-US',
+    timezoneId: 'UTC',
     trace: 'on-first-retry',
+  },
+  expect: {
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.01,
+      animations: 'disabled',
+      caret: 'hide',
+    },
   },
   projects: [
     {
+      // 機能 e2e（既存 10 E2E）。視覚 spec は除外し、機能レーンを不変に保つ。
       name: 'chromium',
+      testIgnore: VISUAL_SPEC,
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+    {
+      // 視覚回帰（visual.spec.ts のみ）。
+      name: 'visual',
+      testMatch: VISUAL_SPEC,
       use: {
         ...devices['Desktop Chrome'],
       },

--- a/apps/desktop/tests/playwright/visual.spec.ts
+++ b/apps/desktop/tests/playwright/visual.spec.ts
@@ -1,0 +1,252 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { DESKTOP_THEME_STORAGE_KEY, type DesktopTheme } from '../../src/lib/theme';
+
+// src/i18n/index.ts の DESKTOP_LOCALE_STORAGE_KEY と一致（実読で確認）。
+// i18n/index.ts を import すると全 locale JSON ロード + react-i18next.init の副作用が
+// テスト評価時に走るため、副作用のない軽量な theme.ts だけを import し、locale キーは
+// リテラルで持つ。
+const DESKTOP_LOCALE_STORAGE_KEY = 'kukuri.desktop.locale';
+
+// 視覚回帰スモーク（WP-S7）。到達操作は既存 E2E（shell.smoke / hash-routing /
+// extended-flow）の deep link + testid パターンを再利用する。付録 B の安定化前処理を
+// 適用し、決定的な名前で toHaveScreenshot を撮る。
+//
+// Windows ローカルでは playwright.config の ignoreSnapshots: !process.env.CI により
+// 比較が skip され、本 spec は「到達操作の smoke」として流れる（baseline PNG は生成しない）。
+// baseline は Linux CI（CI=1）でのみ --update-snapshots で生成する。
+
+const WIDE = { width: 1400, height: 980 } as const;
+const NARROW = { width: 700, height: 980 } as const;
+
+const LOCALE_EN = 'en';
+
+/**
+ * テーマ / ロケールを localStorage へ事前注入する（UI 操作でのテーマ切替は
+ * トランジション残りのリスクがあるため addInitScript で注入する）。goto より前に呼ぶ。
+ */
+async function seedAppearance(page: Page, theme: DesktopTheme): Promise<void> {
+  await page.addInitScript(
+    ({ themeKey, themeValue, localeKey, localeValue }) => {
+      window.localStorage.setItem(themeKey, themeValue);
+      window.localStorage.setItem(localeKey, localeValue);
+    },
+    {
+      themeKey: DESKTOP_THEME_STORAGE_KEY,
+      themeValue: theme,
+      localeKey: DESKTOP_LOCALE_STORAGE_KEY,
+      localeValue: LOCALE_EN,
+    }
+  );
+}
+
+/**
+ * :focus-visible ring（base.css の 2px）や caret の写り込みを避けるため、撮影前に
+ * アクティブ要素を blur し、body へフォーカスを移す。
+ */
+async function clearFocus(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const active = document.activeElement as HTMLElement | null;
+    active?.blur?.();
+    if (document.body) {
+      document.body.focus();
+    }
+    window.scrollTo(0, 0);
+  });
+}
+
+/**
+ * data-theme が反映され、対象要素が visible になるまで待ってから撮影前処理を行う。
+ */
+async function settleForShot(page: Page, theme: DesktopTheme): Promise<void> {
+  await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+  await clearFocus(page);
+}
+
+async function openComposerDialog(page: Page): Promise<void> {
+  await page.getByTestId('shell-fab').click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+}
+
+test.describe('visual regression smoke', () => {
+  // 1: timeline wide dark（シェル全体の基準）
+  test('timeline wide dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(WIDE);
+    await page.goto('/');
+    await expect(page.getByText('browser mock peer post')).toBeVisible();
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('timeline-wide-dark.png');
+  });
+
+  // 2: timeline wide light（トークン退行）
+  test('timeline wide light', async ({ page }) => {
+    await seedAppearance(page, 'light');
+    await page.setViewportSize(WIDE);
+    await page.goto('/');
+    await expect(page.getByText('browser mock peer post')).toBeVisible();
+    await settleForShot(page, 'light');
+    await expect(page).toHaveScreenshot('timeline-wide-light.png');
+  });
+
+  // 3: timeline narrow dark（760px 未満 breakpoint、nav オフキャンバス）
+  test('timeline narrow dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(NARROW);
+    await page.goto('/');
+    await expect(page.getByText('browser mock peer post')).toBeVisible();
+    await expect(page.getByTestId('shell-nav-trigger')).toBeVisible();
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('timeline-narrow-dark.png');
+  });
+
+  // 4: timeline narrow light（narrow × light）
+  test('timeline narrow light', async ({ page }) => {
+    await seedAppearance(page, 'light');
+    await page.setViewportSize(NARROW);
+    await page.goto('/');
+    await expect(page.getByText('browser mock peer post')).toBeVisible();
+    await expect(page.getByTestId('shell-nav-trigger')).toBeVisible();
+    await settleForShot(page, 'light');
+    await expect(page).toHaveScreenshot('timeline-narrow-light.png');
+  });
+
+  // 5: thread pane open（context pane 層）
+  test('thread pane wide dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(WIDE);
+    await page.goto('/');
+    await page.getByText('browser mock peer post').click();
+    await expect(page.getByRole('complementary', { name: 'Thread' })).toBeVisible();
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('thread-pane-wide-dark.png');
+  });
+
+  // 6: author pane open（detail pane スタック）
+  test('author pane wide dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(WIDE);
+    await page.goto('/');
+    await page.getByText('browser mock peer post').click();
+    const threadPane = page.getByRole('complementary', { name: 'Thread' });
+    await expect(threadPane).toBeVisible();
+    // Thread 内のシード post の著者（browser peer）を開いて Author pane を積む。
+    await threadPane
+      .getByRole('button', { name: 'browser peer' })
+      .first()
+      .click();
+    await expect(page.getByRole('complementary', { name: 'Author' })).toBeVisible();
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('author-pane-wide-dark.png');
+  });
+
+  // 7: messages（DM workspace）
+  test('messages wide dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(WIDE);
+    await page.goto('/#/messages');
+    await expect(page.getByRole('heading', { name: 'Messages' })).toBeVisible();
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('messages-wide-dark.png');
+  });
+
+  // 8: notifications（deep link、notification-item 系 CSS）
+  test('notifications wide dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(WIDE);
+    await page.goto('/#/notifications?topic=kukuri%3Atopic%3Ademo');
+    await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible();
+    await expect(page.getByText('browser mock reply notification')).toBeVisible();
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('notifications-wide-dark.png');
+  });
+
+  // 9: settings drawer / appearance（Radix Portal + drawer、H8 最重要）
+  test('settings appearance wide dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(WIDE);
+    await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ademo&settings=appearance');
+    const settingsDialog = page.getByRole('dialog', { name: 'Settings' });
+    await expect(settingsDialog).toBeVisible();
+    await expect(page.getByTestId('shell-settings-trigger')).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    await expect(settingsDialog.getByTestId('settings-section-appearance')).toHaveAttribute(
+      'aria-current',
+      'location'
+    );
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('settings-appearance-wide-dark.png');
+  });
+
+  // 10: settings drawer / appearance light（portal × light）
+  test('settings appearance wide light', async ({ page }) => {
+    await seedAppearance(page, 'light');
+    await page.setViewportSize(WIDE);
+    await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ademo&settings=appearance');
+    const settingsDialog = page.getByRole('dialog', { name: 'Settings' });
+    await expect(settingsDialog).toBeVisible();
+    await expect(page.getByTestId('shell-settings-trigger')).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    await expect(settingsDialog.getByTestId('settings-section-appearance')).toHaveAttribute(
+      'aria-current',
+      'location'
+    );
+    await settleForShot(page, 'light');
+    await expect(page).toHaveScreenshot('settings-appearance-wide-light.png');
+  });
+
+  // 11: settings drawer / connectivity（スクロール drawer・フォーム群）
+  test('settings connectivity wide dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(WIDE);
+    await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ademo&settings=connectivity');
+    const settingsDialog = page.getByRole('dialog', { name: 'Settings' });
+    await expect(settingsDialog).toBeVisible();
+    await expect(settingsDialog.getByTestId('settings-section-connectivity')).toHaveAttribute(
+      'aria-current',
+      'location'
+    );
+    // スクロール top を固定してから撮る（付録 B: スクロール top 固定）。
+    await settingsDialog
+      .locator('.shell-settings-content')
+      .evaluate((element) => element.scrollTo(0, 0));
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('settings-connectivity-wide-dark.png');
+  });
+
+  // 12: composer dialog open（Radix portal dialog）
+  test('composer dialog wide dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(WIDE);
+    await page.goto('/');
+    await expect(page.getByText('browser mock peer post')).toBeVisible();
+    await openComposerDialog(page);
+    await expect(page.getByPlaceholder('Write a post')).toBeVisible();
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('composer-dialog-wide-dark.png');
+  });
+
+  // 13: live workspace（シード空状態、extended 面）
+  test('live wide dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(WIDE);
+    await page.goto('/#/live');
+    await expect(page.getByRole('heading', { name: 'Live Sessions' })).toBeVisible();
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('live-wide-dark.png');
+  });
+
+  // 14: game workspace（Metaverse Rooms 一覧、WebGL 手前まで）
+  test('game wide dark', async ({ page }) => {
+    await seedAppearance(page, 'dark');
+    await page.setViewportSize(WIDE);
+    await page.goto('/#/game');
+    await expect(page.getByRole('heading', { name: 'Metaverse Rooms' })).toBeVisible();
+    await settleForShot(page, 'dark');
+    await expect(page).toHaveScreenshot('game-wide-dark.png');
+  });
+});

--- a/xtask/src/desktop.rs
+++ b/xtask/src/desktop.rs
@@ -37,6 +37,10 @@ pub(crate) fn desktop_browser_test() -> Result<()> {
     run_pnpm(["test:e2e:browser"], &desktop_dir())
 }
 
+pub(crate) fn desktop_visual_test() -> Result<()> {
+    run_pnpm(["test:e2e:visual"], &desktop_dir())
+}
+
 pub(crate) fn desktop_ui_check() -> Result<()> {
     desktop_lint()?;
     desktop_test()?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,6 +34,7 @@ fn main() -> Result<()> {
         "desktop-test" => desktop_test(),
         "desktop-storybook" => desktop_storybook(),
         "desktop-browser-test" => desktop_browser_test(),
+        "desktop-visual-test" => desktop_visual_test(),
         "desktop-ui-check" => desktop_ui_check(),
         "cn-check" => cn_check(),
         "cn-test" => cn_test(),
@@ -90,6 +91,6 @@ fn doctor() -> Result<()> {
 
 fn print_usage() {
     eprintln!(
-        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-ui-check|cn-check|cn-test|desktop-package|release-check [tag]|oversized-files [--update-baseline]|e2e-smoke|scenario <name>>"
+        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-visual-test|desktop-ui-check|cn-check|cn-test|desktop-package|release-check [tag]|oversized-files [--update-baseline]|e2e-smoke|scenario <name>>"
     );
 }


### PR DESCRIPTION
## 概要
WP-S7(視覚回帰ネット — WP-H8「CSS 改名・整理」の前提)の第 1 弾。Playwright `toHaveScreenshot` で主要 14 サーフェスを撮る基盤を配線する。**baseline PNG は本 PR に含めない**(Linux CI 生成に一本化するため。生成・強制化・破壊実証は T2)。

- `tests/playwright/visual.spec.ts`(新規): 付録 A の 14 枚(timeline wide/narrow × dark/light、thread/author/DM/notifications pane、settings drawer appearance/connectivity、composer dialog、live/game workspace)。到達操作は既存 10 E2E の deep link + testid パターンを再利用。
- `playwright.config.ts`: `timezoneId: 'UTC'`(絶対時刻表示が Intl 経由で TZ 依存)/ `animations: 'disabled'` / `caret: 'hide'` / `maxDiffPixelRatio: 0.01` / `snapshotPathTemplate`(プラットフォーム suffix なし)/ `ignoreSnapshots: !process.env.CI`(Windows ローカルは比較 skip → 操作 smoke として流れ、`desktop-ui-check` は従来どおり green)。
- **project 分割**(`chromium`: testIgnore visual / `visual`: testMatch)で機能 e2e と視覚を相互排他化。`test:e2e:browser` を `--project=chromium` にしたことで、**release レーン(linux-verify も desktop-browser-test を実行)を視覚回帰がブロックしない**。
- xtask `desktop-visual-test` 新設(`desktop-ui-check` には未組み込み — T2)。
- `kukuri-visual-baseline.yml`(`workflow_dispatch`): CI では `process.env.CI` により ignoreSnapshots=false → `--update-snapshots` で baseline 生成 → artifact 化。**既存必須ジョブ(fast/nightly/release)は不変**。

## 種別
scenario

## 挙動変更
なし(視覚テストは baseline 未生成のため CI では実行されない。既存の機能レーンも project 分割で不変)

## 検証(Windows ローカルで実走)
- `playwright test --project=visual` → 14/14 pass(ignoreSnapshots で比較 skip・操作 smoke。PNG は 1 枚も生成されず)
- `pnpm test:e2e:browser`(`--project=chromium`)→ 既存 E2E 10/10 pass、visual.spec.ts は不拾。`timezoneId: 'UTC'` 追加で既存 E2E は割れず(絶対時刻 assert なし)
- `cargo xtask desktop-ui-check` → green(browser-test は機能 10 本のみ)

## リスク
- baseline 未生成のため本 PR 単体では視覚回帰は「未武装」(操作 smoke のみ)。武装は T2。
- ubuntu-latest のフォント/Chromium 更新で baseline が一斉に割れ得る(T3 で一括再生成手順を文書化)。

## 後続対応
- **T2 は本 PR の main マージ後に着手**(`workflow_dispatch` はデフォルトブランチに workflow が存在して初めて実行可能なため)。T2 で baseline 生成 → CI ジョブへ step 追加 + `desktop-ui-check` 組み込み + 破壊実証。T3 で運用手順(dev.md)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)