### PR TITLE
[fix] keyring set 失敗時に stale entry を削除して file fallback を有効化 (WP-C2 T3)

### DIFF
--- a/crates/desktop-runtime/src/identity.rs
+++ b/crates/desktop-runtime/src/identity.rs
@@ -163,13 +163,19 @@ fn persist_optional_secret_with_keyring(
     keyring: &dyn KeyringStore,
 ) -> Result<()> {
     let account = optional_secret_account(db_path, purpose, key);
-    if mode == IdentityStorageMode::Auto
-        && keyring
+    if mode == IdentityStorageMode::Auto {
+        if keyring
             .set_password(KEYRING_SERVICE, account.as_str(), secret)
             .is_ok()
-    {
-        let _ = delete_file_if_exists(optional_secret_file_path(db_path, purpose, key).as_path());
-        return Ok(());
+        {
+            let _ =
+                delete_file_if_exists(optional_secret_file_path(db_path, purpose, key).as_path());
+            return Ok(());
+        }
+        // set 失敗時に旧 entry を残すと、load が keyring を優先するため file へ書いた
+        // 新しい値が恒久的にシャドウされる(例: Windows Credential Manager の blob 上限
+        // 超過で set が失敗し始めるケース)。best effort で削除してから file へ倒す。
+        let _ = keyring.delete_password(KEYRING_SERVICE, account.as_str());
     }
 
     persist_secret_to_file_path(
@@ -390,6 +396,7 @@ mod tests {
         entries: Arc<Mutex<HashMap<(String, String), String>>>,
         fail_get: Arc<Mutex<bool>>,
         fail_set: Arc<Mutex<bool>>,
+        fail_delete: Arc<Mutex<bool>>,
     }
 
     impl KeyringStore for FakeKeyringStore {
@@ -417,6 +424,9 @@ mod tests {
         }
 
         fn delete_password(&self, service: &str, account: &str) -> Result<()> {
+            if *self.fail_delete.lock().expect("keyring lock") {
+                anyhow::bail!("fake keyring delete failure");
+            }
             self.entries
                 .lock()
                 .expect("keyring lock")
@@ -529,6 +539,90 @@ mod tests {
                 .to_string()
                 .contains("persisted identity is stored in keyring"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn optional_secret_keyring_set_failure_does_not_shadow_file_fallback() {
+        clear_identity_env();
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("kukuri.db");
+        let keyring = FakeKeyringStore::default();
+
+        persist_optional_secret_with_keyring(
+            &db_path,
+            IdentityStorageMode::Auto,
+            "test-purpose",
+            "registry",
+            "old-value",
+            &keyring,
+        )
+        .expect("persist to keyring");
+        assert_eq!(
+            load_optional_secret_with_keyring(
+                &db_path,
+                IdentityStorageMode::Auto,
+                "test-purpose",
+                "registry",
+                &keyring,
+            )
+            .expect("load from keyring"),
+            Some("old-value".to_string())
+        );
+
+        // keyring 書き込みが失敗し始めた後の更新(例: registry JSON が blob 上限を超過)。
+        // 旧 entry が残ると load(keyring 優先)が file の新しい値を恒久的にシャドウする。
+        *keyring.fail_set.lock().expect("keyring lock") = true;
+        persist_optional_secret_with_keyring(
+            &db_path,
+            IdentityStorageMode::Auto,
+            "test-purpose",
+            "registry",
+            "new-value",
+            &keyring,
+        )
+        .expect("persist with keyring set failure");
+
+        let loaded = load_optional_secret_with_keyring(
+            &db_path,
+            IdentityStorageMode::Auto,
+            "test-purpose",
+            "registry",
+            &keyring,
+        )
+        .expect("load after fallback");
+        assert_eq!(
+            loaded,
+            Some("new-value".to_string()),
+            "stale keyring entry must not shadow the file fallback"
+        );
+    }
+
+    #[test]
+    fn optional_secret_persists_to_file_even_when_keyring_delete_fails() {
+        clear_identity_env();
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("kukuri.db");
+        let keyring = FakeKeyringStore::default();
+
+        *keyring.fail_set.lock().expect("keyring lock") = true;
+        *keyring.fail_delete.lock().expect("keyring lock") = true;
+        persist_optional_secret_with_keyring(
+            &db_path,
+            IdentityStorageMode::Auto,
+            "test-purpose",
+            "registry",
+            "value",
+            &keyring,
+        )
+        .expect("persist must fall back to file even when delete fails");
+
+        assert_eq!(
+            load_secret_from_file_path(
+                optional_secret_file_path(&db_path, "test-purpose", "registry").as_path()
+            )
+            .expect("read fallback file"),
+            Some("value".to_string())
         );
     }
 


### PR DESCRIPTION
## 概要

WP-C2 の PR2(調査で発見した独立既存バグの修正。実装プラン `.claude/plans/2026-07-06-fix-c2-capability-write-through.md` T3 / Decision 1)。

Auto モード(本番既定)の `persist_optional_secret` は keyring `set_password` 失敗時に file へフォールバックするが、**既存の keyring entry を削除しない**。load は keyring を優先するため、以後の更新は file に書かれるのに読み込みは古い keyring 値を返し続ける(サイレント巻き戻り)。

Windows では keyring crate(windows-native)が `CRED_MAX_CREDENTIAL_BLOB_SIZE = 2560` bytes(UTF-16)を書き込み前に検証して決定論的に失敗するため、capability registry JSON(実測: 2 チャンネルで 2654 bytes / 1 チャンネル + archived 5 epoch で 2666 bytes)が上限を超えた時点で必ず発現する。**WP-C2 の export persist 修正(#476)の実効性が Windows Auto で成立するための前提**であり、また C2 と無関係に「2 個目のチャンネルが再起動で消える」形で今日でも発現しうる。

- failing test 先行: `FakeKeyringStore(fail_set)` で「keyring に旧値 → set 失敗 → file に新値 → load が旧値を返す」を赤で実測
- 修正: set 失敗時に best effort で `delete_password` してから file へフォールバック(load は NoEntry → file を正しく読む)。delete 失敗時も file 書き込みは実行
- 対象は optional secret 全経路(capability registry / CN token / gossip state)— いずれも「keyring set 失敗時に正しい値が読めるようになる」方向のみの変化

## 種別

fix(failing test 先行)

## 挙動変更

- Auto モードで keyring set 失敗時のみ: stale entry が削除され、以後 load が file fallback を返す(従来は古い keyring 値)
- keyring set 成功時・FileOnly モードは挙動不変。JSON 形式・purpose/key・keyring account 形式は不変

## failing test の証跡(赤 → 緑)

修正前:

```
assertion `left == right` failed: stale keyring entry must not shadow the file fallback
  left: Some("old-value")
 right: Some("new-value")
```

修正後: identity 系 14 テスト全 green(新規 2 本含む)。

## 検証

- `cargo xtask rust-test` green
- clippy(kukuri-desktop-runtime --all-targets)clean

## リスク

- delete も失敗する環境では従来どおりシャドウが残る(best effort。file 書き込み自体は常に実行される)
- keyring 上限の構造問題(registry が大きくなると常時 file 保存になる)は残るが、file 保存は FileOnly と同一コードパスで動作実績あり(根治はスコープ外)

## 後続対応

- PR3: 永続 registry JSON の形状 fixture(T4)
- PR4: storage callback 注入 boundary(T5)
- T6: Windows 実機確認(Auto モード、keyring 内/超過の両ケース)

🤖 Generated with [Claude Code](https://claude.com/claude-code)