### PR TITLE
[fix] CN セッション維持を desktop-runtime 内スケジューラで駆動 (WP-C1 T1-T3)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3725,6 +3725,7 @@ dependencies = [
  "jsonwebtoken",
  "kukuri-cn-safety",
  "kukuri-cn-safety-runtime",
+ "kukuri-cn-trust",
  "kukuri-core",
  "redis",
  "secp256k1",
@@ -3761,6 +3762,17 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "kukuri-cn-trust"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "kukuri-cn-safety",
+ "serde",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -122,10 +122,12 @@ pub(crate) fn build_desktop_state(app_handle: &tauri::AppHandle) -> Result<Deskt
     let db_path = resolve_db_path(app_handle)?;
     let runtime = tauri::async_runtime::block_on(DesktopRuntime::from_env(db_path))
         .map_err(map_error)?;
+    let runtime = Arc::new(runtime);
+    // トレイ常駐中はフロントのポーリング(hidden で停止)が CN セッションを維持できないため、
+    // runtime 常駐のセッション維持スケジューラをここで起動する(停止は shutdown / プロセス終了)。
+    tauri::async_runtime::block_on(runtime.start_community_node_session_scheduler());
 
-    Ok(DesktopState {
-        runtime: Arc::new(runtime),
-    })
+    Ok(DesktopState { runtime })
 }
 
 fn app_consent_path(db_path: &Path) -> PathBuf {

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -25,6 +25,7 @@ mod manifest_support;
 mod reconnect_support;
 mod report_routing_support;
 mod requests_support;
+mod scheduler_support;
 mod session_runtime_support;
 mod session_state_support;
 mod token_storage_support;
@@ -63,6 +64,10 @@ pub(crate) const COMMUNITY_NODE_SESSION_RETRY_SECONDS: i64 = 30;
 pub(crate) const COMMUNITY_NODE_AUTH_REFRESH_SKEW_SECONDS: i64 = 300;
 pub(crate) const COMMUNITY_NODE_RECONNECT_UNHEALTHY_SECONDS: i64 = 30;
 pub(crate) const COMMUNITY_NODE_RECONNECT_BACKOFF_SECONDS: [i64; 3] = [30, 60, 120];
+// heartbeat の次回期限は「サーバ TTL(90 秒)− 30 秒」で管理されるため、tick は 30 秒未満が必須。
+// 15 秒は失効防止を満たしつつ、tick 毎の consent GET を可視時の現行ポーリング(3 秒 ×2 getter)
+// より低頻度に抑える値(WP-C1 プランの決定事項 1)。
+pub(crate) const COMMUNITY_NODE_SESSION_SCHEDULER_TICK_SECONDS: u64 = 15;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommunityNodeNodeConfig {

--- a/crates/desktop-runtime/src/community_node/scheduler_support.rs
+++ b/crates/desktop-runtime/src/community_node/scheduler_support.rs
@@ -1,0 +1,77 @@
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use super::*;
+
+impl DesktopRuntime {
+    /// CN セッション維持の 1 tick。設定済みの全 node へ registration refresh(if_due)を回し、
+    /// 続けて connectivity self-heal 判定を実行する。従来 `get_sync_status` の副作用として
+    /// UI ポーリング経由でのみ駆動されていた内容を、ポーリング非依存で駆動する(WP-C1)。
+    /// refresh は deadline ゲート済みの冪等設計のため、短い間隔で繰り返し呼んでも安全。
+    pub(crate) async fn run_community_node_session_maintenance_once(&self) {
+        let config = self.community_node_config.lock().await.clone();
+        if config.nodes.is_empty() {
+            return;
+        }
+        for node in config.nodes {
+            if let Err(error) = self
+                .refresh_community_node_registration_if_due(node.base_url.as_str())
+                .await
+            {
+                warn!(
+                    base_url = %node.base_url,
+                    error = %error,
+                    "failed to refresh community-node registration from session scheduler"
+                );
+            }
+        }
+        match self.app_service.get_sync_status().await {
+            Ok(status) => {
+                self.maybe_self_heal_community_node_connectivity(&status)
+                    .await;
+            }
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "failed to load sync status for community-node self-heal from session scheduler"
+                );
+            }
+        }
+    }
+
+    /// セッション維持スケジューラを既定 tick(15 秒)で起動する。
+    /// トレイ常駐中(フロントのポーリング停止時)も CN 側の bootstrap 登録(TTL 90 秒)と
+    /// トークン失効前再認証を維持するための常駐タスク。起動は opt-in(コンストラクタでは
+    /// 起動しない)で、production では src-tauri の状態構築時に 1 回だけ呼ぶ。
+    /// 停止は `DesktopRuntime::shutdown` が行う。
+    pub async fn start_community_node_session_scheduler(self: &Arc<Self>) {
+        self.start_community_node_session_scheduler_with_interval(Duration::from_secs(
+            COMMUNITY_NODE_SESSION_SCHEDULER_TICK_SECONDS,
+        ))
+        .await;
+    }
+
+    /// tick 間隔を注入できる起動口(テスト用)。既に起動済みなら no-op。
+    pub(crate) async fn start_community_node_session_scheduler_with_interval(
+        self: &Arc<Self>,
+        tick: Duration,
+    ) {
+        let mut task = self.community_node_scheduler_task.lock().await;
+        if task.as_ref().is_some_and(|handle| !handle.is_finished()) {
+            return;
+        }
+        // Weak 参照で runtime の所有権を持たない: 最後の Arc が drop されたら tick 側から
+        // 自然終了する(shutdown 忘れでもリークしない)。upgrade した Arc は tick 実行中のみ保持。
+        let weak: Weak<Self> = Arc::downgrade(self);
+        *task = Some(tokio::spawn(async move {
+            loop {
+                let Some(runtime) = weak.upgrade() else {
+                    return;
+                };
+                runtime.run_community_node_session_maintenance_once().await;
+                drop(runtime);
+                tokio::time::sleep(tick).await;
+            }
+        }));
+    }
+}

--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -346,6 +346,10 @@ impl DesktopRuntime {
     }
 
     pub async fn shutdown(&self) {
+        if let Some(handle) = self.community_node_scheduler_task.lock().await.take() {
+            handle.abort();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        }
         self.app_service.shutdown().await;
         let _ = tokio::time::timeout(
             std::time::Duration::from_secs(15),

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -86,6 +86,7 @@ pub struct DesktopRuntime {
     pub(crate) community_node_session_guard: Arc<Mutex<()>>,
     pub(crate) community_node_reconnect_state: Arc<Mutex<CommunityNodeReconnectState>>,
     pub(crate) community_node_reconnect_guard: Arc<Mutex<()>>,
+    pub(crate) community_node_scheduler_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
     pub(crate) active_connectivity_urls: Arc<Mutex<Vec<String>>>,
     pub(crate) last_runtime_connectivity_assist_state:
         Arc<Mutex<Option<crate::community_node::RuntimeConnectivityAssistState>>>,
@@ -296,6 +297,7 @@ impl DesktopRuntime {
                 CommunityNodeReconnectState::default(),
             )),
             community_node_reconnect_guard: Arc::new(Mutex::new(())),
+            community_node_scheduler_task: Mutex::new(None),
             active_connectivity_urls: Arc::new(Mutex::new(relay_config.iroh_relay_urls.clone())),
             last_runtime_connectivity_assist_state: Arc::new(Mutex::new(Some(
                 initial_runtime_connectivity_state,

--- a/crates/desktop-runtime/src/tests/community_node.rs
+++ b/crates/desktop-runtime/src/tests/community_node.rs
@@ -1,4 +1,5 @@
 mod config;
 mod connectivity;
 mod metadata;
+mod scheduler;
 mod session;

--- a/crates/desktop-runtime/src/tests/community_node/scheduler.rs
+++ b/crates/desktop-runtime/src/tests/community_node/scheduler.rs
@@ -1,0 +1,241 @@
+use super::super::*;
+
+/// mock CN のカウンタが `at_least` に達するまで timeout 付きで待つ。
+/// スケジューラ tick は非同期に走るため、hit 数は「以上」でのみ判定する。
+async fn wait_for_counter(counter: &AtomicUsize, at_least: usize, label: &str) {
+    timeout(Duration::from_secs(30), async {
+        loop {
+            if counter.load(Ordering::SeqCst) >= at_least {
+                return;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "{label} did not reach {at_least} within timeout (current: {})",
+            counter.load(Ordering::SeqCst)
+        )
+    });
+}
+
+/// トレイ常駐相当(getter を一切呼ばない)でも bootstrap heartbeat が継続することを固定する。
+/// WP-C1 の failing test: スケジューラ導入前は heartbeat_hits が 0 のまま timeout で赤になる。
+#[tokio::test]
+async fn session_scheduler_keeps_bootstrap_registration_alive_without_getter_polling() {
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-scheduler-keepalive.db");
+    let runtime = Arc::new(
+        DesktopRuntime::new_with_config_and_identity(
+            &db_path,
+            TransportNetworkConfig::loopback(),
+            IdentityStorageMode::FileOnly,
+        )
+        .await
+        .expect("runtime"),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let state = Arc::new(MockCommunityNodeState {
+        base_url: base_url.clone(),
+        seed_peers: Arc::new(Mutex::new(vec![
+            CommunityNodeSeedPeer::new(
+                "1111111111111111111111111111111111111111111111111111111111111111",
+                None,
+            )
+            .expect("seed peer"),
+        ])),
+        heartbeat_seed_peers: Arc::new(Mutex::new(None)),
+        heartbeat_hits: Arc::new(AtomicUsize::new(0)),
+        bootstrap_hits: Arc::new(AtomicUsize::new(0)),
+    });
+    let app = Router::new()
+        .route("/v1/consents/status", get(mock_bootstrap_consent_status))
+        .route("/v1/bootstrap/heartbeat", post(mock_bootstrap_heartbeat))
+        .route("/v1/bootstrap/nodes", get(mock_bootstrap_nodes))
+        .with_state(state.clone());
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    persist_community_node_token(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        base_url.as_str(),
+        &StoredCommunityNodeToken {
+            access_token: "fake-token".to_string(),
+            expires_at: Utc::now().timestamp() + 3600,
+        },
+    )
+    .expect("persist community-node token");
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.clone(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
+                    .expect("resolved urls"),
+            ),
+        }],
+    };
+
+    // トレイ常駐相当: get_sync_status / get_community_node_statuses は一切呼ばない。
+    runtime
+        .start_community_node_session_scheduler_with_interval(Duration::from_millis(200))
+        .await;
+
+    wait_for_counter(&state.heartbeat_hits, 1, "heartbeat_hits").await;
+
+    // heartbeat 期限を過去に注入し、2 発目(維持の継続)を観測する。カウンタは mock が
+    // リクエストを受けた時点で増えるが、クライアント側の次回期限書き込みはその後のため、
+    // 単発注入では初回 tick の書き込みに上書きされうる。観測できるまで注入を繰り返す。
+    if timeout(Duration::from_secs(30), async {
+        loop {
+            runtime
+                .community_node_heartbeat_deadlines
+                .lock()
+                .await
+                .insert(base_url.clone(), Utc::now().timestamp() - 1);
+            if state.heartbeat_hits.load(Ordering::SeqCst) >= 2 {
+                return;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .is_err()
+    {
+        let task_finished = runtime
+            .community_node_scheduler_task
+            .lock()
+            .await
+            .as_ref()
+            .map(|handle| handle.is_finished());
+        panic!(
+            "heartbeat did not continue after deadline expiry\n  hits={} retry_deadlines={:?} phases={:?} last_errors={:?} now={} task_finished={:?}",
+            state.heartbeat_hits.load(Ordering::SeqCst),
+            runtime.community_node_session_retry_deadlines.lock().await,
+            runtime.community_node_session_phases.lock().await,
+            runtime.community_node_last_errors.lock().await,
+            Utc::now().timestamp(),
+            task_finished,
+        );
+    }
+
+    // shutdown でスケジューラ task が停止し、以後 heartbeat が打たれないこと。
+    runtime.shutdown().await;
+    let hits_after_shutdown = state.heartbeat_hits.load(Ordering::SeqCst);
+    runtime
+        .community_node_heartbeat_deadlines
+        .lock()
+        .await
+        .insert(base_url.clone(), Utc::now().timestamp() - 1);
+    sleep(Duration::from_millis(600)).await;
+    assert_eq!(
+        state.heartbeat_hits.load(Ordering::SeqCst),
+        hits_after_shutdown
+    );
+
+    server.abort();
+}
+
+/// トレイ常駐相当(getter を一切呼ばない)でも失効間近トークンの事前再認証が走ることを固定する。
+/// WP-C1 の failing test: スケジューラ導入前は verify_hits が 0 のまま timeout で赤になる。
+#[tokio::test]
+async fn session_scheduler_reauthenticates_near_expiry_token_without_getter_polling() {
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-scheduler-reauth.db");
+    let runtime = Arc::new(
+        DesktopRuntime::new_with_config_and_identity(
+            &db_path,
+            TransportNetworkConfig::loopback(),
+            IdentityStorageMode::FileOnly,
+        )
+        .await
+        .expect("runtime"),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let seed_peer = CommunityNodeSeedPeer::new(
+        "3333333333333333333333333333333333333333333333333333333333333333",
+        None,
+    )
+    .expect("seed peer");
+    let state = Arc::new(MockManagedCommunityNodeState {
+        base_url: base_url.clone(),
+        seed_peers: vec![seed_peer],
+        consent_accepted: Arc::new(AtomicBool::new(true)),
+        current_token: Arc::new(Mutex::new("near-expiry-token".into())),
+        challenge_hits: Arc::new(AtomicUsize::new(0)),
+        verify_hits: Arc::new(AtomicUsize::new(0)),
+        consent_status_hits: Arc::new(AtomicUsize::new(0)),
+        consent_accept_hits: Arc::new(AtomicUsize::new(0)),
+        heartbeat_hits: Arc::new(AtomicUsize::new(0)),
+        bootstrap_hits: Arc::new(AtomicUsize::new(0)),
+        simulate_pending_update: Arc::new(AtomicBool::new(false)),
+    });
+    let app = Router::new()
+        .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
+        .route("/v1/auth/verify", post(mock_managed_auth_verify))
+        .route("/v1/consents/status", get(mock_managed_consent_status))
+        .route("/v1/consents", post(mock_managed_accept_consents))
+        .route(
+            "/v1/bootstrap/heartbeat",
+            post(mock_managed_bootstrap_heartbeat),
+        )
+        .route("/v1/bootstrap/nodes", get(mock_managed_bootstrap_nodes))
+        .with_state(state.clone());
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    persist_community_node_token(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        base_url.as_str(),
+        &StoredCommunityNodeToken {
+            access_token: "near-expiry-token".into(),
+            expires_at: Utc::now().timestamp() + 60,
+        },
+    )
+    .expect("persist near-expiry token");
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.clone(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
+                    .expect("resolved urls"),
+            ),
+        }],
+    };
+
+    // トレイ常駐相当: getter を一切呼ばない。
+    runtime
+        .start_community_node_session_scheduler_with_interval(Duration::from_millis(200))
+        .await;
+
+    wait_for_counter(&state.verify_hits, 1, "verify_hits").await;
+    wait_for_counter(&state.heartbeat_hits, 1, "heartbeat_hits").await;
+
+    let stored = crate::community_node::load_community_node_token(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        base_url.as_str(),
+    )
+    .expect("load token")
+    .expect("stored token");
+    assert_ne!(stored.access_token, "near-expiry-token");
+
+    runtime.shutdown().await;
+    server.abort();
+}


### PR DESCRIPTION
## 概要

トレイ常駐中(フロントのポーリングは `document.visibilityState === 'hidden'` で停止)に CN セッション維持が完全停止し、CN 側の bootstrap 登録(TTL 90 秒)・rendezvous presence(TTL 45 秒)が失効する問題(マスタープラン E-1 / WP-C1)の修正。

セッション維持の駆動主体を UI ポーリング(`get_sync_status` / `get_community_node_statuses` の副作用)から desktop-runtime 内の常駐 tokio スケジューラへ移す。実装プラン: `.claude/plans/2026-07-05-fix-c1-cn-session-keepalive.md`(PR1 = T1〜T3)。

- **tick 本体** `run_community_node_session_maintenance_once`: 設定済み全 node へ既存の冪等な `refresh_community_node_registration_if_due`(deadline ゲート済み・Err→retry state 変換)を回し、続けて self-heal(`maybe_self_heal_community_node_connectivity`)を実行。新しい retry/backoff 機構は作らない
- **起動は opt-in 明示 start**(コンストラクタでは起動しない): production は `build_desktop_state` の `Arc::new` 直後に 1 回だけ起動。tick 15 秒(heartbeat 次回期限 = サーバ TTL 90s − 30s のため 30 秒未満が必須)。task は `Weak<DesktopRuntime>` 保持で Arc 循環なし、二重 start は no-op
- **停止**: `DesktopRuntime::shutdown` 冒頭で abort + join(2s timeout、AppService::shutdown と同型)。harness / 既存テストはスケジューラを起動しないため挙動不変
- 本 PR では getter の副作用は残置(スケジューラと二重駆動でも session_guard + deadline 群で冪等)。`get_sync_status` の読み取り専用化は後続 PR(T4)で実施

## 種別

fix(failing test 先行)

## 挙動変更

- トレイ常駐中(getter 呼び出しゼロ)でも bootstrap heartbeat・トークン失効前再認証が約 15 秒粒度で自律駆動される
- 起動直後(初回 UI ポーリング前)にもセッション確立が走る(従来は初回ポーリング ≤3 秒待ち)
- cn-user-api への HTTP は既存 endpoint のみ(凍結境界に非抵触)。serde・エラー文言・IPC 契約の変更なし

## failing test の証跡(赤 → 緑)

スケジューラ起動なし(現行コード相当)での実測:

```
heartbeat_hits did not reach 1 within timeout (current: 0)
verify_hits did not reach 1 within timeout (current: 0)
test result: FAILED. 0 passed; 2 failed
```

実装後(3 回連続実行で安定):

```
test result: ok. 2 passed; 0 failed; finished in 1.13s
```

## 検証

- `cargo xtask rust-test` green(489 tests)
- `cargo xtask tauri-check` green
- `cargo xtask e2e-smoke` green
- `cargo xtask scenario community_node_public_connectivity` green(実 cn-user-api + Postgres/Valkey + 実 iroh)
- clippy(kukuri-desktop-runtime --all-targets)clean
- Windows 実機のトレイ常駐確認(psql での alive 判定)は T4(読み取り専用化)完了後に実施予定

## リスク

- tick 毎に node ごとの consent GET が飛ぶ(現行 getter 駆動と同じセマンティクス。可視時の 3 秒 ×2 getter より低頻度)
- production では shutdown が呼ばれない(トレイ Quit は `app.exit(0)`)ため、スケジューラは abort-on-exit 前提(Weak 保持でリークなし)
- `apps/desktop/src-tauri/Cargo.lock` の diff は cn-core → cn-trust 依存(#415)の既存 drift を tauri-check が反映したもの(本変更の副作用ではないがビルドに必要)

## 後続対応

- PR2(T4): `get_sync_status` の読み取り専用化 + read-only contract テスト + 駆動依存テストの書き換え
- T5: Windows 実機確認(fix 前失効の再現記録は取得済みの調査実験に依拠、fix 後の維持確認を PR2 後に実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)