### PR TITLE
[refactor:boundary] capability 永続化を AppService の write-through callback へ集約 (WP-C2 T5)

### DIFF
--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -214,6 +214,11 @@ pub(crate) struct ResolvedRepostSource {
     pub(crate) repost_of: RepostSourceSnapshotV1,
 }
 
+/// private channel capability registry の write-through 永続化 callback。
+/// 実体(identity storage への保存)は desktop-runtime が注入する。未接続なら no-op。
+pub type PrivateChannelCapabilityPersist =
+    Arc<dyn Fn(&[crate::PrivateChannelCapability]) -> Result<()> + Send + Sync>;
+
 pub struct AppService {
     pub(crate) store: Arc<dyn Store>,
     pub(crate) projection_store: Arc<dyn ProjectionStore>,
@@ -237,6 +242,9 @@ pub struct AppService {
     pub(crate) empty_recovery_candidates: Arc<Mutex<HashSet<String>>>,
     pub(crate) gossip_disabled_topics: Arc<Mutex<HashSet<String>>>,
     pub(crate) gossip_disabled_channels: Arc<Mutex<HashSet<String>>>,
+    pub(crate) private_channel_capability_persist:
+        std::sync::OnceLock<PrivateChannelCapabilityPersist>,
+    pub(crate) private_channel_capability_persist_guard: Arc<Mutex<()>>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -390,7 +398,18 @@ impl AppService {
             empty_recovery_candidates: Arc::new(Mutex::new(HashSet::new())),
             gossip_disabled_topics: Arc::new(Mutex::new(HashSet::new())),
             gossip_disabled_channels: Arc::new(Mutex::new(HashSet::new())),
+            private_channel_capability_persist: std::sync::OnceLock::new(),
+            private_channel_capability_persist_guard: Arc::new(Mutex::new(())),
         }
+    }
+
+    /// capability registry の write-through 永続化 callback を接続する。
+    /// registry を変異させるメソッド(register/remove 経由の全経路)は、以後
+    /// persist 試行が完了するまで return しない。復元
+    /// (`restore_private_channel_capability`)完了後に 1 回だけ呼ぶこと —
+    /// 復元前に接続すると復元途中の部分リストが永続化される。
+    pub fn set_private_channel_capability_persist(&self, persist: PrivateChannelCapabilityPersist) {
+        let _ = self.private_channel_capability_persist.set(persist);
     }
 
     pub(crate) async fn resolve_repost_source(

--- a/crates/app-api/src/service/private_channels_support.rs
+++ b/crates/app-api/src/service/private_channels_support.rs
@@ -406,6 +406,24 @@ impl AppService {
         .await
     }
 
+    /// registry 変異時の write-through 永続化。callback 未接続(テスト・harness・復元前)
+    /// なら no-op。persist 同士を専用 guard で直列化し、スナップショットを guard 内で
+    /// 取ることで「古いスナップショットが新しい書き込みを上書きする」lost-update を防ぐ
+    /// (全量スナップショットのため、最後に走った persist が必ず最新の registry を反映する)。
+    pub(crate) async fn persist_private_channel_capabilities_if_configured(&self) -> Result<()> {
+        let Some(persist) = self.private_channel_capability_persist.get() else {
+            return Ok(());
+        };
+        let _guard = self.private_channel_capability_persist_guard.lock().await;
+        let snapshot = {
+            let map = self.joined_private_channels.lock().await;
+            map.values()
+                .map(private_channel_capability_snapshot)
+                .collect::<Vec<_>>()
+        };
+        persist(&snapshot)
+    }
+
     pub(crate) async fn register_joined_private_channel(
         &self,
         state: JoinedPrivateChannelState,
@@ -415,6 +433,8 @@ impl AppService {
             joined_private_channel_key(state.topic_id.as_str(), state.channel_id.as_str()),
             state.clone(),
         );
+        self.persist_private_channel_capabilities_if_configured()
+            .await?;
         self.ensure_private_channel_subscription(
             state.topic_id.as_str(),
             state.channel_id.as_str(),
@@ -433,6 +453,10 @@ impl AppService {
             .lock()
             .await
             .remove(joined_private_channel_key(topic_id, channel_id).as_str());
+        if removed.is_some() {
+            self.persist_private_channel_capabilities_if_configured()
+                .await?;
+        }
         let prefix = joined_private_channel_subscription_prefix(topic_id, channel_id);
         let keys = self
             .private_channel_subscriptions
@@ -1024,5 +1048,31 @@ impl AppService {
                 .insert(topic_id.to_string(), handle);
         }
         Ok(())
+    }
+}
+
+/// write-through 永続化用の state-only スナップショット。
+/// `private_channel_capability_from_state` と異なり diagnostics(docs 読みを伴う
+/// async/fallible 処理)に依存しない純関数。diagnostics 派生 3 フィールドは復元時に
+/// 一切読まれない(capability_registry_snapshot テストで固定)ため既定値で永続化する。
+/// JSON のフィールド名・形状(凍結境界)は不変。
+pub(crate) fn private_channel_capability_snapshot(
+    state: &JoinedPrivateChannelState,
+) -> PrivateChannelCapability {
+    PrivateChannelCapability {
+        topic_id: state.topic_id.clone(),
+        channel_id: state.channel_id.as_str().to_string(),
+        label: state.label.clone(),
+        creator_pubkey: state.creator_pubkey.clone(),
+        owner_pubkey: state.owner_pubkey.clone(),
+        joined_via_pubkey: state.joined_via_pubkey.clone(),
+        audience_kind: state.audience_kind.clone(),
+        current_epoch_id: state.current_epoch_id.clone(),
+        current_epoch_secret_hex: state.current_epoch_secret_hex.clone(),
+        archived_epochs: state.archived_epochs.clone(),
+        rotation_required: false,
+        participant_count: 0,
+        stale_participant_count: 0,
+        namespace_secret_hex: state.current_epoch_secret_hex.clone(),
     }
 }

--- a/crates/app-api/src/tests/private_channels.rs
+++ b/crates/app-api/src/tests/private_channels.rs
@@ -2,3 +2,4 @@ mod friend_only;
 mod friend_plus;
 mod invite;
 mod leave;
+mod persist_callback;

--- a/crates/app-api/src/tests/private_channels/persist_callback.rs
+++ b/crates/app-api/src/tests/private_channels/persist_callback.rs
@@ -1,0 +1,135 @@
+use super::super::*;
+
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicUsize;
+
+use crate::PrivateChannelCapability;
+
+/// capability registry の write-through callback が変異経路(register/remove)で
+/// 発火し、state-only スナップショット(diagnostics 既定値)を受け取ることを固定する。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn capability_persist_callback_fires_on_registry_mutations() {
+    let store = Arc::new(MemoryStore::default());
+    let transport = Arc::new(FakeTransport::new("self", FakeNetwork::default()));
+    let app = AppService::new(store, transport);
+
+    let persist_calls = Arc::new(AtomicUsize::new(0));
+    let last_snapshot: Arc<StdMutex<Vec<PrivateChannelCapability>>> =
+        Arc::new(StdMutex::new(Vec::new()));
+    {
+        let persist_calls = persist_calls.clone();
+        let last_snapshot = last_snapshot.clone();
+        app.set_private_channel_capability_persist(Arc::new(move |capabilities| {
+            persist_calls.fetch_add(1, Ordering::SeqCst);
+            *last_snapshot.lock().expect("snapshot lock") = capabilities.to_vec();
+            Ok(())
+        }));
+    }
+
+    let topic = "kukuri:topic:persist-callback";
+    let _ = app.list_timeline(topic, None, 20).await;
+
+    // register 経由(create)で発火し、スナップショットに channel が入る。
+    let channel = app
+        .create_private_channel(CreatePrivateChannelInput {
+            topic_id: TopicId::new(topic),
+            label: "persist-callback".into(),
+            audience_kind: ChannelAudienceKind::InviteOnly,
+        })
+        .await
+        .expect("create private channel");
+    let calls_after_create = persist_calls.load(Ordering::SeqCst);
+    assert!(calls_after_create >= 1, "create must trigger persist");
+    {
+        let snapshot = last_snapshot.lock().expect("snapshot lock");
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].channel_id, channel.channel_id);
+        assert_eq!(snapshot[0].current_epoch_id, channel.current_epoch_id);
+        assert!(
+            !snapshot[0].current_epoch_secret_hex.is_empty(),
+            "secret must be persisted"
+        );
+        // state-only スナップショット: diagnostics 派生フィールドは既定値
+        // (復元時に読まれないことは capability_registry_snapshot テストが固定)。
+        assert!(!snapshot[0].rotation_required);
+        assert_eq!(snapshot[0].participant_count, 0);
+    }
+
+    // rotate(register 経由の epoch 置換)で発火し、新 epoch が反映される。
+    let rotated = app
+        .rotate_private_channel(topic, channel.channel_id.as_str())
+        .await
+        .expect("rotate private channel");
+    assert!(persist_calls.load(Ordering::SeqCst) > calls_after_create);
+    let calls_after_rotate = persist_calls.load(Ordering::SeqCst);
+    {
+        let snapshot = last_snapshot.lock().expect("snapshot lock");
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].current_epoch_id, rotated.current_epoch_id);
+        assert!(
+            snapshot[0]
+                .archived_epochs
+                .iter()
+                .any(|epoch| epoch.epoch_id == channel.current_epoch_id),
+            "pre-rotate epoch must be archived in the persisted snapshot"
+        );
+    }
+
+    // remove 経由(leave)で発火し、スナップショットから消える。
+    app.leave_private_channel(topic, channel.channel_id.as_str())
+        .await
+        .expect("leave private channel");
+    assert!(persist_calls.load(Ordering::SeqCst) > calls_after_rotate);
+    assert!(
+        last_snapshot.lock().expect("snapshot lock").is_empty(),
+        "leave must persist the removal"
+    );
+}
+
+/// callback 未接続なら registry 変異は従来どおり成功する(テスト・harness 互換)。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn registry_mutations_succeed_without_persist_callback() {
+    let store = Arc::new(MemoryStore::default());
+    let transport = Arc::new(FakeTransport::new("self", FakeNetwork::default()));
+    let app = AppService::new(store, transport);
+
+    let topic = "kukuri:topic:persist-callback-none";
+    let _ = app.list_timeline(topic, None, 20).await;
+    let channel = app
+        .create_private_channel(CreatePrivateChannelInput {
+            topic_id: TopicId::new(topic),
+            label: "no-callback".into(),
+            audience_kind: ChannelAudienceKind::InviteOnly,
+        })
+        .await
+        .expect("create private channel without callback");
+    app.leave_private_channel(topic, channel.channel_id.as_str())
+        .await
+        .expect("leave private channel without callback");
+}
+
+/// persist 失敗は変異コマンドのエラーとして伝播する(rollback はしない — 現行同等)。
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn persist_failure_propagates_from_mutation() {
+    let store = Arc::new(MemoryStore::default());
+    let transport = Arc::new(FakeTransport::new("self", FakeNetwork::default()));
+    let app = AppService::new(store, transport);
+    app.set_private_channel_capability_persist(Arc::new(|_| {
+        anyhow::bail!("fake persist failure")
+    }));
+
+    let topic = "kukuri:topic:persist-callback-fail";
+    let _ = app.list_timeline(topic, None, 20).await;
+    let error = app
+        .create_private_channel(CreatePrivateChannelInput {
+            topic_id: TopicId::new(topic),
+            label: "persist-fail".into(),
+            audience_kind: ChannelAudienceKind::InviteOnly,
+        })
+        .await
+        .expect_err("persist failure must propagate");
+    assert!(
+        format!("{error:#}").contains("fake persist failure"),
+        "unexpected error: {error:#}"
+    );
+}

--- a/crates/app-api/src/tests/private_channels/persist_callback.rs
+++ b/crates/app-api/src/tests/private_channels/persist_callback.rs
@@ -114,9 +114,7 @@ async fn persist_failure_propagates_from_mutation() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(FakeTransport::new("self", FakeNetwork::default()));
     let app = AppService::new(store, transport);
-    app.set_private_channel_capability_persist(Arc::new(|_| {
-        anyhow::bail!("fake persist failure")
-    }));
+    app.set_private_channel_capability_persist(Arc::new(|_| anyhow::bail!("fake persist failure")));
 
     let topic = "kukuri:topic:persist-callback-fail";
     let _ = app.list_timeline(topic, None, 20).await;

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -265,6 +265,16 @@ impl DesktopRuntime {
                 .restore_private_channel_capability(capability)
                 .await?;
         }
+        // 復元完了後に write-through 永続化を接続する(復元前に接続すると復元途中の
+        // 部分リストが persist され、途中クラッシュでディスク上の registry が縮む)。
+        // 以後、capability registry の変異(register/remove 経由の全経路)は AppService
+        // 層でそのまま identity storage へ永続化され、ラッパー側の手動 persist 規約は不要。
+        {
+            let persist_db_path = db_path.clone();
+            app_service.set_private_channel_capability_persist(Arc::new(move |capabilities| {
+                persist_private_channel_capabilities(&persist_db_path, identity_mode, capabilities)
+            }));
+        }
         let gossip_subscription_state = load_gossip_subscription_state(&db_path, identity_mode)?;
         app_service
             .restore_gossip_disabled_state(
@@ -330,14 +340,6 @@ impl DesktopRuntime {
 
     pub fn db_path(&self) -> &Path {
         &self.db_path
-    }
-
-    async fn persist_private_channel_capabilities_from_app(&self) -> Result<()> {
-        persist_private_channel_capabilities(
-            &self.db_path,
-            self.identity_mode,
-            &self.app_service.list_private_channel_capabilities().await?,
-        )
     }
 
     pub(crate) async fn persist_gossip_subscription_state_from_app(&self) -> Result<()> {

--- a/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
+++ b/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
@@ -21,13 +21,17 @@ impl DesktopRuntime {
         &self,
         request: ExportPrivateChannelInviteRequest,
     ) -> Result<String> {
-        self.app_service
+        // owner の Share export は auto-rotate で capability を変異させる(WP-C2 E-2)
+        let token = self
+            .app_service
             .export_private_channel_invite(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await
+            .await?;
+        self.persist_private_channel_capabilities_from_app().await?;
+        Ok(token)
     }
 
     pub async fn import_private_channel_invite(
@@ -46,13 +50,17 @@ impl DesktopRuntime {
         &self,
         request: ExportChannelAccessTokenRequest,
     ) -> Result<ChannelAccessTokenExport> {
-        self.app_service
+        // app-api 内部で export 3 経路へ委譲されるため、このラッパー自身の persist が必要
+        let export = self
+            .app_service
             .export_channel_access_token(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await
+            .await?;
+        self.persist_private_channel_capabilities_from_app().await?;
+        Ok(export)
     }
 
     pub async fn import_channel_access_token(
@@ -80,13 +88,16 @@ impl DesktopRuntime {
         &self,
         request: ExportFriendOnlyGrantRequest,
     ) -> Result<String> {
-        self.app_service
+        let token = self
+            .app_service
             .export_friend_only_grant(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await
+            .await?;
+        self.persist_private_channel_capabilities_from_app().await?;
+        Ok(token)
     }
 
     pub async fn import_friend_only_grant(
@@ -105,13 +116,16 @@ impl DesktopRuntime {
         &self,
         request: ExportFriendPlusShareRequest,
     ) -> Result<String> {
-        self.app_service
+        let token = self
+            .app_service
             .export_friend_plus_share(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await
+            .await?;
+        self.persist_private_channel_capabilities_from_app().await?;
+        Ok(token)
     }
 
     pub async fn import_friend_plus_share(

--- a/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
+++ b/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
@@ -1,78 +1,63 @@
 use super::*;
 
+// capability registry の永続化はラッパー側の手動 persist ではなく、AppService へ注入した
+// write-through callback(registry 変異時に発火)が担う(WP-C2 boundary)。
 impl DesktopRuntime {
     pub async fn create_private_channel(
         &self,
         request: CreatePrivateChannelRequest,
     ) -> Result<JoinedPrivateChannelView> {
-        let channel = self
-            .app_service
+        self.app_service
             .create_private_channel(CreatePrivateChannelInput {
                 topic_id: TopicId::new(request.topic),
                 label: request.label,
                 audience_kind: request.audience_kind,
             })
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(channel)
+            .await
     }
 
     pub async fn export_private_channel_invite(
         &self,
         request: ExportPrivateChannelInviteRequest,
     ) -> Result<String> {
-        // owner の Share export は auto-rotate で capability を変異させる(WP-C2 E-2)
-        let token = self
-            .app_service
+        self.app_service
             .export_private_channel_invite(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(token)
+            .await
     }
 
     pub async fn import_private_channel_invite(
         &self,
         request: ImportPrivateChannelInviteRequest,
     ) -> Result<PrivateChannelInvitePreview> {
-        let preview = self
-            .app_service
+        self.app_service
             .import_private_channel_invite(request.token.as_str())
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(preview)
+            .await
     }
 
     pub async fn export_channel_access_token(
         &self,
         request: ExportChannelAccessTokenRequest,
     ) -> Result<ChannelAccessTokenExport> {
-        // app-api 内部で export 3 経路へ委譲されるため、このラッパー自身の persist が必要
-        let export = self
-            .app_service
+        self.app_service
             .export_channel_access_token(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(export)
+            .await
     }
 
     pub async fn import_channel_access_token(
         &self,
         request: ImportChannelAccessTokenRequest,
     ) -> Result<ChannelAccessTokenPreview> {
-        let preview = self
-            .app_service
+        self.app_service
             .import_channel_access_token(request.token.as_str())
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(preview)
+            .await
     }
 
     pub async fn preview_channel_access_token(
@@ -88,99 +73,77 @@ impl DesktopRuntime {
         &self,
         request: ExportFriendOnlyGrantRequest,
     ) -> Result<String> {
-        let token = self
-            .app_service
+        self.app_service
             .export_friend_only_grant(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(token)
+            .await
     }
 
     pub async fn import_friend_only_grant(
         &self,
         request: ImportFriendOnlyGrantRequest,
     ) -> Result<FriendOnlyGrantPreview> {
-        let preview = self
-            .app_service
+        self.app_service
             .import_friend_only_grant(request.token.as_str())
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(preview)
+            .await
     }
 
     pub async fn export_friend_plus_share(
         &self,
         request: ExportFriendPlusShareRequest,
     ) -> Result<String> {
-        let token = self
-            .app_service
+        self.app_service
             .export_friend_plus_share(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(token)
+            .await
     }
 
     pub async fn import_friend_plus_share(
         &self,
         request: ImportFriendPlusShareRequest,
     ) -> Result<FriendPlusSharePreview> {
-        let preview = self
-            .app_service
+        self.app_service
             .import_friend_plus_share(request.token.as_str())
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(preview)
+            .await
     }
 
     pub async fn freeze_private_channel(
         &self,
         request: FreezePrivateChannelRequest,
     ) -> Result<JoinedPrivateChannelView> {
-        let view = self
-            .app_service
+        self.app_service
             .freeze_private_channel(request.topic.as_str(), request.channel_id.as_str())
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(view)
+            .await
     }
 
     pub async fn rotate_private_channel(
         &self,
         request: RotatePrivateChannelRequest,
     ) -> Result<JoinedPrivateChannelView> {
-        let view = self
-            .app_service
+        self.app_service
             .rotate_private_channel(request.topic.as_str(), request.channel_id.as_str())
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(view)
+            .await
     }
 
     pub async fn leave_private_channel(&self, request: LeavePrivateChannelRequest) -> Result<()> {
         self.app_service
             .leave_private_channel(request.topic.as_str(), request.channel_id.as_str())
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await
+            .await
     }
 
     pub async fn list_joined_private_channels(
         &self,
         request: ListJoinedPrivateChannelsRequest,
     ) -> Result<Vec<JoinedPrivateChannelView>> {
-        let items = self
-            .app_service
+        self.app_service
             .list_joined_private_channels(request.topic.as_str())
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(items)
+            .await
     }
 
     pub async fn update_game_room(&self, request: UpdateGameRoomRequest) -> Result<()> {

--- a/crates/desktop-runtime/src/tests/private_channels.rs
+++ b/crates/desktop-runtime/src/tests/private_channels.rs
@@ -1,3 +1,4 @@
 mod friend_only;
 mod friend_plus;
 mod invite;
+mod persistence;

--- a/crates/desktop-runtime/src/tests/private_channels/persistence.rs
+++ b/crates/desktop-runtime/src/tests/private_channels/persistence.rs
@@ -1,0 +1,190 @@
+use super::super::*;
+
+/// WP-C2 (E-2): owner の export は auto-rotate で in-memory capability を新 epoch に置換する。
+/// rotate 後の capability が再起動を跨いで残ることを固定する failing test 群。
+///
+/// 注意: export と再起動の間に persist 付きラッパー(list_joined_private_channels 等)や
+/// それを内部で呼ぶテストヘルパーを挟むと、rotate 後 epoch が偶発的に persist されて
+/// バグがマスクされる。期待 epoch の取得は非変異の preview_channel_access_token で行う。
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn owner_invite_export_auto_rotate_survives_restart() {
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db = dir.path().join("private-export-persist-invite.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+    let topic = "kukuri:topic:desktop-export-persist-invite";
+
+    let _ = runtime
+        .list_timeline(ListTimelineRequest {
+            topic: topic.into(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await
+        .expect("subscribe");
+
+    let channel = runtime
+        .create_private_channel(CreatePrivateChannelRequest {
+            topic: topic.into(),
+            label: "export-persist-invite".into(),
+            audience_kind: ChannelAudienceKind::InviteOnly,
+        })
+        .await
+        .expect("create private channel");
+    let created_epoch = channel.current_epoch_id.clone();
+
+    let invite = runtime
+        .export_private_channel_invite(ExportPrivateChannelInviteRequest {
+            topic: topic.into(),
+            channel_id: channel.channel_id.clone(),
+            expires_at: None,
+        })
+        .await
+        .expect("export invite");
+
+    let preview = runtime
+        .preview_channel_access_token(PreviewChannelAccessTokenRequest { token: invite })
+        .await
+        .expect("preview invite");
+    let rotated_epoch = preview.epoch_id.clone();
+    assert_ne!(
+        rotated_epoch, created_epoch,
+        "owner invite export must auto-rotate the epoch"
+    );
+
+    timeout(runtime_shutdown_timeout(), runtime.shutdown())
+        .await
+        .expect("runtime shutdown timeout");
+    drop(runtime);
+
+    let restarted = DesktopRuntime::new_with_config_and_identity(
+        &db,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("restart runtime");
+    let joined = restarted
+        .list_joined_private_channels(ListJoinedPrivateChannelsRequest {
+            topic: topic.into(),
+        })
+        .await
+        .expect("list joined after restart");
+    assert_eq!(joined.len(), 1);
+    assert_eq!(
+        joined[0].current_epoch_id, rotated_epoch,
+        "rotated epoch must survive owner restart"
+    );
+    assert!(
+        joined[0]
+            .archived_epoch_ids
+            .contains(&created_epoch),
+        "pre-rotate epoch must be archived after restart (archived: {:?})",
+        joined[0].archived_epoch_ids
+    );
+
+    timeout(runtime_shutdown_timeout(), restarted.shutdown())
+        .await
+        .expect("restarted runtime shutdown timeout");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn owner_access_token_export_auto_rotate_survives_restart() {
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db = dir.path().join("private-export-persist-access-token.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+    let topic = "kukuri:topic:desktop-export-persist-access-token";
+
+    let _ = runtime
+        .list_timeline(ListTimelineRequest {
+            topic: topic.into(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await
+        .expect("subscribe");
+
+    // FriendPlus も owner の Share(export)で毎回 auto-rotate する。access token 経由の
+    // export は app-api 内部で export_friend_plus_share へ委譲されるディスパッチャ経路。
+    let channel = runtime
+        .create_private_channel(CreatePrivateChannelRequest {
+            topic: topic.into(),
+            label: "export-persist-access".into(),
+            audience_kind: ChannelAudienceKind::FriendPlus,
+        })
+        .await
+        .expect("create private channel");
+    let created_epoch = channel.current_epoch_id.clone();
+
+    let export = runtime
+        .export_channel_access_token(ExportChannelAccessTokenRequest {
+            topic: topic.into(),
+            channel_id: channel.channel_id.clone(),
+            expires_at: None,
+        })
+        .await
+        .expect("export access token");
+
+    let preview = runtime
+        .preview_channel_access_token(PreviewChannelAccessTokenRequest {
+            token: export.token,
+        })
+        .await
+        .expect("preview access token");
+    let rotated_epoch = preview.epoch_id.clone();
+    assert_ne!(
+        rotated_epoch, created_epoch,
+        "owner access-token export must auto-rotate the epoch"
+    );
+
+    timeout(runtime_shutdown_timeout(), runtime.shutdown())
+        .await
+        .expect("runtime shutdown timeout");
+    drop(runtime);
+
+    let restarted = DesktopRuntime::new_with_config_and_identity(
+        &db,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("restart runtime");
+    let joined = restarted
+        .list_joined_private_channels(ListJoinedPrivateChannelsRequest {
+            topic: topic.into(),
+        })
+        .await
+        .expect("list joined after restart");
+    assert_eq!(joined.len(), 1);
+    assert_eq!(
+        joined[0].current_epoch_id, rotated_epoch,
+        "rotated epoch must survive owner restart"
+    );
+    assert!(
+        joined[0]
+            .archived_epoch_ids
+            .contains(&created_epoch),
+        "pre-rotate epoch must be archived after restart (archived: {:?})",
+        joined[0].archived_epoch_ids
+    );
+
+    timeout(runtime_shutdown_timeout(), restarted.shutdown())
+        .await
+        .expect("restarted runtime shutdown timeout");
+}

--- a/crates/desktop-runtime/src/tests/private_channels/persistence.rs
+++ b/crates/desktop-runtime/src/tests/private_channels/persistence.rs
@@ -84,9 +84,7 @@ async fn owner_invite_export_auto_rotate_survives_restart() {
         "rotated epoch must survive owner restart"
     );
     assert!(
-        joined[0]
-            .archived_epoch_ids
-            .contains(&created_epoch),
+        joined[0].archived_epoch_ids.contains(&created_epoch),
         "pre-rotate epoch must be archived after restart (archived: {:?})",
         joined[0].archived_epoch_ids
     );
@@ -177,9 +175,7 @@ async fn owner_access_token_export_auto_rotate_survives_restart() {
         "rotated epoch must survive owner restart"
     );
     assert!(
-        joined[0]
-            .archived_epoch_ids
-            .contains(&created_epoch),
+        joined[0].archived_epoch_ids.contains(&created_epoch),
         "pre-rotate epoch must be archived after restart (archived: {:?})",
         joined[0].archived_epoch_ids
     );

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -41,7 +41,7 @@
       "path": "crates/harness/src/scenarios/community_node.rs"
     },
     {
-      "lines": 1028,
+      "lines": 1078,
       "path": "crates/app-api/src/service/private_channels_support.rs"
     },
     {


### PR DESCRIPTION
## 概要

WP-C2 の PR4(最終)。個別計画書 = `.claude/plans/2026-07-06-fix-c2-capability-write-through.md`(T5 / Assumption 2・3・5)。**base は #476 のブランチ**(マージ後に main へ自動リターゲット)。

capability registry の永続化義務は desktop-runtime のラッパーが変異のたびに手動で `persist_private_channel_capabilities_from_app` を呼ぶ規約(#476 後で 13 箇所)だったが、write 系経路(create_post / create_live_session / create_game_room / create_metaverse_room での FriendOnly auto-rotate と全経路の grant redeem)には persist が無く、手動追加は投稿ホットパスに重い diagnostics 込み persist を入れる whack-a-mole になる。本 PR で「registry の変異 = 永続化」を AppService 層で保証し、手動 persist 規約を廃止する。

### 設計(調査で検証済みの制約に基づく)

- **注入**: `AppService` に `OnceLock<PrivateChannelCapabilityPersist>`(同期 `Arc<dyn Fn(&[PrivateChannelCapability]) -> Result<()>>`)+ setter。コンストラクタシグネチャ不変(app-api テスト約 80 箇所 + harness 無変更)。desktop-runtime は**復元ループ完了後**に注入(復元前に接続すると復元途中の部分リストが persist され、途中クラッシュでディスク上の registry が縮む)
- **発火点**: registry の変異はリポジトリ全体で `register_joined_private_channel`(insert)と `remove_joined_private_channel`(remove)の 2 点に完全集約されている(grep 網羅 + 敵対的検証済み)。insert / remove 直後に発火するため、後続処理(subscription 確保等)が失敗しても「map 変異済み・未 persist」の窓が残らない
- **アトミック化の操作的定義**(プラン Assumption 2): (a) 変異メソッドは persist 試行完了まで return しない (b) 専用 guard 内で「スナップショット取得 → persist」を直列化(全量スナップショットのため最後の persist が必ず最新を反映 = lost-update 解消。従来は排他なし) (c) rollback なし(現行同等)
- **state-only スナップショット**: `private_channel_capability_from_state` の diagnostics(docs 読みを伴う async/fallible)に依存しない純関数を新設。diagnostics 3 フィールドは既定値で永続化 — 復元時に一切読まれないことは #478 の fixture が固定(JSON のフィールド名・形状 = 凍結境界は不変、値のみ)。副次効果として「無関係チャンネルの診断失敗が変異コマンドを Err にする」既存の失敗面も消える
- registry lock 保持中に callback を呼ばない(tokio Mutex 非再入)。callback は registry を触らないためデッドロックなし

## 種別

refactor:boundary(個別計画書 = 実装プラン。挙動変更は「write 系経路でも persist されるようになる」方向のみ)

## 挙動変更

- write 系経路(投稿等)での capability 変異も永続化されるようになる(従来は persist 漏れ)
- `list_joined_private_channels` 等の読み取り系は変異(redeem)があった時だけ persist する(従来は毎回全量 persist + diagnostics 再計算)
- 永続 JSON の diagnostics 3 フィールドの「値」が既定値になる(形状不変・復元同値、#478 で固定)
- 手動 persist 呼び出しが 0 件になる(grep で確認済み)

## テスト

- app-api 新規 3 本: counting callback(create/rotate/leave で発火 + state-only スナップショット検証)/ 未接続互換 / persist 失敗伝播
- #476 の failing test 2 本(export → 再起動で epoch 残存)は callback 機構でも green のまま(受入条件の維持)
- テスト削除ゼロ

## 検証

- `cargo xtask rust-test` green
- `cargo xtask e2e-smoke` green(起動時の復元 + 永続往復)
- clippy(kukuri-app-api / kukuri-desktop-runtime --all-targets)clean

## リスク

- 起動時復元(restore)中は callback 未接続のため persist は走らない(現行と同一セマンティクス)
- `gossip_subscription_state` の同型手動 persist 規約(2 箇所)は本 PR のスコープ外(横展開は boundary の形が実証されてから)
- app-api テストの `joined_private_channels` 直接 clear(bookmarks.rs:87、テスト専用)は callback を素通りする(意図どおり: メモリ喪失の模擬)

## 後続対応

- T6: Windows 実機確認(Auto モード、keyring 内 / 超過の両ケース)— 全 PR マージ後に実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 大型ファイルポリシー(oversized baseline 更新の正当化)

`crates/app-api/src/service/private_channels_support.rs` を 1028 → 1078 行に更新した。増分は本 PR の中核である (a) registry 変異 2 点(register/remove)への write-through 発火、(b) persist 直列化ヘルパ(`persist_private_channel_capabilities_if_configured`)、(c) state-only スナップショット純関数(`private_channel_capability_snapshot`)であり、変異点と同一ファイルに置くことが「変更 = 永続化」の境界を最短で保証する。本ファイルの本格分割は H5-(3)(import 3 系統のテンプレート統合)の領分であり、本 PR では先取りしない。
