### PR TITLE
[refactor] 購読タスク管理を SubscriptionRegistry へ集約 (WP-H5 PR5)

### DIFF
--- a/crates/app-api/src/live.rs
+++ b/crates/app-api/src/live.rs
@@ -51,7 +51,7 @@ impl AppService {
             .collect();
         }
         self.cleanup_ended_live_presence_tasks(&rows).await;
-        let joined_sessions = self.live_presence_tasks.lock().await;
+        let joined_sessions = self.subscription_registry.live_presence_tasks.lock().await;
         let mut items = Vec::with_capacity(rows.len());
         for row in rows {
             items.push(LiveSessionView {
@@ -252,6 +252,7 @@ impl AppService {
         let channel_key = channel_storage_id(state.channel_id.as_ref());
         let task_key = live_presence_task_key(topic_id, channel_key.as_str(), session_id);
         if self
+            .subscription_registry
             .live_presence_tasks
             .lock()
             .await
@@ -296,7 +297,8 @@ impl AppService {
                     .await;
             }
         });
-        self.live_presence_tasks
+        self.subscription_registry
+            .live_presence_tasks
             .lock()
             .await
             .insert(task_key, handle);

--- a/crates/app-api/src/service/attachment_support.rs
+++ b/crates/app-api/src/service/attachment_support.rs
@@ -546,22 +546,26 @@ pub(crate) fn effective_topic_status_detail(
 
 impl Drop for AppService {
     fn drop(&mut self) {
-        if let Ok(mut subscriptions) = self.subscriptions.try_lock() {
+        if let Ok(mut subscriptions) = self.subscription_registry.subscriptions.try_lock() {
             for (_, handle) in subscriptions.drain() {
                 handle.abort();
             }
         }
-        if let Ok(mut subscriptions) = self.private_channel_subscriptions.try_lock() {
+        if let Ok(mut subscriptions) = self
+            .subscription_registry
+            .private_channel_subscriptions
+            .try_lock()
+        {
             for (_, handle) in subscriptions.drain() {
                 handle.abort();
             }
         }
-        if let Ok(mut subscriptions) = self.author_subscriptions.try_lock() {
+        if let Ok(mut subscriptions) = self.subscription_registry.author_subscriptions.try_lock() {
             for (_, handle) in subscriptions.drain() {
                 handle.abort();
             }
         }
-        if let Ok(mut tasks) = self.live_presence_tasks.try_lock() {
+        if let Ok(mut tasks) = self.subscription_registry.live_presence_tasks.try_lock() {
             for (_, handle) in tasks.drain() {
                 handle.abort();
             }

--- a/crates/app-api/src/service/direct_messages_subscription_support.rs
+++ b/crates/app-api/src/service/direct_messages_subscription_support.rs
@@ -20,7 +20,7 @@ impl AppService {
             Arc::clone(&self.transport),
             Arc::clone(&self.keys),
             Arc::clone(&self.last_sync_ts),
-            Arc::clone(&self.direct_message_subscriptions),
+            Arc::clone(&self.subscription_registry.direct_message_subscriptions),
             self.current_author_pubkey().as_str(),
         )
         .await
@@ -250,6 +250,7 @@ impl AppService {
             return Ok(());
         }
         let has_active_handle = self
+            .subscription_registry
             .direct_message_subscriptions
             .lock()
             .await
@@ -266,7 +267,7 @@ impl AppService {
             return Ok(());
         }
         Self::spawn_direct_message_subscription_with_services(
-            Arc::clone(&self.direct_message_subscriptions),
+            Arc::clone(&self.subscription_registry.direct_message_subscriptions),
             Arc::clone(&self.projection_store),
             Arc::clone(&self.blob_service),
             Arc::clone(&self.hint_transport),
@@ -285,14 +286,16 @@ impl AppService {
     ) -> Result<()> {
         let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
         stop_direct_message_subscription_with_services(
-            self.direct_message_subscriptions.as_ref(),
+            self.subscription_registry
+                .direct_message_subscriptions
+                .as_ref(),
             self.hint_transport.as_ref(),
             self.keys.as_ref(),
             peer_pubkey.as_str(),
         )
         .await?;
         Self::spawn_direct_message_subscription_with_services(
-            Arc::clone(&self.direct_message_subscriptions),
+            Arc::clone(&self.subscription_registry.direct_message_subscriptions),
             Arc::clone(&self.projection_store),
             Arc::clone(&self.blob_service),
             Arc::clone(&self.hint_transport),
@@ -336,7 +339,8 @@ impl AppService {
             return Ok(false);
         };
         if snapshot.joined || snapshot.peer_count > 0 || snapshot.configured_peer_ids.is_empty() {
-            self.direct_message_subscription_restart_deadlines
+            self.subscription_registry
+                .direct_message_subscription_restart_deadlines
                 .lock()
                 .await
                 .remove(peer_pubkey.as_str());
@@ -344,6 +348,7 @@ impl AppService {
         }
         let now = Utc::now().timestamp();
         let mut deadlines = self
+            .subscription_registry
             .direct_message_subscription_restart_deadlines
             .lock()
             .await;

--- a/crates/app-api/src/service/gossip_subscription_support.rs
+++ b/crates/app-api/src/service/gossip_subscription_support.rs
@@ -74,6 +74,7 @@ impl AppService {
     ) -> Result<()> {
         let prefix = joined_private_channel_subscription_prefix(topic_id, channel_id);
         let keys = self
+            .subscription_registry
             .private_channel_subscriptions
             .lock()
             .await
@@ -83,6 +84,7 @@ impl AppService {
             .collect::<Vec<_>>();
         for key in keys {
             if let Some(handle) = self
+                .subscription_registry
                 .private_channel_subscriptions
                 .lock()
                 .await

--- a/crates/app-api/src/service/live_game_support.rs
+++ b/crates/app-api/src/service/live_game_support.rs
@@ -8,7 +8,12 @@ impl AppService {
         session_id: &str,
     ) {
         let key = live_presence_task_key(topic_id, channel_id, session_id);
-        let handle = self.live_presence_tasks.lock().await.remove(key.as_str());
+        let handle = self
+            .subscription_registry
+            .live_presence_tasks
+            .lock()
+            .await
+            .remove(key.as_str());
         if let Some(handle) = handle {
             handle.abort();
             let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;

--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -110,6 +110,7 @@ mod profile_docs_support;
 mod projection_support;
 mod social_helpers;
 mod social_runtime_support;
+mod subscription_registry;
 mod timeline_subscription_support;
 mod timeline_view_support;
 
@@ -190,6 +191,7 @@ pub(crate) use social_helpers::{
     schedule_direct_message_reconcile_with_services,
     stop_direct_message_subscription_with_services,
 };
+pub(crate) use subscription_registry::SubscriptionRegistry;
 pub(crate) use timeline_view_support::{
     MAX_POST_CONTENT_CHARS, MAX_PROFILE_ABOUT_CHARS, MAX_PROFILE_DISPLAY_NAME_CHARS,
     MAX_PROFILE_NAME_CHARS, MAX_REPOST_COMMENTARY_CHARS, content_from_payload_ref,
@@ -325,18 +327,12 @@ pub struct AppService {
     pub(crate) docs_sync: Arc<dyn DocsSync>,
     pub(crate) blob_service: Arc<dyn BlobService>,
     pub(crate) keys: Arc<KukuriKeys>,
-    pub(crate) subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
-    pub(crate) direct_message_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
-    pub(crate) private_channel_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
-    pub(crate) author_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
+    /// 購読タスクの台帳(task ×5 / 世代 / 復旧 deadline。WP-H5 PR5)。
+    pub(crate) subscription_registry: SubscriptionRegistry,
     pub(crate) joined_private_channels: Arc<Mutex<HashMap<String, JoinedPrivateChannelState>>>,
-    pub(crate) live_presence_tasks: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
     pub(crate) metaverse_room_events: Arc<Mutex<HashMap<String, VecDeque<MetaverseRoomEventView>>>>,
     pub(crate) last_sync_ts: Arc<Mutex<Option<i64>>>,
-    pub(crate) subscription_generations: Arc<Mutex<HashMap<String, u64>>>,
     pub(crate) public_topic_delivery: Arc<Mutex<HashMap<String, PublicTopicDeliveryStatus>>>,
-    pub(crate) direct_message_subscription_restart_deadlines: Arc<Mutex<HashMap<String, i64>>>,
-    pub(crate) replica_sync_restart_deadlines: Arc<Mutex<HashMap<String, i64>>>,
     pub(crate) empty_recovery_candidates: Arc<Mutex<HashSet<String>>>,
     pub(crate) gossip_disabled_topics: Arc<Mutex<HashSet<String>>>,
     pub(crate) gossip_disabled_channels: Arc<Mutex<HashSet<String>>>,
@@ -481,18 +477,11 @@ impl AppService {
             docs_sync,
             blob_service,
             keys: Arc::new(keys),
-            subscriptions: Arc::new(Mutex::new(HashMap::new())),
-            direct_message_subscriptions: Arc::new(Mutex::new(HashMap::new())),
-            private_channel_subscriptions: Arc::new(Mutex::new(HashMap::new())),
-            author_subscriptions: Arc::new(Mutex::new(HashMap::new())),
+            subscription_registry: SubscriptionRegistry::default(),
             joined_private_channels: Arc::new(Mutex::new(HashMap::new())),
-            live_presence_tasks: Arc::new(Mutex::new(HashMap::new())),
             metaverse_room_events: Arc::new(Mutex::new(HashMap::new())),
             last_sync_ts: Arc::new(Mutex::new(None)),
-            subscription_generations: Arc::new(Mutex::new(HashMap::new())),
             public_topic_delivery: Arc::new(Mutex::new(HashMap::new())),
-            direct_message_subscription_restart_deadlines: Arc::new(Mutex::new(HashMap::new())),
-            replica_sync_restart_deadlines: Arc::new(Mutex::new(HashMap::new())),
             empty_recovery_candidates: Arc::new(Mutex::new(HashSet::new())),
             gossip_disabled_topics: Arc::new(Mutex::new(HashSet::new())),
             gossip_disabled_channels: Arc::new(Mutex::new(HashSet::new())),
@@ -628,7 +617,11 @@ impl AppService {
     }
 
     pub(crate) async fn next_subscription_generation(&self, key: &str) -> u64 {
-        let mut generations = self.subscription_generations.lock().await;
+        let mut generations = self
+            .subscription_registry
+            .subscription_generations
+            .lock()
+            .await;
         let generation = generations
             .get(key)
             .copied()
@@ -669,6 +662,7 @@ impl AppService {
 
     pub(crate) async fn restart_active_subscriptions(&self) -> Result<()> {
         let topics = self
+            .subscription_registry
             .subscriptions
             .lock()
             .await
@@ -697,6 +691,7 @@ impl AppService {
         }
 
         let authors = self
+            .subscription_registry
             .author_subscriptions
             .lock()
             .await
@@ -712,6 +707,7 @@ impl AppService {
 
     pub async fn shutdown(&self) {
         let topics_to_unsubscribe = self
+            .subscription_registry
             .subscriptions
             .lock()
             .await
@@ -719,6 +715,7 @@ impl AppService {
             .cloned()
             .collect::<BTreeSet<_>>();
         let private_channels_to_unsubscribe = self
+            .subscription_registry
             .private_channel_subscriptions
             .lock()
             .await
@@ -726,7 +723,7 @@ impl AppService {
             .filter_map(|key| key.split("::").nth(1).map(str::to_owned))
             .collect::<BTreeSet<_>>();
         let handles = {
-            let mut subscriptions = self.subscriptions.lock().await;
+            let mut subscriptions = self.subscription_registry.subscriptions.lock().await;
             subscriptions
                 .drain()
                 .map(|(_, handle)| handle)
@@ -737,7 +734,11 @@ impl AppService {
             let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
         }
         let private_handles = {
-            let mut subscriptions = self.private_channel_subscriptions.lock().await;
+            let mut subscriptions = self
+                .subscription_registry
+                .private_channel_subscriptions
+                .lock()
+                .await;
             subscriptions
                 .drain()
                 .map(|(_, handle)| handle)
@@ -760,6 +761,7 @@ impl AppService {
                 .await;
         }
         let dm_peers_to_unsubscribe = self
+            .subscription_registry
             .direct_message_subscriptions
             .lock()
             .await
@@ -767,7 +769,11 @@ impl AppService {
             .cloned()
             .collect::<Vec<_>>();
         let dm_handles = {
-            let mut subscriptions = self.direct_message_subscriptions.lock().await;
+            let mut subscriptions = self
+                .subscription_registry
+                .direct_message_subscriptions
+                .lock()
+                .await;
             subscriptions
                 .drain()
                 .map(|(_, handle)| handle)
@@ -785,7 +791,7 @@ impl AppService {
             }
         }
         let author_handles = {
-            let mut subscriptions = self.author_subscriptions.lock().await;
+            let mut subscriptions = self.subscription_registry.author_subscriptions.lock().await;
             subscriptions
                 .drain()
                 .map(|(_, handle)| handle)
@@ -796,7 +802,7 @@ impl AppService {
             let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
         }
         let presence_handles = {
-            let mut tasks = self.live_presence_tasks.lock().await;
+            let mut tasks = self.subscription_registry.live_presence_tasks.lock().await;
             tasks.drain().map(|(_, handle)| handle).collect::<Vec<_>>()
         };
         for handle in presence_handles {

--- a/crates/app-api/src/service/private_channels_support.rs
+++ b/crates/app-api/src/service/private_channels_support.rs
@@ -459,6 +459,7 @@ impl AppService {
         }
         let prefix = joined_private_channel_subscription_prefix(topic_id, channel_id);
         let keys = self
+            .subscription_registry
             .private_channel_subscriptions
             .lock()
             .await
@@ -468,6 +469,7 @@ impl AppService {
             .collect::<Vec<_>>();
         for key in keys {
             if let Some(handle) = self
+                .subscription_registry
                 .private_channel_subscriptions
                 .lock()
                 .await
@@ -545,6 +547,7 @@ impl AppService {
     ) -> Result<()> {
         let prefix = joined_private_channel_subscription_prefix(topic_id, channel_id);
         let keys = self
+            .subscription_registry
             .private_channel_subscriptions
             .lock()
             .await
@@ -554,6 +557,7 @@ impl AppService {
             .collect::<Vec<_>>();
         for key in keys {
             if let Some(handle) = self
+                .subscription_registry
                 .private_channel_subscriptions
                 .lock()
                 .await
@@ -590,6 +594,7 @@ impl AppService {
                 &replica,
             );
             if self
+                .subscription_registry
                 .private_channel_subscriptions
                 .lock()
                 .await
@@ -1037,12 +1042,14 @@ impl AppService {
         });
 
         if let Some(private_key) = private_key {
-            self.private_channel_subscriptions
+            self.subscription_registry
+                .private_channel_subscriptions
                 .lock()
                 .await
                 .insert(private_key, handle);
         } else {
-            self.subscriptions
+            self.subscription_registry
+                .subscriptions
                 .lock()
                 .await
                 .insert(topic_id.to_string(), handle);

--- a/crates/app-api/src/service/social_runtime_support.rs
+++ b/crates/app-api/src/service/social_runtime_support.rs
@@ -35,6 +35,7 @@ impl AppService {
 
     pub(crate) async fn restart_direct_message_subscriptions(&self) -> Result<()> {
         let existing_peers = self
+            .subscription_registry
             .direct_message_subscriptions
             .lock()
             .await
@@ -43,7 +44,9 @@ impl AppService {
             .collect::<Vec<_>>();
         for peer_pubkey in existing_peers {
             stop_direct_message_subscription_with_services(
-                self.direct_message_subscriptions.as_ref(),
+                self.subscription_registry
+                    .direct_message_subscriptions
+                    .as_ref(),
                 self.hint_transport.as_ref(),
                 self.keys.as_ref(),
                 peer_pubkey.as_str(),
@@ -84,7 +87,7 @@ impl AppService {
     pub(crate) async fn ensure_author_subscription(&self, author_pubkey: &str) -> Result<()> {
         let author_pubkey = normalize_author_pubkey(author_pubkey)?;
         let stale_key = {
-            let subscriptions = self.author_subscriptions.lock().await;
+            let subscriptions = self.subscription_registry.author_subscriptions.lock().await;
             match subscriptions.get(author_pubkey.as_str()) {
                 Some(handle) if !handle.is_finished() => return Ok(()),
                 Some(_) => Some(author_pubkey.to_string()),
@@ -92,7 +95,8 @@ impl AppService {
             }
         };
         if let Some(stale_key) = stale_key {
-            self.author_subscriptions
+            self.subscription_registry
+                .author_subscriptions
                 .lock()
                 .await
                 .remove(stale_key.as_str());
@@ -104,6 +108,7 @@ impl AppService {
     pub(crate) async fn restart_author_subscription(&self, author_pubkey: &str) -> Result<()> {
         let author_pubkey = normalize_author_pubkey(author_pubkey)?;
         if let Some(handle) = self
+            .subscription_registry
             .author_subscriptions
             .lock()
             .await
@@ -121,7 +126,11 @@ impl AppService {
         let key = format!("author-subscription:{author_pubkey}");
         let now = Utc::now().timestamp();
         {
-            let mut deadlines = self.replica_sync_restart_deadlines.lock().await;
+            let mut deadlines = self
+                .subscription_registry
+                .replica_sync_restart_deadlines
+                .lock()
+                .await;
             let next_due_at = deadlines.get(key.as_str()).copied().unwrap_or_default();
             if next_due_at > now {
                 return;
@@ -149,7 +158,8 @@ impl AppService {
         let transport = Arc::clone(&self.transport);
         let keys = Arc::clone(&self.keys);
         let last_sync = Arc::clone(&self.last_sync_ts);
-        let direct_message_subscriptions = Arc::clone(&self.direct_message_subscriptions);
+        let direct_message_subscriptions =
+            Arc::clone(&self.subscription_registry.direct_message_subscriptions);
         let author_key = normalize_author_pubkey(author_pubkey)?;
         let local_author_pubkey = self.current_author_pubkey();
         let replica = author_replica_id(author_key.as_str());
@@ -339,7 +349,8 @@ impl AppService {
                 }
             }
         });
-        self.author_subscriptions
+        self.subscription_registry
+            .author_subscriptions
             .lock()
             .await
             .insert(author_key, handle);

--- a/crates/app-api/src/service/subscription_registry.rs
+++ b/crates/app-api/src/service/subscription_registry.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+/// 購読タスクの台帳(WP-H5 PR5)。
+///
+/// かつて AppService に生のまま並んでいた購読管理 8 フィールド(task map ×5 +
+/// 世代番号 + 復旧 deadline ×2)の置き場所。守るべき不変条件はここに集約する:
+/// - task を張り替えるときは必ず旧 task を abort してから登録する(取り残し防止)
+/// - 世代番号(generations)は購読の張り替え毎に進み、旧世代の task が古い状態を
+///   書き戻さないためのフェンスになる
+/// - 復旧 deadline は「同じ対象への再起動が短時間に連打されない」ためのクールダウン
+///
+/// フィールドは従来と同じ粒度の Mutex map のまま(スケジューリングの挙動は不変)。
+#[derive(Clone, Default)]
+pub(crate) struct SubscriptionRegistry {
+    /// 公開 topic の購読 task(key = topic_id)。
+    pub(crate) subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
+    /// DM の購読 task(key = dm topic)。
+    pub(crate) direct_message_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
+    /// private channel の購読 task(key = channel 購読キー)。
+    pub(crate) private_channel_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
+    /// 作者(プロフィール)購読 task(key = author pubkey)。
+    pub(crate) author_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
+    /// live presence の期限管理 task(key = live_presence_task_key)。
+    pub(crate) live_presence_tasks: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
+    /// 購読の世代番号(key = topic_id)。
+    pub(crate) subscription_generations: Arc<Mutex<HashMap<String, u64>>>,
+    /// DM 購読の再起動クールダウン(key = dm topic、値 = 次回可能時刻)。
+    pub(crate) direct_message_subscription_restart_deadlines: Arc<Mutex<HashMap<String, i64>>>,
+    /// replica sync の再起動クールダウン(key = replica id、値 = 次回可能時刻)。
+    pub(crate) replica_sync_restart_deadlines: Arc<Mutex<HashMap<String, i64>>>,
+}

--- a/crates/app-api/src/service/timeline_subscription_support.rs
+++ b/crates/app-api/src/service/timeline_subscription_support.rs
@@ -9,7 +9,7 @@ impl AppService {
             return Ok(());
         }
         let stale_key = {
-            let subscriptions = self.subscriptions.lock().await;
+            let subscriptions = self.subscription_registry.subscriptions.lock().await;
             match subscriptions.get(topic_id) {
                 Some(handle) if !handle.is_finished() => return Ok(()),
                 Some(_) => Some(topic_id.to_string()),
@@ -17,14 +17,19 @@ impl AppService {
             }
         };
         if let Some(stale_key) = stale_key {
-            self.subscriptions.lock().await.remove(stale_key.as_str());
+            self.subscription_registry
+                .subscriptions
+                .lock()
+                .await
+                .remove(stale_key.as_str());
         }
 
         self.spawn_topic_subscription(topic_id).await
     }
 
     pub(crate) async fn has_topic_subscription(&self, topic_id: &str) -> bool {
-        self.subscriptions
+        self.subscription_registry
+            .subscriptions
             .lock()
             .await
             .get(topic_id)
@@ -44,7 +49,13 @@ impl AppService {
     }
 
     pub(crate) async fn restart_topic_subscription(&self, topic_id: &str) -> Result<()> {
-        if let Some(handle) = self.subscriptions.lock().await.remove(topic_id) {
+        if let Some(handle) = self
+            .subscription_registry
+            .subscriptions
+            .lock()
+            .await
+            .remove(topic_id)
+        {
             handle.abort();
         }
         self.hint_transport
@@ -383,7 +394,7 @@ impl AppService {
     pub(crate) async fn maybe_restart_replica_sync(&self, topic_id: &str, replica: &ReplicaId) {
         maybe_restart_replica_sync_with_cooldown(
             self.docs_sync.as_ref(),
-            &self.replica_sync_restart_deadlines,
+            &self.subscription_registry.replica_sync_restart_deadlines,
             topic_id,
             replica,
         )
@@ -398,7 +409,11 @@ impl AppService {
         let key = format!("private-channel:{topic_id}:{channel_id}");
         let now = Utc::now().timestamp();
         {
-            let mut deadlines = self.replica_sync_restart_deadlines.lock().await;
+            let mut deadlines = self
+                .subscription_registry
+                .replica_sync_restart_deadlines
+                .lock()
+                .await;
             let next_due_at = deadlines.get(key.as_str()).copied().unwrap_or_default();
             if next_due_at > now {
                 return;
@@ -422,7 +437,11 @@ impl AppService {
         let key = format!("topic-subscription:{topic_id}");
         let now = Utc::now().timestamp();
         {
-            let mut deadlines = self.replica_sync_restart_deadlines.lock().await;
+            let mut deadlines = self
+                .subscription_registry
+                .replica_sync_restart_deadlines
+                .lock()
+                .await;
             let next_due_at = deadlines.get(key.as_str()).copied().unwrap_or_default();
             if next_due_at > now {
                 return;

--- a/crates/app-api/src/sync.rs
+++ b/crates/app-api/src/sync.rs
@@ -169,11 +169,18 @@ impl AppService {
     }
 
     pub async fn unsubscribe_topic(&self, topic_id: &str) -> Result<()> {
-        if let Some(handle) = self.subscriptions.lock().await.remove(topic_id) {
+        if let Some(handle) = self
+            .subscription_registry
+            .subscriptions
+            .lock()
+            .await
+            .remove(topic_id)
+        {
             handle.abort();
         }
         self.clear_public_topic_delivery(topic_id).await;
         let private_keys = self
+            .subscription_registry
             .private_channel_subscriptions
             .lock()
             .await
@@ -183,6 +190,7 @@ impl AppService {
             .collect::<Vec<_>>();
         for key in private_keys {
             if let Some(handle) = self
+                .subscription_registry
                 .private_channel_subscriptions
                 .lock()
                 .await
@@ -199,6 +207,7 @@ impl AppService {
             }
         }
         let keys_to_remove = self
+            .subscription_registry
             .live_presence_tasks
             .lock()
             .await

--- a/crates/app-api/src/tests/direct_messages/delivery.rs
+++ b/crates/app-api/src/tests/direct_messages/delivery.rs
@@ -79,6 +79,7 @@ async fn dm_first_message_appears_in_recipient_conversation_list_without_opening
         .expect("rebuild relationships for app b");
     assert!(
         app_b
+            .subscription_registry
             .direct_message_subscriptions
             .lock()
             .await
@@ -191,7 +192,8 @@ async fn dm_outbox_retry_stops_when_mutual_is_lost_and_resumes_when_it_returns()
         .await
         .expect("seed relationship projection");
     assert!(
-        app.direct_message_subscriptions
+        app.subscription_registry
+            .direct_message_subscriptions
             .lock()
             .await
             .contains_key(peer_pubkey.as_str()),
@@ -225,7 +227,8 @@ async fn dm_outbox_retry_stops_when_mutual_is_lost_and_resumes_when_it_returns()
         .await
         .expect("rebuild relationships after mutual loss");
     assert!(
-        !app.direct_message_subscriptions
+        !app.subscription_registry
+            .direct_message_subscriptions
             .lock()
             .await
             .contains_key(peer_pubkey.as_str()),
@@ -286,7 +289,8 @@ async fn dm_outbox_retry_stops_when_mutual_is_lost_and_resumes_when_it_returns()
         .await
         .expect("rebuild relationships after mutual restore");
     assert!(
-        app.direct_message_subscriptions
+        app.subscription_registry
+            .direct_message_subscriptions
             .lock()
             .await
             .contains_key(peer_pubkey.as_str()),

--- a/crates/app-api/src/tests/direct_messages/restart.rs
+++ b/crates/app-api/src/tests/direct_messages/restart.rs
@@ -121,6 +121,7 @@ async fn dm_restart_resumes_pending_outbox_and_local_delete_prevents_duplicate_r
         .expect("resume direct message state");
     assert!(
         reopened_app_a
+            .subscription_registry
             .direct_message_subscriptions
             .lock()
             .await

--- a/crates/app-api/src/tests/direct_messages/subscription_status.rs
+++ b/crates/app-api/src/tests/direct_messages/subscription_status.rs
@@ -208,7 +208,8 @@ async fn dm_import_peer_ticket_restarts_active_mutual_subscription() {
     let topic = derive_direct_message_topic(app.keys.as_ref(), &Pubkey::from(peer_pubkey.as_str()))
         .expect("derive dm topic");
     assert!(
-        app.direct_message_subscriptions
+        app.subscription_registry
+            .direct_message_subscriptions
             .lock()
             .await
             .contains_key(peer_pubkey.as_str()),
@@ -284,6 +285,7 @@ async fn dm_status_restarts_mutual_subscription_when_handle_is_missing() {
     assert_eq!(*hint_transport.subscribe_count.lock().await, 1);
 
     if let Some(handle) = app
+        .subscription_registry
         .direct_message_subscriptions
         .lock()
         .await
@@ -300,7 +302,8 @@ async fn dm_status_restarts_mutual_subscription_when_handle_is_missing() {
     assert!(status.mutual);
     assert_eq!(*hint_transport.subscribe_count.lock().await, 2);
     assert!(
-        app.direct_message_subscriptions
+        app.subscription_registry
+            .direct_message_subscriptions
             .lock()
             .await
             .contains_key(peer_pubkey.as_str()),

--- a/crates/app-api/src/tests/sync/subscription_restarts.rs
+++ b/crates/app-api/src/tests/sync/subscription_restarts.rs
@@ -102,7 +102,7 @@ async fn ensure_topic_subscription_recreates_finished_handle() {
     assert_eq!(*hint_transport.subscribe_count.lock().await, 1);
 
     {
-        let subscriptions = app.subscriptions.lock().await;
+        let subscriptions = app.subscription_registry.subscriptions.lock().await;
         subscriptions
             .get(topic)
             .expect("topic subscription handle")

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -33,12 +33,12 @@
       "path": "crates/harness/src/scenarios/community_node.rs"
     },
     {
-      "lines": 1079,
-      "path": "crates/app-api/src/private_channels.rs"
+      "lines": 1085,
+      "path": "crates/app-api/src/service/private_channels_support.rs"
     },
     {
-      "lines": 1078,
-      "path": "crates/app-api/src/service/private_channels_support.rs"
+      "lines": 1079,
+      "path": "crates/app-api/src/private_channels.rs"
     }
   ]
 }


### PR DESCRIPTION
## 概要

リファクタリング マスタープラン Phase 3 Wave B / WP-H5 の PR5(最終)。AppService に生のまま並んでいた購読管理 8 フィールドを `SubscriptionRegistry` へ集約する。個別プラン: `.claude/plans/2026-07-07-refactor-h5-app-api-split.md`(ローカル)。

- 集約対象: 購読 task map ×5(公開 topic / DM / private channel / 作者 / live presence)+ 世代番号 + 復旧クールダウン ×2(DM 購読 / replica sync)
- 守るべき不変条件(**張り替え時の旧 task abort・世代番号のフェンス・再起動クールダウン**)をレジストリの doc コメントに明文化し、置き場所を 1 箇所に
- AppService 本体は依存注入(store / transport 等)と状態(joined channels 等)に痩せる

## 種別

refactor(挙動不変)

## 挙動変更

**なし**。フィールドの粒度・Mutex 構成・スケジューリング(spawn / abort / クールダウン判定)は従来のまま — 利用 63 箇所(14 ファイル)の機械置換(`self.xxx` → `self.subscription_registry.xxx`)のみで、ロジックには触れていない。

## oversized baseline の更新(正当化)

`private_channels_support.rs` 1,078 → 1,085 行。参照パスが長くなったことによる fmt の折り返しのみで、ロジック追加はない。

## 検証

- rust-test 全 green(購読の再起動・復旧系テスト = subscription_restarts / private_channels / DM 系を含む、テスト本体無変更)
- `cargo fmt --check` / workspace clippy -D warnings pass

## リスク

- なし(機械置換。コンパイルが同一性を保証)

## 後続対応

- なし(**WP-H5 完結**: PR1 #495 / PR2 #496 / PR3 #497 / PR4 #498 / PR5 = 本 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)