### PR TITLE
[docs] 参照チェーン整合(README/AGENTS 順序 + progress 分離規約 + preview checklist)(WP-S8 T3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@
 
 ## 作業対象
 - 新規実装・修正は原則 root workspace の現行実装のみ。
-- 現行スコープの参照優先順位は `docs/README.md` に従う。
-- foundation baseline は `docs/progress/2026-03-10-foundation.md`。
+- 現行スコープの参照優先順位は `docs/README.md` に従う（現行アクティブマイルストーンは builder preview）。
 - builder preview / 配布 / 初回体験は `docs/progress/2026-04-16-mvp-builder-preview-plan.md`。
+- その capability baseline は `docs/progress/2026-03-10-foundation.md`。
 - Windows desktop support、seeded DHT discovery、community-node connectivity/auth、social graph v1、private channel audience v1 は current scope に含まれる。
 
 ## 実行入口

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ## 目的
 - 現行 kukuri 実装に必要な情報だけを置く。
 - 仕様は ADR、実行手順は runbook、状態は progress に分ける。
+- `docs/progress/` は 2 種を置く: (a) named な current-state / 計画文書（最新のマイルストーン状態・ロードマップ）と (b) `YYYY-MM-DD-<issue#>-<slug>.md` の per-issue 作業報告（個別 issue の実装ログ）。current-state は「今どうなっているか」、per-issue は「その issue で何をしたか」を書き分ける。
 
 ## 優先参照順
 1. `docs/progress/2026-04-16-mvp-builder-preview-plan.md`

--- a/docs/progress/2026-04-16-mvp-builder-preview-plan.md
+++ b/docs/progress/2026-04-16-mvp-builder-preview-plan.md
@@ -50,9 +50,9 @@
 
 ## Launch Checklist
 
-- [ ] GitHub Release で Windows installer を公開
-- [ ] README 冒頭を builder preview 導線へ更新
-- [ ] `mvp-user-quickstart` と `mvp-troubleshooting` を公開
+- [x] GitHub Release で Windows installer を公開（`v0.1.x-preview.*` を GitHub Releases に公開済み）
+- [x] README 冒頭を builder preview 導線へ更新（root `README.md` に「Builder Preview」節あり）
+- [x] `mvp-user-quickstart` と `mvp-troubleshooting` を公開（`docs/runbooks/` に存在）
 - [ ] hosted preview node 上で starter topic seed content を確認
 - [ ] GitHub feedback surface を preview copy から辿れるようにする
 - [ ] packaged Windows app で `launch -> ready -> post -> reply -> private channel` を手動確認


### PR DESCRIPTION
## 概要
WP-S8 第 3 弾(独立)。AGENTS.md → docs/README.md → progress の参照チェーンを現状に一致させる。

- **AGENTS.md ↔ docs/README.md の優先参照順の食い違いを解消**: AGENTS が foundation を baseline 筆頭にしていたのを、docs/README.md の優先参照順(builder-preview 筆頭)に合わせ、foundation を「その capability baseline」と位置づけ直した(2026-05-27 progress:88 が指摘済みの食い違い。現行アクティブマイルストーンが builder preview のため)。
- **progress の分離規約を明文化**(docs/README.md「目的」): `docs/progress/` は (a) named な current-state/計画 と (b) `YYYY-MM-DD-<issue#>-<slug>.md` の per-issue 報告の 2 種、という書き分けを規定。
- **builder-preview checklist を実態へ確定**(docs/progress/2026-04-16-mvp-builder-preview-plan.md): リポジトリで検証可能な 3 項目を `[x]` に(Release 公開=`v0.1.x-preview.*` が GitHub Releases に存在 / README 導線=root README に「Builder Preview」節 / mvp runbook 公開=`docs/runbooks/` に存在)。hosted node seed・feedback surface・packaged 手動 QA の launch-ops は `[ ]` のまま。

docs/README.md 優先参照順の 14 参照先はすべて実在(壊れリンクゼロ)を確認。

## 種別
docs

## 挙動変更
なし(ドキュメントのみ。product 挙動・launch 状態の誤主張はしていない — checklist は検証可能な項目のみ反映)

## 検証
- 優先参照順 14 リンク・AGENTS「まず読む」/「真実の置き場所」の参照先の実在を確認
- Release 公開は `gh release list`(v0.1.2-preview.1 が Latest)、README「Builder Preview」節・mvp runbook の存在を確認

## 後続対応
- WP-S8 完了 = **Phase 1(安全ネット S1-S8)完了**。次は Phase 2(クリティカル修正 C1-C8)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)