### PR TITLE
[fix] GossipHint parse 失敗を warn ログとカウンタで可観測化 (WP-C4)

### DIFF
--- a/crates/transport/src/iroh/mod.rs
+++ b/crates/transport/src/iroh/mod.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 #[cfg(test)]
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock as StdRwLock};
 use std::time::Duration;
 
@@ -35,7 +35,7 @@ use tokio::sync::{Mutex, Notify, RwLock, Semaphore, broadcast};
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, timeout};
 use tokio_stream::wrappers::BroadcastStream;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::config::{
     ConnectMode, ConnectionPath, DhtDiscoveryOptions, DiscoveryMode, DiscoverySnapshot, SeedPeer,
@@ -57,6 +57,10 @@ struct HintTopicState {
     neighbors: Arc<RwLock<BTreeSet<String>>>,
     last_received_at: Arc<Mutex<Option<i64>>>,
     last_error: Arc<Mutex<Option<String>>>,
+    // parse 失敗した受信 hint の累計(wire 非互換の観測用。WP-C4)。プロセス生存中は単調増加。
+    // 現状の読み手は cfg(test) のアクセサのみ(診断 UI への露出は契約変更のため別 WP)。
+    #[cfg_attr(not(test), allow(dead_code))]
+    invalid_hint_count: Arc<AtomicU64>,
     _receiver_task: JoinHandle<()>,
 }
 

--- a/crates/transport/src/iroh/tests/mod.rs
+++ b/crates/transport/src/iroh/tests/mod.rs
@@ -595,4 +595,141 @@ async fn transport_custom_relay_static_peer_seed_peers_connect_without_ticket_im
     drop(connection);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invalid_hint_payload_increments_counter_and_keeps_stream_healthy() {
+    let transport_a = IrohGossipTransport::bind_local()
+        .await
+        .expect("transport a");
+    let transport_b = IrohGossipTransport::bind_local()
+        .await
+        .expect("transport b");
+    let ticket_a = transport_a
+        .export_ticket()
+        .await
+        .expect("ticket a")
+        .expect("ticket a value");
+    let ticket_b = transport_b
+        .export_ticket()
+        .await
+        .expect("ticket b")
+        .expect("ticket b value");
+    transport_a
+        .import_ticket(&ticket_b)
+        .await
+        .expect("import b");
+    transport_b
+        .import_ticket(&ticket_a)
+        .await
+        .expect("import a");
+    let topic = TopicId::new("kukuri:topic:invalid-hint");
+    let join_timeout = initial_topic_join_timeout();
+    let (mut stream_a, mut stream_b) = tokio::try_join!(
+        transport_a.subscribe_hints(&topic),
+        transport_b.subscribe_hints(&topic)
+    )
+    .expect("subscribe both");
+    // gossip メッシュ確立と正常経路の成立を先に確認する。
+    wait_for_hint_roundtrip(
+        HintRoundtripParticipant {
+            transport: &transport_a,
+            stream: &mut stream_a,
+            expected_source_peer: None,
+        },
+        HintRoundtripParticipant {
+            transport: &transport_b,
+            stream: &mut stream_b,
+            expected_source_peer: None,
+        },
+        &topic,
+        join_timeout,
+        "invalid-hint-setup",
+    )
+    .await;
+
+    // B の gossip sender から wire に生の不正 bytes を注入する
+    // (hint_publish_hint_impl と同一経路。GossipHint の serde には触れない)。
+    let hint_topic = kukuri_core::wire::hint_topic_id(&topic);
+    {
+        let states = transport_b.topic_states.lock().await;
+        let state = states
+            .get(hint_topic.as_str())
+            .expect("hint topic state on b");
+        let sender = state.sender.lock().await;
+        sender
+            .broadcast(b"not-a-gossip-hint".to_vec().into())
+            .await
+            .expect("broadcast invalid payload");
+    }
+
+    // A 側: 不正 hint がカウンタと last_error で観測できる(WP-C4)。
+    timeout(join_timeout, async {
+        loop {
+            if transport_a.invalid_hint_count(&topic).await >= 1 {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("invalid hint counter timeout");
+    timeout(join_timeout, async {
+        loop {
+            let peers = transport_a.peers().await.expect("peers a");
+            let diag = peers
+                .topic_diagnostics
+                .iter()
+                .find(|diag| diag.topic == hint_topic.as_str());
+            if diag.is_some_and(|diag| {
+                diag.last_error.as_deref() == Some("failed to decode hint payload")
+            }) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("invalid hint last_error timeout");
+
+    // 正常経路は不変: 不正 hint の後も正常 hint が配送され、last_error が消える。
+    let recovery_hint = GossipHint::TopicObjectsChanged {
+        topic_id: topic.clone(),
+        objects: vec![HintObjectRef {
+            object_id: "invalid-hint-recovery".into(),
+            object_kind: "post".into(),
+        }],
+    };
+    timeout(join_timeout, async {
+        loop {
+            transport_b
+                .publish_hint(&topic, recovery_hint.clone())
+                .await
+                .expect("publish recovery hint");
+            if let Ok(Some(envelope)) = timeout(Duration::from_millis(500), stream_a.next()).await
+                && envelope.hint == recovery_hint
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("recovery hint delivery timeout");
+    timeout(join_timeout, async {
+        loop {
+            let peers = transport_a.peers().await.expect("peers a");
+            let diag = peers
+                .topic_diagnostics
+                .iter()
+                .find(|diag| diag.topic == hint_topic.as_str());
+            if diag.is_some_and(|diag| diag.last_error.is_none()) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("last_error clear timeout");
+    assert!(transport_a.invalid_hint_count(&topic).await >= 1);
+}
+
 mod relay_connectivity;

--- a/crates/transport/src/iroh/topics.rs
+++ b/crates/transport/src/iroh/topics.rs
@@ -303,6 +303,8 @@ impl IrohGossipTransport {
         let last_received_at_task = Arc::clone(&last_received_at);
         let last_error = Arc::new(Mutex::new(None));
         let last_error_task = Arc::clone(&last_error);
+        let invalid_hint_count = Arc::new(AtomicU64::new(0));
+        let invalid_hint_count_task = Arc::clone(&invalid_hint_count);
         let transport_last_error = Arc::clone(&self.last_error);
         let imported_count = bootstrap_peers.len();
         let warm_endpoint = self.endpoint.clone();
@@ -361,17 +363,44 @@ impl IrohGossipTransport {
                             .collect::<BTreeSet<_>>();
                         *neighbors_task.write().await = current_neighbors;
                         *last_received_at_task.lock().await = Some(Utc::now().timestamp_millis());
-                        if let Ok(parsed) = serde_json::from_slice::<GossipHint>(&message.content) {
-                            *last_error_task.lock().await = None;
-                            *transport_last_error.lock().await = None;
-                            let _ = outbound.send(HintEnvelope {
-                                hint: parsed,
-                                received_at: Utc::now().timestamp_millis(),
-                                source_peer: message.delivered_from.to_string(),
-                            });
-                        } else {
-                            *last_error_task.lock().await =
-                                Some("failed to decode hint payload".to_string());
+                        match serde_json::from_slice::<GossipHint>(&message.content) {
+                            Ok(parsed) => {
+                                *last_error_task.lock().await = None;
+                                *transport_last_error.lock().await = None;
+                                let _ = outbound.send(HintEnvelope {
+                                    hint: parsed,
+                                    received_at: Utc::now().timestamp_millis(),
+                                    source_peer: message.delivered_from.to_string(),
+                                });
+                            }
+                            Err(error) => {
+                                // wire 非互換・不正 payload の観測点(WP-C4)。payload 本体は
+                                // ログに出さない。悪性 peer によるログ洪水を避けるため warn は
+                                // 初回と 100 回毎に絞り、それ以外は debug に落とす。
+                                let count =
+                                    invalid_hint_count_task.fetch_add(1, Ordering::SeqCst) + 1;
+                                if count == 1 || count.is_multiple_of(100) {
+                                    warn!(
+                                        topic = %topic_name,
+                                        source_peer = %message.delivered_from,
+                                        payload_len = message.content.len(),
+                                        invalid_hint_count = count,
+                                        error = %error,
+                                        "failed to decode gossip hint payload"
+                                    );
+                                } else {
+                                    debug!(
+                                        topic = %topic_name,
+                                        source_peer = %message.delivered_from,
+                                        payload_len = message.content.len(),
+                                        invalid_hint_count = count,
+                                        error = %error,
+                                        "failed to decode gossip hint payload"
+                                    );
+                                }
+                                *last_error_task.lock().await =
+                                    Some("failed to decode hint payload".to_string());
+                            }
                         }
                     }
                     Ok(GossipEvent::NeighborUp(peer_id)) => {
@@ -415,6 +444,7 @@ impl IrohGossipTransport {
                 neighbors,
                 last_received_at,
                 last_error,
+                invalid_hint_count,
                 _receiver_task: task,
             },
         );
@@ -445,6 +475,18 @@ impl IrohGossipTransport {
         let hint_topic = kukuri_core::wire::hint_topic_id(topic);
         let sender = self.ensure_hint_topic(&hint_topic).await?;
         Ok(Self::stream_from_sender(&sender))
+    }
+
+    /// 対象 topic の hint parse 失敗の累計(WP-C4 の観測用)。未購読なら 0。
+    #[cfg(test)]
+    pub(crate) async fn invalid_hint_count(&self, topic: &TopicId) -> u64 {
+        let hint_topic = kukuri_core::wire::hint_topic_id(topic);
+        self.topic_states
+            .lock()
+            .await
+            .get(hint_topic.as_str())
+            .map(|state| state.invalid_hint_count.load(Ordering::SeqCst))
+            .unwrap_or(0)
     }
 
     pub(crate) async fn hint_unsubscribe_hints_impl(&self, topic: &TopicId) -> Result<()> {


### PR DESCRIPTION
## 概要

WP-C4(finding E-3)。実装プラン: `.claude/plans/2026-07-06-fix-c4-gossip-hint-observability.md`。

受信 hint の parse 失敗(wire 非互換・不正 payload)は現状 `last_error` に固定文言が入るのみで、**ログ・カウンタが無く、次の正常 hint / NeighborUp で消える揮発状態**のため断続的な wire 非互換が実質観測不能だった(E-3 の「黙殺」の現行形)。

- **failing test 先行**: 2-transport 実 iroh テストで、送信側 transport の gossip sender から**生の不正 bytes を注入**(`hint_publish_hint_impl` と同一 wire 経路。GossipHint の serde には触れない)→ (a) 受信側でカウンタ観測(API 不在で赤)(b) `last_error == "failed to decode hint payload"` (c) 直後の正常 hint が従来どおり配送され `last_error` が None に戻る(正常経路不変)を固定
- `HintTopicState` に per-topic `invalid_hint_count: Arc<AtomicU64>`(プロセス生存中単調増加)+ cfg(test) アクセサ
- parse 失敗時のログ: topic / source peer / payload 長 / serde エラー / 累計(payload 本体は出さない)。**warn は初回 + 100 回毎、それ以外 debug**(悪性 peer によるログ洪水対策 — プラン Decision 1)
- カウンタの IPC 露出はしない(`TopicPeerSnapshot` → `TopicSyncStatus` → types.ts の 3 点同期 + views fixture 再生成を要する契約変更のため。診断 UI への露出は別 WP — プラン Decision 2)

## 種別

fix(小、failing test 先行)

## 挙動変更

- parse 失敗時に warn/debug ログとカウンタ増加が発生する(診断のみ)
- GossipHint の wire 形式(凍結境界 3)・`last_error` の文言と揮発セマンティクス・正常経路(parse 成功時の処理)・IPC は全て不変

## 検証

- `cargo xtask rust-test` green(transport の実 iroh テスト + 新規 1 本を含む)
- workspace clippy `-D warnings` / `cargo fmt --check` / `oversized-files` clean
- 実行しなかった validation: connectivity scenario — peer の振る舞い(接続・配送経路)は不変で変更は診断のみのため、マトリクスの「振る舞いが変わる場合」に該当しない

## リスク

- カウンタは現状 cfg(test) アクセサのみが読む(将来の診断露出の土台)。フィールドに `#[cfg_attr(not(test), allow(dead_code))]` を付与し理由をコメントで明示

🤖 Generated with [Claude Code](https://claude.com/claude-code)