### PR TITLE
[DO NOT MERGE] WP-S7 視覚回帰の破壊実証

### DIFF
--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -28,14 +28,14 @@
 
 :root,
 :root[data-theme='dark'] {
-  --background: #3a1030;
-  --shell-background: #3a1030;
+  --background: #101923;
+  --shell-background: #101923;
   --foreground: #f6f1e8;
   --foreground-strong: #fff7ef;
   --muted-foreground: #cbbdae;
   --muted-foreground-soft: #a89b8f;
-  --surface-panel: #0c1721;
-  --surface-panel-solid: #0c1721;
+  --surface-panel: #d81b8c;
+  --surface-panel-solid: #d81b8c;
   --surface-panel-accent: #162231;
   --surface-panel-muted: #13202c;
   --surface-panel-soft: #182632;

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -28,8 +28,8 @@
 
 :root,
 :root[data-theme='dark'] {
-  --background: #101923;
-  --shell-background: #101923;
+  --background: #3a1030;
+  --shell-background: #3a1030;
   --foreground: #f6f1e8;
   --foreground-strong: #fff7ef;
   --muted-foreground: #cbbdae;


### PR DESCRIPTION
視覚回帰ネット(WP-S7 T2)が CSS 変更を検出することの実証用。dark テーマの --background を #101923 → #3a1030 に変更した。linux-desktop-browser の視覚 step が赤くなることを確認したら close して破棄する。マージしない。