### PR TITLE
[refactor] docs-sync / blob-service のピア管理を kukuri-transport へ共通化 (WP-H2 PR1)

### DIFF
--- a/crates/blob-service/src/lib.rs
+++ b/crates/blob-service/src/lib.rs
@@ -1,13 +1,14 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use iroh::EndpointId;
 use kukuri_core::BlobHash;
 use kukuri_docs_sync::IrohDocsNode;
-use kukuri_transport::{SeedPeer, parse_endpoint_ticket, relay_assisted_endpoint_addr};
+use kukuri_transport::{
+    PeerAddrBook, RemoteFetchRetryState, RemoteFetchStart, SeedPeer, parse_endpoint_ticket,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::{Duration, Instant, timeout};
@@ -29,41 +30,6 @@ pub enum BlobStatus {
 
 const REMOTE_FETCH_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const REMOTE_FETCH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15);
-const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(3);
-
-#[derive(Debug, PartialEq, Eq)]
-enum RemoteFetchStart {
-    Ready,
-    CoolingDown,
-}
-
-#[derive(Debug, Default)]
-struct RemoteFetchRetryState {
-    retry_after: BTreeMap<String, Instant>,
-}
-
-impl RemoteFetchRetryState {
-    fn try_begin(&mut self, key: &str, now: Instant) -> RemoteFetchStart {
-        if self
-            .retry_after
-            .get(key)
-            .is_some_and(|retry_after| *retry_after > now)
-        {
-            return RemoteFetchStart::CoolingDown;
-        }
-        self.retry_after.remove(key);
-        RemoteFetchStart::Ready
-    }
-
-    fn finish(&mut self, key: &str, success: bool, now: Instant) {
-        if success {
-            self.retry_after.remove(key);
-        } else {
-            self.retry_after
-                .insert(key.to_string(), now + REMOTE_FETCH_RETRY_COOLDOWN);
-        }
-    }
-}
 
 #[async_trait]
 pub trait BlobService: Send + Sync {
@@ -87,9 +53,9 @@ pub trait BlobService: Send + Sync {
 pub struct IrohBlobService {
     node: Arc<IrohDocsNode>,
     pinned: Arc<RwLock<HashSet<String>>>,
-    learned_peers: Arc<Mutex<BTreeMap<String, iroh::EndpointAddr>>>,
-    seed_peers: Arc<Mutex<BTreeMap<String, iroh::EndpointAddr>>>,
-    imported_peers: Arc<Mutex<BTreeMap<String, iroh::EndpointAddr>>>,
+    // ピア台帳・接続候補・リトライ状態は kukuri-transport の共通実装(WP-H2)。
+    // 台帳変化の bool は blob-service では使わない(レプリカへの配り直しが無いため)。
+    peers: Arc<PeerAddrBook>,
     remote_fetch_retries: Arc<Mutex<RemoteFetchRetryState>>,
 }
 
@@ -107,12 +73,11 @@ pub struct MemoryBlobService {
 
 impl IrohBlobService {
     pub fn new(node: Arc<IrohDocsNode>) -> Self {
+        let peers = Arc::new(PeerAddrBook::new(node.endpoint().clone(), node.discovery()));
         Self {
             node,
             pinned: Arc::new(RwLock::new(HashSet::new())),
-            learned_peers: Arc::new(Mutex::new(BTreeMap::new())),
-            seed_peers: Arc::new(Mutex::new(BTreeMap::new())),
-            imported_peers: Arc::new(Mutex::new(BTreeMap::new())),
+            peers,
             remote_fetch_retries: Arc::new(Mutex::new(RemoteFetchRetryState::default())),
         }
     }
@@ -121,138 +86,41 @@ impl IrohBlobService {
         &self,
         imported_peer: &iroh::EndpointAddr,
     ) -> Vec<iroh::EndpointAddr> {
-        let mut candidates = Vec::new();
-        let direct_imported = direct_endpoint_addr(imported_peer);
-        if let Some(candidate) = direct_imported {
-            candidates.push(candidate);
-        }
-        if let Some(remote_info) = self.node.endpoint().remote_info(imported_peer.id).await {
-            let learned_peer = iroh::EndpointAddr::from_parts(
-                remote_info.id(),
-                remote_info.into_addrs().map(|addr| addr.into_addr()),
-            );
-            if !learned_peer.is_empty() {
-                candidates.push(learned_peer);
-            }
-        }
-        let relay_supported = relay_assisted_endpoint_addr(imported_peer);
-        if relay_supported.relay_urls().next().is_some()
-            && !candidates
-                .iter()
-                .any(|candidate| candidate == &relay_supported)
-        {
-            candidates.push(relay_supported);
-        }
-        if candidates.is_empty()
-            || !candidates
-                .iter()
-                .any(|candidate| candidate == imported_peer)
-        {
-            candidates.push(imported_peer.clone());
-        }
-        candidates
+        self.peers.connect_candidates(imported_peer).await
     }
 
     async fn fetch_peers(&self) -> Vec<iroh::EndpointAddr> {
-        let mut peers = self
-            .learned_peers
-            .lock()
-            .await
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        for peer in self.seed_peers.lock().await.values() {
-            if !peers.iter().any(|existing| existing.id == peer.id) {
-                peers.push(peer.clone());
-            }
-        }
-        for peer in self.imported_peers.lock().await.values() {
-            if !peers.iter().any(|existing| existing.id == peer.id) {
-                peers.push(peer.clone());
-            }
-        }
-        peers
-    }
-
-    async fn insert_learned_peer_addr(&self, endpoint_addr: iroh::EndpointAddr) {
-        if !endpoint_addr.is_empty() {
-            self.node
-                .discovery()
-                .add_endpoint_info(endpoint_addr.clone());
-        }
-        self.learned_peers
-            .lock()
-            .await
-            .insert(endpoint_addr.id.to_string(), endpoint_addr);
-    }
-
-    async fn insert_imported_peer_addr(&self, endpoint_addr: iroh::EndpointAddr) {
-        self.node
-            .discovery()
-            .add_endpoint_info(endpoint_addr.clone());
-        self.imported_peers
-            .lock()
-            .await
-            .insert(endpoint_addr.id.to_string(), endpoint_addr);
+        self.peers.merged_peers().await
     }
 
     pub async fn peer_state(&self) -> BlobPeerState {
         BlobPeerState {
-            learned_peers: self.learned_peers.lock().await.values().cloned().collect(),
-            imported_peers: self.imported_peers.lock().await.values().cloned().collect(),
+            learned_peers: self.peers.learned_peers_snapshot().await,
+            imported_peers: self.peers.imported_peers_snapshot().await,
         }
     }
 
     pub async fn restore_peer_state(&self, state: BlobPeerState) -> Result<()> {
         for endpoint_addr in state.learned_peers {
-            self.insert_learned_peer_addr(endpoint_addr).await;
+            let _ = self.peers.insert_learned_peer_addr(endpoint_addr).await;
         }
         for endpoint_addr in state.imported_peers {
-            self.insert_imported_peer_addr(endpoint_addr).await;
+            self.peers.insert_imported_peer_addr(endpoint_addr).await;
         }
         Ok(())
     }
 
     async fn available_fetch_peer_ids(&self) -> Vec<String> {
-        let peers = self.fetch_peers().await;
-        let mut available = std::collections::BTreeSet::new();
-        for peer in peers {
-            if self
-                .node
-                .endpoint()
-                .remote_info(peer.id)
-                .await
-                .is_some_and(|info| {
-                    info.addrs().any(|addr| {
-                        matches!(addr.usage(), iroh::endpoint::TransportAddrUsage::Active)
-                    })
-                })
-            {
-                available.insert(peer.id.to_string());
-            }
-        }
-        available.into_iter().collect()
+        self.peers.available_peer_ids().await
     }
 
     async fn record_learned_peer(&self, endpoint_id: &str) -> Result<()> {
-        let endpoint_id = EndpointId::from_str(endpoint_id.trim())?;
         let relay_urls = self.node.relay_urls().await;
-        let mut endpoint_addr = self
-            .node
-            .endpoint()
-            .remote_info(endpoint_id)
-            .await
-            .map(|remote_info| {
-                iroh::EndpointAddr::from_parts(
-                    remote_info.id(),
-                    remote_info.into_addrs().map(|addr| addr.into_addr()),
-                )
-            })
-            .unwrap_or_else(|| iroh::EndpointAddr::new(endpoint_id));
-        for relay_url in relay_urls {
-            endpoint_addr = endpoint_addr.with_relay_url(relay_url.clone());
-        }
-        self.insert_learned_peer_addr(endpoint_addr).await;
+        // 台帳変化の bool は使わない(docs-sync と違い配り直す対象が無い)。
+        let _ = self
+            .peers
+            .record_learned_peer(endpoint_id, &relay_urls)
+            .await?;
         Ok(())
     }
 
@@ -364,14 +232,6 @@ impl IrohBlobService {
     }
 }
 
-fn direct_endpoint_addr(endpoint_addr: &iroh::EndpointAddr) -> Option<iroh::EndpointAddr> {
-    let mut direct = iroh::EndpointAddr::new(endpoint_addr.id);
-    for addr in endpoint_addr.ip_addrs() {
-        direct = direct.with_ip_addr(*addr);
-    }
-    (!direct.is_empty()).then_some(direct)
-}
-
 #[async_trait]
 impl BlobService for MemoryBlobService {
     async fn put_blob(&self, data: Vec<u8>, mime: &str) -> Result<StoredBlob> {
@@ -475,7 +335,7 @@ impl BlobService for IrohBlobService {
 
     async fn import_peer_ticket(&self, ticket: &str) -> Result<()> {
         let endpoint_addr = parse_endpoint_ticket(ticket)?;
-        self.insert_imported_peer_addr(endpoint_addr).await;
+        self.peers.insert_imported_peer_addr(endpoint_addr).await;
         Ok(())
     }
 
@@ -485,16 +345,7 @@ impl BlobService for IrohBlobService {
 
     async fn set_seed_peers(&self, peers: Vec<SeedPeer>) -> Result<()> {
         let relay_urls = self.node.relay_urls().await;
-        let mut parsed = BTreeMap::new();
-        for peer in peers {
-            let endpoint_addr = peer.to_endpoint_addr_with_relays(&relay_urls)?;
-            self.node
-                .discovery()
-                .add_endpoint_info(endpoint_addr.clone());
-            parsed.insert(endpoint_addr.id.to_string(), endpoint_addr);
-        }
-        *self.seed_peers.lock().await = parsed;
-        Ok(())
+        self.peers.set_seed_peers(peers, &relay_urls).await
     }
 
     async fn assist_peer_ids(&self) -> Result<Vec<String>> {
@@ -542,30 +393,7 @@ mod tests {
         !addr.ip().is_unspecified()
     }
 
-    #[test]
-    fn remote_fetch_retry_state_cools_down_failures_without_blocking_active_fetches() {
-        let now = Instant::now();
-        let mut state = RemoteFetchRetryState::default();
-
-        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
-        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
-
-        state.finish("hash-a", false, now);
-        assert_eq!(
-            state.try_begin("hash-a", now + Duration::from_secs(1)),
-            RemoteFetchStart::CoolingDown
-        );
-        assert_eq!(
-            state.try_begin("hash-a", now + REMOTE_FETCH_RETRY_COOLDOWN),
-            RemoteFetchStart::Ready
-        );
-
-        state.finish("hash-a", true, now + REMOTE_FETCH_RETRY_COOLDOWN);
-        assert_eq!(
-            state.try_begin("hash-a", now + REMOTE_FETCH_RETRY_COOLDOWN),
-            RemoteFetchStart::Ready
-        );
-    }
+    // リトライ状態のテストは共通実装側(kukuri-transport::peers)へ移動した(WP-H2)。
 
     #[tokio::test]
     async fn blob_roundtrip_basic() {

--- a/crates/docs-sync/src/iroh_sync.rs
+++ b/crates/docs-sync/src/iroh_sync.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -6,12 +6,13 @@ use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use iroh::EndpointAddr;
-use iroh::EndpointId;
 use iroh_docs::api::Doc;
 use iroh_docs::store::Query;
 use iroh_docs::{Capability, DocTicket, NamespaceSecret};
 use kukuri_core::ReplicaId;
-use kukuri_transport::{SeedPeer, parse_endpoint_ticket, relay_assisted_endpoint_addr};
+use kukuri_transport::{
+    PeerAddrBook, RemoteFetchRetryState, RemoteFetchStart, SeedPeer, parse_endpoint_ticket,
+};
 use tokio::sync::{Mutex, broadcast};
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant, timeout};
@@ -34,41 +35,6 @@ struct ReplicaHandle {
 
 const REMOTE_FETCH_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const REMOTE_FETCH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15);
-const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(3);
-
-#[derive(Debug, PartialEq, Eq)]
-enum RemoteFetchStart {
-    Ready,
-    CoolingDown,
-}
-
-#[derive(Debug, Default)]
-struct RemoteFetchRetryState {
-    retry_after: BTreeMap<String, Instant>,
-}
-
-impl RemoteFetchRetryState {
-    fn try_begin(&mut self, key: &str, now: Instant) -> RemoteFetchStart {
-        if self
-            .retry_after
-            .get(key)
-            .is_some_and(|retry_after| *retry_after > now)
-        {
-            return RemoteFetchStart::CoolingDown;
-        }
-        self.retry_after.remove(key);
-        RemoteFetchStart::Ready
-    }
-
-    fn finish(&mut self, key: &str, success: bool, now: Instant) {
-        if success {
-            self.retry_after.remove(key);
-        } else {
-            self.retry_after
-                .insert(key.to_string(), now + REMOTE_FETCH_RETRY_COOLDOWN);
-        }
-    }
-}
 
 #[derive(Clone, Debug, Default)]
 pub struct DocsPeerState {
@@ -80,21 +46,20 @@ pub struct DocsPeerState {
 pub struct IrohDocsSync {
     node: Arc<IrohDocsNode>,
     replicas: Arc<Mutex<HashMap<String, ReplicaHandle>>>,
-    learned_peers: Arc<Mutex<BTreeMap<String, EndpointAddr>>>,
-    seed_peers: Arc<Mutex<BTreeMap<String, EndpointAddr>>>,
-    imported_peers: Arc<Mutex<BTreeMap<String, EndpointAddr>>>,
+    // ピア台帳・接続候補・リトライ状態は kukuri-transport の共通実装(WP-H2)。
+    // 台帳変化(bool)を見て reapply_sync_peers を呼ぶのはこちら側の責務。
+    peers: Arc<PeerAddrBook>,
     private_replica_secrets: Arc<Mutex<HashMap<String, NamespaceSecret>>>,
     remote_fetch_retries: Arc<Mutex<RemoteFetchRetryState>>,
 }
 
 impl IrohDocsSync {
     pub fn new(node: Arc<IrohDocsNode>) -> Self {
+        let peers = Arc::new(PeerAddrBook::new(node.endpoint().clone(), node.discovery()));
         Self {
             node,
             replicas: Arc::new(Mutex::new(HashMap::new())),
-            learned_peers: Arc::new(Mutex::new(BTreeMap::new())),
-            seed_peers: Arc::new(Mutex::new(BTreeMap::new())),
-            imported_peers: Arc::new(Mutex::new(BTreeMap::new())),
+            peers,
             private_replica_secrets: Arc::new(Mutex::new(HashMap::new())),
             remote_fetch_retries: Arc::new(Mutex::new(RemoteFetchRetryState::default())),
         }
@@ -114,140 +79,33 @@ impl IrohDocsSync {
     }
 
     async fn sync_peers(&self) -> Vec<EndpointAddr> {
-        let mut peers = self
-            .learned_peers
-            .lock()
-            .await
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        for peer in self.seed_peers.lock().await.values() {
-            if !peers.iter().any(|existing| existing.id == peer.id) {
-                peers.push(peer.clone());
-            }
-        }
-        for peer in self.imported_peers.lock().await.values() {
-            if !peers.iter().any(|existing| existing.id == peer.id) {
-                peers.push(peer.clone());
-            }
-        }
-        peers
-    }
-
-    async fn insert_learned_peer_addr(&self, endpoint_addr: EndpointAddr) -> bool {
-        if !endpoint_addr.is_empty() {
-            self.node
-                .discovery()
-                .add_endpoint_info(endpoint_addr.clone());
-        }
-        let key = endpoint_addr.id.to_string();
-        let mut learned_peers = self.learned_peers.lock().await;
-        if learned_peers.get(key.as_str()) == Some(&endpoint_addr) {
-            return false;
-        }
-        learned_peers.insert(key, endpoint_addr);
-        true
-    }
-
-    async fn insert_imported_peer_addr(&self, endpoint_addr: EndpointAddr) {
-        self.node
-            .discovery()
-            .add_endpoint_info(endpoint_addr.clone());
-        self.imported_peers
-            .lock()
-            .await
-            .insert(endpoint_addr.id.to_string(), endpoint_addr);
+        self.peers.merged_peers().await
     }
 
     pub async fn peer_state(&self) -> DocsPeerState {
         DocsPeerState {
-            learned_peers: self.learned_peers.lock().await.values().cloned().collect(),
-            imported_peers: self.imported_peers.lock().await.values().cloned().collect(),
+            learned_peers: self.peers.learned_peers_snapshot().await,
+            imported_peers: self.peers.imported_peers_snapshot().await,
         }
     }
 
     pub async fn restore_peer_state(&self, state: DocsPeerState) -> Result<()> {
         for endpoint_addr in state.learned_peers {
-            let _ = self.insert_learned_peer_addr(endpoint_addr).await;
+            let _ = self.peers.insert_learned_peer_addr(endpoint_addr).await;
         }
         for endpoint_addr in state.imported_peers {
-            self.insert_imported_peer_addr(endpoint_addr).await;
+            self.peers.insert_imported_peer_addr(endpoint_addr).await;
         }
+        // 復元後の reapply は docs-sync 側の責務(共通台帳は行わない)。
         self.reapply_sync_peers().await
     }
 
-    async fn record_learned_peer(&self, endpoint_id: &str) -> Result<bool> {
-        let endpoint_id = EndpointId::from_str(endpoint_id.trim())?;
-        let relay_urls = self.node.relay_urls().await;
-        let mut endpoint_addr = self
-            .node
-            .endpoint()
-            .remote_info(endpoint_id)
-            .await
-            .map(|remote_info| {
-                EndpointAddr::from_parts(
-                    remote_info.id(),
-                    remote_info.into_addrs().map(|addr| addr.into_addr()),
-                )
-            })
-            .unwrap_or_else(|| EndpointAddr::new(endpoint_id));
-        for relay_url in relay_urls {
-            endpoint_addr = endpoint_addr.with_relay_url(relay_url);
-        }
-        Ok(self.insert_learned_peer_addr(endpoint_addr).await)
-    }
-
     async fn connect_candidates(&self, imported_peer: &EndpointAddr) -> Vec<EndpointAddr> {
-        let mut candidates = Vec::new();
-        if let Some(candidate) = direct_endpoint_addr(imported_peer) {
-            candidates.push(candidate);
-        }
-        if let Some(remote_info) = self.node.endpoint().remote_info(imported_peer.id).await {
-            let learned_peer = EndpointAddr::from_parts(
-                remote_info.id(),
-                remote_info.into_addrs().map(|addr| addr.into_addr()),
-            );
-            if !learned_peer.is_empty() {
-                candidates.push(learned_peer);
-            }
-        }
-        let relay_supported = relay_assisted_endpoint_addr(imported_peer);
-        if relay_supported.relay_urls().next().is_some()
-            && !candidates
-                .iter()
-                .any(|candidate| candidate == &relay_supported)
-        {
-            candidates.push(relay_supported);
-        }
-        if candidates.is_empty()
-            || !candidates
-                .iter()
-                .any(|candidate| candidate == imported_peer)
-        {
-            candidates.push(imported_peer.clone());
-        }
-        candidates
+        self.peers.connect_candidates(imported_peer).await
     }
 
     pub(crate) async fn available_sync_peer_ids(&self) -> Vec<String> {
-        let peers = self.sync_peers().await;
-        let mut available = BTreeSet::new();
-        for peer in peers {
-            if self
-                .node
-                .endpoint()
-                .remote_info(peer.id)
-                .await
-                .is_some_and(|info| {
-                    info.addrs().any(|addr| {
-                        matches!(addr.usage(), iroh::endpoint::TransportAddrUsage::Active)
-                    })
-                })
-            {
-                available.insert(peer.id.to_string());
-            }
-        }
-        available.into_iter().collect()
+        self.peers.available_peer_ids().await
     }
 
     async fn reapply_sync_peers(&self) -> Result<()> {
@@ -495,14 +353,6 @@ impl IrohDocsSync {
     }
 }
 
-fn direct_endpoint_addr(endpoint_addr: &EndpointAddr) -> Option<EndpointAddr> {
-    let mut direct = EndpointAddr::new(endpoint_addr.id);
-    for addr in endpoint_addr.ip_addrs() {
-        direct = direct.with_ip_addr(*addr);
-    }
-    (!direct.is_empty()).then_some(direct)
-}
-
 #[async_trait]
 impl DocsSync for IrohDocsSync {
     async fn open_replica(&self, replica_id: &ReplicaId) -> Result<()> {
@@ -616,13 +466,19 @@ impl DocsSync for IrohDocsSync {
 
     async fn import_peer_ticket(&self, ticket: &str) -> Result<()> {
         let endpoint_addr = parse_endpoint_ticket(ticket)?;
-        self.insert_imported_peer_addr(endpoint_addr).await;
+        self.peers.insert_imported_peer_addr(endpoint_addr).await;
         self.reapply_sync_peers().await?;
         Ok(())
     }
 
     async fn learn_peer(&self, endpoint_id: &str) -> Result<()> {
-        if self.record_learned_peer(endpoint_id).await? {
+        let relay_urls = self.node.relay_urls().await;
+        // 台帳に変化があったときだけ全レプリカへ同期先を配り直す(bool は docs-sync 固有の挙動)。
+        if self
+            .peers
+            .record_learned_peer(endpoint_id, &relay_urls)
+            .await?
+        {
             self.reapply_sync_peers().await?;
         }
         Ok(())
@@ -657,15 +513,8 @@ impl DocsSync for IrohDocsSync {
 
     async fn set_seed_peers(&self, peers: Vec<SeedPeer>) -> Result<()> {
         let relay_urls = self.node.relay_urls().await;
-        let mut parsed = BTreeMap::new();
-        for peer in peers {
-            let endpoint_addr = peer.to_endpoint_addr_with_relays(&relay_urls)?;
-            self.node
-                .discovery()
-                .add_endpoint_info(endpoint_addr.clone());
-            parsed.insert(endpoint_addr.id.to_string(), endpoint_addr);
-        }
-        *self.seed_peers.lock().await = parsed;
+        self.peers.set_seed_peers(peers, &relay_urls).await?;
+        // seed 差し替え後の reapply は docs-sync 固有の挙動(共通台帳は行わない)。
         self.reapply_sync_peers().await
     }
 
@@ -681,29 +530,63 @@ async fn doc_start_sync(doc: &Doc, peers: Vec<EndpointAddr>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kukuri_transport::TransportNetworkConfig;
+    use tempfile::tempdir;
+    use tokio::time::sleep;
 
-    #[test]
-    fn remote_fetch_retry_state_cools_down_failures_without_blocking_active_fetches() {
-        let now = Instant::now();
-        let mut state = RemoteFetchRetryState::default();
+    // 接続候補の順序は外部挙動(characterization、WP-H2)。
+    // direct(remote_info 由来)→ relay 付き → 元の値、の優先順位を固定する。
+    // blob-service 側の同名観点テストと対になる。
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn connect_candidates_prefers_direct_remote_info_before_relay_hint() {
+        let sender_dir = tempdir().expect("sender tempdir");
+        let receiver_dir = tempdir().expect("receiver tempdir");
+        let config = TransportNetworkConfig::loopback();
 
-        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
-        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
+        let sender_node = IrohDocsNode::persistent_with_config(sender_dir.path(), config.clone())
+            .await
+            .expect("sender node");
+        let receiver_node = IrohDocsNode::persistent_with_config(receiver_dir.path(), config)
+            .await
+            .expect("receiver node");
 
-        state.finish("hash-a", false, now);
-        assert_eq!(
-            state.try_begin("hash-a", now + Duration::from_secs(1)),
-            RemoteFetchStart::CoolingDown
-        );
-        assert_eq!(
-            state.try_begin("hash-a", now + REMOTE_FETCH_RETRY_COOLDOWN),
-            RemoteFetchStart::Ready
-        );
+        let receiver = IrohDocsSync::new(receiver_node.clone());
+        let relay_url = "https://relay.example.invalid/".parse().expect("relay url");
+        let sender_addr = EndpointAddr::new(sender_node.endpoint().id()).with_relay_url(relay_url);
 
-        state.finish("hash-a", true, now + REMOTE_FETCH_RETRY_COOLDOWN);
-        assert_eq!(
-            state.try_begin("hash-a", now + REMOTE_FETCH_RETRY_COOLDOWN),
-            RemoteFetchStart::Ready
-        );
+        let seeded = sender_node
+            .endpoint()
+            .connect(receiver_node.endpoint().addr(), iroh_gossip::ALPN)
+            .await
+            .expect("seed connection");
+        drop(seeded);
+
+        timeout(Duration::from_secs(5), async {
+            loop {
+                if receiver_node
+                    .endpoint()
+                    .remote_info(sender_node.endpoint().id())
+                    .await
+                    .is_some()
+                {
+                    return;
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("receiver should learn sender remote info");
+
+        let candidates = receiver.connect_candidates(&sender_addr).await;
+        assert!(!candidates.is_empty());
+        assert_ne!(candidates[0], sender_addr);
+        assert!(candidates[0].relay_urls().next().is_none());
+        assert_eq!(candidates.last(), Some(&sender_addr));
+
+        receiver.shutdown().await;
+        let _ = sender_node.shutdown().await;
+        let _ = receiver_node.shutdown().await;
     }
+
+    // リトライ状態のテストは共通実装側(kukuri-transport::peers)へ移動した(WP-H2)。
 }

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -3,6 +3,7 @@ mod diagnostics;
 mod discovery;
 mod fake;
 mod iroh;
+mod peers;
 mod tickets;
 mod traits;
 
@@ -10,5 +11,6 @@ pub use config::*;
 pub use discovery::*;
 pub use fake::*;
 pub use iroh::*;
+pub use peers::*;
 pub use tickets::*;
 pub use traits::*;

--- a/crates/transport/src/peers.rs
+++ b/crates/transport/src/peers.rs
@@ -1,0 +1,275 @@
+//! docs-sync / blob-service で共有するピア台帳とリモートフェッチのリトライ状態(WP-H2)。
+//!
+//! かつて両 crate にほぼ写しで存在したピア管理(learned / seed / imported の 3 台帳、
+//! 合成順序、接続候補の優先順位、失敗クールダウン)の単一実装。
+//!
+//! **挙動差分は呼び出し側に残す**(REFACTORING.md / WP-H2 プランの決定):
+//! - `insert_learned_peer_addr` は「台帳に変化があったか」の bool を返す。docs-sync は
+//!   これを見て全レプリカへ同期先を配り直す(reapply)。blob-service は無視する。
+//! - 状態復元(peer_state / restore)後の reapply も docs-sync 呼び出し側の責務。
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use iroh::address_lookup::MemoryLookup;
+use iroh::{Endpoint, EndpointAddr, EndpointId, RelayUrl};
+use tokio::sync::Mutex;
+// 元実装(docs-sync / blob-service)と同じ tokio の Instant を使う(テストでの時間制御と互換)。
+use tokio::time::Instant;
+
+use crate::config::SeedPeer;
+use crate::tickets::relay_assisted_endpoint_addr;
+
+pub const REMOTE_FETCH_RETRY_COOLDOWN: Duration = Duration::from_secs(3);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RemoteFetchStart {
+    Ready,
+    CoolingDown,
+}
+
+/// リモートフェッチ失敗のクールダウン(対象キー毎)。
+#[derive(Default)]
+pub struct RemoteFetchRetryState {
+    retry_after: BTreeMap<String, Instant>,
+}
+
+impl RemoteFetchRetryState {
+    pub fn try_begin(&mut self, key: &str, now: Instant) -> RemoteFetchStart {
+        if self
+            .retry_after
+            .get(key)
+            .is_some_and(|retry_after| *retry_after > now)
+        {
+            return RemoteFetchStart::CoolingDown;
+        }
+        self.retry_after.remove(key);
+        RemoteFetchStart::Ready
+    }
+
+    pub fn finish(&mut self, key: &str, success: bool, now: Instant) {
+        if success {
+            self.retry_after.remove(key);
+        } else {
+            self.retry_after
+                .insert(key.to_string(), now + REMOTE_FETCH_RETRY_COOLDOWN);
+        }
+    }
+}
+
+/// direct(IP アドレス)だけを残した EndpointAddr(relay を含まない候補)。
+pub fn direct_endpoint_addr(endpoint_addr: &EndpointAddr) -> Option<EndpointAddr> {
+    let mut direct = EndpointAddr::new(endpoint_addr.id);
+    for addr in endpoint_addr.ip_addrs() {
+        direct = direct.with_ip_addr(*addr);
+    }
+    (!direct.is_empty()).then_some(direct)
+}
+
+/// learned / seed / imported の 3 台帳を持つピア台帳。
+///
+/// 合成順序(learned → seed → imported、id 重複排除)と接続候補の優先順位
+/// (direct → remote_info 由来 → relay 付き → 元の値)は外部挙動として固定
+/// (characterization: docs-sync / blob-service 双方の
+/// `connect_candidates_prefers_direct_remote_info_before_relay_hint`)。
+pub struct PeerAddrBook {
+    endpoint: Endpoint,
+    discovery: Arc<MemoryLookup>,
+    learned_peers: Mutex<BTreeMap<String, EndpointAddr>>,
+    seed_peers: Mutex<BTreeMap<String, EndpointAddr>>,
+    imported_peers: Mutex<BTreeMap<String, EndpointAddr>>,
+}
+
+impl PeerAddrBook {
+    pub fn new(endpoint: Endpoint, discovery: Arc<MemoryLookup>) -> Self {
+        Self {
+            endpoint,
+            discovery,
+            learned_peers: Mutex::new(BTreeMap::new()),
+            seed_peers: Mutex::new(BTreeMap::new()),
+            imported_peers: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// 3 台帳の合成(learned → seed → imported の順、id 重複排除)。
+    pub async fn merged_peers(&self) -> Vec<EndpointAddr> {
+        let mut peers = self
+            .learned_peers
+            .lock()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for peer in self.seed_peers.lock().await.values() {
+            if !peers.iter().any(|existing| existing.id == peer.id) {
+                peers.push(peer.clone());
+            }
+        }
+        for peer in self.imported_peers.lock().await.values() {
+            if !peers.iter().any(|existing| existing.id == peer.id) {
+                peers.push(peer.clone());
+            }
+        }
+        peers
+    }
+
+    /// learned 台帳へ挿入し、台帳に変化があったかを返す(同値なら false)。
+    pub async fn insert_learned_peer_addr(&self, endpoint_addr: EndpointAddr) -> bool {
+        if !endpoint_addr.is_empty() {
+            self.discovery.add_endpoint_info(endpoint_addr.clone());
+        }
+        let key = endpoint_addr.id.to_string();
+        let mut learned_peers = self.learned_peers.lock().await;
+        if learned_peers.get(key.as_str()) == Some(&endpoint_addr) {
+            return false;
+        }
+        learned_peers.insert(key, endpoint_addr);
+        true
+    }
+
+    pub async fn insert_imported_peer_addr(&self, endpoint_addr: EndpointAddr) {
+        self.discovery.add_endpoint_info(endpoint_addr.clone());
+        self.imported_peers
+            .lock()
+            .await
+            .insert(endpoint_addr.id.to_string(), endpoint_addr);
+    }
+
+    /// endpoint の remote_info と relay URL から learned ピアを記録し、
+    /// 台帳に変化があったかを返す。
+    pub async fn record_learned_peer(
+        &self,
+        endpoint_id: &str,
+        relay_urls: &[RelayUrl],
+    ) -> Result<bool> {
+        let endpoint_id = EndpointId::from_str(endpoint_id.trim())?;
+        let mut endpoint_addr = self
+            .endpoint
+            .remote_info(endpoint_id)
+            .await
+            .map(|remote_info| {
+                EndpointAddr::from_parts(
+                    remote_info.id(),
+                    remote_info.into_addrs().map(|addr| addr.into_addr()),
+                )
+            })
+            .unwrap_or_else(|| EndpointAddr::new(endpoint_id));
+        for relay_url in relay_urls {
+            endpoint_addr = endpoint_addr.with_relay_url(relay_url.clone());
+        }
+        Ok(self.insert_learned_peer_addr(endpoint_addr).await)
+    }
+
+    /// seed 台帳を丸ごと差し替える(SeedPeer → EndpointAddr 変換 + discovery 登録)。
+    pub async fn set_seed_peers(
+        &self,
+        peers: Vec<SeedPeer>,
+        relay_urls: &[RelayUrl],
+    ) -> Result<()> {
+        let mut parsed = BTreeMap::new();
+        for peer in peers {
+            let endpoint_addr = peer.to_endpoint_addr_with_relays(relay_urls)?;
+            self.discovery.add_endpoint_info(endpoint_addr.clone());
+            parsed.insert(endpoint_addr.id.to_string(), endpoint_addr);
+        }
+        *self.seed_peers.lock().await = parsed;
+        Ok(())
+    }
+
+    /// 接続候補を優先順位つきで並べる: direct → remote_info 由来 → relay 付き → 元の値。
+    pub async fn connect_candidates(&self, imported_peer: &EndpointAddr) -> Vec<EndpointAddr> {
+        let mut candidates = Vec::new();
+        if let Some(candidate) = direct_endpoint_addr(imported_peer) {
+            candidates.push(candidate);
+        }
+        if let Some(remote_info) = self.endpoint.remote_info(imported_peer.id).await {
+            let learned_peer = EndpointAddr::from_parts(
+                remote_info.id(),
+                remote_info.into_addrs().map(|addr| addr.into_addr()),
+            );
+            if !learned_peer.is_empty() {
+                candidates.push(learned_peer);
+            }
+        }
+        let relay_supported = relay_assisted_endpoint_addr(imported_peer);
+        if relay_supported.relay_urls().next().is_some()
+            && !candidates
+                .iter()
+                .any(|candidate| candidate == &relay_supported)
+        {
+            candidates.push(relay_supported);
+        }
+        if candidates.is_empty()
+            || !candidates
+                .iter()
+                .any(|candidate| candidate == imported_peer)
+        {
+            candidates.push(imported_peer.clone());
+        }
+        candidates
+    }
+
+    /// 合成台帳のうち、endpoint がアクティブなアドレスを持つピア id を返す。
+    pub async fn available_peer_ids(&self) -> Vec<String> {
+        let peers = self.merged_peers().await;
+        let mut available = BTreeSet::new();
+        for peer in peers {
+            if self
+                .endpoint
+                .remote_info(peer.id)
+                .await
+                .is_some_and(|info| {
+                    info.addrs().any(|addr| {
+                        matches!(addr.usage(), iroh::endpoint::TransportAddrUsage::Active)
+                    })
+                })
+            {
+                available.insert(peer.id.to_string());
+            }
+        }
+        available.into_iter().collect()
+    }
+
+    /// 状態保存用のスナップショット(learned / imported。seed は設定から再構築される)。
+    pub async fn learned_peers_snapshot(&self) -> Vec<EndpointAddr> {
+        self.learned_peers.lock().await.values().cloned().collect()
+    }
+
+    pub async fn imported_peers_snapshot(&self) -> Vec<EndpointAddr> {
+        self.imported_peers.lock().await.values().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // かつて docs-sync / blob-service に同名で重複していたテストの単一版(WP-H2)。
+    #[test]
+    fn remote_fetch_retry_state_cools_down_failures_without_blocking_active_fetches() {
+        let now = Instant::now();
+        let mut state = RemoteFetchRetryState::default();
+
+        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
+        assert_eq!(state.try_begin("hash-a", now), RemoteFetchStart::Ready);
+
+        state.finish("hash-a", false, now);
+        assert_eq!(
+            state.try_begin("hash-a", now + Duration::from_secs(1)),
+            RemoteFetchStart::CoolingDown
+        );
+        assert_eq!(
+            state.try_begin("hash-a", now + REMOTE_FETCH_RETRY_COOLDOWN),
+            RemoteFetchStart::Ready
+        );
+
+        state.finish("hash-a", true, now + REMOTE_FETCH_RETRY_COOLDOWN);
+        assert_eq!(
+            state.try_begin("hash-a", now + REMOTE_FETCH_RETRY_COOLDOWN),
+            RemoteFetchStart::Ready
+        );
+    }
+}


### PR DESCRIPTION
## 概要

リファクタリング マスタープラン Phase 3 Wave A / WP-H2 の 1 段目。docs-sync(`IrohDocsSync`)と blob-service(`IrohBlobService`)にほぼ写し(リトライ状態はバイト同一、同名テストまで重複)で存在したピア管理を、kukuri-transport の `peers` モジュールの単一実装へ集約する。個別プラン: `.claude/plans/2026-07-07-refactor-h2-iroh-boundary.md`(ローカル)。

- `PeerAddrBook`: learned / seed / imported の 3 台帳、合成順序、接続候補の優先順位、seed 差し替え、learned 記録、稼働ピア id 列挙
- `RemoteFetchRetryState`(失敗クールダウン)+ 同名重複テスト `remote_fetch_retry_state_cools_down_failures_without_blocking_active_fetches` を単一化
- `direct_endpoint_addr` ヘルパ(`relay_assisted_endpoint_addr` を transport に置いた前例に追随)

## 種別

refactor(挙動不変)

## 挙動変更

**なし**。以下は外部挙動として固定を維持:
- ピアの合成順序(learned → seed → imported、id 重複排除)
- 接続候補の優先順位(direct → remote_info 由来 → relay 付き → 元の値)
- 失敗クールダウン(3 秒)

**挙動差分は統一せず呼び出し側に残した**(マスタープラン指定):
- 台帳変化の bool 返却 → docs-sync だけが「変化があったときに全レプリカへ同期先を配り直す」ために使う。blob-service は無視
- 状態復元・seed 差し替え後の配り直し(reapply)→ docs-sync 側の責務(コードコメントで明示)

## 検証

- **先行 characterization**: docs-sync に接続候補順序のテスト `connect_candidates_prefers_direct_remote_info_before_relay_hint` を追加し、現行実装で緑を確認してから共通実装へ差し替え(blob-service 側には既存の同観点テストあり、双方緑)
- `cargo xtask scenario community_node_public_connectivity` green(実ノード間の接続経路の回帰網)
- docs-sync の実 relay replication テスト(tests/relay.rs)含む rust-test 全 green
- `cargo fmt --check` / `cargo clippy --workspace --all-targets(cn 系 exclude) -- -D warnings` / `cargo xtask oversized-files` すべて pass

## リスク

- 接続優先順位は外部挙動 — 上記 characterization(両 crate)と connectivity scenario で固定済み
- `Instant` は元実装と同じ tokio の型を維持(テストでの時間制御と互換)

## 後続対応

- WP-H2 PR2: iroh ノード所有権の集約(`IrohDocsNode` を新 crate kukuri-iroh-node へ移動)

🤖 Generated with [Claude Code](https://claude.com/claude-code)