### PR TITLE
[contract] capability registry 永続 JSON の形状 fixture を追加 (WP-C2 T4)

### DIFF
--- a/crates/app-api/src/tests/capability_registry_snapshot.rs
+++ b/crates/app-api/src/tests/capability_registry_snapshot.rs
@@ -1,0 +1,124 @@
+use super::*;
+
+use crate::service::projection_support::joined_private_channel_state_from_capability;
+use crate::{PrivateChannelCapability, PrivateChannelEpochCapability};
+use kukuri_core::ChannelAudienceKind;
+
+// private channel capability registry の永続 JSON(desktop-runtime が identity storage に
+// purpose="private-channel-capabilities" / key="registry" で保存する
+// `Vec<PrivateChannelCapability>` の serde 表現)は、既存ユーザーのディスク上に存在する
+// 凍結境界である。フィールド名・形状の変更は migration なしに不可。
+// このテストはその形状を固定し、意図しない serde 変更を CI で検出する。
+
+fn full_capability() -> PrivateChannelCapability {
+    PrivateChannelCapability {
+        topic_id: "kukuri:topic:snapshot".into(),
+        channel_id: "channel-1".into(),
+        label: "snapshot".into(),
+        creator_pubkey: "11".repeat(32),
+        owner_pubkey: "22".repeat(32),
+        joined_via_pubkey: Some("33".repeat(32)),
+        audience_kind: ChannelAudienceKind::FriendPlus,
+        current_epoch_id: "epoch-1700000000000-aabbccdd".into(),
+        current_epoch_secret_hex: "44".repeat(32),
+        archived_epochs: vec![PrivateChannelEpochCapability {
+            epoch_id: "epoch-1600000000000-aabbccdd".into(),
+            namespace_secret_hex: "55".repeat(32),
+        }],
+        rotation_required: true,
+        participant_count: 3,
+        stale_participant_count: 1,
+        namespace_secret_hex: "44".repeat(32),
+    }
+}
+
+#[test]
+fn capability_registry_json_shape_is_frozen() {
+    let registry = vec![full_capability()];
+    let encoded = serde_json::to_string(&registry).expect("encode registry");
+    let expected = format!(
+        concat!(
+            "[{{",
+            "\"topic_id\":\"kukuri:topic:snapshot\",",
+            "\"channel_id\":\"channel-1\",",
+            "\"label\":\"snapshot\",",
+            "\"creator_pubkey\":\"{c}\",",
+            "\"owner_pubkey\":\"{o}\",",
+            "\"joined_via_pubkey\":\"{j}\",",
+            "\"audience_kind\":\"friend_plus\",",
+            "\"current_epoch_id\":\"epoch-1700000000000-aabbccdd\",",
+            "\"current_epoch_secret_hex\":\"{s}\",",
+            "\"archived_epochs\":[{{",
+            "\"epoch_id\":\"epoch-1600000000000-aabbccdd\",",
+            "\"namespace_secret_hex\":\"{a}\"",
+            "}}],",
+            "\"rotation_required\":true,",
+            "\"participant_count\":3,",
+            "\"stale_participant_count\":1,",
+            "\"namespace_secret_hex\":\"{s}\"",
+            "}}]"
+        ),
+        c = "11".repeat(32),
+        o = "22".repeat(32),
+        j = "33".repeat(32),
+        s = "44".repeat(32),
+        a = "55".repeat(32),
+    );
+    assert_eq!(encoded, expected);
+
+    let decoded: Vec<PrivateChannelCapability> =
+        serde_json::from_str(&encoded).expect("decode registry");
+    assert_eq!(decoded, registry);
+}
+
+#[test]
+fn capability_registry_accepts_minimal_legacy_json() {
+    // 過去バージョンが書いた最小形(必須 4 フィールドのみ)と、legacy 世代の
+    // 「namespace_secret_hex のみ・current_epoch_* 空」形の両方が読めること。
+    let minimal = r#"[{
+        "topic_id": "kukuri:topic:legacy",
+        "channel_id": "channel-legacy",
+        "label": "legacy",
+        "creator_pubkey": "aa"
+    }]"#;
+    let decoded: Vec<PrivateChannelCapability> =
+        serde_json::from_str(minimal).expect("decode minimal registry");
+    assert_eq!(decoded.len(), 1);
+    assert_eq!(decoded[0].owner_pubkey, "");
+    assert_eq!(decoded[0].audience_kind, ChannelAudienceKind::InviteOnly);
+    assert!(decoded[0].archived_epochs.is_empty());
+
+    let legacy = r#"[{
+        "topic_id": "kukuri:topic:legacy",
+        "channel_id": "channel-legacy",
+        "label": "legacy",
+        "creator_pubkey": "aa",
+        "namespace_secret_hex": "bb"
+    }]"#;
+    let decoded: Vec<PrivateChannelCapability> =
+        serde_json::from_str(legacy).expect("decode legacy registry");
+    let state = joined_private_channel_state_from_capability(decoded[0].clone())
+        .expect("restore legacy capability");
+    // legacy 形: current_epoch_id は legacy epoch、secret は namespace_secret_hex へ
+    // フォールバック、owner は creator へフォールバックする。
+    assert_eq!(state.current_epoch_secret_hex, "bb");
+    assert_eq!(state.owner_pubkey, "aa");
+}
+
+#[test]
+fn diagnostics_fields_do_not_affect_restored_state() {
+    // rotation_required / participant_count / stale_participant_count は復元時に
+    // 一切読まれない(= 永続化時に既定値へ落としても復元同値)。boundary PR の
+    // state-only スナップショット化が凍結境界を壊さないことの固定。
+    let populated = full_capability();
+    let mut defaulted = populated.clone();
+    defaulted.rotation_required = false;
+    defaulted.participant_count = 0;
+    defaulted.stale_participant_count = 0;
+
+    let state_populated =
+        joined_private_channel_state_from_capability(populated).expect("restore populated");
+    let state_defaulted =
+        joined_private_channel_state_from_capability(defaulted).expect("restore defaulted");
+    assert_eq!(state_populated, state_defaulted);
+}

--- a/crates/app-api/src/tests/capability_registry_snapshot.rs
+++ b/crates/app-api/src/tests/capability_registry_snapshot.rs
@@ -1,5 +1,3 @@
-use super::*;
-
 use crate::service::projection_support::joined_private_channel_state_from_capability;
 use crate::{PrivateChannelCapability, PrivateChannelEpochCapability};
 use kukuri_core::ChannelAudienceKind;

--- a/crates/app-api/src/tests/mod.rs
+++ b/crates/app-api/src/tests/mod.rs
@@ -21,6 +21,7 @@ use tokio::sync::{Mutex as TokioMutex, broadcast};
 use tokio::time::{Duration, sleep, timeout};
 use tokio_stream::wrappers::BroadcastStream;
 
+mod capability_registry_snapshot;
 mod direct_messages;
 mod game;
 mod live;


### PR DESCRIPTION
## 概要

WP-C2 の PR3(実装プラン `.claude/plans/2026-07-06-fix-c2-capability-write-through.md` T4)。

private channel capability registry の永続 JSON(identity storage の purpose=`private-channel-capabilities` / key=`registry` に保存される `Vec<PrivateChannelCapability>` の serde 表現)は既存ユーザーのディスク上に存在する凍結境界だが、これまで形状を固定するテストが存在しなかった(views_wire_snapshot の対象は `JoinedPrivateChannelView` のみ)。

- **形状 golden**: 全フィールド populated の registry → serializer 出力の JSON 文字列一致(フィールド名の rename・追加位置の変更・形状変更で fail する)
- **後方互換の固定**: 必須 4 フィールドのみの最小 JSON、および legacy 形(`namespace_secret_hex` のみ・`current_epoch_*` 空)の読み込み + 復元フォールバック(legacy epoch 化 / secret フォールバック / creator→owner)
- **diagnostics 非依存の固定**: `rotation_required` / `participant_count` / `stale_participant_count` は復元結果(`JoinedPrivateChannelState`)に影響しない — 後続 boundary PR(storage callback の state-only スナップショット化)がこのフィールドの「値」を既定値に変えても復元同値であることの検出装置

## 種別

contract(実装変更なし)

## 挙動変更

なし(テスト追加のみ)

## 検証

- `cargo xtask rust-test` green
- clippy(kukuri-app-api --all-targets)clean

## リスク

なし

## 後続対応

- PR4: AppService への storage callback 注入 + 手動 persist 規約の廃止(refactor:boundary、本 fixture が安全網)

🤖 Generated with [Claude Code](https://claude.com/claude-code)