### PR TITLE
[fix] export 系ラッパーの capability persist 漏れを修正 (WP-C2 T1-T2)

### DIFF
--- a/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
+++ b/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
@@ -21,13 +21,17 @@ impl DesktopRuntime {
         &self,
         request: ExportPrivateChannelInviteRequest,
     ) -> Result<String> {
-        self.app_service
+        // owner の Share export は auto-rotate で capability を変異させる(WP-C2 E-2)
+        let token = self
+            .app_service
             .export_private_channel_invite(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await
+            .await?;
+        self.persist_private_channel_capabilities_from_app().await?;
+        Ok(token)
     }
 
     pub async fn import_private_channel_invite(
@@ -46,13 +50,17 @@ impl DesktopRuntime {
         &self,
         request: ExportChannelAccessTokenRequest,
     ) -> Result<ChannelAccessTokenExport> {
-        self.app_service
+        // app-api 内部で export 3 経路へ委譲されるため、このラッパー自身の persist が必要
+        let export = self
+            .app_service
             .export_channel_access_token(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await
+            .await?;
+        self.persist_private_channel_capabilities_from_app().await?;
+        Ok(export)
     }
 
     pub async fn import_channel_access_token(
@@ -80,13 +88,16 @@ impl DesktopRuntime {
         &self,
         request: ExportFriendOnlyGrantRequest,
     ) -> Result<String> {
-        self.app_service
+        let token = self
+            .app_service
             .export_friend_only_grant(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await
+            .await?;
+        self.persist_private_channel_capabilities_from_app().await?;
+        Ok(token)
     }
 
     pub async fn import_friend_only_grant(
@@ -105,13 +116,16 @@ impl DesktopRuntime {
         &self,
         request: ExportFriendPlusShareRequest,
     ) -> Result<String> {
-        self.app_service
+        let token = self
+            .app_service
             .export_friend_plus_share(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await
+            .await?;
+        self.persist_private_channel_capabilities_from_app().await?;
+        Ok(token)
     }
 
     pub async fn import_friend_plus_share(

--- a/crates/desktop-runtime/src/tests/private_channels.rs
+++ b/crates/desktop-runtime/src/tests/private_channels.rs
@@ -1,3 +1,4 @@
 mod friend_only;
 mod friend_plus;
 mod invite;
+mod persistence;

--- a/crates/desktop-runtime/src/tests/private_channels/persistence.rs
+++ b/crates/desktop-runtime/src/tests/private_channels/persistence.rs
@@ -1,0 +1,190 @@
+use super::super::*;
+
+/// WP-C2 (E-2): owner の export は auto-rotate で in-memory capability を新 epoch に置換する。
+/// rotate 後の capability が再起動を跨いで残ることを固定する failing test 群。
+///
+/// 注意: export と再起動の間に persist 付きラッパー(list_joined_private_channels 等)や
+/// それを内部で呼ぶテストヘルパーを挟むと、rotate 後 epoch が偶発的に persist されて
+/// バグがマスクされる。期待 epoch の取得は非変異の preview_channel_access_token で行う。
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn owner_invite_export_auto_rotate_survives_restart() {
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db = dir.path().join("private-export-persist-invite.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+    let topic = "kukuri:topic:desktop-export-persist-invite";
+
+    let _ = runtime
+        .list_timeline(ListTimelineRequest {
+            topic: topic.into(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await
+        .expect("subscribe");
+
+    let channel = runtime
+        .create_private_channel(CreatePrivateChannelRequest {
+            topic: topic.into(),
+            label: "export-persist-invite".into(),
+            audience_kind: ChannelAudienceKind::InviteOnly,
+        })
+        .await
+        .expect("create private channel");
+    let created_epoch = channel.current_epoch_id.clone();
+
+    let invite = runtime
+        .export_private_channel_invite(ExportPrivateChannelInviteRequest {
+            topic: topic.into(),
+            channel_id: channel.channel_id.clone(),
+            expires_at: None,
+        })
+        .await
+        .expect("export invite");
+
+    let preview = runtime
+        .preview_channel_access_token(PreviewChannelAccessTokenRequest { token: invite })
+        .await
+        .expect("preview invite");
+    let rotated_epoch = preview.epoch_id.clone();
+    assert_ne!(
+        rotated_epoch, created_epoch,
+        "owner invite export must auto-rotate the epoch"
+    );
+
+    timeout(runtime_shutdown_timeout(), runtime.shutdown())
+        .await
+        .expect("runtime shutdown timeout");
+    drop(runtime);
+
+    let restarted = DesktopRuntime::new_with_config_and_identity(
+        &db,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("restart runtime");
+    let joined = restarted
+        .list_joined_private_channels(ListJoinedPrivateChannelsRequest {
+            topic: topic.into(),
+        })
+        .await
+        .expect("list joined after restart");
+    assert_eq!(joined.len(), 1);
+    assert_eq!(
+        joined[0].current_epoch_id, rotated_epoch,
+        "rotated epoch must survive owner restart"
+    );
+    assert!(
+        joined[0]
+            .archived_epoch_ids
+            .contains(&created_epoch),
+        "pre-rotate epoch must be archived after restart (archived: {:?})",
+        joined[0].archived_epoch_ids
+    );
+
+    timeout(runtime_shutdown_timeout(), restarted.shutdown())
+        .await
+        .expect("restarted runtime shutdown timeout");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn owner_access_token_export_auto_rotate_survives_restart() {
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db = dir.path().join("private-export-persist-access-token.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+    let topic = "kukuri:topic:desktop-export-persist-access-token";
+
+    let _ = runtime
+        .list_timeline(ListTimelineRequest {
+            topic: topic.into(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await
+        .expect("subscribe");
+
+    // FriendPlus も owner の Share(export)で毎回 auto-rotate する。access token 経由の
+    // export は app-api 内部で export_friend_plus_share へ委譲されるディスパッチャ経路。
+    let channel = runtime
+        .create_private_channel(CreatePrivateChannelRequest {
+            topic: topic.into(),
+            label: "export-persist-access".into(),
+            audience_kind: ChannelAudienceKind::FriendPlus,
+        })
+        .await
+        .expect("create private channel");
+    let created_epoch = channel.current_epoch_id.clone();
+
+    let export = runtime
+        .export_channel_access_token(ExportChannelAccessTokenRequest {
+            topic: topic.into(),
+            channel_id: channel.channel_id.clone(),
+            expires_at: None,
+        })
+        .await
+        .expect("export access token");
+
+    let preview = runtime
+        .preview_channel_access_token(PreviewChannelAccessTokenRequest {
+            token: export.token,
+        })
+        .await
+        .expect("preview access token");
+    let rotated_epoch = preview.epoch_id.clone();
+    assert_ne!(
+        rotated_epoch, created_epoch,
+        "owner access-token export must auto-rotate the epoch"
+    );
+
+    timeout(runtime_shutdown_timeout(), runtime.shutdown())
+        .await
+        .expect("runtime shutdown timeout");
+    drop(runtime);
+
+    let restarted = DesktopRuntime::new_with_config_and_identity(
+        &db,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("restart runtime");
+    let joined = restarted
+        .list_joined_private_channels(ListJoinedPrivateChannelsRequest {
+            topic: topic.into(),
+        })
+        .await
+        .expect("list joined after restart");
+    assert_eq!(joined.len(), 1);
+    assert_eq!(
+        joined[0].current_epoch_id, rotated_epoch,
+        "rotated epoch must survive owner restart"
+    );
+    assert!(
+        joined[0]
+            .archived_epoch_ids
+            .contains(&created_epoch),
+        "pre-rotate epoch must be archived after restart (archived: {:?})",
+        joined[0].archived_epoch_ids
+    );
+
+    timeout(runtime_shutdown_timeout(), restarted.shutdown())
+        .await
+        .expect("restarted runtime shutdown timeout");
+}

--- a/crates/desktop-runtime/src/tests/private_channels/persistence.rs
+++ b/crates/desktop-runtime/src/tests/private_channels/persistence.rs
@@ -84,9 +84,7 @@ async fn owner_invite_export_auto_rotate_survives_restart() {
         "rotated epoch must survive owner restart"
     );
     assert!(
-        joined[0]
-            .archived_epoch_ids
-            .contains(&created_epoch),
+        joined[0].archived_epoch_ids.contains(&created_epoch),
         "pre-rotate epoch must be archived after restart (archived: {:?})",
         joined[0].archived_epoch_ids
     );
@@ -177,9 +175,7 @@ async fn owner_access_token_export_auto_rotate_survives_restart() {
         "rotated epoch must survive owner restart"
     );
     assert!(
-        joined[0]
-            .archived_epoch_ids
-            .contains(&created_epoch),
+        joined[0].archived_epoch_ids.contains(&created_epoch),
         "pre-rotate epoch must be archived after restart (archived: {:?})",
         joined[0].archived_epoch_ids
     );


### PR DESCRIPTION
## 概要

WP-C2 の PR1。owner が private channel を export(共有)すると `private_channel_state_for_owner_action(Share)` 経由の auto-rotate(InviteOnly / FriendPlus は毎回無条件)で in-memory capability が新 epoch に置換されるが、desktop-runtime の export 系ラッパー **4 本**だけが `persist_private_channel_capabilities_from_app` を呼んでおらず、再起動で新 epoch secret が失われていた(finding E-2 / D-3 の顕在化部分)。

owner は rotation grant の配布対象外(rotate 時にスキップ)のため自動回復経路がなく、エラーも出ずにサイレントに旧 epoch へ巻き戻り、次の export で二重 rotate してメンバーと恒久分断する。実装プラン: `.claude/plans/2026-07-06-fix-c2-capability-write-through.md`(T1〜T2)。

- failing test 先行(restart 型 2 本、FileOnly・単一 runtime):
  - InviteOnly: create → `export_private_channel_invite` → 再起動 → `current_epoch_id` が rotate 後 epoch のまま + 旧 epoch が archived に残る
  - FriendPlus: create → `export_channel_access_token`(ディスパッチャ経由で `export_friend_plus_share` を貫通)→ 同様の restart 検証
  - 期待 epoch は非変異の `preview_channel_access_token` で取得(persist 付きラッパーを挟むとバグがマスクされるため)
- 4 ラッパー(invite / **access_token** / friend_only_grant / friend_plus_share)に persist を追加(既存 9 箇所と同型)
  - マスタープランの「3 経路」は app-api 側 Share 変異点の数。`export_channel_access_token` は app-api **内部で** 3 export へ委譲するため、desktop-runtime ラッパーとしては 4 本目の独立修正が必要
  - `export_friend_only_grant` は rotation_required(stale participant)時のみ rotate するため専用 failing test は置かず同型機械修正(再現には 2 runtime + 相互フォロー成立→解除が必要で重い)

## 種別

fix(failing test 先行)

## 挙動変更

- export 成功時に capability レジストリが persist される(rotate 後の新 epoch secret がディスクに残る)
- persist 失敗時は export がエラーを返す(既存の import/rotate 等 9 箇所と同セマンティクス)
- serde・HTTP・IPC 契約・エラー文言の変更なし

## failing test の証跡(赤 → 緑)

修正前:

```
assertion `left == right` failed: rotated epoch must survive owner restart
  left: "epoch-1783271628282-0a7c18dd"   (再起動後 = rotate 前に巻き戻り)
 right: "epoch-1783271628302-0a7c18dd"   (rotate 後の期待値)
test result: FAILED. 0 passed; 2 failed
```

修正後: `test result: ok. 2 passed; 0 failed`

## 検証

- `cargo xtask rust-test` green(app-api / desktop-runtime の private_channels テスト全部を含む)
- clippy(kukuri-desktop-runtime --all-targets)clean

## リスク

- write 系 4 経路(create_post / create_live_session / create_game_room / create_metaverse_room)にも同型の persist 漏れが残る(FriendOnly の rotation_required 時 auto-rotate + 全経路の grant redeem)。投稿ホットパスに毎回の diagnostics 込み persist を入れる whack-a-mole は避け、後続の boundary PR(AppService への storage callback 注入、変異時のみ軽量 persist)で構造的に解消する
- Windows 既定(Auto/keyring)モードでは registry JSON が keyring blob 上限(2560B ≒ 2 チャンネル分)を超えると stale keyring 値へのサイレント巻き戻りが起きる既存バグがあり、後続 PR(keyring stale-entry 修正)で対処する

## 後続対応

- PR2: keyring stale-entry 修正(T3)
- PR3: 永続 registry JSON の形状 fixture(T4)
- PR4: AppService への storage callback 注入 + 手動 persist 規約の廃止(T5、refactor:boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)