### PR TITLE
[fix] endpoint secret を version + hex の自前形式で永続化 (WP-C5)

### DIFF
--- a/crates/docs-sync/src/node.rs
+++ b/crates/docs-sync/src/node.rs
@@ -150,9 +150,18 @@ pub struct IrohDocsNode {
     shutdown_started: AtomicBool,
 }
 
+const ENDPOINT_SECRET_FORMAT_VERSION: u32 = 1;
+
+/// endpoint secret の自前永続形式(WP-C5)。iroh::SecretKey の serde 表現
+/// (ed25519_dalek へ素通しのバイト配列)に依存すると iroh 更新がディスク互換を
+/// 壊しうるため、version + hex 32 bytes の自前スキーマで保存する。
+/// 旧形式(`{"secret_key":[..]}`)の読み込み fallback は置かない — 本リリース前の
+/// 破壊的変更。旧ファイルは parse 失敗で起動エラーになり、ファイルを削除すれば
+/// 新しい endpoint ID で再生成される。
 #[derive(Serialize, Deserialize)]
 struct StoredEndpointSecret {
-    secret_key: iroh::SecretKey,
+    version: u32,
+    secret_key_hex: String,
 }
 
 impl IrohDocsNode {
@@ -459,13 +468,29 @@ fn load_endpoint_secret(root: &Path) -> Result<Option<iroh::SecretKey>> {
         .with_context(|| format!("failed to read endpoint secret at {}", path.display()))?;
     let stored: StoredEndpointSecret = serde_json::from_slice(&bytes)
         .with_context(|| format!("failed to parse endpoint secret at {}", path.display()))?;
-    Ok(Some(stored.secret_key))
+    if stored.version != ENDPOINT_SECRET_FORMAT_VERSION {
+        bail!(
+            "failed to parse endpoint secret at {}: unsupported version {}",
+            path.display(),
+            stored.version
+        );
+    }
+    let decoded = hex::decode(stored.secret_key_hex.as_str())
+        .with_context(|| format!("failed to parse endpoint secret at {}", path.display()))?;
+    let secret_bytes: [u8; 32] = decoded.as_slice().try_into().map_err(|_| {
+        anyhow!(
+            "failed to parse endpoint secret at {}: secret must be 32 bytes",
+            path.display()
+        )
+    })?;
+    Ok(Some(iroh::SecretKey::from_bytes(&secret_bytes)))
 }
 
 fn save_endpoint_secret(root: &Path, secret_key: &iroh::SecretKey) -> Result<()> {
     let path = endpoint_secret_path(root);
     let bytes = serde_json::to_vec(&StoredEndpointSecret {
-        secret_key: secret_key.clone(),
+        version: ENDPOINT_SECRET_FORMAT_VERSION,
+        secret_key_hex: hex::encode(secret_key.to_bytes()),
     })
     .with_context(|| format!("failed to serialize endpoint secret at {}", path.display()))?;
     std::fs::write(&path, bytes)

--- a/crates/docs-sync/src/tests/node.rs
+++ b/crates/docs-sync/src/tests/node.rs
@@ -35,7 +35,7 @@ async fn persistent_node_recovers_corrupt_docs_store() {
     .expect("write stale author");
     fs::write(
         root.join("endpoint-secret.json"),
-        "{\"secret_key\":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]}",
+        "{\"version\":1,\"secret_key_hex\":\"0101010101010101010101010101010101010101010101010101010101010101\"}",
     )
     .expect("write endpoint secret");
 
@@ -93,4 +93,107 @@ async fn persistent_node_does_not_recover_healthy_store() {
     assert!(recovery_dirs(root).is_empty());
     assert!(root.join("docs.redb").exists());
     assert!(root.join("default-author").exists());
+}
+
+// ---- endpoint secret の自前形式(WP-C5) ----
+// 固定 secret bytes 1..=32 に対する値。ENDPOINT_ID は SecretKey::from_bytes(...).public() の実出力。
+const ENDPOINT_SECRET_HEX: &str =
+    "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+const ENDPOINT_SECRET_ENDPOINT_ID: &str =
+    "79b5562e8fe654f94078b112e8a98ba7901f853ae695bed7e0e3910bad049664";
+// 旧形式 = iroh::SecretKey の serde 素通し表現(ed25519_dalek 由来のバイト配列)。
+// iroh 1.0 の実出力から生成したリテラル。V1 導入により「読めない」ことを固定する
+// (本リリース前の破壊的変更として fallback は置かない — プラン Decision 2)。
+const LEGACY_ENDPOINT_SECRET_JSON: &str = "{\"secret_key\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]}";
+
+fn read_endpoint_secret_json(root: &Path) -> serde_json::Value {
+    let bytes = fs::read(root.join("endpoint-secret.json")).expect("read endpoint secret file");
+    serde_json::from_slice(&bytes).expect("endpoint secret file must be JSON")
+}
+
+#[tokio::test]
+async fn persistent_node_reads_v1_endpoint_secret_and_keeps_endpoint_id() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path();
+    fs::write(
+        root.join("endpoint-secret.json"),
+        format!("{{\"version\":1,\"secret_key_hex\":\"{ENDPOINT_SECRET_HEX}\"}}"),
+    )
+    .expect("write v1 endpoint secret");
+
+    let node = IrohDocsNode::persistent(root)
+        .await
+        .expect("node should read the v1 endpoint secret");
+    assert_eq!(
+        node.endpoint().id().to_string(),
+        ENDPOINT_SECRET_ENDPOINT_ID,
+        "endpoint id must be derived from the stored secret"
+    );
+    node.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn persistent_node_endpoint_id_survives_restart_and_saves_v1() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path();
+
+    let node = IrohDocsNode::persistent(root).await.expect("initial node");
+    let endpoint_id = node.endpoint().id().to_string();
+    node.shutdown().await.expect("initial shutdown");
+
+    let stored = read_endpoint_secret_json(root);
+    assert_eq!(
+        stored.get("version").and_then(serde_json::Value::as_u64),
+        Some(1),
+        "endpoint secret must be persisted in the v1 schema (got: {stored})"
+    );
+    let secret_hex = stored
+        .get("secret_key_hex")
+        .and_then(serde_json::Value::as_str)
+        .expect("secret_key_hex field");
+    assert_eq!(secret_hex.len(), 64, "secret must be 32 bytes hex");
+
+    let restarted = IrohDocsNode::persistent(root).await.expect("restart node");
+    assert_eq!(
+        restarted.endpoint().id().to_string(),
+        endpoint_id,
+        "endpoint id must survive a restart"
+    );
+    restarted.shutdown().await.expect("restart shutdown");
+}
+
+#[tokio::test]
+async fn persistent_node_rejects_legacy_endpoint_secret() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path();
+    fs::write(
+        root.join("endpoint-secret.json"),
+        LEGACY_ENDPOINT_SECRET_JSON,
+    )
+    .expect("write legacy endpoint secret");
+
+    let error = match IrohDocsNode::persistent(root).await {
+        Ok(_) => panic!("legacy endpoint secret must fail loudly (no silent key regeneration)"),
+        Err(error) => error,
+    };
+    assert!(
+        format!("{error:#}").contains("failed to parse endpoint secret"),
+        "unexpected error: {error:#}"
+    );
+}
+
+#[tokio::test]
+async fn persistent_node_rejects_corrupted_endpoint_secret() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path();
+    fs::write(root.join("endpoint-secret.json"), b"not-json").expect("write corrupted secret");
+
+    let error = match IrohDocsNode::persistent(root).await {
+        Ok(_) => panic!("corrupted endpoint secret must fail loudly"),
+        Err(error) => error,
+    };
+    assert!(
+        format!("{error:#}").contains("failed to parse endpoint secret"),
+        "unexpected error: {error:#}"
+    );
 }


### PR DESCRIPTION
## 概要

WP-C5(凍結境界 6 のハザード解消)。実装プラン: `.claude/plans/2026-07-06-fix-c5-endpoint-secret-format.md`。

endpoint secret(`<docs-root>/endpoint-secret.json`)は `iroh::SecretKey` の serde 表現をそのまま永続していた。iroh-base の実装(registry ソース実読)では SecretKey の Serialize は `ed25519_dalek::SigningKey` への**素通し委譲**(JSON ではバイト配列)で、`PublicKey` が human-readable で hex 文字列を返すのと非対称 — 上流の内部表現に直結しており、iroh 更新がディスク互換 = **endpoint identity**(CN 登録・ticket・rendezvous の参照先)を壊しうる。

- 保存形式を `{"version":1,"secret_key_hex":"<64 hex>"}` の自前スキーマへ変更(`to_bytes`/`from_bytes` 経由で iroh の serde 表現に非依存。hex は 32 bytes 厳密検証)
- **読み込みは V1 のみ — 旧形式 fallback なし(破壊的変更)**: プラン Decision 2 のユーザー判断(本リリース前のため破壊的変更可・実装のシンプルさ優先)。旧形式ファイルは parse 失敗で spawn Err(fail-loud)となり、`endpoint-secret.json` を削除すれば新しい endpoint ID で再生成される(CN 再登録・配布済み ticket の失効はプレリリースとして許容)
- **fail-loud の維持**(Decision 1): 破損・旧形式・不明 version で黙って鍵を再生成しない(endpoint ID がサイレントに変わると参照が静かに壊れる最悪形を防ぐ)

## 種別

fix(failing test 先行。既存環境に対する破壊的変更を含む — 下記)

## 挙動変更(破壊的)

- **既存の preview/dev 環境は次回起動で `failed to parse endpoint secret at <path>` の起動エラーになる**。復旧: 該当ファイルを削除して再起動(新 endpoint ID で再生成。CN への再認証・ticket 再配布が必要)
- 新規環境・V1 形式では挙動不変(endpoint ID は再起動を跨いで不変 — テストで固定)

## テスト(赤 → 緑)

- V1 読み込み + 固定 secret → 期待 endpoint ID 一致(現行 loader は V1 を parse 不能で赤)
- 再起動 roundtrip で endpoint ID 不変 + 保存ファイルが V1 スキーマ(現行は旧形式保存で赤)
- 旧形式(iroh 1.0 実出力から生成したリテラル fixture)の拒否(現行は受理するため赤)
- 破損ファイルの fail-loud(現行挙動の固定)
- 既存テスト 1 本(corrupt docs store 回復)の endpoint secret fixture を V1 へ追随

## 検証

- `cargo xtask rust-test` green
- `cargo xtask scenario community_node_public_connectivity` green(desktop 再起動ステップが endpoint ID 永続の実往復を通る)
- workspace clippy `-D warnings` / `cargo fmt --check` clean

## リスク

- 破壊的変更の影響は上記のとおり(プレリリース前提で許容 — ユーザー判断済み)。マージ後の各自の dev 環境は初回起動時にファイル削除が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)