### PR TITLE
[fix] 判定根拠(basis)の導出を verdict 文脈対応にし ADR 0027 §2.2 の既知ギャップを解消 (WP-C7)

### DIFF
--- a/crates/cn-safety-runtime/src/artifacts.rs
+++ b/crates/cn-safety-runtime/src/artifacts.rs
@@ -16,7 +16,7 @@
 //!   safety category を示さないため、risk signal を生成しない（虚偽の risk label を作らない）。
 //! - suspected unknown CSAM / CSE の visibility は既定 `Local`（誤検知を public に拡散しない）。
 
-use kukuri_cn_safety::policy::basis_for_reason;
+use kukuri_cn_safety::policy::basis_for_verdict;
 use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
 use kukuri_cn_safety::{
     AppealStatus, Basis, ModerationAction, ModerationEventBody, ReasonCode, RiskSignalTarget,
@@ -50,7 +50,7 @@ pub(crate) fn build_artifacts(
         return (None, None);
     }
 
-    let basis = basis_for_reason(verdict.reason_code);
+    let basis = basis_for_verdict(verdict);
     let category = primary_category(verdict);
     let severity = severity_for(verdict);
 

--- a/crates/cn-safety-runtime/tests/orchestrator.rs
+++ b/crates/cn-safety-runtime/tests/orchestrator.rs
@@ -12,8 +12,8 @@ use kukuri_cn_safety::provider::{
 };
 use kukuri_cn_safety::verdict::{ReasonCode, SafetyAction, SafetyLabel};
 use kukuri_cn_safety::{
-    MockSafetyProvider, RiskSignalTarget, SafetyCategory, SafetyPolicy, SafetyProviderCapability,
-    Visibility,
+    Basis, MockSafetyProvider, RiskSignalTarget, SafetyCategory, SafetyPolicy,
+    SafetyProviderCapability, Visibility,
 };
 use kukuri_cn_safety_runtime::{
     EventIdGenerator, SafetyOrchestrator, SafetyRuntimeError, ScanClock, map_scan_error,
@@ -150,11 +150,91 @@ async fn known_hash_match_is_excluded_and_emits_event_and_signal() {
     assert_eq!(event.created_at, SCANNED_AT);
     // confirmed は subscribed_nodes 以上が許される。
     assert_eq!(event.visibility, Visibility::SubscribedNodes);
+    // 完全一致の根拠は KnownHashMatch(WP-C7 以後も不変であることを固定)。
+    assert_eq!(event.basis, Basis::KnownHashMatch);
 
     let signal = report.risk_signal.expect("signal for excluded content");
     assert_eq!(signal.target, RiskSignalTarget::BlobCid);
     assert_eq!(signal.category, SafetyCategory::Csam);
     assert_eq!(signal.visibility, Visibility::SubscribedNodes);
+    assert_eq!(signal.basis, Basis::KnownHashMatch);
+}
+
+#[tokio::test]
+async fn perceptual_match_confirmed_uses_provider_verdict_basis() {
+    // 近似(perceptual)一致による confirmed(ADR 0027 §7.1 の near match)。
+    // 排除・critical・subscribed_nodes 配布は完全一致と同じだが、根拠ラベルは
+    // 「完全一致」ではなく「provider による断定」(ProviderVerdict)になる(§2.2 / §2.7)。
+    let result = ProviderScanResult {
+        provider: "known".to_string(),
+        capability: SafetyProviderCapability::PerceptualHashMatch,
+        outcome: ScanOutcome::Completed,
+        known_hash_match: true,
+        score: None,
+        labels: vec![SafetyLabel::new(SafetyCategory::Csam)],
+    };
+    let provider = Arc::new(StaticProvider {
+        name: "known",
+        capabilities: vec![SafetyProviderCapability::PerceptualHashMatch],
+        result,
+    });
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    assert_eq!(report.verdict.reason_code, ReasonCode::CsamConfirmed);
+    assert_eq!(report.verdict.action, SafetyAction::Exclude);
+    assert!(report.verdict.critical);
+
+    let event = report.moderation_event.expect("event for excluded content");
+    assert_eq!(event.basis, Basis::ProviderVerdict);
+    assert_eq!(event.visibility, Visibility::SubscribedNodes);
+
+    let signal = report.risk_signal.expect("signal for excluded content");
+    assert_eq!(signal.basis, Basis::ProviderVerdict);
+    assert_eq!(signal.visibility, Visibility::SubscribedNodes);
+}
+
+#[tokio::test]
+async fn general_moderation_uses_classifier_basis_and_local_visibility() {
+    // 一般判定(nsfw / spam 等)は分類器の推定であり「provider による断定」ではない。
+    // 根拠ラベルは ClassifierScore、既定の配布範囲は Local(自ノード内のみ)になる
+    // (§2.2 / §2.6。confirmed 相当の根拠 + subscribed_nodes 配布にしない)。
+    let result = ProviderScanResult {
+        provider: "general".to_string(),
+        capability: SafetyProviderCapability::GeneralMediaModeration,
+        outcome: ScanOutcome::Completed,
+        known_hash_match: false,
+        score: Some(95),
+        labels: vec![SafetyLabel::new(SafetyCategory::Nsfw).with_confidence(95)],
+    };
+    let provider = Arc::new(StaticProvider {
+        name: "general",
+        capabilities: vec![SafetyProviderCapability::GeneralMediaModeration],
+        result,
+    });
+    let mut policy = SafetyPolicy::public_node_default();
+    policy.require_known_csam = false;
+    let orchestrator = SafetyOrchestrator::builder("node-1", clock(), ids())
+        .policy(policy)
+        .provider(provider)
+        .build()
+        .unwrap();
+    let report = orchestrator.scan_subject(&blob_request()).await;
+
+    assert_eq!(report.verdict.reason_code, ReasonCode::GeneralModeration);
+    assert!(!report.verdict.critical);
+    assert!(!report.verdict.is_indexable());
+
+    let event = report.moderation_event.expect("event for excluded content");
+    assert_eq!(event.basis, Basis::ClassifierScore);
+    assert_eq!(event.visibility, Visibility::Local);
+
+    let signal = report.risk_signal.expect("signal for excluded content");
+    assert_eq!(signal.basis, Basis::ClassifierScore);
+    assert_eq!(signal.visibility, Visibility::Local);
 }
 
 #[tokio::test]

--- a/crates/cn-safety/src/policy.rs
+++ b/crates/cn-safety/src/policy.rs
@@ -328,14 +328,27 @@ fn non_empty_labels(result: &ProviderScanResult, category: SafetyCategory) -> Ve
 }
 
 // Basis を verdict に直接は載せていない（verdict は reason_code を持つ）。Basis は
-// moderation event / risk signal 側で使う。ここでは router が決めた reason_code から
+// moderation event / risk signal 側で使う。ここでは router が決めた verdict から
 // 後段が basis を導出できるよう、対応関係を関数で提供する。
-/// reason_code から対応する基準（basis）を導く補助。
-pub fn basis_for_reason(reason: ReasonCode) -> Basis {
-    match reason {
-        ReasonCode::CsamConfirmed => Basis::KnownHashMatch,
-        ReasonCode::CsamSuspected | ReasonCode::CseSuspected => Basis::ClassifierScore,
-        ReasonCode::GeneralModeration => Basis::ProviderVerdict,
+/// verdict から対応する判定根拠（basis）を導く補助（ADR 0027 §2.2）。
+///
+/// - confirmed（`CsamConfirmed`）は capability で分ける: 完全一致
+///   （`KnownCsamHashMatch`）は `KnownHashMatch`、それ以外（perceptual near match 等の
+///   provider 断定）は `ProviderVerdict`（§2.7「near match は exact ではない」との整合）。
+/// - 一般判定（`GeneralModeration`）は provider の分類器由来なので `ClassifierScore`
+///   （`ProviderVerdict` にしない — confirmed 相当の根拠を分類結果に付けない）。
+pub fn basis_for_verdict(verdict: &SafetyVerdict) -> Basis {
+    match verdict.reason_code {
+        ReasonCode::CsamConfirmed => {
+            if verdict.provider_capability == Some(SafetyProviderCapability::KnownCsamHashMatch) {
+                Basis::KnownHashMatch
+            } else {
+                Basis::ProviderVerdict
+            }
+        }
+        ReasonCode::CsamSuspected | ReasonCode::CseSuspected | ReasonCode::GeneralModeration => {
+            Basis::ClassifierScore
+        }
         _ => Basis::LocalPolicy,
     }
 }

--- a/docs/adr/0027-deterministic-moderation-critical-safety.md
+++ b/docs/adr/0027-deterministic-moderation-critical-safety.md
@@ -84,7 +84,10 @@ community node の moderation のうち **決定論的 moderation（既知 hash 
 - action は `SafetyAction`（`allow` / `hold` / `quarantine` / `exclude`）。**`allow` のみが index / discovery / recommendation へ surfacing を許す**（`SafetyAction::allows_indexing` / `SafetyVerdict::is_indexable`）。
 - 検知ラベル `SafetyLabel`（category / confidence / provider_capability）は action と独立。
 - `ReasonCode` で `CsamConfirmed`（**決定論的**: known hash match / provider confirmed）と `CsamSuspected` / `CseSuspected`（classifier = 非決定論、#411）を型で分離する。
-- **router が confirmed CSAM に付ける basis は `Basis::KnownHashMatch`**（`basis_for_reason(CsamConfirmed) → KnownHashMatch`）。`Basis::ProviderVerdict` は「provider が confirmed と返した」意味の basis だが、現状の `route()` は `ProviderVerdict` を `GeneralModeration` に割り当てており、provider-confirmed CSAM を confirmed basis として emit する経路は未整備（既知ギャップ。#391 provider 統合時に `basis_for_reason` と `default_visibility_for` の整合を取る）。`Basis::ClassifierScore` は suspected どまり（confirmed に昇格させない、#411）。
+- **basis の導出は `basis_for_verdict`**（`cn-safety/src/policy.rs`。2026-07-07 WP-C7 で `basis_for_reason` から置換し、本節の既知ギャップを解消）:
+  - confirmed CSAM（`CsamConfirmed`）は capability で分ける。完全一致（`KnownCsamHashMatch`）→ `Basis::KnownHashMatch`、それ以外（`PerceptualHashMatch` の near match 等、provider が confirmed と返したもの）→ `Basis::ProviderVerdict`。いずれも confirmed として扱われ、既定 visibility は `SubscribedNodes`（§2.6 の `default_visibility_for`）。
+  - suspected（`CsamSuspected` / `CseSuspected`）と一般判定（`GeneralModeration`）→ `Basis::ClassifierScore`。分類器の推定に confirmed 相当の根拠を付けない。これにより一般判定の既定 visibility は `Local`（かつては `GeneralModeration` に `ProviderVerdict` が付き既定で `SubscribedNodes` に配布されていたが、根拠の誤ラベルとして WP-C7 で修正）。
+  - `Basis::ClassifierScore` は suspected どまり（confirmed に昇格させない、#411）。
 
 ### 2.3 policy routing（critical と general の分離、純関数）
 - `route(&[ProviderScanResult], &SafetyPolicy, scanned_at) -> SafetyVerdict` は純関数。`SafetyPolicy::public_node_default()` を public-node 既定とする。
@@ -173,14 +176,14 @@ public-node profile が public indexing を有効化する前に満たすべき�
 
 ### 7.1 classification → domain の写像
 
-| Shield classification | match_type | ProviderScanResult | router 出力 |
-|---|---|---|---|
-| `csam` | `exact` / 欠落 | `known_hash_match=true`、capability `KnownCsamHashMatch`、label `csam` | `exclude` / `csam_confirmed` / critical |
-| `csam` | `near` | 同上（capability `PerceptualHashMatch`）| 同上 |
-| `harmful-abusive-material` | 任意 | `csam` と同じ（下記 7.2） | 同上 |
-| `test` | 任意 | `known_hash_match=false`、label `provider_test`（非 critical） | `exclude` / `provider_test_match` / 非 critical |
-| `no-known-match` | - | `ScanOutcome::NoKnownMatch` | `allow` / `no_known_match`（safe の証明ではない） |
-| 未知の値（将来拡張） | - | deserialize 失敗 → `ScanError::Protocol` | fail-closed（`hold` / `scan_failed`） |
+| Shield classification | match_type | ProviderScanResult | router 出力 | basis（moderation event / risk signal） |
+|---|---|---|---|---|
+| `csam` | `exact` / 欠落 | `known_hash_match=true`、capability `KnownCsamHashMatch`、label `csam` | `exclude` / `csam_confirmed` / critical | `known_hash_match` |
+| `csam` | `near` | 同上（capability `PerceptualHashMatch`）| 同上 | `provider_verdict`（完全一致ではないため。§2.2、WP-C7） |
+| `harmful-abusive-material` | 任意 | `csam` と同じ（下記 7.2） | 同上 | match_type に従う（上 2 行と同じ） |
+| `test` | 任意 | `known_hash_match=false`、label `provider_test`（非 critical） | `exclude` / `provider_test_match` / 非 critical | `local_policy` |
+| `no-known-match` | - | `ScanOutcome::NoKnownMatch` | `allow` / `no_known_match`（safe の証明ではない） | -（allow は artifact を作らない） |
+| 未知の値（将来拡張） | - | deserialize 失敗 → `ScanError::Protocol` | fail-closed（`hold` / `scan_failed`） | `local_policy` |
 
 ### 7.2 保守的写像（over-exclusion 側に倒す）
 


### PR DESCRIPTION
## 概要

ADR 0027 §2.2 に明記されていた既知ギャップ「provider-confirmed CSAM を confirmed basis として emit する経路が未整備で、`ProviderVerdict` が `GeneralModeration` に誤って割り当てられている」を解消する。リファクタリング マスタープラン Phase 2 / WP-C7。

- `basis_for_reason(ReasonCode)` を verdict 文脈対応の `basis_for_verdict(&SafetyVerdict)` に置換(`crates/cn-safety/src/policy.rs`)
- 呼び出し側(`crates/cn-safety-runtime/src/artifacts.rs`)を差し替え
- ADR 0027 §2.2 のギャップ記述を解消後の記述へ更新し、§7.1 の写像表に basis 列を追記

## 種別

fix + docs(ADR 更新)

## 挙動変更

moderation event / risk signal に載る「判定根拠(basis)」と既定の配布範囲(visibility)が変わる。**対処(排除・保留)や fail-closed 経路は一切変わらない。**

| 判定 | 根拠(変更前 → 変更後) | 既定配布範囲(変更前 → 変更後) |
|---|---|---|
| 既知 CSAM への完全一致 | known_hash_match(不変) | subscribed_nodes(不変) |
| 既知 CSAM への近似一致(perceptual) | known_hash_match → **provider_verdict** | subscribed_nodes(不変) |
| 一般判定(nsfw / spam 等) | provider_verdict → **classifier_score** | subscribed_nodes → **local** |

- 一般判定は分類器の推定なのに「provider による断定」の根拠ラベルが付き、その副作用で既定が購読ノード配布になっていた。修正後は実態どおりの根拠になり、配布は自ノード内のみ(誤検知を外へ広げない安全側)。CSAM 等の重大判定の配布は変わらない。
- 近似一致は「完全一致」と記録されていたのを正確な根拠に改める。排除・critical・購読ノード配布はそのまま。
- basis / visibility の enum 表現(serde)は変更なし(値の選び方だけが変わる)。preview 段階のため emit 値の変更は破壊的変更として許容(C5/C6 と同方針)。

## 検証(赤→緑)

- **赤**: orchestrator テストに 2 本追加し、現行コードで失敗を実測
  - `perceptual_match_confirmed_uses_provider_verdict_basis`: `left: KnownHashMatch / right: ProviderVerdict` で失敗
  - `general_moderation_uses_classifier_basis_and_local_visibility`: `left: ProviderVerdict / right: ClassifierScore` で失敗
- **固定**: 完全一致 → known_hash_match / subscribed_nodes を既存テストに assert 追加で pin(修正前後とも緑)
- **緑**: 実装後 orchestrator 19/19 pass
- CI 相当: `cargo fmt --check` / `cargo xtask cn-check`(cn 9 crate clippy -D warnings) / `cargo xtask cn-test`(postgres 付き) すべて pass
- fail-closed 不変条件(allow のみ index 可)には触れておらず、既存の policy_router / domain_model テストも green

## リスク

- cn-trust の cross-node 開示は「絶対成分(critical カテゴリ)かつ confirmed 根拠」のみが対象のため、一般判定の根拠変更が信頼スコアの開示に影響しないことを確認済み(成分振り分けは category ベース)
- cn DB(`safety_events.basis` は TEXT)にスキーマ変更はない。既存行の遡及修正はしない(preview 段階・実運用データなし)

## 後続対応

- なし(WP-C7 完結。Phase 2 の残りは C8 = 互換パス sunset 条件の文書化のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)