### PR TITLE
[refactor:boundary] HTTP パス定数と request 型を cn-protocol で共有 (WP-H3 PR2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,6 +3125,7 @@ dependencies = [
  "kukuri-cn-core",
  "kukuri-cn-indexer",
  "kukuri-cn-operator",
+ "kukuri-cn-protocol",
  "kukuri-cn-safety",
  "kukuri-cn-trust",
  "kukuri-core",

--- a/crates/cn-core/src/rendezvous.rs
+++ b/crates/cn-core/src/rendezvous.rs
@@ -14,35 +14,11 @@ pub struct TopicRendezvousStore {
     ttl_seconds: u64,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TopicRendezvousHeartbeat {
-    pub endpoint_id: String,
-    pub addr_hint: Option<String>,
-    pub joins: Vec<String>,
-    pub refreshes: Vec<String>,
-    pub leaves: Vec<String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TopicRendezvousCandidate {
-    pub endpoint_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub addr_hint: Option<String>,
-    #[serde(default)]
-    pub relay_urls: Vec<String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TopicRendezvousTopicResponse {
-    pub topic_key: String,
-    pub peers: Vec<TopicRendezvousCandidate>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TopicRendezvousHeartbeatResponse {
-    pub expires_in_seconds: u64,
-    pub topics: Vec<TopicRendezvousTopicResponse>,
-}
+// rendezvous の wire 型は kukuri-cn-protocol へ移動した(WP-H3 PR2)。
+pub use kukuri_cn_protocol::{
+    TopicRendezvousCandidate, TopicRendezvousHeartbeat, TopicRendezvousHeartbeatResponse,
+    TopicRendezvousTopicResponse,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct StoredRendezvousPeer {

--- a/crates/cn-protocol/src/lib.rs
+++ b/crates/cn-protocol/src/lib.rs
@@ -12,8 +12,14 @@ pub mod auth;
 pub mod manifest;
 pub mod models;
 pub mod normalize;
+pub mod paths;
+pub mod rendezvous;
+pub mod requests;
 
 pub use auth::*;
 pub use manifest::*;
 pub use models::*;
 pub use normalize::*;
+pub use paths::*;
+pub use rendezvous::*;
+pub use requests::*;

--- a/crates/cn-protocol/src/paths.rs
+++ b/crates/cn-protocol/src/paths.rs
@@ -1,0 +1,16 @@
+//! デスクトップが対向する community node の HTTP パス(cn endpoint contract の一部)。
+//!
+//! cn-user-api の route 定義と desktop-runtime の URL 構築が同じ定数を参照することで、
+//! パス変更が両側にコンパイルエラーとして届く(文字列の二重持ちを解消。WP-H3 PR2)。
+
+pub const AUTH_CHALLENGE_PATH: &str = "/v1/auth/challenge";
+pub const AUTH_VERIFY_PATH: &str = "/v1/auth/verify";
+pub const CONSENTS_PATH: &str = "/v1/consents";
+pub const CONSENTS_STATUS_PATH: &str = "/v1/consents/status";
+pub const BOOTSTRAP_NODES_PATH: &str = "/v1/bootstrap/nodes";
+pub const BOOTSTRAP_HEARTBEAT_PATH: &str = "/v1/bootstrap/heartbeat";
+pub const NODE_MANIFEST_PATH: &str = "/v1/node/manifest";
+pub const TOPIC_RENDEZVOUS_HEARTBEAT_PATH: &str = "/v1/rendezvous/topics/heartbeat";
+/// 通報受付。client は manifest の `report_endpoint` から動的に解決するため
+/// 直接この定数で URL を組み立てるのはサーバ側(route 定義)のみ。
+pub const REPORT_PATH: &str = "/v1/report";

--- a/crates/cn-protocol/src/rendezvous.rs
+++ b/crates/cn-protocol/src/rendezvous.rs
@@ -1,0 +1,34 @@
+//! topic rendezvous の wire 型(cn endpoint contract の一部)。
+//! 保存側(redis store)は cn-core に残り、ここは request / response の形のみ。
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopicRendezvousHeartbeat {
+    pub endpoint_id: String,
+    pub addr_hint: Option<String>,
+    pub joins: Vec<String>,
+    pub refreshes: Vec<String>,
+    pub leaves: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopicRendezvousCandidate {
+    pub endpoint_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub addr_hint: Option<String>,
+    #[serde(default)]
+    pub relay_urls: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopicRendezvousTopicResponse {
+    pub topic_key: String,
+    pub peers: Vec<TopicRendezvousCandidate>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopicRendezvousHeartbeatResponse {
+    pub expires_in_seconds: u64,
+    pub topics: Vec<TopicRendezvousTopicResponse>,
+}

--- a/crates/cn-protocol/src/requests.rs
+++ b/crates/cn-protocol/src/requests.rs
@@ -1,0 +1,42 @@
+//! デスクトップが送る request body の型(cn endpoint contract の一部)。
+//!
+//! かつては cn-user-api がハンドラ内に Deserialize 専用で持ち、desktop は
+//! `serde_json::json!` で同じ形を手書きしていた(二重持ち)。共有型にすることで
+//! フィールド変更が両側にコンパイルエラーとして届く(WP-H3 PR2)。
+//!
+//! Option フィールドは `skip_serializing_if` で欠落として送る(サーバ側は
+//! `#[serde(default)]` で null / 欠落の双方を受理するため互換)。
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AuthChallengeRequest {
+    pub pubkey: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthVerifyRequest {
+    pub auth_envelope_json: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub addr_hint: Option<String>,
+    /// invite mode の community node に参加するための招待コード(#383)。
+    /// open / whitelist mode や既存 subscriber では不要。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invite_code: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct AcceptConsentsRequest {
+    #[serde(default)]
+    pub policy_slugs: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BootstrapHeartbeatRequest {
+    pub endpoint_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub addr_hint: Option<String>,
+}

--- a/crates/cn-user-api/Cargo.toml
+++ b/crates/cn-user-api/Cargo.toml
@@ -21,6 +21,7 @@ tower_governor.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
+kukuri-cn-protocol = { path = "../cn-protocol" }
 kukuri-cn-core = { path = "../cn-core" }
 kukuri-cn-indexer = { path = "../cn-indexer" }
 kukuri-cn-operator = { path = "../cn-operator" }

--- a/crates/cn-user-api/src/lib.rs
+++ b/crates/cn-user-api/src/lib.rs
@@ -9,6 +9,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use kukuri_cn_core::PgIndexEntryStore;
+// request body / HTTP パスは kukuri-cn-protocol の共有定義(WP-H3 PR2)。
 use kukuri_cn_core::{
     AdmissionRejection, ApiError, ApiResult, AuthChallengeResponse, AuthVerifyResponse,
     BootstrapHeartbeatResponse, COMMUNITY_NODE_RENDEZVOUS_KEY_PREFIX_ENV,
@@ -29,6 +30,12 @@ use kukuri_cn_indexer::{
     ArcadeDbConfig, ArcadeDbProjection, ArcadeDbRelationGraph, FailClosedIndexQuery, IndexQuery,
 };
 use kukuri_cn_operator::{CommunityNodeManifest, build_manifest, load_and_validate};
+use kukuri_cn_protocol::{
+    AUTH_CHALLENGE_PATH, AUTH_VERIFY_PATH, AcceptConsentsRequest, AuthChallengeRequest,
+    AuthVerifyRequest, BOOTSTRAP_HEARTBEAT_PATH, BOOTSTRAP_NODES_PATH, BootstrapHeartbeatRequest,
+    CONSENTS_PATH, CONSENTS_STATUS_PATH, NODE_MANIFEST_PATH, REPORT_PATH,
+    TOPIC_RENDEZVOUS_HEARTBEAT_PATH,
+};
 use kukuri_cn_safety::RiskSignalTarget;
 use kukuri_cn_trust::{
     PullAudience, RelationStore, TrustParams, TrustReadView, UniformRelationWeight,
@@ -150,37 +157,6 @@ impl std::fmt::Debug for UserApiConfig {
             .field("trust_read_enabled", &self.trust_read_enabled)
             .finish()
     }
-}
-
-#[derive(Debug, Deserialize)]
-struct AuthChallengeRequest {
-    pubkey: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct AuthVerifyRequest {
-    auth_envelope_json: Value,
-    #[serde(default)]
-    endpoint_id: Option<String>,
-    #[serde(default)]
-    addr_hint: Option<String>,
-    /// invite mode の community node に参加するための招待コード（#383）。
-    /// open / whitelist mode や既存 subscriber では不要。
-    #[serde(default)]
-    invite_code: Option<String>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct AcceptConsentsRequest {
-    #[serde(default)]
-    policy_slugs: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct BootstrapHeartbeatRequest {
-    endpoint_id: String,
-    #[serde(default)]
-    addr_hint: Option<String>,
 }
 
 /// 通報受信リクエスト（#370）。client（#310）が provenance + manifest authority scope で
@@ -481,17 +457,17 @@ pub fn app_router(state: UserApiState) -> Router {
     let manifest = manifest_routes(state.manifest.clone());
     let api = Router::new()
         .route("/healthz", get(healthz))
-        .route("/v1/auth/challenge", post(auth_challenge))
-        .route("/v1/auth/verify", post(auth_verify))
-        .route("/v1/consents/status", get(consent_status))
-        .route("/v1/consents", post(accept_consents_handler))
-        .route("/v1/bootstrap/nodes", get(bootstrap_nodes))
-        .route("/v1/bootstrap/heartbeat", post(bootstrap_heartbeat))
+        .route(AUTH_CHALLENGE_PATH, post(auth_challenge))
+        .route(AUTH_VERIFY_PATH, post(auth_verify))
+        .route(CONSENTS_STATUS_PATH, get(consent_status))
+        .route(CONSENTS_PATH, post(accept_consents_handler))
+        .route(BOOTSTRAP_NODES_PATH, get(bootstrap_nodes))
+        .route(BOOTSTRAP_HEARTBEAT_PATH, post(bootstrap_heartbeat))
         .route(
-            "/v1/rendezvous/topics/heartbeat",
+            TOPIC_RENDEZVOUS_HEARTBEAT_PATH,
             post(topic_rendezvous_heartbeat),
         )
-        .route("/v1/report", post(submit_report))
+        .route(REPORT_PATH, post(submit_report))
         .route("/v1/indexing/requests", post(submit_indexing_request))
         .route("/v1/index/search", get(index_search))
         .route("/v1/index/discovery", get(index_discovery))
@@ -519,7 +495,7 @@ pub fn manifest_routes(manifest: Option<Arc<CommunityNodeManifest>>) -> Router {
             "/.well-known/kukuri/community-node.json",
             get(node_manifest),
         )
-        .route("/v1/node/manifest", get(node_manifest))
+        .route(NODE_MANIFEST_PATH, get(node_manifest))
         .with_state(ManifestState { manifest })
 }
 

--- a/crates/desktop-runtime/src/community_node/manifest_support.rs
+++ b/crates/desktop-runtime/src/community_node/manifest_support.rs
@@ -37,7 +37,7 @@ impl DesktopRuntime {
     ) -> Result<CommunityNodeManifestFetch> {
         let base_url = normalize_http_url(base_url)?;
         let client = community_node_http_client()?;
-        let url = format!("{}/v1/node/manifest", base_url);
+        let url = format!("{base_url}{NODE_MANIFEST_PATH}");
         let response = client
             .get(url)
             .send()

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -4,9 +4,12 @@ use std::path::Path;
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use kukuri_cn_protocol::{
-    AuthChallengeResponse, AuthVerifyResponse, BootstrapHeartbeatResponse,
-    CommunityNodeConsentStatus, CommunityNodeResolvedUrls, CommunityNodeSeedPeer,
-    build_auth_envelope_json, normalize_http_url,
+    AUTH_CHALLENGE_PATH, AUTH_VERIFY_PATH, AcceptConsentsRequest, AuthChallengeRequest,
+    AuthChallengeResponse, AuthVerifyRequest, AuthVerifyResponse, BOOTSTRAP_HEARTBEAT_PATH,
+    BOOTSTRAP_NODES_PATH, BootstrapHeartbeatRequest, BootstrapHeartbeatResponse, CONSENTS_PATH,
+    CONSENTS_STATUS_PATH, CommunityNodeConsentStatus, CommunityNodeResolvedUrls,
+    CommunityNodeSeedPeer, NODE_MANIFEST_PATH, TOPIC_RENDEZVOUS_HEARTBEAT_PATH,
+    TopicRendezvousHeartbeat, build_auth_envelope_json, normalize_http_url,
 };
 use kukuri_core::{TopicId, public_topic_rendezvous_key};
 use kukuri_transport::{SeedPeer, Transport, TransportRelayConfig, parse_seed_peer};

--- a/crates/desktop-runtime/src/community_node/requests_support.rs
+++ b/crates/desktop-runtime/src/community_node/requests_support.rs
@@ -7,12 +7,12 @@ impl DesktopRuntime {
     ) -> Result<StoredCommunityNodeToken> {
         let base_url = normalize_http_url(base_url)?;
         let client = community_node_http_client()?;
-        let challenge_url = format!("{}/v1/auth/challenge", base_url);
+        let challenge_url = format!("{base_url}{AUTH_CHALLENGE_PATH}");
         let pubkey = self.author_keys.public_key_hex();
         let seed_peer = self.local_community_node_seed_peer("auth").await?;
         let challenge = client
             .post(challenge_url)
-            .json(&serde_json::json!({ "pubkey": pubkey }))
+            .json(&AuthChallengeRequest { pubkey })
             .send()
             .await
             .context("failed to request auth challenge")?
@@ -43,14 +43,15 @@ impl DesktopRuntime {
             challenge.challenge.as_str(),
             public_base_url.as_str(),
         )?;
-        let verify_url = format!("{}/v1/auth/verify", base_url);
+        let verify_url = format!("{base_url}{AUTH_VERIFY_PATH}");
         let verify = client
             .post(verify_url)
-            .json(&serde_json::json!({
-                "auth_envelope_json": auth_envelope_json,
-                "endpoint_id": seed_peer.endpoint_id,
-                "addr_hint": seed_peer.addr_hint,
-            }))
+            .json(&AuthVerifyRequest {
+                auth_envelope_json,
+                endpoint_id: Some(seed_peer.endpoint_id),
+                addr_hint: seed_peer.addr_hint,
+                invite_code: None,
+            })
             .send()
             .await
             .context("failed to verify auth envelope")?
@@ -74,7 +75,7 @@ impl DesktopRuntime {
     ) -> std::result::Result<CommunityNodeConsentStatus, CommunityNodeRequestError> {
         let client = community_node_http_client().map_err(CommunityNodeRequestError::Other)?;
         let response = client
-            .get(format!("{}/v1/consents/status", base_url))
+            .get(format!("{base_url}{CONSENTS_STATUS_PATH}"))
             .bearer_auth(access_token)
             .send()
             .await
@@ -109,9 +110,11 @@ impl DesktopRuntime {
     ) -> std::result::Result<CommunityNodeConsentStatus, CommunityNodeRequestError> {
         let client = community_node_http_client().map_err(CommunityNodeRequestError::Other)?;
         let response = client
-            .post(format!("{}/v1/consents", base_url))
+            .post(format!("{base_url}{CONSENTS_PATH}"))
             .bearer_auth(access_token)
-            .json(&serde_json::json!({ "policy_slugs": policy_slugs }))
+            .json(&AcceptConsentsRequest {
+                policy_slugs: policy_slugs.to_vec(),
+            })
             .send()
             .await
             .map_err(|error| {
@@ -159,7 +162,7 @@ impl DesktopRuntime {
         };
         let client = community_node_http_client().map_err(CommunityNodeRequestError::Other)?;
         let response = client
-            .get(format!("{}/v1/bootstrap/nodes", base_url))
+            .get(format!("{base_url}{BOOTSTRAP_NODES_PATH}"))
             .bearer_auth(access_token)
             .send()
             .await
@@ -366,15 +369,15 @@ impl DesktopRuntime {
             .map_err(CommunityNodeRequestError::Other)?;
         let client = community_node_http_client().map_err(CommunityNodeRequestError::Other)?;
         let response = client
-            .post(format!("{}/v1/rendezvous/topics/heartbeat", base_url))
+            .post(format!("{base_url}{TOPIC_RENDEZVOUS_HEARTBEAT_PATH}"))
             .bearer_auth(access_token)
-            .json(&serde_json::json!({
-                "endpoint_id": seed_peer.endpoint_id,
-                "addr_hint": seed_peer.addr_hint,
-                "joins": [],
-                "refreshes": topic_keys,
-                "leaves": []
-            }))
+            .json(&TopicRendezvousHeartbeat {
+                endpoint_id: seed_peer.endpoint_id,
+                addr_hint: seed_peer.addr_hint,
+                joins: Vec::new(),
+                refreshes: topic_keys,
+                leaves: Vec::new(),
+            })
             .send()
             .await
             .map_err(|error| {
@@ -575,12 +578,12 @@ impl DesktopRuntime {
         );
         let client = community_node_http_client().map_err(CommunityNodeRequestError::Other)?;
         let response = client
-            .post(format!("{}/v1/bootstrap/heartbeat", base_url))
+            .post(format!("{base_url}{BOOTSTRAP_HEARTBEAT_PATH}"))
             .bearer_auth(access_token)
-            .json(&serde_json::json!({
-                "endpoint_id": seed_peer.endpoint_id,
-                "addr_hint": seed_peer.addr_hint,
-            }))
+            .json(&BootstrapHeartbeatRequest {
+                endpoint_id: seed_peer.endpoint_id,
+                addr_hint: seed_peer.addr_hint,
+            })
             .send()
             .await;
         match response {


### PR DESCRIPTION
## 概要

リファクタリング マスタープラン Phase 3 Wave A / WP-H3 の PR2(最終)。デスクトップと cn-user-api の間で文字列・形の二重持ちだった HTTP パスと request body を、kukuri-cn-protocol の共有定義に置き換える。個別プラン: `.claude/plans/2026-07-07-refactor-h3-cn-protocol-crate.md`(ローカル)。

- **paths.rs**: desktop 対向の HTTP パス定数 9 本(auth / consents / bootstrap / manifest / rendezvous / report)。cn-user-api の route 定義と desktop の URL 構築が同じ定数を参照
- **requests.rs**: request body 型 4 つ。cn-user-api のハンドラ内 Deserialize 専用 struct を共有型へ置換し、desktop の `serde_json::json!` インライン構築 5 箇所を型へ置換(json! はゼロに)
- **rendezvous.rs**: rendezvous の wire 型 4 つを cn-core から移動(redis store は cn-core 残置、cn-core は re-export で互換維持)

これにより**パスやフィールドの変更が両側にコンパイルエラーとして届く**ようになる(この WP の本質的価値)。

## 種別

refactor:boundary(挙動不変・wire 互換)

## 挙動変更

**実質なし**。1 点だけ request JSON の表現が変わる: Option フィールド(addr_hint 等)が None のとき、従来は `null` を送っていたが、共有型は `skip_serializing_if` により**フィールド省略**で送る。サーバ側は従来から `#[serde(default)]` で null / 欠落の双方を受理するため互換(新旧どの組み合わせでも動作)。パス・必須フィールド・レスポンスは完全に不変。

- desktop が送らない `invite_code` は省略される(従来どおり送信されない)
- サーバ専用 route(index / trust / relation 系)は対象外で無変更

## 検証

- `cargo xtask cn-test` green(cn-user-api の HTTP contract テスト群 = 実サーバに対する request/response の回帰網)
- `cargo xtask scenario community_node_public_connectivity` green(実ノードとの認証 → consents → bootstrap → rendezvous heartbeat の実経路)
- rust-test 全 green / `cargo xtask cn-check` green
- `cargo fmt --check` / `cargo clippy --workspace --all-targets(cn 系 exclude) -- -D warnings` / `cargo xtask oversized-files` すべて pass

## リスク

- cn-user-api のハンドラ近傍に触れるため進行中の cn 機能 PR と衝突しうる(節目差し込みの前提どおり)。変更は struct 定義の置換と route 文字列の定数化のみでロジック無変更

## 後続対応

- なし(WP-H3 完結。Phase 3 Wave A = H1〜H3 完了。次は Wave B の H4〜H8 から機能ブロックの節目に合わせて選択)

🤖 Generated with [Claude Code](https://claude.com/claude-code)