### PR TITLE
[docs] REFACTORING.md に地雷リストと互換パス sunset 条件を追記 (WP-S8 T2)

### DIFF
--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -129,6 +129,41 @@ PR を作成または説明するときは、タスク種別を明確にする�
    Rust 側 crates/app-api/src/tests/views_wire_snapshot.rs と TS 側 viewsContract.ts(+ .test.ts)が
    両側から検証する(再生成手順は各ファイル冒頭)。CommunityNode 系・requests.rs 入力方向は未。
 
+## 地雷リスト(直したくなるが、してはいけない)
+
+凍結境界とは別に、「一見 dead code / 不整合 / 冗長に見えるが、消す・揃える・golden 化すると
+壊れる」ものを挙げる。詳細な調査記録は `.claude/plans/2026-07-02-refactoring_master_plan.md` §3.2。
+
+1. **`ConnectionPath::RelayFallback` は削除禁止の第3経路**: `AGENTS.md`「通信経路」節が規定する
+   `Direct P2P -> Relay Supported P2P -> Relay Fallback` の 3 番目。variant は
+   `crates/transport/src/config.rs` に定義され、TS 側表示分岐(`apps/desktop/src/lib/api/types.ts` /
+   `apps/desktop/src/shell/selectors.ts` の `relay_fallback`)も実在する。**実行時に値として構築される
+   箇所が現状ゼロ**(ライブ代入は DirectP2p / RelaySupportedP2p のみ)なので「未使用だから削除」に
+   見えるが、これは削除対象ではなく診断の実装ギャップである。**variant は削除しない。診断は現状
+   RelayFallback を報告しない**(判定実装は別 issue。本リファクタでは事実固定に留める)。
+2. **`apps/desktop/src/styles/shell-phase1-legacy.css` は名前に反して現役の本番 CSS**: 大半の
+   クラスが現在も使われ、Radix Portal 経由の dialog / popover では `.shell-phase1` の外に描画される
+   ため unscoped な phase1 側だけが効く。「legacy だから削除」は禁止。安全なのは改名のみ(H8)。
+   統合は宣言単位・コンテキスト別の実効値判定 + 視覚回帰ネット(検証マトリクスの
+   `apps/desktop/**` = `test:e2e:visual`)を前提にする。
+3. **署名バイトは非決定的なので golden 化しない**: `KukuriKeys::sign_schnorr`
+   (`crates/core/src/crypto.rs`)は毎回 aux_rand を生成するため署名バイトは実行毎に変わる。凍結対象は
+   canonical バイト列と「過去 fixture の verify 継続」であり、署名バイトを snapshot golden にすると
+   毎回 fail する(理由は `crates/core/src/tests/signing_canonical.rs` の doc）。
+
+## 互換パスと sunset 条件
+
+以下は後方互換のために残している経路で、「いつ削除してよいか」を明文化せずに消すと既存データ・
+既存ユーザーが壊れる。現状は削除せず、撤去は Phase 2(master plan C6 / C8)で条件を確定してから行う。
+撤去条件が決まるまでは削除しない(このリストが「消してよいか」の判断入口)。
+
+| 互換パス | 所在 | 誤削除の影響 | sunset 条件 |
+|---|---|---|---|
+| epoch `"legacy"` 互換 | `crates/app-api/src/service/projection_support.rs` | legacy epoch の projection が読めなくなる | 未決定(全既存 projection の再構築完了が前提) |
+| 旧 `.nsec` 鍵ファイル読込 | `crates/desktop-runtime/src/identity.rs`(`db_path.with_extension("nsec")`。テスト `legacy_nsec_file_still_loads` が固定) | 旧形式で鍵を持つユーザーの identity ロスト | 未決定(全ユーザーの新形式移行が前提) |
+| `resolved_urls` fallback(seed_peers 空 / None 時) | `crates/desktop-runtime/src/community_node/requests_support.rs` | 旧 community-node 設定の URL が壊れる | 未決定 |
+| CRLF checksum 自己修復 | `crates/store/src/sqlite/connection.rs`(`repair_line_ending_only_migration_checksums`。**store 初期化=pool 作成時に1回**実行) | CRLF 時代に migration checksum がずれた DB が起動不能になる | 未決定(master plan C6 = バージョン条件付き撤去 or 一度きりメンテ処理へ隔離) |
+
 ## 真実の置き場所ルール
 
 - 現行ドキュメントの優先順位は `docs/README.md` に従う。

--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -145,16 +145,18 @@ PR を作成または説明するときは、タスク種別を明確にする�
 | `crates/core/**` | `cargo xtask rust-test` |
 | `crates/store/**` | `cargo xtask rust-test` + 永続化の振る舞いが変わる場合は関連 scenario |
 | `crates/transport/**` | `cargo xtask rust-test` + peer の振る舞いが変わる場合は関連 connectivity scenario |
-| `crates/docs-sync/**` | `cargo xtask rust-test` + `cargo xtask e2e-smoke` |
+| `crates/docs-sync/**` | `cargo xtask rust-test`（実 relay replication テスト `src/tests/relay.rs` を含む）+ replication / relay 経路の振る舞いが変わる場合は `cargo xtask scenario community_node_public_connectivity` |
 | `crates/blob-service/**` | `cargo xtask rust-test` + media/blob に影響する場合は関連 scenario |
 | `crates/app-api/**` | `cargo xtask rust-test` + payload 形状が変わる場合は frontend test |
-| `crates/desktop-runtime/**` | `cargo xtask rust-test` + `cargo xtask e2e-smoke` |
+| `crates/desktop-runtime/**` | `cargo xtask rust-test`（community_node / identity_restart / seeded_dht / media_blob_restore 等の実挙動テストを含む）+ 起動 / 永続往復が変わる場合は `cargo xtask e2e-smoke`、peer 間 connectivity・CN セッションが変わる場合は `cargo xtask scenario community_node_public_connectivity` |
 | `crates/cn-*` | `cargo xtask cn-check` + `cargo xtask cn-test` |
 | `harness/scenarios/**` | `cargo xtask scenario <changed-scenario>` |
 | `apps/desktop/**` | `cargo xtask desktop-ui-check`（視覚回帰 `test:e2e:visual` を含む。CSS/スタイル変更で見た目が変わると CI の視覚 step が赤くなる。意図的な変更時は baseline を再生成する — 手順は `docs/runbooks/dev.md` の「視覚回帰」を参照） |
 | `apps/desktop/src-tauri/**` | `cargo xtask tauri-check` + `cargo xtask e2e-smoke` |
 | `docs/adr/**` | 対応する tests / contracts / scenarios を確認または更新する |
 | `docs/runbooks/**` | runbook 内の command と path を確認する |
+
+`cargo xtask e2e-smoke` は `desktop_smoke_post_persist`（`FakeNetwork`・in-process 単一 runtime）1 本を回す desktop 永続 smoke であり、post 作成 → timeline → restart → 再表示の永続往復のみを検証する。実 transport / docs-sync の peer 間経路・relay replication は通らない。peer / replication / CN 接続の検証は該当 crate の `cargo xtask rust-test`（実 iroh テストを含む）と `cargo xtask scenario <connectivity scenario>` が担う。CI 実配線の connectivity scenario は `community_node_public_connectivity`（fast / release）、加えて `community_node_multi_device_connectivity`（nightly）。connectivity scenario は cn-postgres 起動 + 実 iroh peer 複数で重いため、マトリクスでは「振る舞いが変わる場合」の条件付き要求とする。
 
 必須validationの全実行がローカルで重すぎる場合は、最も狭い関連 command を実行し、実行しなかった内容と理由を明確に報告する。実行していない validation を passed と報告しない。
 


### PR DESCRIPTION
## 概要
WP-S8 第 2 弾(base: T1)。凍結境界章(§3.1 相当・S3 #443 で移植済み)に続けて、master plan §3.2 相当を規範文書に載せる。

**地雷リスト(直したくなるが、してはいけない)**:
1. `ConnectionPath::RelayFallback` は AGENTS.md「通信経路」が規定する第3経路。variant は config.rs、TS 表示分岐(types.ts / selectors.ts の `relay_fallback`)も実在。実行時に構築される箇所は現状ゼロだが「未使用だから削除」ではなく診断の実装ギャップ → **variant 削除禁止・診断は現状これを報告しない(判定実装は別 issue)**
2. `shell-phase1-legacy.css` は名前に反して現役の本番 CSS(Radix Portal 経由では unscoped な phase1 側だけが効く)→ 削除禁止・改名のみ可・統合は視覚回帰ネット(S7)前提
3. 署名バイトは非決定的(`sign_schnorr` の aux_rand)→ golden 化しない。凍結は canonical と fixture verify 継続

**互換パスと sunset 条件**(削除条件を書くべき対象を表で列挙、実撤去は Phase 2 C6/C8): epoch legacy / 旧 nsec 鍵読込 / resolved_urls fallback / CRLF checksum 自己修復(**store 初期化=pool 作成時に1回**実行。「接続毎」は誤りだったので修正)。

要約 + master plan §3.2 参照に留め(規範文書の肥大化回避)、数値は drift 耐性の表現にした。

## 種別
docs

## 挙動変更
なし(ドキュメントのみ)

## 検証
各 evidence(`RelayFallback` variant / `relay_fallback` TS 分岐 / `sign_schnorr` / `repair_line_ending_only_migration_checksums` / `with_extension("nsec")` / `legacy_epoch_id`)が実コードに実在することを grep で確認。CRLF 修復が pool 作成時 1 回であることを connection.rs で確認。

## マージ順
base は T1。**T1 を先にマージ(ブランチ削除)** → 本 PR の base が main に切り替わったのを確認してからマージ。

## 後続対応
- T3(参照チェーン整合)

🤖 Generated with [Claude Code](https://claude.com/claude-code)