### PR TITLE
[refactor] metaverse/game/live 型を ts-rs で生成物化 (WP-H7 PR3 / Stage 2)

### DIFF
--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -83,3 +83,41 @@ export type DiscoveryStatus = { mode: DiscoveryMode, connect_mode: ConnectMode, 
 
 export type SyncStatus = { connected: boolean, delivery_state: DeliveryState, last_sync_ts?: number | null, peer_count: number, pending_events: number, status_detail: string, last_error?: string | null, configured_peers: Array<string>, subscribed_topics: Array<string>, active_path: ConnectionPath, fallback_peer_ids: Array<string>, topic_diagnostics: Array<TopicSyncStatus>, local_author_pubkey: string, discovery: DiscoveryStatus, gossip_disabled_topics: Array<string>, gossip_disabled_channels: Array<string>, };
 
+export type LiveSessionStatus = "Scheduled" | "Live" | "Paused" | "Ended";
+
+export type LiveSessionView = { session_id: string, host_pubkey: string, title: string, description: string, status: LiveSessionStatus, started_at: number, ended_at?: number | null, viewer_count: number, joined_by_me: boolean, channel_id?: string | null, audience_label: string, };
+
+export type GameRoomStatus = "Waiting" | "Running" | "Paused" | "Ended";
+
+export type GameRoomKind = "score_game" | "metaverse_room";
+
+export type GameScoreView = { participant_id: string, label: string, score: number, };
+
+export type MetaverseAssetKind = "vrm" | "glb" | "texture" | "other";
+
+export type MetaverseAssetRef = { kind: MetaverseAssetKind, blob_hash: string, mime_type?: string | null, size_bytes?: number | null, name?: string | null, };
+
+export type MetaversePrimitive = "cube" | "sphere";
+
+export type MetaverseRoomPresenceV1 = { room_id: string, peer_id: string, display_name?: string | null, avatar_asset_ref?: MetaverseAssetRef | null, joined_at: number, last_seen_at: number, };
+
+export type MetaverseAvatarTransformV1 = { room_id: string, peer_id: string, seq: number, position: [number, number, number], rotation: [number, number, number], animation?: string | null, sent_at: number, };
+
+export type MetaverseRoomChatMessageV1 = { room_id: string, message_id: string, author_peer_id: string, display_name?: string | null, body: string, created_at: number, };
+
+export type SharedRoomObjectV1 = { object_id: string, asset_ref?: MetaverseAssetRef | null, primitive_fallback: MetaversePrimitive, position: [number, number, number], rotation: [number, number, number], scale: [number, number, number], updated_by: string, updated_at: number, };
+
+export type MetaverseRoomEventV1 = { "type": "presence_join", presence: MetaverseRoomPresenceV1, } | { "type": "presence_leave", room_id: string, peer_id: string, left_at: number, } | { "type": "avatar_transform", transform: MetaverseAvatarTransformV1, } | { "type": "chat_message", message: MetaverseRoomChatMessageV1, } | { "type": "object_update", object: SharedRoomObjectV1, };
+
+export type MetaverseRoomEventEnvelopeContentV1 = { event_id: string, topic_id: string, channel_id?: string | null, room_id: string, peer_id: string, seq: number, sent_at: number, event: MetaverseRoomEventV1, };
+
+export type MetaverseRoomSceneV1 = { ground: string, shared_object: SharedRoomObjectV1, };
+
+export type MetaverseRoomSpawnV1 = { position: [number, number, number], rotation: [number, number, number], };
+
+export type MetaverseRoomStateV1 = { world_version: number, max_peers?: number | null, scene: MetaverseRoomSceneV1, default_spawn: MetaverseRoomSpawnV1, asset_refs: Array<MetaverseAssetRef>, chat_history?: Array<MetaverseRoomChatMessageV1> | null, };
+
+export type GameRoomView = { room_id: string, host_pubkey: string, title: string, description: string, status: GameRoomStatus, phase_label?: string | null, scores: Array<GameScoreView>, room_kind: GameRoomKind, metaverse?: MetaverseRoomStateV1 | null, manifest_blob_hash: string, updated_at: number, channel_id?: string | null, audience_label: string, };
+
+export type MetaverseRoomEventView = { envelope_id: string, content: MetaverseRoomEventEnvelopeContentV1, envelope: Record<string, unknown>, received_at: number, source_peer: string, };
+

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -15,7 +15,15 @@ import type {
   DirectMessageStatusView,
   DirectMessageTimelineView,
   DiscoveryMode,
+  GameRoomStatus,
+  GameRoomView,
+  GameScoreView,
   JoinedPrivateChannelView,
+  LiveSessionView,
+  MetaverseAssetKind,
+  MetaverseAssetRef,
+  MetaverseRoomEventV1,
+  MetaverseRoomEventView,
   NotificationStatusView,
   NotificationView,
   PostView as WirePostView,
@@ -284,137 +292,6 @@ export type SubmitCommunityNodeReportStatus = 'submitted';
 export type SubmitCommunityNodeReportResult = {
   status: SubmitCommunityNodeReportStatus;
   reference_id?: string | null;
-};
-
-export type LiveSessionStatus = 'Scheduled' | 'Live' | 'Paused' | 'Ended';
-
-export type LiveSessionView = {
-  session_id: string;
-  host_pubkey: string;
-  title: string;
-  description: string;
-  status: LiveSessionStatus;
-  started_at: number;
-  ended_at?: number | null;
-  viewer_count: number;
-  joined_by_me: boolean;
-  channel_id?: string | null;
-  audience_label: string;
-};
-
-export type GameRoomStatus = 'Waiting' | 'Running' | 'Paused' | 'Ended';
-export type GameRoomKind = 'score_game' | 'metaverse_room';
-
-export type MetaverseAssetKind = 'vrm' | 'glb' | 'texture' | 'other';
-
-export type MetaverseAssetRef = {
-  kind: MetaverseAssetKind;
-  blob_hash: string;
-  mime_type?: string | null;
-  size_bytes?: number | null;
-  name?: string | null;
-};
-
-export type MetaversePrimitive = 'cube' | 'sphere';
-
-export type SharedRoomObjectV1 = {
-  object_id: string;
-  asset_ref?: MetaverseAssetRef | null;
-  primitive_fallback: MetaversePrimitive;
-  position: [number, number, number];
-  rotation: [number, number, number];
-  scale: [number, number, number];
-  updated_by: string;
-  updated_at: number;
-};
-
-export type MetaverseRoomStateV1 = {
-  world_version: number;
-  max_peers?: number | null;
-  scene: {
-    ground: string;
-    shared_object: SharedRoomObjectV1;
-  };
-  default_spawn: {
-    position: [number, number, number];
-    rotation: [number, number, number];
-  };
-  asset_refs: MetaverseAssetRef[];
-  chat_history?: MetaverseRoomChatMessageV1[];
-};
-
-export type MetaverseRoomPresenceV1 = {
-  room_id: string;
-  peer_id: string;
-  display_name?: string | null;
-  avatar_asset_ref?: MetaverseAssetRef | null;
-  joined_at: number;
-  last_seen_at: number;
-};
-
-export type MetaverseAvatarTransformV1 = {
-  room_id: string;
-  peer_id: string;
-  seq: number;
-  position: [number, number, number];
-  rotation: [number, number, number];
-  animation?: string | null;
-  sent_at: number;
-};
-
-export type MetaverseRoomChatMessageV1 = {
-  room_id: string;
-  message_id: string;
-  author_peer_id: string;
-  display_name?: string | null;
-  body: string;
-  created_at: number;
-};
-
-export type MetaverseRoomEventV1 =
-  | { type: 'presence_join'; presence: MetaverseRoomPresenceV1 }
-  | { type: 'presence_leave'; room_id: string; peer_id: string; left_at: number }
-  | { type: 'avatar_transform'; transform: MetaverseAvatarTransformV1 }
-  | { type: 'chat_message'; message: MetaverseRoomChatMessageV1 }
-  | { type: 'object_update'; object: SharedRoomObjectV1 };
-
-export type MetaverseRoomEventView = {
-  envelope_id: string;
-  content: {
-    event_id: string;
-    topic_id: string;
-    channel_id?: string | null;
-    room_id: string;
-    peer_id: string;
-    seq: number;
-    sent_at: number;
-    event: MetaverseRoomEventV1;
-  };
-  envelope: Record<string, unknown>;
-  received_at: number;
-  source_peer: string;
-};
-
-export type GameScoreView = {
-  participant_id: string;
-  label: string;
-  score: number;
-};
-
-export type GameRoomView = {
-  room_id: string;
-  host_pubkey: string;
-  title: string;
-  description: string;
-  status: GameRoomStatus;
-  phase_label?: string | null;
-  scores: GameScoreView[];
-  room_kind: GameRoomKind;
-  metaverse?: MetaverseRoomStateV1 | null;
-  manifest_blob_hash: string;
-  updated_at: number;
-  channel_id?: string | null;
-  audience_label: string;
 };
 
 export type PrivateChannelInvitePreview = {

--- a/crates/app-api/src/ipc_ts_export.rs
+++ b/crates/app-api/src/ipc_ts_export.rs
@@ -25,7 +25,13 @@ fn emit<T: TS>(cfg: &ts_rs::Config, out: &mut String) {
 #[test]
 fn export_ipc_types() {
     use crate::views::*;
-    use kukuri_core::{ChannelAudienceKind, ChannelSharingState};
+    use kukuri_core::{
+        ChannelAudienceKind, ChannelSharingState, GameRoomKind, GameRoomStatus, LiveSessionStatus,
+        MetaverseAssetKind, MetaverseAssetRef, MetaverseAvatarTransformV1, MetaversePrimitive,
+        MetaverseRoomChatMessageV1, MetaverseRoomEventEnvelopeContentV1, MetaverseRoomEventV1,
+        MetaverseRoomPresenceV1, MetaverseRoomSceneV1, MetaverseRoomSpawnV1, MetaverseRoomStateV1,
+        SharedRoomObjectV1,
+    };
     use kukuri_store::{NotificationKind, TimelineCursor};
     use kukuri_transport::{ConnectMode, ConnectionPath, DiscoveryMode};
 
@@ -78,6 +84,26 @@ fn export_ipc_types() {
         TopicSyncStatus,
         DiscoveryStatus,
         SyncStatus,
+        // Stage 2: metaverse / game / live
+        LiveSessionStatus,
+        LiveSessionView,
+        GameRoomStatus,
+        GameRoomKind,
+        GameScoreView,
+        MetaverseAssetKind,
+        MetaverseAssetRef,
+        MetaversePrimitive,
+        MetaverseRoomPresenceV1,
+        MetaverseAvatarTransformV1,
+        MetaverseRoomChatMessageV1,
+        SharedRoomObjectV1,
+        MetaverseRoomEventV1,
+        MetaverseRoomEventEnvelopeContentV1,
+        MetaverseRoomSceneV1,
+        MetaverseRoomSpawnV1,
+        MetaverseRoomStateV1,
+        GameRoomView,
+        MetaverseRoomEventView,
     );
 
     let path = concat!(

--- a/crates/app-api/src/views.rs
+++ b/crates/app-api/src/views.rs
@@ -340,6 +340,8 @@ pub struct NotificationStatusView {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct LiveSessionView {
     pub session_id: String,
     pub host_pubkey: String,
@@ -355,6 +357,8 @@ pub struct LiveSessionView {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct GameRoomView {
     pub room_id: String,
     pub host_pubkey: String,
@@ -372,6 +376,8 @@ pub struct GameRoomView {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct GameScoreView {
     pub participant_id: String,
     pub label: String,
@@ -422,9 +428,12 @@ pub struct PublishMetaverseRoomEventInput {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct MetaverseRoomEventView {
     pub envelope_id: String,
     pub content: MetaverseRoomEventEnvelopeContentV1,
+    #[cfg_attr(feature = "ts", ts(type = "Record<string, unknown>"))]
     pub envelope: KukuriEnvelope,
     pub received_at: i64,
     pub source_peer: String,

--- a/crates/core/src/game.rs
+++ b/crates/core/src/game.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{ChannelId, EnvelopeId, ManifestBlobRef, Pubkey, TopicId};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(rename_all = "snake_case")]
 pub enum GameRoomKind {
     #[default]
@@ -12,6 +13,7 @@ pub enum GameRoomKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 pub enum GameRoomStatus {
     Waiting,
     Running,
@@ -33,6 +35,7 @@ pub struct GameScoreEntry {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(rename_all = "snake_case")]
 pub enum MetaverseAssetKind {
     Vrm,
@@ -42,6 +45,8 @@ pub enum MetaverseAssetKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct MetaverseAssetRef {
     pub kind: MetaverseAssetKind,
     pub blob_hash: String,
@@ -51,6 +56,8 @@ pub struct MetaverseAssetRef {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct MetaverseRoomPresenceV1 {
     pub room_id: String,
     pub peer_id: String,
@@ -61,6 +68,8 @@ pub struct MetaverseRoomPresenceV1 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct MetaverseAvatarTransformV1 {
     pub room_id: String,
     pub peer_id: String,
@@ -72,6 +81,8 @@ pub struct MetaverseAvatarTransformV1 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct MetaverseRoomChatMessageV1 {
     pub room_id: String,
     pub message_id: String,
@@ -82,6 +93,7 @@ pub struct MetaverseRoomChatMessageV1 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(rename_all = "snake_case")]
 pub enum MetaversePrimitive {
     Cube,
@@ -89,6 +101,8 @@ pub enum MetaversePrimitive {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SharedRoomObjectV1 {
     pub object_id: String,
     pub asset_ref: Option<MetaverseAssetRef>,
@@ -96,11 +110,13 @@ pub struct SharedRoomObjectV1 {
     pub position: [i64; 3],
     pub rotation: [i64; 3],
     pub scale: [i64; 3],
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
     pub updated_by: Pubkey,
     pub updated_at: i64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MetaverseRoomEventV1 {
     PresenceJoin {
@@ -123,9 +139,13 @@ pub enum MetaverseRoomEventV1 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct MetaverseRoomEventEnvelopeContentV1 {
     pub event_id: String,
+    #[cfg_attr(feature = "ts", ts(type = "string"))]
     pub topic_id: TopicId,
+    #[cfg_attr(feature = "ts", ts(as = "Option<String>"))]
     pub channel_id: Option<ChannelId>,
     pub room_id: String,
     pub peer_id: String,
@@ -135,18 +155,24 @@ pub struct MetaverseRoomEventEnvelopeContentV1 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct MetaverseRoomSceneV1 {
     pub ground: String,
     pub shared_object: SharedRoomObjectV1,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct MetaverseRoomSpawnV1 {
     pub position: [i64; 3],
     pub rotation: [i64; 3],
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct MetaverseRoomStateV1 {
     pub world_version: u64,
     pub max_peers: Option<u32>,
@@ -154,6 +180,7 @@ pub struct MetaverseRoomStateV1 {
     pub default_spawn: MetaverseRoomSpawnV1,
     pub asset_refs: Vec<MetaverseAssetRef>,
     #[serde(default)]
+    #[cfg_attr(feature = "ts", ts(as = "Option<Vec<MetaverseRoomChatMessageV1>>"))]
     pub chat_history: Vec<MetaverseRoomChatMessageV1>,
 }
 

--- a/crates/core/src/live.rs
+++ b/crates/core/src/live.rs
@@ -11,6 +11,7 @@ pub enum LiveSignalKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 pub enum LiveSessionStatus {
     Scheduled,
     Live,


### PR DESCRIPTION
## 概要

WP-H7 PR3 の Stage 2。Stage 1([#506](https://github.com/KingYoSun/kukuri/pull/506))に続き、IPC 型生成の対象を **metaverse / game / live 系 19 型**へ広げる。

- `core/game.rs` の metaverse family 14 型 + `core/live.rs` の `LiveSessionStatus` に `derive(TS)` を追加
- `views.rs` の `LiveSessionView` / `GameScoreView` / `GameRoomView` / `MetaverseRoomEventView`(Stage 1 で保留していた 4 型)を生成対象へ
- `ipc_ts_export.rs` の emit リストに 19 型を追加、`types.ts` の該当手書き 16 型を除去して `types.generated.ts` からの再輸出へ

## 種別

refactor(挙動不変)。serde 表現は不変。

## 現行 TS との整合

- **tagged enum** `MetaverseRoomEventV1`: Rust の `#[serde(tag = "type", rename_all = "snake_case")]` がそのまま `{ type: "presence_join", ... } | ...` に(現行と等価。プロパティキーが引用符付きになるだけ)
- **tuple** `[i64; 3]` → `[number, number, number]`(`TS_RS_LARGE_INT=number`)
- **newtype**(Pubkey / TopicId / ChannelId)は `ts(type = "string")` で `string` に(型エイリアスを増やさない)
- **chat_history**(`#[serde(default)] Vec`)は `ts(as = "Option<Vec<..>>")` で `?: T[] | null`(現行の optional に一致)
- **envelope** は現行同様 opaque(`ts(type = "Record<string, unknown>")`)
- **scene / default_spawn / content** は Rust の named 型(`MetaverseRoomSceneV1` 等)を参照(現行の inline object から名前付きへ。構造は等価で消費側は不変)

## 検証

- `pnpm typecheck` / `pnpm lint` green(**消費側の型修正はゼロ** — 生成物が現行規約に一致)
- `pnpm test` 545 / `cargo test`(core 52 + app-api 162)green。**S4 fixture golden 継続**
- `cargo fmt --check` / `cargo clippy`(core / app-api)green
- `cargo xtask ipc-types --check` 冪等(生成差分は Stage-2 の 19 型の純増のみ)
- `cargo xtask desktop-ui-check` green(Storybook / ブラウザ E2E / visual)

## リスク

- 低。feature-gate で production 無影響。乖離は CI 再生成 diff + S4 fixture で二重検出

## 後続(全型表面へ)

- **Stage 3**: desktop-runtime(community-node 系)/ cn-protocol(manifest)/ Profile・ChannelRef 等の残り core 型と front 専用入力型の整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)