### PR TITLE
[refactor] shell の Record 更新 / AsyncPanelState ヘルパー導入 (WP-H6 PR1)

### DIFF
--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -49,6 +49,7 @@ import {
   syncStatusBadgeLabel,
   syncStatusBadgeTone,
 } from '@/shell/selectors';
+import { setRecordEntry } from '@/shell/stateUpdates';
 import { useDesktopShellData } from '@/shell/useDesktopShellData';
 import { useDesktopShellRouting } from '@/shell/useDesktopShellRouting';
 import { useDesktopShellActions } from '@/shell/useDesktopShellActions';
@@ -477,18 +478,9 @@ export function DesktopShellPage({
         setTrackedTopics(nextTopics);
       }
       setActiveTopic(topic);
-      setSelectedChannelIdByTopic((current) => ({
-        ...current,
-        [topic]: channelId,
-      }));
-      setTimelineScopeByTopic((current) => ({
-        ...current,
-        [topic]: privateTimelineScope(channelId),
-      }));
-      setComposeChannelByTopic((current) => ({
-        ...current,
-        [topic]: privateComposeTarget(channelId),
-      }));
+      setSelectedChannelIdByTopic(setRecordEntry(topic, channelId));
+      setTimelineScopeByTopic(setRecordEntry(topic, privateTimelineScope(channelId)));
+      setComposeChannelByTopic(setRecordEntry(topic, privateComposeTarget(channelId)));
       await loadTopics(nextTopics, topic, null);
     },
     [

--- a/apps/desktop/src/shell/actions/directMessages.ts
+++ b/apps/desktop/src/shell/actions/directMessages.ts
@@ -6,6 +6,7 @@ import type {
   DirectMessageMessageView,
 } from '@/lib/api';
 
+import { updateRecordEntry } from '@/shell/stateUpdates';
 import type { DesktopShellState } from '@/shell/store';
 import { messageFromError } from '@/shell/selectors';
 
@@ -125,13 +126,10 @@ export function createDirectMessageActions({
             pending_outbox_count: 0,
           },
       } satisfies DirectMessageConversationView;
-      setDirectMessageTimelineByPeer((current) => ({
-        ...current,
-        [peerPubkey]: [
+      setDirectMessageTimelineByPeer(updateRecordEntry(peerPubkey, (prev) => [
           optimisticMessage,
-          ...(current[peerPubkey] ?? []).filter((message) => message.message_id !== messageId),
-        ],
-      }));
+          ...(prev ?? []).filter((message) => message.message_id !== messageId),
+        ]));
       setDirectMessages((current) => {
         const remaining = current.filter((conversation) => conversation.peer_pubkey !== peerPubkey);
         return [optimisticConversation, ...remaining];

--- a/apps/desktop/src/shell/actions/liveGame.ts
+++ b/apps/desktop/src/shell/actions/liveGame.ts
@@ -2,6 +2,7 @@ import type { FormEvent } from 'react';
 
 import type { ChannelRef, GameRoomView, GameScoreView } from '@/lib/api';
 
+import { removeRecordEntry, setRecordEntry } from '@/shell/stateUpdates';
 import { createGameEditorDraft, messageFromError } from '@/shell/selectors';
 import type { GameEditorDraft } from '@/shell/store';
 
@@ -129,10 +130,7 @@ export function createLiveGameActions({
   }
 
   async function handleJoinLiveSession(sessionId: string) {
-    setLivePendingBySessionId((current) => ({
-      ...current,
-      [sessionId]: true,
-    }));
+    setLivePendingBySessionId(setRecordEntry(sessionId, true));
     try {
       await api.joinLiveSession(activeTopic, sessionId);
       setLiveError(null);
@@ -140,19 +138,12 @@ export function createLiveGameActions({
     } catch (joinError) {
       setLiveError(messageFromError(joinError, translate('live:errors.failedJoin')));
     } finally {
-      setLivePendingBySessionId((current) => {
-        const next = { ...current };
-        delete next[sessionId];
-        return next;
-      });
+      setLivePendingBySessionId(removeRecordEntry(sessionId));
     }
   }
 
   async function handleLeaveLiveSession(sessionId: string) {
-    setLivePendingBySessionId((current) => ({
-      ...current,
-      [sessionId]: true,
-    }));
+    setLivePendingBySessionId(setRecordEntry(sessionId, true));
     try {
       await api.leaveLiveSession(activeTopic, sessionId);
       setLiveError(null);
@@ -160,19 +151,12 @@ export function createLiveGameActions({
     } catch (leaveError) {
       setLiveError(messageFromError(leaveError, translate('live:errors.failedLeave')));
     } finally {
-      setLivePendingBySessionId((current) => {
-        const next = { ...current };
-        delete next[sessionId];
-        return next;
-      });
+      setLivePendingBySessionId(removeRecordEntry(sessionId));
     }
   }
 
   async function handleEndLiveSession(sessionId: string) {
-    setLivePendingBySessionId((current) => ({
-      ...current,
-      [sessionId]: true,
-    }));
+    setLivePendingBySessionId(setRecordEntry(sessionId, true));
     try {
       await api.endLiveSession(activeTopic, sessionId);
       setLiveError(null);
@@ -180,11 +164,7 @@ export function createLiveGameActions({
     } catch (endError) {
       setLiveError(messageFromError(endError, translate('live:errors.failedEnd')));
     } finally {
-      setLivePendingBySessionId((current) => {
-        const next = { ...current };
-        delete next[sessionId];
-        return next;
-      });
+      setLivePendingBySessionId(removeRecordEntry(sessionId));
     }
   }
 
@@ -269,10 +249,7 @@ export function createLiveGameActions({
         score: parsed,
       });
     }
-    setGameSavingByRoomId((current) => ({
-      ...current,
-      [room.room_id]: true,
-    }));
+    setGameSavingByRoomId(setRecordEntry(room.room_id, true));
     try {
       await api.updateGameRoom(
         activeTopic,
@@ -282,20 +259,12 @@ export function createLiveGameActions({
         scores
       );
       setGameError(null);
-      setGameDrafts((current) => {
-        const next = { ...current };
-        delete next[room.room_id];
-        return next;
-      });
+      setGameDrafts(removeRecordEntry(room.room_id));
       await loadTopics(trackedTopics, activeTopic, selectedThread);
     } catch (updateError) {
       setGameError(messageFromError(updateError, translate('game:errors.failedUpdate')));
     } finally {
-      setGameSavingByRoomId((current) => {
-        const next = { ...current };
-        delete next[room.room_id];
-        return next;
-      });
+      setGameSavingByRoomId(removeRecordEntry(room.room_id));
     }
   }
 

--- a/apps/desktop/src/shell/actions/messageReactionSocial.ts
+++ b/apps/desktop/src/shell/actions/messageReactionSocial.ts
@@ -1,3 +1,4 @@
+import { setRecordEntry } from '@/shell/stateUpdates';
 import type {
   CustomReactionCropRect,
   DesktopApi,
@@ -147,18 +148,9 @@ export function createMessageReactionSocialActions({
 
     setTrackedTopics(nextTopics);
     setActiveTopic(targetTopic);
-    setSelectedChannelIdByTopic((current) => ({
-      ...current,
-      [targetTopic]: nextChannelId,
-    }));
-    setTimelineScopeByTopic((current) => ({
-      ...current,
-      [targetTopic]: privateTimelineScope(nextChannelId),
-    }));
-    setComposeChannelByTopic((current) => ({
-      ...current,
-      [targetTopic]: privateComposeTarget(nextChannelId),
-    }));
+    setSelectedChannelIdByTopic(setRecordEntry(targetTopic, nextChannelId));
+    setTimelineScopeByTopic(setRecordEntry(targetTopic, privateTimelineScope(nextChannelId)));
+    setComposeChannelByTopic(setRecordEntry(targetTopic, privateComposeTarget(nextChannelId)));
     clearAuxiliaryPanels();
     setShellChromeState((current) => ({
       ...current,

--- a/apps/desktop/src/shell/actions/profileTopicChannel.ts
+++ b/apps/desktop/src/shell/actions/profileTopicChannel.ts
@@ -1,3 +1,4 @@
+import { setRecordEntry, updateRecordEntry } from '@/shell/stateUpdates';
 import type { FormEvent } from 'react';
 
 import type {
@@ -145,10 +146,7 @@ export function createProfileTopicChannelActions({
 }: ProfileTopicChannelParams) {
   function handleProfileFieldChange(field: 'displayName' | 'name' | 'about', value: string) {
     const nextField: keyof ProfileInput = field === 'displayName' ? 'display_name' : field;
-    setProfileDraft((current) => ({
-      ...current,
-      [nextField]: value,
-    }));
+    setProfileDraft(setRecordEntry(nextField, value));
     setProfileDirty(true);
   }
 
@@ -211,24 +209,15 @@ export function createProfileTopicChannelActions({
   }
 
   function handleSelectPrivateChannel(topicId: string, channelId: string) {
-    setSelectedChannelIdByTopic((current) => ({
-      ...current,
-      [topicId]: channelId,
-    }));
-    setTimelineScopeByTopic((current) => ({
-      ...current,
-      [topicId]: {
+    setSelectedChannelIdByTopic(setRecordEntry(topicId, channelId));
+    setTimelineScopeByTopic(setRecordEntry(topicId, {
         kind: 'channel',
         channel_id: channelId,
-      },
-    }));
-    setComposeChannelByTopic((current) => ({
-      ...current,
-      [topicId]: {
+      }));
+    setComposeChannelByTopic(setRecordEntry(topicId, {
         kind: 'private_channel',
         channel_id: channelId,
-      },
-    }));
+      }));
     setActiveTopic(topicId);
     setShellChromeState((current) => ({
       ...current,
@@ -319,18 +308,9 @@ export function createProfileTopicChannelActions({
 
   async function handleSelectTopic(topic: string) {
     setActiveTopic(topic);
-    setSelectedChannelIdByTopic((current) => ({
-      ...current,
-      [topic]: null,
-    }));
-    setTimelineScopeByTopic((current) => ({
-      ...current,
-      [topic]: PUBLIC_TIMELINE_SCOPE,
-    }));
-    setComposeChannelByTopic((current) => ({
-      ...current,
-      [topic]: PUBLIC_CHANNEL_REF,
-    }));
+    setSelectedChannelIdByTopic(setRecordEntry(topic, null));
+    setTimelineScopeByTopic(setRecordEntry(topic, PUBLIC_TIMELINE_SCOPE));
+    setComposeChannelByTopic(setRecordEntry(topic, PUBLIC_CHANNEL_REF));
     setShellChromeState((current) => ({
       ...current,
       activePrimarySection: 'timeline',
@@ -426,38 +406,23 @@ export function createProfileTopicChannelActions({
           translate('channels:errors.failedShareChannel')
         );
       }
-      setJoinedChannelsByTopic((current) => ({
-        ...current,
-        [activeTopic]: upsertJoinedChannel(current[activeTopic] ?? [], channel),
-      }));
-      setChannelPanelStateByTopic((current) => ({
-        ...current,
-        [activeTopic]: {
+      setJoinedChannelsByTopic(updateRecordEntry(activeTopic, (prev) => upsertJoinedChannel(prev ?? [], channel)));
+      setChannelPanelStateByTopic(setRecordEntry(activeTopic, {
           status: 'ready',
           error: null,
-        },
-      }));
+        }));
       setChannelLabelInput('');
       setChannelAudienceInput('invite_only');
       setChannelError(nextChannelError);
-      setTimelineScopeByTopic((current) => ({
-        ...current,
-        [activeTopic]: {
+      setTimelineScopeByTopic(setRecordEntry(activeTopic, {
           kind: 'channel',
           channel_id: channel.channel_id,
-        },
-      }));
-      setSelectedChannelIdByTopic((current) => ({
-        ...current,
-        [activeTopic]: channel.channel_id,
-      }));
-      setComposeChannelByTopic((current) => ({
-        ...current,
-        [activeTopic]: {
+        }));
+      setSelectedChannelIdByTopic(setRecordEntry(activeTopic, channel.channel_id));
+      setComposeChannelByTopic(setRecordEntry(activeTopic, {
           kind: 'private_channel',
           channel_id: channel.channel_id,
-        },
-      }));
+        }));
       setShellChromeState((current) => ({
         ...current,
         activePrimarySection: 'timeline',
@@ -489,35 +454,20 @@ export function createProfileTopicChannelActions({
     setChannelActionPending('leave');
     try {
       await api.leavePrivateChannel(topicId, channelId);
-      setJoinedChannelsByTopic((current) => ({
-        ...current,
-        [topicId]: (current[topicId] ?? []).filter(
+      setJoinedChannelsByTopic(updateRecordEntry(topicId, (prev) => (prev ?? []).filter(
           (channel) => channel.channel_id !== channelId
-        ),
-      }));
-      setChannelPanelStateByTopic((current) => ({
-        ...current,
-        [topicId]: {
+        )));
+      setChannelPanelStateByTopic(setRecordEntry(topicId, {
           status: 'ready',
           error: null,
-        },
-      }));
+        }));
       setInviteOutput(null);
       setChannelError(null);
       const leavingSelectedChannel = selectedChannelIdByTopic[topicId] === channelId;
       if (leavingSelectedChannel) {
-        setSelectedChannelIdByTopic((current) => ({
-          ...current,
-          [topicId]: null,
-        }));
-        setTimelineScopeByTopic((current) => ({
-          ...current,
-          [topicId]: PUBLIC_TIMELINE_SCOPE,
-        }));
-        setComposeChannelByTopic((current) => ({
-          ...current,
-          [topicId]: PUBLIC_CHANNEL_REF,
-        }));
+        setSelectedChannelIdByTopic(setRecordEntry(topicId, null));
+        setTimelineScopeByTopic(setRecordEntry(topicId, PUBLIC_TIMELINE_SCOPE));
+        setComposeChannelByTopic(setRecordEntry(topicId, PUBLIC_CHANNEL_REF));
         if (topicId === activeTopic) {
           syncRoute('replace', {
             activeTopic: topicId,
@@ -563,36 +513,21 @@ export function createProfileTopicChannelActions({
     setTrackedTopics(nextTopics);
     setActiveTopic(topicId);
     if (placeholderChannel) {
-      setJoinedChannelsByTopic((current) => ({
-        ...current,
-        [topicId]: upsertJoinedChannel(current[topicId] ?? [], placeholderChannel),
-      }));
-      setChannelPanelStateByTopic((current) => ({
-        ...current,
-        [topicId]: {
+      setJoinedChannelsByTopic(updateRecordEntry(topicId, (prev) => upsertJoinedChannel(prev ?? [], placeholderChannel)));
+      setChannelPanelStateByTopic(setRecordEntry(topicId, {
           status: 'ready',
           error: null,
-        },
-      }));
+        }));
     }
-    setSelectedChannelIdByTopic((current) => ({
-      ...current,
-      [topicId]: channelId,
-    }));
-    setTimelineScopeByTopic((current) => ({
-      ...current,
-      [topicId]: {
+    setSelectedChannelIdByTopic(setRecordEntry(topicId, channelId));
+    setTimelineScopeByTopic(setRecordEntry(topicId, {
         kind: 'channel',
         channel_id: channelId,
-      },
-    }));
-    setComposeChannelByTopic((current) => ({
-      ...current,
-      [topicId]: {
+      }));
+    setComposeChannelByTopic(setRecordEntry(topicId, {
         kind: 'private_channel',
         channel_id: channelId,
-      },
-    }));
+      }));
     setInviteTokenInput('');
     setInviteOutput(null);
     setChannelError(null);

--- a/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
+++ b/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
@@ -22,6 +22,7 @@ import {
   type DesktopShellStateValue,
   type DesktopShellStoreApi,
 } from '@/shell/store';
+import { setRecordEntry } from '@/shell/stateUpdates';
 import { VISIBLE_TIMELINE_LIMIT } from '@/shell/pagination';
 import {
   authorViewFromDirectMessageConversation,
@@ -440,20 +441,11 @@ export function useDesktopShellDataEffects({
         }
         startTransition(() => {
           if (timelineResult.status === 'fulfilled') {
-            setDirectMessageTimelineByPeer((current) => ({
-              ...current,
-              [selectedPeerPubkey]: timelineResult.value.items,
-            }));
-            setDirectMessageTimelineNextCursorByPeer((current) => ({
-              ...current,
-              [selectedPeerPubkey]: timelineResult.value.next_cursor ?? null,
-            }));
+            setDirectMessageTimelineByPeer(setRecordEntry(selectedPeerPubkey, timelineResult.value.items));
+            setDirectMessageTimelineNextCursorByPeer(setRecordEntry(selectedPeerPubkey, timelineResult.value.next_cursor ?? null));
           }
           if (statusResult.status === 'fulfilled') {
-            setDirectMessageStatusByPeer((current) => ({
-              ...current,
-              [selectedPeerPubkey]: statusResult.value,
-            }));
+            setDirectMessageStatusByPeer(setRecordEntry(selectedPeerPubkey, statusResult.value));
           }
           setDirectMessageError(
             timelineResult.status === 'fulfilled' && statusResult.status === 'fulfilled'
@@ -619,10 +611,7 @@ export function useDesktopShellDataEffects({
     if (selectedStillJoined) {
       return;
     }
-    setSelectedChannelIdByTopic((current) => ({
-      ...current,
-      [activeTopic]: null,
-    }));
+    setSelectedChannelIdByTopic(setRecordEntry(activeTopic, null));
     setComposeChannelByTopic((current) =>
       current[activeTopic]?.kind === 'private_channel' &&
       current[activeTopic].channel_id === selectedPrivateChannelId

--- a/apps/desktop/src/shell/routing/useRouteSynchronization.ts
+++ b/apps/desktop/src/shell/routing/useRouteSynchronization.ts
@@ -1,3 +1,4 @@
+import { setRecordEntry } from '@/shell/stateUpdates';
 import { useEffect, type MutableRefObject } from 'react';
 import type { NavigateFunction } from 'react-router-dom';
 
@@ -250,18 +251,9 @@ export function useRouteSynchronization({
       currentSelectedChannelIdForTopic !== nextSelectedChannelId &&
       !channelRoutePendingValidation
     ) {
-      setSelectedChannelIdByTopic((current) => ({
-        ...current,
-        [nextTopic]: nextSelectedChannelId,
-      }));
-      setTimelineScopeByTopic((current) => ({
-        ...current,
-        [nextTopic]: privateTimelineScope(nextSelectedChannelId),
-      }));
-      setComposeChannelByTopic((current) => ({
-        ...current,
-        [nextTopic]: privateComposeTarget(nextSelectedChannelId),
-      }));
+      setSelectedChannelIdByTopic(setRecordEntry(nextTopic, nextSelectedChannelId));
+      setTimelineScopeByTopic(setRecordEntry(nextTopic, privateTimelineScope(nextSelectedChannelId)));
+      setComposeChannelByTopic(setRecordEntry(nextTopic, privateComposeTarget(nextSelectedChannelId)));
       shouldReload = true;
     }
 

--- a/apps/desktop/src/shell/stateUpdates.test.ts
+++ b/apps/desktop/src/shell/stateUpdates.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  panelError,
+  panelLoading,
+  panelReady,
+  removeRecordEntry,
+  setRecordEntry,
+  updateRecordEntry,
+} from '@/shell/stateUpdates';
+
+describe('stateUpdates', () => {
+  it('setRecordEntry は 1 キーだけ差し替えた新オブジェクトを返す', () => {
+    const current = { a: 1, b: 2 };
+    const next = setRecordEntry('a', 10)(current);
+    expect(next).toEqual({ a: 10, b: 2 });
+    expect(next).not.toBe(current);
+    expect(current).toEqual({ a: 1, b: 2 });
+  });
+
+  it('updateRecordEntry は現在値(未定義含む)から導出する', () => {
+    const current: Record<string, number> = { a: 1 };
+    expect(updateRecordEntry<number>('a', (prev) => (prev ?? 0) + 1)(current)).toEqual({ a: 2 });
+    expect(updateRecordEntry<number>('b', (prev) => (prev ?? 0) + 1)(current)).toEqual({
+      a: 1,
+      b: 1,
+    });
+  });
+
+  it('removeRecordEntry はキーが無ければ current をそのまま返す(参照同一)', () => {
+    const current = { a: 1 };
+    expect(removeRecordEntry('missing')(current)).toBe(current);
+    const next = removeRecordEntry('a')(current);
+    expect(next).toEqual({});
+    expect(next).not.toBe(current);
+  });
+
+  it('パネル状態コンストラクタは status と error を対で揃える', () => {
+    expect(panelLoading()).toEqual({ status: 'loading', error: null });
+    expect(panelReady()).toEqual({ status: 'ready', error: null });
+    expect(panelError('boom')).toEqual({ status: 'error', error: 'boom' });
+  });
+});

--- a/apps/desktop/src/shell/stateUpdates.ts
+++ b/apps/desktop/src/shell/stateUpdates.ts
@@ -1,0 +1,53 @@
+import type { AsyncPanelState } from '@/shell/store';
+
+// Record 状態(`Record<string, V>`)の 1 キー更新・削除の定型(WP-H6 PR1)。
+// shell の状態更新はこの形が大半で、各所で spread / delete を手書きしていた。
+// setter にそのまま渡せる updater を返す。
+
+/** 1 キーを値で差し替える updater。常に新しいオブジェクトを返す(従来の spread と同じ)。 */
+export function setRecordEntry<V>(
+  key: string,
+  value: V
+): (current: Record<string, V>) => Record<string, V> {
+  return (current) => ({ ...current, [key]: value });
+}
+
+/** 1 キーを「現在値からの導出」で差し替える updater。 */
+export function updateRecordEntry<V>(
+  key: string,
+  update: (prev: V | undefined) => V
+): (current: Record<string, V>) => Record<string, V> {
+  return (current) => ({ ...current, [key]: update(current[key]) });
+}
+
+/**
+ * 1 キーを削除する updater。キーが無ければ **current をそのまま返す**
+ * (参照同一性を保ち、不要な再レンダーを起こさない。従来の手書き delete と同じ)。
+ */
+export function removeRecordEntry<V>(
+  key: string
+): (current: Record<string, V>) => Record<string, V> {
+  return (current) => {
+    if (!(key in current)) {
+      return current;
+    }
+    const next = { ...current };
+    delete next[key];
+    return next;
+  };
+}
+
+// AsyncPanelState({ status, error })の定型コンストラクタ。
+// 「loading にするとき error を消し忘れる」类のずれを防ぐ。
+
+export function panelLoading(): AsyncPanelState {
+  return { status: 'loading', error: null };
+}
+
+export function panelReady(): AsyncPanelState {
+  return { status: 'ready', error: null };
+}
+
+export function panelError(error: string): AsyncPanelState {
+  return { status: 'error', error };
+}

--- a/apps/desktop/src/shell/stateUpdates.ts
+++ b/apps/desktop/src/shell/stateUpdates.ts
@@ -4,20 +4,25 @@ import type { AsyncPanelState } from '@/shell/store';
 // shell の状態更新はこの形が大半で、各所で spread / delete を手書きしていた。
 // setter にそのまま渡せる updater を返す。
 
-/** 1 キーを値で差し替える updater。常に新しいオブジェクトを返す(従来の spread と同じ)。 */
+/**
+ * 1 キーを値で差し替える updater。常に新しいオブジェクトを返す(従来の spread と同じ)。
+ *
+ * `NoInfer` により V は渡した値からではなく setter の文脈(状態フィールドの型)から
+ * 推論される(`null` やリテラルを渡したとき V が狭く固定されるのを防ぐ)。
+ */
 export function setRecordEntry<V>(
   key: string,
-  value: V
+  value: NoInfer<V>
 ): (current: Record<string, V>) => Record<string, V> {
-  return (current) => ({ ...current, [key]: value });
+  return (current) => ({ ...current, [key]: value as V });
 }
 
-/** 1 キーを「現在値からの導出」で差し替える updater。 */
+/** 1 キーを「現在値からの導出」で差し替える updater。V は文脈から推論(上と同じ理由)。 */
 export function updateRecordEntry<V>(
   key: string,
-  update: (prev: V | undefined) => V
+  update: (prev: NoInfer<V> | undefined) => NoInfer<V>
 ): (current: Record<string, V>) => Record<string, V> {
-  return (current) => ({ ...current, [key]: update(current[key]) });
+  return (current) => ({ ...current, [key]: update(current[key]) as V });
 }
 
 /**

--- a/apps/desktop/src/shell/useDesktopShellActions.ts
+++ b/apps/desktop/src/shell/useDesktopShellActions.ts
@@ -17,6 +17,7 @@ import {
   useDesktopShellStore,
   useDesktopShellStoreApi,
 } from '@/shell/store';
+import { setRecordEntry, updateRecordEntry } from '@/shell/stateUpdates';
 import { publishedTopicIdForPost } from '@/shell/selectors';
 import { createComposeInteractionsActions } from './actions/composeInteractions';
 import { createDirectMessageActions } from './actions/directMessages';
@@ -254,10 +255,7 @@ export function useDesktopShellActions({
       }
       return changed ? next : current;
     });
-    setPublicTimelinesByTopic((current) => ({
-      ...current,
-      [topicId]: patch(current[topicId] ?? []),
-    }));
+    setPublicTimelinesByTopic(updateRecordEntry(topicId, (prev) => patch(prev ?? [])));
     setThread((current) => patch(current));
     setProfileTimeline((current) => patch(current));
     setSelectedAuthorTimeline((current) => patch(current));
@@ -296,11 +294,7 @@ export function useDesktopShellActions({
     setComposer(draft.content);
     setDraftMediaItems(draftMedia as DraftMediaItem[]);
     setAttachmentInputKey((value) => value + 1);
-    setComposeChannelByTopic((current) => ({
-      ...current,
-      [draft.topic]:
-        draft.kind === 'repost' ? PUBLIC_CHANNEL_REF : (draft.channel_ref ?? PUBLIC_CHANNEL_REF),
-    }));
+    setComposeChannelByTopic(setRecordEntry(draft.topic, draft.kind === 'repost' ? PUBLIC_CHANNEL_REF : (draft.channel_ref ?? PUBLIC_CHANNEL_REF)));
     if (draft.kind === 'repost' && draft.source_object_id) {
       setRepostTarget(findKnownPost(draft.source_object_id));
       setReplyTarget(null);
@@ -313,10 +307,7 @@ export function useDesktopShellActions({
       setRepostTarget(null);
       const channelRef = draft.channel_ref;
       if (channelRef && channelRef.kind === 'private_channel') {
-        setSelectedChannelIdByTopic((current) => ({
-          ...current,
-          [draft.topic]: channelRef.channel_id,
-        }));
+        setSelectedChannelIdByTopic(setRecordEntry(draft.topic, channelRef.channel_id));
       }
     }
     setComposerError(post.local_error ?? null);
@@ -427,16 +418,10 @@ export function useDesktopShellActions({
       : selectedChannelId === null;
 
     if (belongsToActiveTimeline) {
-      setTimelinesByKey((current) => ({
-        ...current,
-        [timelineKey]: prependPost(current[timelineKey] ?? [], post),
-      }));
+      setTimelinesByKey(updateRecordEntry(timelineKey, (prev) => prependPost(prev ?? [], post)));
     }
     if (!post.channel_id) {
-      setPublicTimelinesByTopic((current) => ({
-        ...current,
-        [topicId]: prependPost(current[topicId] ?? [], post),
-      }));
+      setPublicTimelinesByTopic(updateRecordEntry(topicId, (prev) => prependPost(prev ?? [], post)));
     }
     if (post.root_id && currentState.selectedThread === post.root_id) {
       setThread((current) => prependPost(current, post));

--- a/apps/desktop/src/shell/useDesktopShellData.ts
+++ b/apps/desktop/src/shell/useDesktopShellData.ts
@@ -15,6 +15,7 @@ import type {
   PostView,
 } from '@/lib/api';
 
+import { removeRecordEntry, setRecordEntry, updateRecordEntry } from '@/shell/stateUpdates';
 import { useDesktopShellDataEffects } from '@/shell/data/useDesktopShellDataEffects';
 import { useDraftMediaHelpers } from '@/shell/data/useDraftMediaHelpers';
 import { useQueuedLoadTopics } from '@/shell/data/useQueuedLoadTopics';
@@ -254,14 +255,7 @@ export function useDesktopShellData({
         delete next[key];
         return next;
       });
-      setPendingTimelineNextCursorByKey((current) => {
-        if (!(key in current)) {
-          return current;
-        }
-        const next = { ...current };
-        delete next[key];
-        return next;
-      });
+      setPendingTimelineNextCursorByKey(removeRecordEntry(key));
     },
     [
       setPendingTimelineCountsByKey,
@@ -285,18 +279,12 @@ export function useDesktopShellData({
       const currentTimelinePosts = currentState.timelinesByKey[key] ?? EMPTY_POSTS;
       const preserveOlderPages = hasLoadedOlderAuthoritativePosts(currentTimelinePosts, pendingItems);
       startTransition(() => {
-        setTimelinesByKey((current) => ({
-          ...current,
-          [key]: mergeRefreshedVisiblePosts(
-            current[key] ?? EMPTY_POSTS,
+        setTimelinesByKey(updateRecordEntry(key, (prev) => mergeRefreshedVisiblePosts(
+            prev ?? EMPTY_POSTS,
             pendingItems,
             preserveOlderPages
-          ),
-        }));
-        setTimelineNextCursorByKey((current) => ({
-          ...current,
-          [key]: currentState.pendingTimelineNextCursorByKey[key] ?? null,
-        }));
+          )));
+        setTimelineNextCursorByKey(setRecordEntry(key, currentState.pendingTimelineNextCursorByKey[key] ?? null));
       });
       clearPendingTimeline(key);
       return true;
@@ -379,31 +367,16 @@ export function useDesktopShellData({
           const shouldBuffer = mode === 'buffer' && hasAuthoritativeBaseline && pendingCount > 0;
 
           if (shouldBuffer) {
-            setPendingTimelineSnapshotsByKey((current) => ({
-              ...current,
-              [timelineKey]: normalizedTimelineItems,
-            }));
-            setPendingTimelineCountsByKey((current) => ({
-              ...current,
-              [timelineKey]: pendingCount,
-            }));
-            setPendingTimelineNextCursorByKey((current) => ({
-              ...current,
-              [timelineKey]: resolvedTimelineCursor,
-            }));
+            setPendingTimelineSnapshotsByKey(setRecordEntry(timelineKey, normalizedTimelineItems));
+            setPendingTimelineCountsByKey(setRecordEntry(timelineKey, pendingCount));
+            setPendingTimelineNextCursorByKey(setRecordEntry(timelineKey, resolvedTimelineCursor));
           } else {
-            setTimelinesByKey((current) => ({
-              ...current,
-              [timelineKey]: mergeRefreshedVisiblePosts(
-                current[timelineKey] ?? EMPTY_POSTS,
+            setTimelinesByKey(updateRecordEntry(timelineKey, (prev) => mergeRefreshedVisiblePosts(
+                prev ?? EMPTY_POSTS,
                 normalizedTimelineItems,
                 preserveTimelinePages
-              ),
-            }));
-            setTimelineNextCursorByKey((current) => ({
-              ...current,
-              [timelineKey]: resolvedTimelineCursor,
-            }));
+              )));
+            setTimelineNextCursorByKey(setRecordEntry(timelineKey, resolvedTimelineCursor));
             clearPendingTimeline(timelineKey);
           }
         }
@@ -417,43 +390,28 @@ export function useDesktopShellData({
           const resolvedPublicTimelineCursor = preservePublicTimelinePages
             ? (currentState.publicTimelineNextCursorByTopic[topic] ?? null)
             : (publicTimeline.next_cursor ?? null);
-          setPublicTimelinesByTopic((current) => ({
-            ...current,
-            [topic]: mergeRefreshedVisiblePosts(
-              current[topic] ?? EMPTY_POSTS,
+          setPublicTimelinesByTopic(updateRecordEntry(topic, (prev) => mergeRefreshedVisiblePosts(
+              prev ?? EMPTY_POSTS,
               publicTimeline.items,
               preservePublicTimelinePages
-            ),
-          }));
-          setPublicTimelineNextCursorByTopic((current) => ({
-            ...current,
-            [topic]: resolvedPublicTimelineCursor,
-          }));
+            )));
+          setPublicTimelineNextCursorByTopic(setRecordEntry(topic, resolvedPublicTimelineCursor));
         }
 
         if (joinedChannelsResult.status === 'fulfilled') {
-          setJoinedChannelsByTopic((current) => ({
-            ...current,
-            [topic]: joinedChannelsResult.value,
-          }));
-          setChannelPanelStateByTopic((current) => ({
-            ...current,
-            [topic]: {
+          setJoinedChannelsByTopic(setRecordEntry(topic, joinedChannelsResult.value));
+          setChannelPanelStateByTopic(setRecordEntry(topic, {
               status: 'ready',
               error: null,
-            },
-          }));
+            }));
         } else {
-          setChannelPanelStateByTopic((current) => ({
-            ...current,
-            [topic]: {
+          setChannelPanelStateByTopic(setRecordEntry(topic, {
               status: 'error',
               error: messageFromError(
                 joinedChannelsResult.reason,
                 translate('common:errors.failedToLoadPrivateChannels')
               ),
-            },
-          }));
+            }));
         }
 
         if (currentThread) {
@@ -470,10 +428,7 @@ export function useDesktopShellData({
             setThread((current) =>
               mergeRefreshedVisiblePosts(current, incomingThreadItems, preserveThreadPages)
             );
-            setThreadNextCursorById((current) => ({
-              ...current,
-              [currentThread]: resolvedThreadCursor,
-            }));
+            setThreadNextCursorById(setRecordEntry(currentThread, resolvedThreadCursor));
           }
         } else {
           setThread([]);
@@ -528,10 +483,7 @@ export function useDesktopShellData({
         return;
       }
       const selectedChannelId = currentState.selectedChannelIdByTopic[topic] ?? null;
-      setTimelineLoadingMoreByKey((current) => ({
-        ...current,
-        [timelineKey]: true,
-      }));
+      setTimelineLoadingMoreByKey(setRecordEntry(timelineKey, true));
       try {
         const timeline = await api.listTimeline(
           topic,
@@ -540,20 +492,11 @@ export function useDesktopShellData({
           privateTimelineScope(selectedChannelId)
         );
         startTransition(() => {
-          setTimelinesByKey((current) => ({
-            ...current,
-            [timelineKey]: mergeUniquePosts(current[timelineKey] ?? EMPTY_POSTS, timeline.items),
-          }));
-          setTimelineNextCursorByKey((current) => ({
-            ...current,
-            [timelineKey]: timeline.next_cursor ?? null,
-          }));
+          setTimelinesByKey(updateRecordEntry(timelineKey, (prev) => mergeUniquePosts(prev ?? EMPTY_POSTS, timeline.items)));
+          setTimelineNextCursorByKey(setRecordEntry(timelineKey, timeline.next_cursor ?? null));
         });
       } finally {
-        setTimelineLoadingMoreByKey((current) => ({
-          ...current,
-          [timelineKey]: false,
-        }));
+        setTimelineLoadingMoreByKey(setRecordEntry(timelineKey, false));
       }
     },
     [
@@ -572,24 +515,15 @@ export function useDesktopShellData({
       if (!cursor || currentState.threadLoadingMoreById[threadId]) {
         return;
       }
-      setThreadLoadingMoreById((current) => ({
-        ...current,
-        [threadId]: true,
-      }));
+      setThreadLoadingMoreById(setRecordEntry(threadId, true));
       try {
         const threadView = await api.listThread(topic, threadId, cursor, THREAD_TIMELINE_LIMIT);
         startTransition(() => {
           setThread((current) => mergeUniquePosts(current, threadView.items));
-          setThreadNextCursorById((current) => ({
-            ...current,
-            [threadId]: threadView.next_cursor ?? null,
-          }));
+          setThreadNextCursorById(setRecordEntry(threadId, threadView.next_cursor ?? null));
         });
       } finally {
-        setThreadLoadingMoreById((current) => ({
-          ...current,
-          [threadId]: false,
-        }));
+        setThreadLoadingMoreById(setRecordEntry(threadId, false));
       }
     },
     [
@@ -651,27 +585,18 @@ export function useDesktopShellData({
             .listLiveSessions(currentActiveTopic, privateTimelineScope(selectedChannelId))
             .then((sessions) => {
               startTransition(() => {
-                setLiveSessionsByTopic((current) => ({
-                  ...current,
-                  [currentActiveTopic]: sessions,
-                }));
-                setLivePanelStateByTopic((current) => ({
-                  ...current,
-                  [currentActiveTopic]: { status: 'ready', error: null },
-                }));
+                setLiveSessionsByTopic(setRecordEntry(currentActiveTopic, sessions));
+                setLivePanelStateByTopic(setRecordEntry(currentActiveTopic, { status: 'ready', error: null }));
               });
             })
             .catch((error) => {
-              setLivePanelStateByTopic((current) => ({
-                ...current,
-                [currentActiveTopic]: {
+              setLivePanelStateByTopic(setRecordEntry(currentActiveTopic, {
                   status: 'error',
                   error: messageFromError(
                     error,
                     translate('common:errors.failedToLoadLiveSessions')
                   ),
-                },
-              }));
+                }));
             })
         );
       }
@@ -682,24 +607,15 @@ export function useDesktopShellData({
             .listGameRooms(currentActiveTopic, privateTimelineScope(selectedChannelId))
             .then((rooms) => {
               startTransition(() => {
-                setGameRoomsByTopic((current) => ({
-                  ...current,
-                  [currentActiveTopic]: rooms,
-                }));
-                setGamePanelStateByTopic((current) => ({
-                  ...current,
-                  [currentActiveTopic]: { status: 'ready', error: null },
-                }));
+                setGameRoomsByTopic(setRecordEntry(currentActiveTopic, rooms));
+                setGamePanelStateByTopic(setRecordEntry(currentActiveTopic, { status: 'ready', error: null }));
               });
             })
             .catch((error) => {
-              setGamePanelStateByTopic((current) => ({
-                ...current,
-                [currentActiveTopic]: {
+              setGamePanelStateByTopic(setRecordEntry(currentActiveTopic, {
                   status: 'error',
                   error: messageFromError(error, translate('common:errors.failedToLoadGameRooms')),
-                },
-              }));
+                }));
             })
         );
       }
@@ -786,20 +702,11 @@ export function useDesktopShellData({
               ]);
               startTransition(() => {
                 if (timelineResult.status === 'fulfilled') {
-                  setDirectMessageTimelineByPeer((current) => ({
-                    ...current,
-                    [selectedPeerPubkey]: timelineResult.value.items,
-                  }));
-                  setDirectMessageTimelineNextCursorByPeer((current) => ({
-                    ...current,
-                    [selectedPeerPubkey]: timelineResult.value.next_cursor ?? null,
-                  }));
+                  setDirectMessageTimelineByPeer(setRecordEntry(selectedPeerPubkey, timelineResult.value.items));
+                  setDirectMessageTimelineNextCursorByPeer(setRecordEntry(selectedPeerPubkey, timelineResult.value.next_cursor ?? null));
                 }
                 if (statusResult.status === 'fulfilled') {
-                  setDirectMessageStatusByPeer((current) => ({
-                    ...current,
-                    [selectedPeerPubkey]: statusResult.value,
-                  }));
+                  setDirectMessageStatusByPeer(setRecordEntry(selectedPeerPubkey, statusResult.value));
                 }
                 setDirectMessageError(
                   timelineResult.status === 'fulfilled' && statusResult.status === 'fulfilled'
@@ -931,25 +838,18 @@ export function useDesktopShellData({
                     void api
                       .fetchCommunityNodeManifest(baseUrl)
                       .then((result) => {
-                        setCommunityNodeManifests((current) => ({
-                          ...current,
-                          [baseUrl]:
-                            result.status === 'ok' && result.manifest
+                        setCommunityNodeManifests(setRecordEntry(baseUrl, result.status === 'ok' && result.manifest
                               ? { status: 'ok', manifest: result.manifest }
-                              : { status: 'absent' },
-                        }));
+                              : { status: 'absent' }));
                       })
                       .catch((error) => {
-                        setCommunityNodeManifests((current) => ({
-                          ...current,
-                          [baseUrl]: {
+                        setCommunityNodeManifests(setRecordEntry(baseUrl, {
                             status: 'error',
                             error: messageFromError(
                               error,
                               translate('common:errors.failedToLoadSettings')
                             ),
-                          },
-                        }));
+                          }));
                       });
                   }
                 }

--- a/apps/desktop/src/shell/useDesktopShellRouting.ts
+++ b/apps/desktop/src/shell/useDesktopShellRouting.ts
@@ -22,6 +22,7 @@ import {
   parsePrimarySectionPath,
   resolveHashBackedRouteLocation,
 } from '@/shell/routes';
+import { setRecordEntry } from '@/shell/stateUpdates';
 import { THREAD_TIMELINE_LIMIT } from '@/shell/pagination';
 import { useRouteSynchronization } from '@/shell/routing/useRouteSynchronization';
 import { useSyncRoute } from '@/shell/routing/useSyncRoute';
@@ -216,14 +217,8 @@ export function useDesktopShellRouting({
           const remaining = current.filter((entry) => entry.peer_pubkey !== conversation.peer_pubkey);
           return [conversation, ...remaining];
         });
-        setDirectMessageTimelineByPeer((current) => ({
-          ...current,
-          [peerPubkey]: timeline.items,
-        }));
-        setDirectMessageStatusByPeer((current) => ({
-          ...current,
-          [peerPubkey]: status,
-        }));
+        setDirectMessageTimelineByPeer(setRecordEntry(peerPubkey, timeline.items));
+        setDirectMessageStatusByPeer(setRecordEntry(peerPubkey, status));
         setKnownAuthorsByPubkey((current) =>
           mergeKnownAuthors(current, [authorViewFromDirectMessageConversation(conversation)])
         );
@@ -334,10 +329,7 @@ export function useDesktopShellRouting({
           setSelectedThread(threadId);
           setFocusedObjectId(nextFocusedObjectId);
           setThread(threadView.items);
-          setThreadNextCursorById((current) => ({
-            ...current,
-            [threadId]: threadView.next_cursor ?? null,
-          }));
+          setThreadNextCursorById(setRecordEntry(threadId, threadView.next_cursor ?? null));
           setSelectedAuthorPubkey(null);
           setSelectedAuthor(null);
           setAuthorError(null);


### PR DESCRIPTION
## 概要

リファクタリング マスタープラン Phase 3 Wave B / WP-H6 の PR1(4 PR 直列の 1 本目)。shell の状態更新で各所が手書きしていた定型パターンをヘルパーへ等価置換する。個別プラン: `.claude/plans/2026-07-08-refactor-h6-shell-state.md`(ローカル)。

- `stateUpdates.ts` を新設(単体テスト付き):
  - `setRecordEntry(key, value)` — Record の 1 キー差し替え
  - `updateRecordEntry(key, prev => …)` — 現在値からの導出
  - `removeRecordEntry(key)` — **参照同一性を保つ削除**(キー不在なら current をそのまま返す = 不要な再レンダーを起こさない)
  - `panelLoading / panelReady / panelError` — 既存 `AsyncPanelState` のコンストラクタ(「loading にするとき error を消し忘れる」類のずれを防ぐ)
- **85 箇所 / 10 ファイルを等価置換**(計算キーの spread 更新 74 + 導出 11 + 削除ブロック)。値が他の状態フィールドを参照する複雑なケースは変換対象外の判定にしたが該当ゼロ

## 種別

refactor(等価置換)

## 挙動変更

**なし**。2 点だけ判断を明記:
- falsy ガード付き削除 2 箇所(`if (!current[key])` — 値が 0 でも残す挙動)は `key in` 判定のヘルパーと意味が異なるため**手書きのまま残置**
- 無ガード削除(常に新オブジェクトを返していた 6 箇所)は removeRecordEntry 化により「キー不在時は参照同一」へ — 状態値は同一で、無駄な再レンダーが消える方向のみの差(該当キーは常に存在するコードパスのため実質不変)

## 検証

- `cargo xtask desktop-ui-check` green(lint / 型 / vitest 全テスト = S1 統合テスト 15 ファイル + S5 characterization、テスト本体無変更 / Storybook ビルド)
- stateUpdates の単体テスト追加(参照同一性の保証を固定)

## リスク

- なし(機械変換 + 単体テスト。統合テスト群が回帰網)

## 後続対応

- WP-H6 PR2: selector 購読化 + レンダー回数 smoke(全木再レンダー解消)

🤖 Generated with [Claude Code](https://claude.com/claude-code)