### PR TITLE
[refactor] DesktopShellState をドメインスライス合成へ分割 (WP-H6 PR3)

### DIFF
--- a/apps/desktop/src/shell/slices/chrome.ts
+++ b/apps/desktop/src/shell/slices/chrome.ts
@@ -1,0 +1,69 @@
+import { type SettingsSection, type ShellChromeState } from '@/components/shell/types';
+import { parseHashRouteLocation } from '@/shell/routes';
+
+/// shell chrome(ナビ・設定ドロワー)とルート記憶・全体エラー(WP-H6 PR3 のドメインスライス)。
+export type ChromeSliceState = {
+  error: string | null;
+  lastNonNotificationsRoute: string | null;
+  shellChromeState: ShellChromeState;
+};
+
+const DEFAULT_SETTINGS_SECTION: SettingsSection = 'connectivity';
+
+function parseInitialSettingsSection(): {
+  activeSettingsSection: SettingsSection;
+  settingsOpen: boolean;
+} {
+  if (typeof window === 'undefined') {
+    return {
+      activeSettingsSection: DEFAULT_SETTINGS_SECTION,
+      settingsOpen: false,
+    };
+  }
+
+  const { search } = parseHashRouteLocation(window.location.hash);
+  if (!search) {
+    return {
+      activeSettingsSection: DEFAULT_SETTINGS_SECTION,
+      settingsOpen: false,
+    };
+  }
+
+  const requestedSection = new URLSearchParams(search).get('settings');
+  if (
+    requestedSection !== 'about' &&
+    requestedSection !== 'appearance' &&
+    requestedSection !== 'connectivity' &&
+    requestedSection !== 'discovery' &&
+    requestedSection !== 'community-node' &&
+    requestedSection !== 'reactions' &&
+    requestedSection !== 'release'
+  ) {
+    return {
+      activeSettingsSection: DEFAULT_SETTINGS_SECTION,
+      settingsOpen: false,
+    };
+  }
+
+  return {
+    activeSettingsSection: requestedSection,
+    settingsOpen: true,
+  };
+}
+
+export function createInitialChromeSlice(): ChromeSliceState {
+  const initialSettingsState = parseInitialSettingsSection();
+  return {
+    error: null,
+    lastNonNotificationsRoute: null,
+    shellChromeState: {
+      activePrimarySection: 'timeline',
+      timelineView: 'feed',
+      activeSettingsSection: initialSettingsState.activeSettingsSection,
+      profileMode: 'overview',
+      profileConnectionsView: 'following',
+      navOpen: false,
+      settingsOpen: initialSettingsState.settingsOpen,
+    },
+  };
+}

--- a/apps/desktop/src/shell/slices/connectivity.ts
+++ b/apps/desktop/src/shell/slices/connectivity.ts
@@ -1,0 +1,99 @@
+import type {
+  CommunityNodeConfig,
+  CommunityNodeManifest,
+  CommunityNodeNodeStatus,
+  DiscoveryConfig,
+  SyncStatus,
+} from '@/lib/api';
+
+/// 接続まわり(discovery / community node / sync 状態)(WP-H6 PR3 のドメインスライス)。
+
+export type CommunityNodeDraftNode = {
+  id: string;
+  base_url: string;
+  auto_approve: boolean;
+};
+
+// public manifest endpoint (#356) からの取得状態。base_url ごとに保持する。
+export type CommunityNodeManifestEntry =
+  | { status: 'loading' }
+  | { status: 'ok'; manifest: CommunityNodeManifest }
+  | { status: 'absent' }
+  | { status: 'error'; error: string };
+
+export type ConnectivitySliceState = {
+  peerTicket: string;
+  localPeerTicket: string | null;
+  discoveryConfig: DiscoveryConfig;
+  discoverySeedInput: string;
+  discoveryEditorDirty: boolean;
+  discoveryError: string | null;
+  communityNodeConfig: CommunityNodeConfig;
+  communityNodeStatuses: CommunityNodeNodeStatus[];
+  communityNodeManifests: Record<string, CommunityNodeManifestEntry>;
+  communityNodeInput: CommunityNodeDraftNode[];
+  communityNodeEditorDirty: boolean;
+  communityNodeError: string | null;
+  syncStatus: SyncStatus;
+};
+
+export const DEFAULT_DISCOVERY_CONFIG: DiscoveryConfig = {
+  mode: 'seeded_dht',
+  connect_mode: 'direct_only',
+  env_locked: false,
+  seed_peers: [],
+};
+
+export const DEFAULT_COMMUNITY_NODE_CONFIG: CommunityNodeConfig = {
+  nodes: [],
+};
+
+export const DEFAULT_SYNC_STATUS: SyncStatus = {
+  connected: false,
+  delivery_state: 'Offline',
+  peer_count: 0,
+  pending_events: 0,
+  status_detail: '',
+  last_error: null,
+  configured_peers: [],
+  subscribed_topics: [],
+  active_path: 'direct_p2p',
+  fallback_peer_ids: [],
+  topic_diagnostics: [],
+  local_author_pubkey: '',
+  discovery: {
+    mode: 'seeded_dht',
+    connect_mode: 'direct_only',
+    active_path: 'direct_p2p',
+    fallback_peer_ids: [],
+    env_locked: false,
+    configured_seed_peer_ids: [],
+    bootstrap_seed_peer_ids: [],
+    manual_ticket_peer_ids: [],
+    connected_peer_ids: [],
+    docs_assist_peer_ids: [],
+    blob_assist_peer_ids: [],
+    local_endpoint_id: '',
+    last_discovery_error: null,
+  },
+  gossip_disabled_topics: [],
+  gossip_disabled_channels: [],
+};
+
+export function createInitialConnectivitySlice(): ConnectivitySliceState {
+  return {
+    peerTicket: '',
+    localPeerTicket: null,
+    discoveryConfig: DEFAULT_DISCOVERY_CONFIG,
+    discoverySeedInput: '',
+    discoveryEditorDirty: false,
+    discoveryError: null,
+    communityNodeConfig: DEFAULT_COMMUNITY_NODE_CONFIG,
+    communityNodeStatuses: [],
+    communityNodeManifests: {},
+    communityNodeInput: [],
+    communityNodeEditorDirty: false,
+    communityNodeError: null,
+    syncStatus: DEFAULT_SYNC_STATUS,
+  };
+}

--- a/apps/desktop/src/shell/slices/directMessages.ts
+++ b/apps/desktop/src/shell/slices/directMessages.ts
@@ -1,0 +1,41 @@
+import type {
+  DirectMessageConversationView,
+  DirectMessageMessageView,
+  DirectMessageStatusView,
+  TimelineCursor,
+} from '@/lib/api';
+
+import { type DraftMediaItem } from '@/shell/slices/shared';
+
+/// ダイレクトメッセージ(WP-H6 PR3 のドメインスライス)。
+export type DirectMessagesSliceState = {
+  directMessagePaneOpen: boolean;
+  selectedDirectMessagePeerPubkey: string | null;
+  directMessages: DirectMessageConversationView[];
+  directMessageTimelineByPeer: Record<string, DirectMessageMessageView[]>;
+  directMessageTimelineNextCursorByPeer: Record<string, TimelineCursor | null>;
+  directMessageTimelineLoadingMoreByPeer: Record<string, boolean>;
+  directMessageStatusByPeer: Record<string, DirectMessageStatusView>;
+  directMessageComposer: string;
+  directMessageDraftMediaItems: DraftMediaItem[];
+  directMessageAttachmentInputKey: number;
+  directMessageError: string | null;
+  directMessageSending: boolean;
+};
+
+export function createInitialDirectMessagesSlice(): DirectMessagesSliceState {
+  return {
+    directMessagePaneOpen: false,
+    selectedDirectMessagePeerPubkey: null,
+    directMessages: [],
+    directMessageTimelineByPeer: {},
+    directMessageTimelineNextCursorByPeer: {},
+    directMessageTimelineLoadingMoreByPeer: {},
+    directMessageStatusByPeer: {},
+    directMessageComposer: '',
+    directMessageDraftMediaItems: [],
+    directMessageAttachmentInputKey: 0,
+    directMessageError: null,
+    directMessageSending: false,
+  };
+}

--- a/apps/desktop/src/shell/slices/liveGame.ts
+++ b/apps/desktop/src/shell/slices/liveGame.ts
@@ -1,0 +1,59 @@
+import type { GameRoomStatus, GameRoomView, LiveSessionView } from '@/lib/api';
+
+import {
+  type AsyncPanelState,
+  DEFAULT_ASYNC_PANEL_STATE,
+  buildStarterTopicRecord,
+} from '@/shell/slices/shared';
+
+/// ライブセッション・ゲームルーム(WP-H6 PR3 のドメインスライス)。
+
+export type GameEditorDraft = {
+  status: GameRoomStatus;
+  phase_label: string;
+  scores: Record<string, string>;
+};
+
+export type LiveGameSliceState = {
+  liveSessionsByTopic: Record<string, LiveSessionView[]>;
+  gameRoomsByTopic: Record<string, GameRoomView[]>;
+  liveTitle: string;
+  liveDescription: string;
+  liveError: string | null;
+  livePanelStateByTopic: Record<string, AsyncPanelState>;
+  liveCreatePending: boolean;
+  livePendingBySessionId: Record<string, true>;
+  selectedLiveSessionId: string | null;
+  gameTitle: string;
+  gameDescription: string;
+  gameParticipantsInput: string;
+  gameError: string | null;
+  gameDrafts: Record<string, GameEditorDraft>;
+  gamePanelStateByTopic: Record<string, AsyncPanelState>;
+  gameCreatePending: boolean;
+  gameSavingByRoomId: Record<string, true>;
+  selectedGameRoomId: string | null;
+};
+
+export function createInitialLiveGameSlice(): LiveGameSliceState {
+  return {
+    liveSessionsByTopic: buildStarterTopicRecord(() => [] as LiveSessionView[]),
+    gameRoomsByTopic: buildStarterTopicRecord(() => [] as GameRoomView[]),
+    liveTitle: '',
+    liveDescription: '',
+    liveError: null,
+    livePanelStateByTopic: buildStarterTopicRecord(() => ({ ...DEFAULT_ASYNC_PANEL_STATE })),
+    liveCreatePending: false,
+    livePendingBySessionId: {},
+    selectedLiveSessionId: null,
+    gameTitle: '',
+    gameDescription: '',
+    gameParticipantsInput: '',
+    gameError: null,
+    gameDrafts: {},
+    gamePanelStateByTopic: buildStarterTopicRecord(() => ({ ...DEFAULT_ASYNC_PANEL_STATE })),
+    gameCreatePending: false,
+    gameSavingByRoomId: {},
+    selectedGameRoomId: null,
+  };
+}

--- a/apps/desktop/src/shell/slices/media.ts
+++ b/apps/desktop/src/shell/slices/media.ts
@@ -1,0 +1,12 @@
+/// メディア(blob object URL・非対応動画)(WP-H6 PR3 のドメインスライス)。
+export type MediaSliceState = {
+  mediaObjectUrls: Record<string, string | null>;
+  unsupportedVideoManifests: Record<string, true>;
+};
+
+export function createInitialMediaSlice(): MediaSliceState {
+  return {
+    mediaObjectUrls: {},
+    unsupportedVideoManifests: {},
+  };
+}

--- a/apps/desktop/src/shell/slices/notifications.ts
+++ b/apps/desktop/src/shell/slices/notifications.ts
@@ -1,0 +1,24 @@
+import type { NotificationStatusView, NotificationView } from '@/lib/api';
+
+import { type AsyncPanelState, DEFAULT_ASYNC_PANEL_STATE } from '@/shell/slices/shared';
+
+/// 通知(WP-H6 PR3 のドメインスライス)。
+export type NotificationsSliceState = {
+  notifications: NotificationView[];
+  notificationStatus: NotificationStatusView;
+  notificationPanelState: AsyncPanelState;
+  notificationAutoReadError: string | null;
+};
+
+export const DEFAULT_NOTIFICATION_STATUS: NotificationStatusView = {
+  unread_count: 0,
+};
+
+export function createInitialNotificationsSlice(): NotificationsSliceState {
+  return {
+    notifications: [],
+    notificationStatus: DEFAULT_NOTIFICATION_STATUS,
+    notificationPanelState: DEFAULT_ASYNC_PANEL_STATE,
+    notificationAutoReadError: null,
+  };
+}

--- a/apps/desktop/src/shell/slices/privateChannel.ts
+++ b/apps/desktop/src/shell/slices/privateChannel.ts
@@ -1,0 +1,41 @@
+import {
+  type ChannelAudienceOption,
+  type InviteOutputLabel,
+  type PrivateChannelPendingAction,
+} from '@/components/extended/types';
+import type { JoinedPrivateChannelView } from '@/lib/api';
+
+import {
+  type AsyncPanelState,
+  DEFAULT_ASYNC_PANEL_STATE,
+  buildStarterTopicRecord,
+} from '@/shell/slices/shared';
+
+/// プライベートチャンネル(参加・作成・共有トークン)(WP-H6 PR3 のドメインスライス)。
+export type PrivateChannelSliceState = {
+  joinedChannelsByTopic: Record<string, JoinedPrivateChannelView[]>;
+  selectedChannelIdByTopic: Record<string, string | null>;
+  channelLabelInput: string;
+  channelAudienceInput: ChannelAudienceOption['value'];
+  inviteTokenInput: string;
+  inviteOutput: string | null;
+  inviteOutputLabel: InviteOutputLabel;
+  channelError: string | null;
+  channelPanelStateByTopic: Record<string, AsyncPanelState>;
+  channelActionPending: PrivateChannelPendingAction;
+};
+
+export function createInitialPrivateChannelSlice(): PrivateChannelSliceState {
+  return {
+    joinedChannelsByTopic: buildStarterTopicRecord(() => [] as JoinedPrivateChannelView[]),
+    selectedChannelIdByTopic: buildStarterTopicRecord(() => null as string | null),
+    channelLabelInput: '',
+    channelAudienceInput: 'invite_only',
+    inviteTokenInput: '',
+    inviteOutput: null,
+    inviteOutputLabel: 'invite',
+    channelError: null,
+    channelPanelStateByTopic: buildStarterTopicRecord(() => ({ ...DEFAULT_ASYNC_PANEL_STATE })),
+    channelActionPending: null,
+  };
+}

--- a/apps/desktop/src/shell/slices/profileSocial.ts
+++ b/apps/desktop/src/shell/slices/profileSocial.ts
@@ -1,0 +1,65 @@
+import { type ProfileConnectionsView } from '@/components/shell/types';
+import type {
+  AuthorSocialView,
+  PostView,
+  Profile,
+  ProfileInput,
+  TimelineCursor,
+} from '@/lib/api';
+
+import { type AsyncPanelState, DEFAULT_ASYNC_PANEL_STATE } from '@/shell/slices/shared';
+
+/// プロフィール・作者詳細・ソーシャルグラフ(WP-H6 PR3 のドメインスライス)。
+
+export type SocialConnectionsState = Record<ProfileConnectionsView, AuthorSocialView[]>;
+export type KnownAuthorsByPubkey = Record<string, AuthorSocialView>;
+
+export type ProfileSocialSliceState = {
+  localProfile: Profile | null;
+  profileTimeline: PostView[];
+  profileTimelineNextCursor: TimelineCursor | null;
+  profileTimelineLoadingMore: boolean;
+  knownAuthorsByPubkey: KnownAuthorsByPubkey;
+  socialConnections: SocialConnectionsState;
+  socialConnectionsPanelState: AsyncPanelState;
+  profileDraft: ProfileInput;
+  profileDirty: boolean;
+  profileError: string | null;
+  profilePanelState: AsyncPanelState;
+  profileSaving: boolean;
+  selectedAuthorPubkey: string | null;
+  selectedAuthor: AuthorSocialView | null;
+  selectedAuthorTimeline: PostView[];
+  selectedAuthorTimelineNextCursor: TimelineCursor | null;
+  selectedAuthorTimelineLoadingMore: boolean;
+  authorError: string | null;
+};
+
+export const DEFAULT_SOCIAL_CONNECTIONS: SocialConnectionsState = {
+  following: [],
+  followed: [],
+  muted: [],
+};
+
+export function createInitialProfileSocialSlice(): ProfileSocialSliceState {
+  return {
+    localProfile: null,
+    profileTimeline: [],
+    profileTimelineNextCursor: null,
+    profileTimelineLoadingMore: false,
+    knownAuthorsByPubkey: {},
+    socialConnections: DEFAULT_SOCIAL_CONNECTIONS,
+    socialConnectionsPanelState: DEFAULT_ASYNC_PANEL_STATE,
+    profileDraft: {},
+    profileDirty: false,
+    profileError: null,
+    profilePanelState: DEFAULT_ASYNC_PANEL_STATE,
+    profileSaving: false,
+    selectedAuthorPubkey: null,
+    selectedAuthor: null,
+    selectedAuthorTimeline: [],
+    selectedAuthorTimelineNextCursor: null,
+    selectedAuthorTimelineLoadingMore: false,
+    authorError: null,
+  };
+}

--- a/apps/desktop/src/shell/slices/reactionsBookmarks.ts
+++ b/apps/desktop/src/shell/slices/reactionsBookmarks.ts
@@ -1,0 +1,29 @@
+import type {
+  BookmarkedCustomReactionView,
+  BookmarkedPostView,
+  CustomReactionAssetView,
+  RecentReactionView,
+} from '@/lib/api';
+
+import { type AsyncPanelState, DEFAULT_ASYNC_PANEL_STATE } from '@/shell/slices/shared';
+
+/// リアクション資産・ブックマーク(WP-H6 PR3 のドメインスライス)。
+export type ReactionsBookmarksSliceState = {
+  ownedReactionAssets: CustomReactionAssetView[];
+  bookmarkedReactionAssets: BookmarkedCustomReactionView[];
+  bookmarkedPosts: BookmarkedPostView[];
+  recentReactions: RecentReactionView[];
+  reactionPanelState: AsyncPanelState;
+  reactionCreatePending: boolean;
+};
+
+export function createInitialReactionsBookmarksSlice(): ReactionsBookmarksSliceState {
+  return {
+    ownedReactionAssets: [],
+    bookmarkedReactionAssets: [],
+    bookmarkedPosts: [],
+    recentReactions: [],
+    reactionPanelState: DEFAULT_ASYNC_PANEL_STATE,
+    reactionCreatePending: false,
+  };
+}

--- a/apps/desktop/src/shell/slices/shared.ts
+++ b/apps/desktop/src/shell/slices/shared.ts
@@ -1,0 +1,60 @@
+import type { ChannelRef, CreateAttachmentInput, TimelineScope } from '@/lib/api';
+import { type ExtendedPanelStatus } from '@/components/extended/types';
+
+// スライス横断で使う基本型・定数(WP-H6 PR3)。
+// スライス → shared の一方向依存に固定し、store.ts との循環を作らない。
+
+export type DraftMediaItem = {
+  id: string;
+  source_name: string;
+  preview_url: string;
+  attachments: CreateAttachmentInput[];
+};
+
+export type AsyncPanelState = {
+  status: ExtendedPanelStatus;
+  error: string | null;
+};
+
+export const DEFAULT_ASYNC_PANEL_STATE: AsyncPanelState = {
+  status: 'loading',
+  error: null,
+};
+
+export const DEFAULT_TOPIC = 'kukuri:topic:demo';
+export const STARTER_TOPICS = [
+  DEFAULT_TOPIC,
+  'kukuri:topic:iroh',
+  'kukuri:topic:nostr',
+  'kukuri:topic:operators',
+] as const;
+export const PUBLIC_CHANNEL_REF: ChannelRef = { kind: 'public' };
+export const PUBLIC_TIMELINE_SCOPE: TimelineScope = { kind: 'public' };
+
+export function timelineScopeStorageKey(topic: string, scope: TimelineScope): string {
+  if (scope.kind === 'channel') {
+    return `${topic}::channel::${scope.channel_id}`;
+  }
+  return `${topic}::${scope.kind}`;
+}
+
+export function timelineStorageKeyForChannel(topic: string, channelId: string | null): string {
+  return timelineScopeStorageKey(
+    topic,
+    channelId ? { kind: 'channel', channel_id: channelId } : PUBLIC_TIMELINE_SCOPE
+  );
+}
+
+export function activeTimelineStorageKey(
+  state: { timelineScopeByTopic: Record<string, TimelineScope> },
+  topic: string
+): string {
+  return timelineScopeStorageKey(topic, state.timelineScopeByTopic[topic] ?? PUBLIC_TIMELINE_SCOPE);
+}
+
+export function buildStarterTopicRecord<T>(factory: () => T): Record<string, T> {
+  return Object.fromEntries(STARTER_TOPICS.map((topic) => [topic, factory()])) as Record<
+    string,
+    T
+  >;
+}

--- a/apps/desktop/src/shell/slices/timeline.ts
+++ b/apps/desktop/src/shell/slices/timeline.ts
@@ -1,0 +1,80 @@
+import type {
+  ChannelRef,
+  PostView,
+  TimelineCursor,
+  TimelineScope,
+} from '@/lib/api';
+
+import {
+  type DraftMediaItem,
+  PUBLIC_CHANNEL_REF,
+  PUBLIC_TIMELINE_SCOPE,
+  STARTER_TOPICS,
+  buildStarterTopicRecord,
+  timelineScopeStorageKey,
+} from '@/shell/slices/shared';
+
+/// タイムライン・スレッド・投稿コンポーザ(WP-H6 PR3 のドメインスライス)。
+export type TimelineSliceState = {
+  trackedTopics: string[];
+  activeTopic: string;
+  topicInput: string;
+  composer: string;
+  draftMediaItems: DraftMediaItem[];
+  attachmentInputKey: number;
+  timelinesByKey: Record<string, PostView[]>;
+  timelineNextCursorByKey: Record<string, TimelineCursor | null>;
+  timelineLoadingMoreByKey: Record<string, boolean>;
+  pendingTimelineSnapshotsByKey: Record<string, PostView[]>;
+  pendingTimelineCountsByKey: Record<string, number>;
+  pendingTimelineNextCursorByKey: Record<string, TimelineCursor | null>;
+  publicTimelinesByTopic: Record<string, PostView[]>;
+  publicTimelineNextCursorByTopic: Record<string, TimelineCursor | null>;
+  publicTimelineLoadingMoreByTopic: Record<string, boolean>;
+  timelineScopeByTopic: Record<string, TimelineScope>;
+  composeChannelByTopic: Record<string, ChannelRef>;
+  thread: PostView[];
+  threadNextCursorById: Record<string, TimelineCursor | null>;
+  threadLoadingMoreById: Record<string, boolean>;
+  selectedThread: string | null;
+  focusedObjectId: string | null;
+  replyTarget: PostView | null;
+  repostTarget: PostView | null;
+  composerError: string | null;
+};
+
+export function createInitialTimelineSlice(): TimelineSliceState {
+  return {
+    trackedTopics: [...STARTER_TOPICS],
+    activeTopic: STARTER_TOPICS[0],
+    topicInput: '',
+    composer: '',
+    draftMediaItems: [],
+    attachmentInputKey: 0,
+    timelinesByKey: Object.fromEntries(
+      STARTER_TOPICS.map((topic) => [timelineScopeStorageKey(topic, PUBLIC_TIMELINE_SCOPE), []])
+    ),
+    timelineNextCursorByKey: Object.fromEntries(
+      STARTER_TOPICS.map((topic) => [timelineScopeStorageKey(topic, PUBLIC_TIMELINE_SCOPE), null])
+    ),
+    timelineLoadingMoreByKey: Object.fromEntries(
+      STARTER_TOPICS.map((topic) => [timelineScopeStorageKey(topic, PUBLIC_TIMELINE_SCOPE), false])
+    ),
+    pendingTimelineSnapshotsByKey: {},
+    pendingTimelineCountsByKey: {},
+    pendingTimelineNextCursorByKey: {},
+    publicTimelinesByTopic: buildStarterTopicRecord(() => [] as PostView[]),
+    publicTimelineNextCursorByTopic: buildStarterTopicRecord(() => null as TimelineCursor | null),
+    publicTimelineLoadingMoreByTopic: buildStarterTopicRecord(() => false),
+    timelineScopeByTopic: buildStarterTopicRecord(() => ({ ...PUBLIC_TIMELINE_SCOPE })),
+    composeChannelByTopic: buildStarterTopicRecord(() => ({ ...PUBLIC_CHANNEL_REF })),
+    thread: [],
+    threadNextCursorById: {},
+    threadLoadingMoreById: {},
+    selectedThread: null,
+    focusedObjectId: null,
+    replyTarget: null,
+    repostTarget: null,
+    composerError: null,
+  };
+}

--- a/apps/desktop/src/shell/store.ts
+++ b/apps/desktop/src/shell/store.ts
@@ -2,200 +2,54 @@ import { createContext, useCallback, useContext } from 'react';
 import { useStore } from 'zustand';
 import { createStore } from 'zustand/vanilla';
 
-import {
-  type ChannelAudienceOption,
-  type ExtendedPanelStatus,
-  type InviteOutputLabel,
-  type PrivateChannelPendingAction,
-} from '@/components/extended/types';
-import {
-  type ProfileConnectionsView,
-  type SettingsSection,
-  type ShellChromeState,
-} from '@/components/shell/types';
-import { parseHashRouteLocation } from '@/shell/routes';
-import {
-  type AuthorSocialView,
-  type BookmarkedCustomReactionView,
-  type BookmarkedPostView,
-  type ChannelRef,
-  type CommunityNodeConfig,
-  type CommunityNodeManifest,
-  type CommunityNodeNodeStatus,
-  type CreateAttachmentInput,
-  type CustomReactionAssetView,
-  type DesktopApi,
-  type DirectMessageConversationView,
-  type DirectMessageMessageView,
-  type DirectMessageStatusView,
-  type DiscoveryConfig,
-  type GameRoomStatus,
-  type GameRoomView,
-  type JoinedPrivateChannelView,
-  type LiveSessionView,
-  type NotificationStatusView,
-  type NotificationView,
-  type PostView,
-  type Profile,
-  type ProfileInput,
-  type RecentReactionView,
-  type SyncStatus,
-  type TimelineCursor,
-  type TimelineScope,
-} from '@/lib/api';
+import { type DesktopApi } from '@/lib/api';
 import type { DesktopTheme } from '@/lib/theme';
+import { type ChromeSliceState, createInitialChromeSlice } from '@/shell/slices/chrome';
+import {
+  type ConnectivitySliceState,
+  createInitialConnectivitySlice,
+} from '@/shell/slices/connectivity';
+import {
+  type DirectMessagesSliceState,
+  createInitialDirectMessagesSlice,
+} from '@/shell/slices/directMessages';
+import { type LiveGameSliceState, createInitialLiveGameSlice } from '@/shell/slices/liveGame';
+import { type MediaSliceState, createInitialMediaSlice } from '@/shell/slices/media';
+import {
+  type NotificationsSliceState,
+  createInitialNotificationsSlice,
+} from '@/shell/slices/notifications';
+import {
+  type PrivateChannelSliceState,
+  createInitialPrivateChannelSlice,
+} from '@/shell/slices/privateChannel';
+import {
+  type ProfileSocialSliceState,
+  createInitialProfileSocialSlice,
+} from '@/shell/slices/profileSocial';
+import {
+  type ReactionsBookmarksSliceState,
+  createInitialReactionsBookmarksSlice,
+} from '@/shell/slices/reactionsBookmarks';
+import { type TimelineSliceState, createInitialTimelineSlice } from '@/shell/slices/timeline';
 
 export type AppProps = {
   api?: DesktopApi;
 };
 
-export type DraftMediaItem = {
-  id: string;
-  source_name: string;
-  preview_url: string;
-  attachments: CreateAttachmentInput[];
-};
-
-export type GameEditorDraft = {
-  status: GameRoomStatus;
-  phase_label: string;
-  scores: Record<string, string>;
-};
-
-export type AsyncPanelState = {
-  status: ExtendedPanelStatus;
-  error: string | null;
-};
-
-export type SocialConnectionsState = Record<ProfileConnectionsView, AuthorSocialView[]>;
-export type KnownAuthorsByPubkey = Record<string, AuthorSocialView>;
-
-export type CommunityNodeDraftNode = {
-  id: string;
-  base_url: string;
-  auto_approve: boolean;
-};
-
-// public manifest endpoint (#356) からの取得状態。base_url ごとに保持する。
-export type CommunityNodeManifestEntry =
-  | { status: 'loading' }
-  | { status: 'ok'; manifest: CommunityNodeManifest }
-  | { status: 'absent' }
-  | { status: 'error'; error: string };
-
-export type DesktopShellState = {
-  trackedTopics: string[];
-  activeTopic: string;
-  topicInput: string;
-  composer: string;
-  draftMediaItems: DraftMediaItem[];
-  attachmentInputKey: number;
-  timelinesByKey: Record<string, PostView[]>;
-  timelineNextCursorByKey: Record<string, TimelineCursor | null>;
-  timelineLoadingMoreByKey: Record<string, boolean>;
-  pendingTimelineSnapshotsByKey: Record<string, PostView[]>;
-  pendingTimelineCountsByKey: Record<string, number>;
-  pendingTimelineNextCursorByKey: Record<string, TimelineCursor | null>;
-  publicTimelinesByTopic: Record<string, PostView[]>;
-  publicTimelineNextCursorByTopic: Record<string, TimelineCursor | null>;
-  publicTimelineLoadingMoreByTopic: Record<string, boolean>;
-  liveSessionsByTopic: Record<string, LiveSessionView[]>;
-  gameRoomsByTopic: Record<string, GameRoomView[]>;
-  joinedChannelsByTopic: Record<string, JoinedPrivateChannelView[]>;
-  selectedChannelIdByTopic: Record<string, string | null>;
-  timelineScopeByTopic: Record<string, TimelineScope>;
-  composeChannelByTopic: Record<string, ChannelRef>;
-  thread: PostView[];
-  threadNextCursorById: Record<string, TimelineCursor | null>;
-  threadLoadingMoreById: Record<string, boolean>;
-  selectedThread: string | null;
-  focusedObjectId: string | null;
-  replyTarget: PostView | null;
-  repostTarget: PostView | null;
-  peerTicket: string;
-  localPeerTicket: string | null;
-  discoveryConfig: DiscoveryConfig;
-  discoverySeedInput: string;
-  discoveryEditorDirty: boolean;
-  discoveryError: string | null;
-  communityNodeConfig: CommunityNodeConfig;
-  communityNodeStatuses: CommunityNodeNodeStatus[];
-  communityNodeManifests: Record<string, CommunityNodeManifestEntry>;
-  communityNodeInput: CommunityNodeDraftNode[];
-  communityNodeEditorDirty: boolean;
-  communityNodeError: string | null;
-  mediaObjectUrls: Record<string, string | null>;
-  unsupportedVideoManifests: Record<string, true>;
-  syncStatus: SyncStatus;
-  localProfile: Profile | null;
-  profileTimeline: PostView[];
-  profileTimelineNextCursor: TimelineCursor | null;
-  profileTimelineLoadingMore: boolean;
-  knownAuthorsByPubkey: KnownAuthorsByPubkey;
-  socialConnections: SocialConnectionsState;
-  socialConnectionsPanelState: AsyncPanelState;
-  ownedReactionAssets: CustomReactionAssetView[];
-  bookmarkedReactionAssets: BookmarkedCustomReactionView[];
-  bookmarkedPosts: BookmarkedPostView[];
-  recentReactions: RecentReactionView[];
-  profileDraft: ProfileInput;
-  profileDirty: boolean;
-  profileError: string | null;
-  profilePanelState: AsyncPanelState;
-  profileSaving: boolean;
-  selectedAuthorPubkey: string | null;
-  selectedAuthor: AuthorSocialView | null;
-  selectedAuthorTimeline: PostView[];
-  selectedAuthorTimelineNextCursor: TimelineCursor | null;
-  selectedAuthorTimelineLoadingMore: boolean;
-  authorError: string | null;
-  notifications: NotificationView[];
-  notificationStatus: NotificationStatusView;
-  notificationPanelState: AsyncPanelState;
-  notificationAutoReadError: string | null;
-  directMessagePaneOpen: boolean;
-  selectedDirectMessagePeerPubkey: string | null;
-  directMessages: DirectMessageConversationView[];
-  directMessageTimelineByPeer: Record<string, DirectMessageMessageView[]>;
-  directMessageTimelineNextCursorByPeer: Record<string, TimelineCursor | null>;
-  directMessageTimelineLoadingMoreByPeer: Record<string, boolean>;
-  directMessageStatusByPeer: Record<string, DirectMessageStatusView>;
-  directMessageComposer: string;
-  directMessageDraftMediaItems: DraftMediaItem[];
-  directMessageAttachmentInputKey: number;
-  directMessageError: string | null;
-  directMessageSending: boolean;
-  composerError: string | null;
-  liveTitle: string;
-  liveDescription: string;
-  liveError: string | null;
-  livePanelStateByTopic: Record<string, AsyncPanelState>;
-  liveCreatePending: boolean;
-  livePendingBySessionId: Record<string, true>;
-  selectedLiveSessionId: string | null;
-  channelLabelInput: string;
-  channelAudienceInput: ChannelAudienceOption['value'];
-  inviteTokenInput: string;
-  inviteOutput: string | null;
-  inviteOutputLabel: InviteOutputLabel;
-  channelError: string | null;
-  channelPanelStateByTopic: Record<string, AsyncPanelState>;
-  channelActionPending: PrivateChannelPendingAction;
-  gameTitle: string;
-  gameDescription: string;
-  gameParticipantsInput: string;
-  gameError: string | null;
-  gameDrafts: Record<string, GameEditorDraft>;
-  gamePanelStateByTopic: Record<string, AsyncPanelState>;
-  gameCreatePending: boolean;
-  gameSavingByRoomId: Record<string, true>;
-  selectedGameRoomId: string | null;
-  reactionPanelState: AsyncPanelState;
-  reactionCreatePending: boolean;
-  error: string | null;
-  lastNonNotificationsRoute: string | null;
-  shellChromeState: ShellChromeState;
-};
+// 状態の定義はドメインスライス(@/shell/slices/)へ分割した(WP-H6 PR3)。
+// ここでは合成のみ行う。**実行時は従来どおり単一 store** であり、1 回の set() は
+// スライスをまたいでも原子的(useRouteSynchronization の一括更新が壊れない)。
+export type DesktopShellState = TimelineSliceState &
+  PrivateChannelSliceState &
+  ConnectivitySliceState &
+  MediaSliceState &
+  ProfileSocialSliceState &
+  ReactionsBookmarksSliceState &
+  NotificationsSliceState &
+  DirectMessagesSliceState &
+  LiveGameSliceState &
+  ChromeSliceState;
 
 export type DesktopShellStateValue<K extends keyof DesktopShellState> =
   | DesktopShellState[K]
@@ -215,15 +69,6 @@ export type DesktopShellPageProps = AppProps & {
   onThemeChange: (theme: DesktopTheme) => void;
 };
 
-export const DEFAULT_TOPIC = 'kukuri:topic:demo';
-export const STARTER_TOPICS = [
-  DEFAULT_TOPIC,
-  'kukuri:topic:iroh',
-  'kukuri:topic:nostr',
-  'kukuri:topic:operators',
-] as const;
-export const PUBLIC_CHANNEL_REF: ChannelRef = { kind: 'public' };
-export const PUBLIC_TIMELINE_SCOPE: TimelineScope = { kind: 'public' };
 export const REFRESH_INTERVAL_MS = 3000;
 export const STATUS_REFRESH_INTERVAL_MS = 10000;
 export const VIDEO_POSTER_TIMEOUT_MS = 5000;
@@ -233,263 +78,18 @@ export const SHELL_NAV_ID = 'shell-nav-rail';
 export const SHELL_CONTEXT_ID = 'shell-context-pane';
 export const SHELL_SETTINGS_ID = 'shell-settings-drawer';
 
-export function timelineScopeStorageKey(topic: string, scope: TimelineScope): string {
-  if (scope.kind === 'channel') {
-    return `${topic}::channel::${scope.channel_id}`;
-  }
-  return `${topic}::${scope.kind}`;
-}
-
-export function activeTimelineStorageKey(
-  state: Pick<DesktopShellState, 'timelineScopeByTopic'>,
-  topic: string
-): string {
-  return timelineScopeStorageKey(topic, state.timelineScopeByTopic[topic] ?? PUBLIC_TIMELINE_SCOPE);
-}
-
-export function timelineStorageKeyForChannel(topic: string, channelId: string | null): string {
-  return timelineScopeStorageKey(
-    topic,
-    channelId ? { kind: 'channel', channel_id: channelId } : PUBLIC_TIMELINE_SCOPE
-  );
-}
-
-export const DEFAULT_ASYNC_PANEL_STATE: AsyncPanelState = {
-  status: 'loading',
-  error: null,
-};
-
-export const DEFAULT_DISCOVERY_CONFIG: DiscoveryConfig = {
-  mode: 'seeded_dht',
-  connect_mode: 'direct_only',
-  env_locked: false,
-  seed_peers: [],
-};
-
-export const DEFAULT_COMMUNITY_NODE_CONFIG: CommunityNodeConfig = {
-  nodes: [],
-};
-
-function buildStarterTopicRecord<T>(factory: () => T): Record<string, T> {
-  return Object.fromEntries(STARTER_TOPICS.map((topic) => [topic, factory()])) as Record<
-    string,
-    T
-  >;
-}
-
-export const DEFAULT_SOCIAL_CONNECTIONS: SocialConnectionsState = {
-  following: [],
-  followed: [],
-  muted: [],
-};
-
-const DEFAULT_SETTINGS_SECTION: SettingsSection = 'connectivity';
-
-function parseInitialSettingsSection(): {
-  activeSettingsSection: SettingsSection;
-  settingsOpen: boolean;
-} {
-  if (typeof window === 'undefined') {
-    return {
-      activeSettingsSection: DEFAULT_SETTINGS_SECTION,
-      settingsOpen: false,
-    };
-  }
-
-  const { search } = parseHashRouteLocation(window.location.hash);
-  if (!search) {
-    return {
-      activeSettingsSection: DEFAULT_SETTINGS_SECTION,
-      settingsOpen: false,
-    };
-  }
-
-  const requestedSection = new URLSearchParams(search).get('settings');
-  if (
-    requestedSection !== 'about' &&
-    requestedSection !== 'appearance' &&
-    requestedSection !== 'connectivity' &&
-      requestedSection !== 'discovery' &&
-      requestedSection !== 'community-node' &&
-      requestedSection !== 'reactions' &&
-      requestedSection !== 'release'
-  ) {
-    return {
-      activeSettingsSection: DEFAULT_SETTINGS_SECTION,
-      settingsOpen: false,
-    };
-  }
-
-  return {
-    activeSettingsSection: requestedSection,
-    settingsOpen: true,
-  };
-}
-
-export const DEFAULT_SYNC_STATUS: SyncStatus = {
-  connected: false,
-  delivery_state: 'Offline',
-  peer_count: 0,
-  pending_events: 0,
-  status_detail: '',
-  last_error: null,
-  configured_peers: [],
-  subscribed_topics: [],
-  active_path: 'direct_p2p',
-  fallback_peer_ids: [],
-  topic_diagnostics: [],
-  local_author_pubkey: '',
-  discovery: {
-    mode: 'seeded_dht',
-    connect_mode: 'direct_only',
-    active_path: 'direct_p2p',
-    fallback_peer_ids: [],
-    env_locked: false,
-    configured_seed_peer_ids: [],
-    bootstrap_seed_peer_ids: [],
-    manual_ticket_peer_ids: [],
-    connected_peer_ids: [],
-    docs_assist_peer_ids: [],
-    blob_assist_peer_ids: [],
-    local_endpoint_id: '',
-    last_discovery_error: null,
-  },
-  gossip_disabled_topics: [],
-  gossip_disabled_channels: [],
-};
-
-export const DEFAULT_NOTIFICATION_STATUS: NotificationStatusView = {
-  unread_count: 0,
-};
-
 export function createInitialShellState(): DesktopShellState {
-  const initialSettingsState = parseInitialSettingsSection();
   return {
-    trackedTopics: [...STARTER_TOPICS],
-    activeTopic: DEFAULT_TOPIC,
-    topicInput: '',
-    composer: '',
-    draftMediaItems: [],
-    attachmentInputKey: 0,
-    timelinesByKey: Object.fromEntries(
-      STARTER_TOPICS.map((topic) => [timelineScopeStorageKey(topic, PUBLIC_TIMELINE_SCOPE), []])
-    ),
-    timelineNextCursorByKey: Object.fromEntries(
-      STARTER_TOPICS.map((topic) => [timelineScopeStorageKey(topic, PUBLIC_TIMELINE_SCOPE), null])
-    ),
-    timelineLoadingMoreByKey: Object.fromEntries(
-      STARTER_TOPICS.map((topic) => [timelineScopeStorageKey(topic, PUBLIC_TIMELINE_SCOPE), false])
-    ),
-    pendingTimelineSnapshotsByKey: {},
-    pendingTimelineCountsByKey: {},
-    pendingTimelineNextCursorByKey: {},
-    publicTimelinesByTopic: buildStarterTopicRecord(() => [] as PostView[]),
-    publicTimelineNextCursorByTopic: buildStarterTopicRecord(() => null as TimelineCursor | null),
-    publicTimelineLoadingMoreByTopic: buildStarterTopicRecord(() => false),
-    liveSessionsByTopic: buildStarterTopicRecord(() => [] as LiveSessionView[]),
-    gameRoomsByTopic: buildStarterTopicRecord(() => [] as GameRoomView[]),
-    joinedChannelsByTopic: buildStarterTopicRecord(() => [] as JoinedPrivateChannelView[]),
-    selectedChannelIdByTopic: buildStarterTopicRecord(() => null as string | null),
-    timelineScopeByTopic: buildStarterTopicRecord(() => ({ ...PUBLIC_TIMELINE_SCOPE })),
-    composeChannelByTopic: buildStarterTopicRecord(() => ({ ...PUBLIC_CHANNEL_REF })),
-    thread: [],
-    threadNextCursorById: {},
-    threadLoadingMoreById: {},
-    selectedThread: null,
-    focusedObjectId: null,
-    replyTarget: null,
-    repostTarget: null,
-    peerTicket: '',
-    localPeerTicket: null,
-    discoveryConfig: DEFAULT_DISCOVERY_CONFIG,
-    discoverySeedInput: '',
-    discoveryEditorDirty: false,
-    discoveryError: null,
-    communityNodeConfig: DEFAULT_COMMUNITY_NODE_CONFIG,
-    communityNodeStatuses: [],
-    communityNodeManifests: {},
-    communityNodeInput: [],
-    communityNodeEditorDirty: false,
-    communityNodeError: null,
-    mediaObjectUrls: {},
-    unsupportedVideoManifests: {},
-    syncStatus: DEFAULT_SYNC_STATUS,
-    localProfile: null,
-    profileTimeline: [],
-    profileTimelineNextCursor: null,
-    profileTimelineLoadingMore: false,
-    knownAuthorsByPubkey: {},
-    socialConnections: DEFAULT_SOCIAL_CONNECTIONS,
-    socialConnectionsPanelState: DEFAULT_ASYNC_PANEL_STATE,
-    ownedReactionAssets: [],
-    bookmarkedReactionAssets: [],
-    bookmarkedPosts: [],
-    recentReactions: [],
-    profileDraft: {},
-    profileDirty: false,
-    profileError: null,
-    profilePanelState: DEFAULT_ASYNC_PANEL_STATE,
-    profileSaving: false,
-    selectedAuthorPubkey: null,
-    selectedAuthor: null,
-    selectedAuthorTimeline: [],
-    selectedAuthorTimelineNextCursor: null,
-    selectedAuthorTimelineLoadingMore: false,
-    authorError: null,
-    notifications: [],
-    notificationStatus: DEFAULT_NOTIFICATION_STATUS,
-    notificationPanelState: DEFAULT_ASYNC_PANEL_STATE,
-    notificationAutoReadError: null,
-    directMessagePaneOpen: false,
-    selectedDirectMessagePeerPubkey: null,
-    directMessages: [],
-    directMessageTimelineByPeer: {},
-    directMessageTimelineNextCursorByPeer: {},
-    directMessageTimelineLoadingMoreByPeer: {},
-    directMessageStatusByPeer: {},
-    directMessageComposer: '',
-    directMessageDraftMediaItems: [],
-    directMessageAttachmentInputKey: 0,
-    directMessageError: null,
-    directMessageSending: false,
-    composerError: null,
-    liveTitle: '',
-    liveDescription: '',
-    liveError: null,
-    livePanelStateByTopic: buildStarterTopicRecord(() => ({ ...DEFAULT_ASYNC_PANEL_STATE })),
-    liveCreatePending: false,
-    livePendingBySessionId: {},
-    selectedLiveSessionId: null,
-    channelLabelInput: '',
-    channelAudienceInput: 'invite_only',
-    inviteTokenInput: '',
-    inviteOutput: null,
-    inviteOutputLabel: 'invite',
-    channelError: null,
-    channelPanelStateByTopic: buildStarterTopicRecord(() => ({ ...DEFAULT_ASYNC_PANEL_STATE })),
-    channelActionPending: null,
-    gameTitle: '',
-    gameDescription: '',
-    gameParticipantsInput: '',
-    gameError: null,
-    gameDrafts: {},
-    gamePanelStateByTopic: buildStarterTopicRecord(() => ({ ...DEFAULT_ASYNC_PANEL_STATE })),
-    gameCreatePending: false,
-    gameSavingByRoomId: {},
-    selectedGameRoomId: null,
-    reactionPanelState: DEFAULT_ASYNC_PANEL_STATE,
-    reactionCreatePending: false,
-    error: null,
-    lastNonNotificationsRoute: null,
-    shellChromeState: {
-      activePrimarySection: 'timeline',
-      timelineView: 'feed',
-      activeSettingsSection: initialSettingsState.activeSettingsSection,
-      profileMode: 'overview',
-      profileConnectionsView: 'following',
-      navOpen: false,
-      settingsOpen: initialSettingsState.settingsOpen,
-    },
+    ...createInitialTimelineSlice(),
+    ...createInitialPrivateChannelSlice(),
+    ...createInitialConnectivitySlice(),
+    ...createInitialMediaSlice(),
+    ...createInitialProfileSocialSlice(),
+    ...createInitialReactionsBookmarksSlice(),
+    ...createInitialNotificationsSlice(),
+    ...createInitialDirectMessagesSlice(),
+    ...createInitialLiveGameSlice(),
+    ...createInitialChromeSlice(),
   };
 }
 
@@ -550,3 +150,29 @@ export function useDesktopShellFieldSetter<K extends keyof DesktopShellState>(ke
     [key, setField]
   );
 }
+
+// 既存の import 面の互換 re-export(型・定数はスライス側が定義元)。
+export {
+  DEFAULT_ASYNC_PANEL_STATE,
+  DEFAULT_TOPIC,
+  PUBLIC_CHANNEL_REF,
+  PUBLIC_TIMELINE_SCOPE,
+  STARTER_TOPICS,
+  activeTimelineStorageKey,
+  timelineScopeStorageKey,
+  timelineStorageKeyForChannel,
+} from '@/shell/slices/shared';
+export type { AsyncPanelState, DraftMediaItem } from '@/shell/slices/shared';
+export {
+  DEFAULT_COMMUNITY_NODE_CONFIG,
+  DEFAULT_DISCOVERY_CONFIG,
+  DEFAULT_SYNC_STATUS,
+} from '@/shell/slices/connectivity';
+export type {
+  CommunityNodeDraftNode,
+  CommunityNodeManifestEntry,
+} from '@/shell/slices/connectivity';
+export { DEFAULT_SOCIAL_CONNECTIONS } from '@/shell/slices/profileSocial';
+export type { KnownAuthorsByPubkey, SocialConnectionsState } from '@/shell/slices/profileSocial';
+export { DEFAULT_NOTIFICATION_STATUS } from '@/shell/slices/notifications';
+export type { GameEditorDraft } from '@/shell/slices/liveGame';


### PR DESCRIPTION
## 概要

WP-H6(desktop shell 状態管理の分割)の PR3。552 行の `shell/store.ts` に一枚岩で定義されていた `DesktopShellState`(111 フィールド)を、`shell/slices/` 配下のドメインスライス 10 本 + 横断共有 1 本へ分割し、store.ts は合成と store 生成・フックのみ(178 行)にした。

- `slices/shared.ts` — 横断の基本型(`DraftMediaItem` / `AsyncPanelState`)・トピック定数・timeline storage key 関数。スライス → shared の一方向依存に固定し、store.ts との循環を作らない
- `slices/timeline.ts`(25) / `privateChannel.ts`(10) / `connectivity.ts`(13) / `media.ts`(2) / `profileSocial.ts`(18) / `reactionsBookmarks.ts`(6) / `notifications.ts`(4) / `directMessages.ts`(12) / `liveGame.ts`(18) / `chrome.ts`(3) — 各ドメインの `XxxSliceState` 型 + `createInitialXxxSlice()`(括弧内はフィールド数)
- `store.ts` — `DesktopShellState` をスライスの交差型に、`createInitialShellState()` を spread 合成に置換。移動した型・定数・関数は re-export し、既存 39 ファイルの import 面を無変更で維持

## 種別

refactor(挙動不変)。

## 挙動変更

なし。

- **実行時は従来どおり単一 zustand store**。1 回の `set()` はスライスをまたいでも原子的で、`useRouteSynchronization` の複数ドメイン一括更新 21 箇所は無変更のまま既存テストで green
- 旧 `DesktopShellState` の 111 フィールドと分割後スライス群の 111 フィールドをスクリプトで機械照合し、欠落・重複ゼロを確認
- 初期値・定数・store 生成/フック実装は旧版と等価(`activeTopic` は `DEFAULT_TOPIC` → `STARTER_TOPICS[0]` の表記換えのみで同値)

## 検証

- `pnpm typecheck`(tsc --noEmit)green
- `pnpm lint`(--max-warnings 0)green
- `pnpm test` 61 files / 545 tests green(`renderIsolation.smoke` と `useRouteSynchronization` の一括更新テスト含む)
- `cargo xtask desktop-ui-check` green(visual regression 14 件含む)
- `cargo xtask oversized-files` — store.ts が一覧から消え(552→178 行)、新規違反なし。スライスは最大 99 行

## リスク

- re-export 経由の import 面維持のため、シンボルの定義元がスライスへ移った。IDE の「定義へ移動」は 1 ホップ増えるが、参照は全て型検査済み

## 後続対応

- PR4: `DesktopShellPage` → 配下 4 コンポーネントの prop drilling 縮小(質的基準、1 コンポーネントずつ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)