### PR TITLE
[fix] #479 マージ時に復活した export ラッパーの persist 呼び出し残骸を除去

### DIFF
--- a/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
+++ b/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
@@ -20,17 +20,13 @@ impl DesktopRuntime {
         &self,
         request: ExportPrivateChannelInviteRequest,
     ) -> Result<String> {
-        // owner の Share export は auto-rotate で capability を変異させる(WP-C2 E-2)
-        let token = self
-            .app_service
+        self.app_service
             .export_private_channel_invite(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(token)
+            .await
     }
 
     pub async fn import_private_channel_invite(
@@ -46,17 +42,13 @@ impl DesktopRuntime {
         &self,
         request: ExportChannelAccessTokenRequest,
     ) -> Result<ChannelAccessTokenExport> {
-        // app-api 内部で export 3 経路へ委譲されるため、このラッパー自身の persist が必要
-        let export = self
-            .app_service
+        self.app_service
             .export_channel_access_token(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(export)
+            .await
     }
 
     pub async fn import_channel_access_token(
@@ -81,16 +73,13 @@ impl DesktopRuntime {
         &self,
         request: ExportFriendOnlyGrantRequest,
     ) -> Result<String> {
-        let token = self
-            .app_service
+        self.app_service
             .export_friend_only_grant(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(token)
+            .await
     }
 
     pub async fn import_friend_only_grant(
@@ -106,16 +95,13 @@ impl DesktopRuntime {
         &self,
         request: ExportFriendPlusShareRequest,
     ) -> Result<String> {
-        let token = self
-            .app_service
+        self.app_service
             .export_friend_plus_share(
                 request.topic.as_str(),
                 request.channel_id.as_str(),
                 request.expires_at,
             )
-            .await?;
-        self.persist_private_channel_capabilities_from_app().await?;
-        Ok(token)
+            .await
     }
 
     pub async fn import_friend_plus_share(


### PR DESCRIPTION
## 概要

**main がビルド不能になっているのを修正する hotfix。**

#476 が squash マージされた後、#476 ブランチ由来の #479 を 3-way マージした際に、共通祖先との差分解決で export 系 4 ラッパー(invite / access_token / friend_only_grant / friend_plus_share)だけ main 側(squash #476)の手動 persist 呼び出しが残存した。#479 はヘルパ `persist_private_channel_capabilities_from_app` 自体を削除しているため、main は E0599(メソッド未定義)×4 でコンパイル不能。

`private_channels_game_api.rs` を #479 ブランチの最終形(全ラッパー素通し)へ復元する。永続化は #479 で導入した AppService の write-through callback(registry 変異時に発火)が担っており、**挙動は #479 の意図どおりで変更なし**。main と #479 最終形の他の差分は #477(identity.rs)/ #478(fixture)由来の期待どおりのもののみであることを突き合わせ確認済み。

## 種別

fix(ビルド修復。ロジック変更なし)

## 検証

- `cargo check -p kukuri-desktop-runtime` green(修正前の main は E0599 ×4)
- WP-C2 の restart テスト 2 本 green(write-through callback 経由で persist されることの確認)
- workspace clippy `-D warnings` / `cargo fmt --check` / `oversized-files` green

## リスク

なし(#479 でレビュー済みの最終形への復元)

🤖 Generated with [Claude Code](https://claude.com/claude-code)