### PR TITLE
[docs] 互換パス3本の撤去条件を明文化 (WP-C8)

### DIFF
--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -154,15 +154,21 @@ PR を作成または説明するときは、タスク種別を明確にする�
 ## 互換パスと sunset 条件
 
 以下は後方互換のために残している経路で、「いつ削除してよいか」を明文化せずに消すと既存データ・
-既存ユーザーが壊れる。現状は削除せず、撤去は Phase 2(master plan C6 / C8)で条件を確定してから行う。
-撤去条件が決まるまでは削除しない(このリストが「消してよいか」の判断入口)。
+既存ユーザーが壊れる。撤去条件は WP-C8(2026-07-07)で確定した。条件を満たすまで削除しない
+(このリストが「消してよいか」の判断入口。コード側の該当箇所にも同じ条件をコメントで明記している)。
 
-| 互換パス | 所在 | 誤削除の影響 | sunset 条件 |
+| 互換パス | 所在 | 誤削除の影響 | sunset 条件(WP-C8 で確定) |
 |---|---|---|---|
-| epoch `"legacy"` 互換 | `crates/app-api/src/service/projection_support.rs` | legacy epoch の projection が読めなくなる | 未決定(全既存 projection の再構築完了が前提) |
-| 旧 `.nsec` 鍵ファイル読込 | `crates/desktop-runtime/src/identity.rs`(`db_path.with_extension("nsec")`。テスト `legacy_nsec_file_still_loads` が固定) | 旧形式で鍵を持つユーザーの identity ロスト | 未決定(全ユーザーの新形式移行が前提) |
-| `resolved_urls` fallback(seed_peers 空 / None 時) | `crates/desktop-runtime/src/community_node/requests_support.rs` | 旧 community-node 設定の URL が壊れる | 未決定 |
-| CRLF checksum 自己修復 | `crates/store/src/sqlite/connection.rs`(`repair_line_ending_only_migration_checksums`。**store 初期化=pool 作成時に1回**実行) | CRLF 時代に migration checksum がずれた DB が起動不能になる | 未決定(master plan C6 = バージョン条件付き撤去 or 一度きりメンテ処理へ隔離) |
+| 旧 `.nsec` 鍵ファイル読込 | `crates/desktop-runtime/src/identity.rs`(`legacy_key_file_path`。テスト `legacy_nsec_file_still_loads` が固定) | **利用者が気づかないまま別人の鍵になる**: 旧ファイルは読み込んでも新形式へ再保存されず残り続け、鍵が見つからないと `load_or_create_keys` が黙って新しい鍵を生成するため | **撤去する際は、`.nsec` ファイルを検知したら起動を止めて案内を出す処理(fail-loud)とセットで行うこと**。黙って新しい鍵を生成する現状のまま読込パスだけを消してはならない。鍵は preview 段階でも黙って失ってよいものではない |
+| epoch `"legacy"` 互換 | `crates/app-api/src/service/projection_support.rs`(`legacy_epoch_id` / `private_channel_replica_for_epoch` / `joined_private_channel_state_from_capability`) | epoch 導入前に保存されたプライベートチャンネル capability(epoch_id が空)のチャンネル履歴が読めなくなる。現行ビルドが空の epoch_id を新規に書くことはない | **正式リリースの節目で削除可**(preview データの保全は保証しない方針)。削除時は空の epoch_id を持つ capability をエラーで拒否すること(黙って読めなくならないようにする) |
+| ~~CRLF checksum 自己修復~~ | ~~`crates/store/src/sqlite/connection.rs`~~ | - | **撤去済み**(2026-07-06、WP-C6 / PR #485)。checksum 不一致は fail-loud で起動失敗し、回帰テストで固定済み |
+
+**互換パスではないと再分類したもの(WP-C8):**
+
+- `resolved_urls` の未解決時の扱い(`crates/desktop-runtime/src/community_node/requests_support.rs`。
+  認証時に base_url で代用する fallback と、解決されるまで再取得を繰り返す判定)は、旧設定の互換では
+  なく**恒常経路**。コミュニティノードを新規追加した直後は必ず未解決(None)であり、この経路が初回接続
+  そのものを支えている。削除対象ではないため sunset 条件は持たない。
 
 ## 真実の置き場所ルール
 

--- a/crates/app-api/src/service/projection_support.rs
+++ b/crates/app-api/src/service/projection_support.rs
@@ -152,6 +152,13 @@ pub(crate) async fn fetch_post_object_for_projection(
     Ok(Some(header))
 }
 
+// 互換パス(REFACTORING.md「互換パスと sunset 条件」参照)。
+// epoch 導入前に保存されたプライベートチャンネル capability(epoch_id が空)を "legacy"
+// epoch として扱い、epoch なし時代のレプリカ ID で読む(private_channel_replica_for_epoch /
+// joined_private_channel_state_from_capability)。現行ビルドが空の epoch_id を新規に書くことはない。
+// 撤去条件(WP-C8 で確定): 正式リリースの節目で削除可(preview データの保全は保証しない
+// 方針)。削除時は空の epoch_id を持つ capability をエラーで拒否すること(黙って読めなく
+// ならないようにする)。
 pub(crate) fn legacy_epoch_id() -> &'static str {
     "legacy"
 }

--- a/crates/desktop-runtime/src/community_node/requests_support.rs
+++ b/crates/desktop-runtime/src/community_node/requests_support.rs
@@ -22,6 +22,9 @@ impl DesktopRuntime {
             .await
             .context("failed to decode auth challenge response")?;
 
+        // resolved_urls 未解決時に base_url で代用するのは互換パスではなく恒常経路
+        // (REFACTORING.md「互換パスと sunset 条件」の再分類参照)。ノードを新規追加した
+        // 直後は必ず未解決(None)であり、この代用が初回の認証を支えている。削除対象ではない。
         let public_base_url = self
             .community_node_config
             .lock()

--- a/crates/desktop-runtime/src/identity.rs
+++ b/crates/desktop-runtime/src/identity.rs
@@ -316,6 +316,12 @@ fn key_file_path(db_path: &Path) -> PathBuf {
     db_path.with_extension("identity-key")
 }
 
+// 互換パス(REFACTORING.md「互換パスと sunset 条件」参照)。
+// 旧 `.nsec`(bech32 表記)は読み込んでも新形式 `.identity-key` へ再保存されず残り続ける。
+// 鍵が見つからない場合 `load_or_create_keys` は黙って新しい鍵を生成するため、この読込パス
+// だけを消すと旧ファイルの利用者が気づかないまま別人の鍵になる。
+// 撤去条件(WP-C8 で確定): `.nsec` を検知したら起動を止めて案内を出す処理(fail-loud)と
+// セットで撤去すること。単独では削除しない。
 fn legacy_key_file_path(db_path: &Path) -> PathBuf {
     db_path.with_extension("nsec")
 }


### PR DESCRIPTION
## 概要

REFACTORING.md「互換パスと sunset 条件」の表で「未決定」のままだった3件の撤去条件を確定し、コード側の該当箇所にも同じ条件をコメントで明記する。リファクタリング マスタープラン Phase 2 / WP-C8(Phase 2 の最終 WP)。

## 種別

docs(+挙動不変のコードコメント追記)

## 挙動変更

**なし**。コード変更はコメント追記のみで、互換パス自体の削除・変更は行わない(削除は条件を満たした時点の別作業)。

## 確定した撤去条件

| 互換パス | 撤去条件 |
|---|---|
| 旧 `.nsec` 鍵ファイル読込(identity.rs) | **`.nsec` を検知したら起動を止めて案内を出す処理(fail-loud)とセットで撤去すること。単独では削除しない。** 調査で、旧ファイルは読み込んでも新形式へ再保存されず残り続けること、鍵が見つからないと黙って新しい鍵を生成することが判明。読込パスだけを消すと利用者が気づかないまま別人の鍵になるため |
| epoch "legacy" 互換(projection_support.rs) | **正式リリースの節目で削除可**(preview データの保全は保証しない方針)。削除時は空の epoch_id を持つ capability をエラーで拒否する(黙って読めなくならないようにする) |
| resolved_urls 未解決時の扱い(requests_support.rs) | **互換パスではなく恒常経路と再分類し、削除対象から除外**。ノードを新規追加した直後は必ず未解決(None)であり、この経路が初回の認証・接続そのものを支えている |

あわせて、表の「CRLF checksum 自己修復」行を撤去済み(WP-C6 / #485)へ更新した。

## 検証

- `cargo fmt --check` pass
- `cargo xtask rust-test` pass(コメントのみのため挙動不変。テスト変更なしで全て green)

## リスク

- なし(文書とコメントのみ)

## 後続対応

- Phase 2(クリティカル修正)はこの PR で完了。次はマスタープラン Phase 3(高レバレッジ構造改善、Wave A: H1〜H3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)