### PR TITLE
[refactor] page/ コンポーネントの store 由来 props を子側購読へ (WP-H6 PR4)

### DIFF
--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -2,7 +2,6 @@ import {
   startTransition,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -21,7 +20,7 @@ import { Label } from '@/components/ui/label';
 
 import { type ChannelAccessTokenPreview, runtimeApi } from '@/lib/api';
 import i18n from '@/i18n';
-import { formatLocalizedTime, getResolvedLocale } from '@/i18n/format';
+import { getResolvedLocale } from '@/i18n/format';
 import {
   buildTopicLink,
   parseChannelAccessPreviewDeepLink,
@@ -39,13 +38,11 @@ import {
   useDesktopShellStore,
 } from '@/shell/store';
 import {
-  authorDisplayLabel,
   formatCount,
   mergeKnownAuthors,
   messageFromError,
   privateComposeTarget,
   privateTimelineScope,
-  resolveProfilePictureSrc,
   syncStatusBadgeLabel,
   syncStatusBadgeTone,
   selectShellPageSlice,
@@ -95,10 +92,7 @@ export function DesktopShellPage({
     topicInput,
     selectedThread,
     focusedObjectId,
-    mediaObjectUrls,
     syncStatus,
-    localProfile,
-    knownAuthorsByPubkey,
     selectedAuthorPubkey,
     notifications,
     notificationStatus,
@@ -425,54 +419,6 @@ export function DesktopShellPage({
     notificationStatus.unread_count > 99 ? '99+' : formatCount(notificationStatus.unread_count);
   useOsNotificationBridge();
   useOsNotificationActivation(notifications, handleOpenNotification);
-  const notificationItems = useMemo(
-    () =>
-      notifications.map((notification) => {
-        const knownAuthor = knownAuthorsByPubkey[notification.actor_pubkey] ?? null;
-        const actorLabel = authorDisplayLabel(
-          notification.actor_pubkey,
-          notification.actor_display_name,
-          notification.actor_name
-        );
-        const actorPicture = knownAuthor
-          ? resolveProfilePictureSrc(knownAuthor, mediaObjectUrls)
-          : notification.actor_picture_asset
-            ? mediaObjectUrls[notification.actor_picture_asset.hash] ?? notification.actor_picture ?? null
-            : notification.actor_picture ?? null;
-        const contextLabel =
-          notification.kind === 'direct_message'
-            ? t('shell:notifications.context.directMessage')
-            : notification.topic_id && notification.channel_id
-              ? t('shell:notifications.context.topicChannel', {
-                  channel: notification.channel_id,
-                  topic: notification.topic_id,
-                })
-              : notification.topic_id
-                ? t('shell:notifications.context.topic', {
-                    topic: notification.topic_id,
-                  })
-                : t('shell:notifications.context.authorActivity');
-        const previewText =
-          notification.preview_text ??
-          (notification.kind === 'followed'
-            ? t('shell:notifications.preview.followed')
-            : notification.kind === 'direct_message'
-              ? t('shell:notifications.preview.noMessage')
-              : t('shell:notifications.preview.noContent'));
-
-        return {
-          ...notification,
-          actorLabel,
-          actorPicture,
-          contextLabel,
-          kindLabel: t(`shell:notifications.kinds.${notification.kind}`),
-          previewText,
-          receivedLabel: formatLocalizedTime(notification.received_at, locale),
-          unread: !notification.read_at,
-        };
-      }),
-    [knownAuthorsByPubkey, locale, mediaObjectUrls, notifications, t]
-  );
   const syncTopicContext = useCallback(
     async (topic: string, channelId: string | null) => {
       const nextTopics = trackedTopics.includes(topic) ? trackedTopics : [...trackedTopics, topic];
@@ -880,11 +826,6 @@ export function DesktopShellPage({
     </div>
   );
 
-  const profileAuthorLabel = authorDisplayLabel(
-    syncStatus.local_author_pubkey,
-    localProfile?.display_name,
-    localProfile?.name
-  );
   const messagesWorkspace = (
     <DesktopShellMessagesWorkspace
       t={t}
@@ -903,7 +844,7 @@ export function DesktopShellPage({
   const notificationsWorkspace = (
     <DesktopShellNotificationsWorkspace
       t={t}
-      notificationItems={notificationItems}
+      locale={locale}
       onRefresh={() => {
         setNotificationAutoReadError(null);
         setNotificationPanelState({
@@ -918,7 +859,6 @@ export function DesktopShellPage({
   const detailPaneStack = (
     <DesktopShellDetailPaneStack
       t={t}
-      activeTopic={activeTopic}
       viewModels={viewModels}
       closeAuthorPane={closeAuthorPane}
       closeThreadPane={closeThreadPane}
@@ -985,7 +925,6 @@ export function DesktopShellPage({
             api={api}
             locale={locale}
             routeSection={routeSection}
-            profileAuthorLabel={profileAuthorLabel}
             profileAvatarInputKey={profileAvatarInputKey}
             messagesWorkspace={messagesWorkspace}
             notificationsWorkspace={notificationsWorkspace}
@@ -1066,7 +1005,6 @@ export function DesktopShellPage({
 
       <DesktopShellOverlays
         t={t}
-        activeTopic={activeTopic}
         viewModels={viewModels}
         profileAvatarCropOpen={profileAvatarCropOpen}
         profileAvatarCropFile={profileAvatarCropFile}
@@ -1128,7 +1066,6 @@ export function DesktopShellPage({
       />
 
       <DesktopShellSettingsDrawer
-        drawerId={SHELL_SETTINGS_ID}
         onThemeChange={onThemeChange}
         onLocaleChange={(nextLocale) => {
           void i18nInstance.changeLanguage(nextLocale);

--- a/apps/desktop/src/shell/page/DesktopShellAuxiliaryPanels.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellAuxiliaryPanels.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, FormEvent } from 'react';
+import { useMemo, type ChangeEvent, type FormEvent } from 'react';
 
 import { AuthorAvatar } from '@/components/core/AuthorAvatar';
 import { AuthorDetailCard } from '@/components/core/AuthorDetailCard';
@@ -414,29 +414,81 @@ export function DesktopShellMessagesWorkspace({
 
 type NotificationsWorkspaceProps = {
   t: Translate;
-  notificationItems: NotificationItemView[];
+  locale: SupportedLocale;
   onRefresh: () => void;
   handleOpenNotification: (notification: NotificationView) => Promise<void>;
 };
 
 export function DesktopShellNotificationsWorkspace({
   t,
-  notificationItems,
+  locale,
   onRefresh,
   handleOpenNotification,
 }: NotificationsWorkspaceProps) {
   const {
+    knownAuthorsByPubkey,
+    mediaObjectUrls,
     notifications,
     notificationAutoReadError,
     notificationPanelState,
     notificationStatus,
   } = useDesktopShellStore(
     useShallow((s) => ({
+      knownAuthorsByPubkey: s.knownAuthorsByPubkey,
+      mediaObjectUrls: s.mediaObjectUrls,
       notifications: s.notifications,
       notificationAutoReadError: s.notificationAutoReadError,
       notificationPanelState: s.notificationPanelState,
       notificationStatus: s.notificationStatus,
     }))
+  );
+  const notificationItems = useMemo<NotificationItemView[]>(
+    () =>
+      notifications.map((notification) => {
+        const knownAuthor = knownAuthorsByPubkey[notification.actor_pubkey] ?? null;
+        const actorLabel = authorDisplayLabel(
+          notification.actor_pubkey,
+          notification.actor_display_name,
+          notification.actor_name
+        );
+        const actorPicture = knownAuthor
+          ? resolveProfilePictureSrc(knownAuthor, mediaObjectUrls)
+          : notification.actor_picture_asset
+            ? mediaObjectUrls[notification.actor_picture_asset.hash] ?? notification.actor_picture ?? null
+            : notification.actor_picture ?? null;
+        const contextLabel =
+          notification.kind === 'direct_message'
+            ? t('shell:notifications.context.directMessage')
+            : notification.topic_id && notification.channel_id
+              ? t('shell:notifications.context.topicChannel', {
+                  channel: notification.channel_id,
+                  topic: notification.topic_id,
+                })
+              : notification.topic_id
+                ? t('shell:notifications.context.topic', {
+                    topic: notification.topic_id,
+                  })
+                : t('shell:notifications.context.authorActivity');
+        const previewText =
+          notification.preview_text ??
+          (notification.kind === 'followed'
+            ? t('shell:notifications.preview.followed')
+            : notification.kind === 'direct_message'
+              ? t('shell:notifications.preview.noMessage')
+              : t('shell:notifications.preview.noContent'));
+
+        return {
+          ...notification,
+          actorLabel,
+          actorPicture,
+          contextLabel,
+          kindLabel: t(`shell:notifications.kinds.${notification.kind}`),
+          previewText,
+          receivedLabel: formatLocalizedTime(notification.received_at, locale),
+          unread: !notification.read_at,
+        };
+      }),
+    [knownAuthorsByPubkey, locale, mediaObjectUrls, notifications, t]
   );
 
   return (
@@ -518,7 +570,6 @@ export function DesktopShellNotificationsWorkspace({
 
 type DetailPaneStackProps = {
   t: Translate;
-  activeTopic: string;
   viewModels: Pick<
     ViewModels,
     | 'authorDetailView'
@@ -551,7 +602,6 @@ type DetailPaneStackProps = {
 
 export function DesktopShellDetailPaneStack({
   t,
-  activeTopic,
   viewModels,
   closeAuthorPane,
   closeThreadPane,
@@ -574,6 +624,7 @@ export function DesktopShellDetailPaneStack({
   handleOpenOriginalTopic,
 }: DetailPaneStackProps) {
   const {
+    activeTopic,
     bookmarkedReactionAssets,
     focusedObjectId,
     mediaObjectUrls,
@@ -587,6 +638,7 @@ export function DesktopShellDetailPaneStack({
     threadNextCursorById,
   } = useDesktopShellStore(
     useShallow((s) => ({
+      activeTopic: s.activeTopic,
       bookmarkedReactionAssets: s.bookmarkedReactionAssets,
       focusedObjectId: s.focusedObjectId,
       mediaObjectUrls: s.mediaObjectUrls,

--- a/apps/desktop/src/shell/page/DesktopShellOverlays.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellOverlays.tsx
@@ -39,7 +39,6 @@ type ViewModels = ReturnType<typeof useDesktopShellViewModels>;
 
 type DesktopShellOverlaysProps = {
   t: Translate;
-  activeTopic: string;
   viewModels: Pick<
     ViewModels,
     | 'activeComposeAudienceLabel'
@@ -122,7 +121,6 @@ function AccessPreviewItem({
 
 export function DesktopShellOverlays({
   t,
-  activeTopic,
   viewModels,
   profileAvatarCropOpen,
   profileAvatarCropFile,
@@ -179,6 +177,7 @@ export function DesktopShellOverlays({
     mentionCandidates,
   } = viewModels;
   const {
+    activeTopic,
     attachmentInputKey,
     channelActionPending,
     channelAudienceInput,
@@ -205,6 +204,7 @@ export function DesktopShellOverlays({
     syncStatus,
   } = useDesktopShellStore(
     useShallow((s) => ({
+      activeTopic: s.activeTopic,
       attachmentInputKey: s.attachmentInputKey,
       channelActionPending: s.channelActionPending,
       channelAudienceInput: s.channelAudienceInput,

--- a/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
@@ -33,6 +33,7 @@ import {
   useDesktopShellStore,
 } from '@/shell/store';
 import {
+  authorDisplayLabel,
   formatCount,
   localizeAudienceLabel,
   resolveProfilePictureSrc,
@@ -49,7 +50,6 @@ type DesktopShellPrimaryWorkspaceProps = {
   api: DesktopApi;
   locale: SupportedLocale;
   routeSection: PrimarySection;
-  profileAuthorLabel: string;
   profileAvatarInputKey: number;
   messagesWorkspace: ReactNode;
   notificationsWorkspace: ReactNode;
@@ -120,7 +120,6 @@ export function DesktopShellPrimaryWorkspace({
   api,
   locale,
   routeSection,
-  profileAuthorLabel,
   profileAvatarInputKey,
   messagesWorkspace,
   notificationsWorkspace,
@@ -216,6 +215,11 @@ export function DesktopShellPrimaryWorkspace({
     }))
   );
   const setShellChromeState = useDesktopShellFieldSetter('shellChromeState');
+  const profileAuthorLabel = authorDisplayLabel(
+    syncStatus.local_author_pubkey,
+    localProfile?.display_name,
+    localProfile?.name
+  );
   const bookmarkedPostIds = useMemo(
     () => new Set(bookmarkedPosts.map((item) => item.post.object_id)),
     [bookmarkedPosts]

--- a/apps/desktop/src/shell/page/DesktopShellSettingsDrawer.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellSettingsDrawer.tsx
@@ -11,7 +11,11 @@ import type { SupportedLocale } from '@/i18n';
 import type { CustomReactionCropRect } from '@/lib/api';
 import type { DesktopTheme } from '@/lib/theme';
 import { communityNodesToDraftNodes, seedPeersToEditorValue } from '@/shell/selectors';
-import { useDesktopShellFieldSetter, useDesktopShellStore } from '@/shell/store';
+import {
+  SHELL_SETTINGS_ID,
+  useDesktopShellFieldSetter,
+  useDesktopShellStore,
+} from '@/shell/store';
 import type { SyncRoute } from '@/shell/actions/shared';
 import { useDesktopShellViewModels } from '@/shell/useDesktopShellViewModels';
 import { useShallow } from 'zustand/react/shallow';
@@ -19,7 +23,6 @@ import { useShallow } from 'zustand/react/shallow';
 type ViewModels = ReturnType<typeof useDesktopShellViewModels>;
 
 type DesktopShellSettingsDrawerProps = {
-  drawerId: string;
   onThemeChange: (theme: DesktopTheme) => void;
   onLocaleChange: (locale: SupportedLocale) => void;
   syncRoute: SyncRoute;
@@ -55,7 +58,6 @@ function createCommunityNodeDraftId(): string {
 }
 
 export function DesktopShellSettingsDrawer({
-  drawerId,
   onThemeChange,
   onLocaleChange,
   syncRoute,
@@ -227,7 +229,7 @@ export function DesktopShellSettingsDrawer({
 
   return (
     <SettingsDrawer
-      drawerId={drawerId}
+      drawerId={SHELL_SETTINGS_ID}
       open={shellChromeState.settingsOpen}
       onOpenChange={(open) => setSettingsOpen(open, !open)}
       activeSection={shellChromeState.activeSettingsSection}

--- a/apps/desktop/src/shell/selectors.ts
+++ b/apps/desktop/src/shell/selectors.ts
@@ -796,15 +796,11 @@ export const selectShellPageSlice = (s: DesktopShellStore) => ({
   topicInput: s.topicInput,
   selectedThread: s.selectedThread,
   focusedObjectId: s.focusedObjectId,
-  mediaObjectUrls: s.mediaObjectUrls,
   syncStatus: s.syncStatus,
-  localProfile: s.localProfile,
-  knownAuthorsByPubkey: s.knownAuthorsByPubkey,
   selectedAuthorPubkey: s.selectedAuthorPubkey,
   notifications: s.notifications,
   notificationStatus: s.notificationStatus,
   selectedLiveSessionId: s.selectedLiveSessionId,
   selectedGameRoomId: s.selectedGameRoomId,
   shellChromeState: s.shellChromeState,
-    
 });

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -13,16 +13,16 @@
       "path": "apps/desktop/src/components/extended/MetaverseRoomPanel.tsx"
     },
     {
-      "lines": 1153,
-      "path": "apps/desktop/src/shell/DesktopShellPage.tsx"
-    },
-    {
       "lines": 1141,
       "path": "apps/desktop/src/styles/shell-phase1-legacy.css"
     },
     {
       "lines": 1140,
       "path": "apps/desktop/src/shell/useDesktopShellViewModels.ts"
+    },
+    {
+      "lines": 1090,
+      "path": "apps/desktop/src/shell/DesktopShellPage.tsx"
     },
     {
       "lines": 1087,


### PR DESCRIPTION
## 概要

WP-H6(desktop shell 状態管理の分割)の最終 PR4。DesktopShellPage → page/ 4 コンポーネントの props のうち、store 由来のものを子側の selector 購読へ移し、prop drilling を本質依存のみに縮小した。

| コンポーネント | 変更 |
|---|---|
| PrimaryWorkspace | `profileAuthorLabel` を削除。購読済みの `syncStatus` / `localProfile` から子側で算出(MessagesWorkspace と同型) |
| NotificationsWorkspace | `notificationItems`(48 行の useMemo)を Page から移設し、`locale` prop に置換。`knownAuthorsByPubkey` / `mediaObjectUrls` は子側購読に |
| DetailPaneStack / Overlays | `activeTopic` を子側 selector 購読に |
| SettingsDrawer | `drawerId` を `SHELL_SETTINGS_ID` の直接 import に(AuxiliaryPanels の `SHELL_CONTEXT_ID` と同型) |

Page 側は `selectShellPageSlice` から `localProfile` / `mediaObjectUrls` / `knownAuthorsByPubkey` の 3 フィールドを削除。**メディア読込(mediaObjectUrls)や作者情報(knownAuthorsByPubkey)の更新で木の根である Page が再レンダーされなくなり**、PR2 の購読分離が Page 自身にも及ぶ。

## 到達点(計画の質的基準)

計画どおり数値目標は置かず、「残った props に理由が言えること」を基準とした。残る props の内訳:

- **フック単一インスタンスの出力**: `viewModels`(useDesktopShellViewModels を Page で 1 回だけ計算)と routing / actions / data 各フックの handler 群。子で再取得するとフックが多重実行されるため props が正しい
- **Page ローカル useState / ref 由来**: ダイアログ開閉、share preview、avatar crop、`clipboardToastId` 等。actions フックが setter を要求するため Page 所有が正しい
- **環境**: `t` / `locale` / `api`(Page の引数・i18n)
- **合成用 ReactNode**: `messagesWorkspace` / `notificationsWorkspace`

## 種別

refactor(挙動不変)。

## 挙動変更

なし。移した計算(profileAuthorLabel / notificationItems)は同一入力・同一ロジックのままで、購読場所が親から子へ移っただけ。page/ 4 コンポーネントは DesktopShellPage 経由でのみレンダーされるため props 型変更の外部影響もない。

## 検証

- `pnpm typecheck` / `pnpm lint`(--max-warnings 0)green
- `pnpm test` 61 files / 545 tests green(DesktopShellPage 統合テスト 15 ファイル、renderIsolation smoke 含む)
- `cargo xtask desktop-ui-check` green(Storybook ビルド + visual regression 14 件)
- `cargo xtask oversized-files` — DesktopShellPage 1153 → 1090 行に縮小、baseline を ratchet down(新規違反なし)

## リスク

- NotificationsWorkspace が knownAuthorsByPubkey / mediaObjectUrls を購読するため、通知パネル表示中はメディア読込で同パネルが再レンダーされる(従来は Page ごと再レンダーされていたので範囲は縮小)

## 後続対応

- WP-H6 はこれで完了(PR1 #500 / PR2 #501 / PR3 #502 / PR4)。マスタープランへ完了記録を追記する
- Wave B 残り: H7(IPC codegen)/ H8(CSS 負債)

🤖 Generated with [Claude Code](https://claude.com/claude-code)