### PR TITLE
[docs] 視覚回帰の運用手順を dev.md に追加し検証マトリクスを更新 (WP-S7 T3)

### DIFF
--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -151,7 +151,7 @@ PR を作成または説明するときは、タスク種別を明確にする�
 | `crates/desktop-runtime/**` | `cargo xtask rust-test` + `cargo xtask e2e-smoke` |
 | `crates/cn-*` | `cargo xtask cn-check` + `cargo xtask cn-test` |
 | `harness/scenarios/**` | `cargo xtask scenario <changed-scenario>` |
-| `apps/desktop/**` | `cargo xtask desktop-ui-check` |
+| `apps/desktop/**` | `cargo xtask desktop-ui-check`（視覚回帰 `test:e2e:visual` を含む。CSS/スタイル変更で見た目が変わると CI の視覚 step が赤くなる。意図的な変更時は baseline を再生成する — 手順は `docs/runbooks/dev.md` の「視覚回帰」を参照） |
 | `apps/desktop/src-tauri/**` | `cargo xtask tauri-check` + `cargo xtask e2e-smoke` |
 | `docs/adr/**` | 対応する tests / contracts / scenarios を確認または更新する |
 | `docs/runbooks/**` | runbook 内の command と path を確認する |

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -26,17 +26,18 @@ cargo xtask desktop-lint
 cargo xtask desktop-test
 cargo xtask desktop-storybook
 cargo xtask desktop-browser-test
+cargo xtask desktop-visual-test
 ```
 
 `cargo xtask check` は non-CN Rust check、`apps/desktop/src-tauri` の Tauri backend compile、frontend lint/typecheck をまとめた日常 fast path。
 
 `cargo xtask test` は non-CN Rust test と `apps/desktop` の Vitest をまとめた日常 regression path。
 
-`cargo xtask desktop-ui-check` は `apps/desktop` の `lint`, `typecheck`, `test`, `storybook:build`, `test:e2e:browser` をまとめて流す browser-aware frontend gate。
+`cargo xtask desktop-ui-check` は `apps/desktop` の `lint`, `typecheck`, `test`, `storybook:build`, `test:e2e:browser`, `test:e2e:visual` をまとめて流す browser-aware frontend gate。`test:e2e:visual`(視覚回帰)は Windows などの非 CI 環境では `ignoreSnapshots` により比較が skip され、到達操作の smoke としてのみ流れる（下記「視覚回帰」を参照）。
 
 - `cargo xtask rust-test` は `cargo-nextest` を優先して non-CN package を流し、`kukuri-harness` は serial 実行、doctest は `cargo test --doc` で補完する。local で `cargo-nextest` が無い場合だけ `cargo test` に fallback する。
 - `cargo xtask tauri-check` は `CARGO_TARGET_DIR=target/desktop-tauri-check` を使って `apps/desktop/src-tauri` を warm cache 向けに compile する。
-- `cargo xtask desktop-lint` / `desktop-test` / `desktop-storybook` / `desktop-browser-test` は targeted rerun 用。workflow とローカル rerun のどちらでも同じ entrypoint を使う。
+- `cargo xtask desktop-lint` / `desktop-test` / `desktop-storybook` / `desktop-browser-test` / `desktop-visual-test` は targeted rerun 用。workflow とローカル rerun のどちらでも同じ entrypoint を使う。
 - `cargo xtask cn-check` / `cargo xtask cn-test` は `cn-*` server slice の compile/test 用。
 - `cargo xtask cn-test` は `docker-compose.community-node.yml` の `cn-postgres` を自動起動し、`KUKURI_CN_RUN_INTEGRATION_TESTS=1` を付けて contract/integration test を流す。
 - `cargo xtask scenario community_node_public_connectivity` も `cn-postgres` を自動起動し、in-process の `cn-user-api` / `cn-iroh-relay` を立てて 2 desktop scenario を流す。
@@ -47,6 +48,29 @@ cargo xtask desktop-browser-test
 - browser-level UI change: 追加で `cargo xtask desktop-ui-check`
 - community-node / Postgres 変更: 追加で `cargo xtask cn-check` + `cargo xtask cn-test`
 - runtime / end-to-end 変更: 追加で `cargo xtask e2e-smoke` または対象 `cargo xtask scenario ...`
+- CSS / スタイル変更: `cargo xtask desktop-ui-check`（視覚回帰を含む）。見た目が意図的に変わる場合は下記手順で baseline を更新する
+
+## 視覚回帰 (visual regression)
+
+WP-H8（CSS 改名・整理）の安全網として、主要 14 サーフェスを Playwright `toHaveScreenshot` で撮って baseline と比較する（`apps/desktop/tests/playwright/visual.spec.ts`）。
+
+- **baseline は Linux / Chromium 固定**。`apps/desktop/tests/playwright/__screenshots__/visual.spec.ts/*.png` に commit されている。フォントは非同梱（システムフォント依存）のため Windows 開発機と CI の pixel 一致は構造的に不可能。
+- **ローカル（非 CI）は比較 skip**。`playwright.config.ts` の `ignoreSnapshots: !process.env.CI` により、Windows 等では `cargo xtask desktop-visual-test` / `desktop-ui-check` は到達操作の smoke としてのみ流れ、比較は行わない（従来どおり green）。
+- **CI（`linux-desktop-browser`）が比較を強制**。CSS 変更で見た目が変わると視覚 step が赤くなる。
+- 決定性のための固定: `timezoneId: 'UTC'`（絶対時刻表示が TZ 依存）、`animations: 'disabled'`、`maxDiffPixelRatio: 0.01`（AA 微差を吸収）。
+
+### 視覚 step が赤くなったら
+1. Actions の失敗ジョブから artifact `kukuri-desktop-visual-diff` をダウンロードし、`*-actual.png` / `*-diff.png` を baseline と目視比較する。
+2. **意図しない差分（退行）** → CSS を修正して push。
+3. **意図した差分** → baseline を更新（下記）。CSS 変更 PR に baseline 更新を同梱し、diff 画像を PR 本文に貼る。
+
+### baseline の再生成（意図的な見た目変更・deps 更新時）
+- **必ず Linux/Chromium で生成する。Windows ローカルでの `--update-snapshots` は禁止**（フォント差で CI と不一致になり、生成した baseline が即割れる）。
+- 手順: GitHub Actions の **「Kukuri Visual Baseline」ワークフロー（`workflow_dispatch`）** を対象ブランチで実行 → 生成された artifact `kukuri-desktop-visual-baseline` をダウンロード → `apps/desktop/tests/playwright/__screenshots__/visual.spec.ts/` に上書き展開して commit。
+  - CLI 例: `gh workflow run kukuri-visual-baseline.yml --ref <branch>` → 完了後 `gh run download <run-id> -n kukuri-desktop-visual-baseline -D <tmp>`。
+- optional（ローカルで Linux baseline を再生成したい場合）: Playwright 公式 Docker イメージ `mcr.microsoft.com/playwright:v1.59.1-jammy`（`pnpm-lock.yaml` の `@playwright/test` バージョンと一致させる）内で `pnpm test:e2e:visual --update-snapshots` を実行する。
+- `@playwright/test`（同梱 Chromium）更新や ubuntu-latest ランナーイメージ更新でフォント/AA が変わると baseline が一斉に割れることがある。その場合は deps 更新 PR に baseline 再生成を同梱する。
+- baseline の置き場は `apps/desktop/tests/playwright/__screenshots__/`（`.gitignore` 済みの `test-results/` とは別。混同しない）。
 
 ## community-node compose
 ```bash


### PR DESCRIPTION
## 概要
WP-S7(視覚回帰ネット)の締め(T1 #466 / T2 #467 の後続)。視覚回帰ネットの運用を文書化する。

- `docs/runbooks/dev.md`: 「視覚回帰」セクション新設
  - baseline は Linux/Chromium 固定・ローカル(非 CI)は `ignoreSnapshots` で比較 skip・CI(linux-desktop-browser)が比較を強制
  - fail 時フロー: artifact `kukuri-desktop-visual-diff` の `*-actual.png`/`*-diff.png` を目視 → 退行なら CSS 修正 / 意図的差分なら baseline 再生成
  - baseline 再生成は `workflow_dispatch`「Kukuri Visual Baseline」経由。**Windows ローカルでの `--update-snapshots` は禁止**(フォント差で CI と不一致)。optional で Playwright 公式 Docker
  - deps 更新(Chromium/ランナーイメージ)で一斉に割れた場合は同一 PR で再生成
  - 日常コマンド一覧に `desktop-visual-test` 追加、`desktop-ui-check` の説明更新
- `REFACTORING.md`: 検証マトリクスの `apps/desktop/**` 行に視覚回帰の注記

## 破壊実証(ネットが効くことの確認)
- 高コントラスト CSS 変更(`--surface-panel` を暗色 → 明マゼンタ)で視覚 step が **failure**: https://github.com/KingYoSun/kukuri/actions/runs/28694535780(実証後 revert・ブランチ破棄済み)
- **知見**: 初回は暗色→暗色(`#101923`→`#3a1030`)を試したが緑だった。Playwright 既定のピクセルしきい値(`threshold` 0.2、YIQ 色空間)が知覚差の小さい暗色間の変更を吸収するため。**ネットは「見た目が変わる(知覚できる)変更」を検出する**(= S7 受入要件)一方、知覚できないほど微細な色ズレは既定しきい値で吸収される。より高感度が必要なら `threshold` を下げられるが、ランナー間 AA 差による flake とのトレードオフ(現状は据え置き)。

## 種別
docs

## 挙動変更
なし(ドキュメントのみ)

## 検証
- markdown のリンク・手順の整合を確認。参照する artifact 名・workflow 名・パスは T1/T2 の実装と一致

## 後続対応
- WP-S7 完了。Phase 1 残りは S8(ドキュメント整合)のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)