### PR TITLE
[refactor] core/transport の残り IPC 型を ts-rs で生成物化 (WP-H7 PR3 / Stage 3a)

### DIFF
--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -121,3 +121,23 @@ export type GameRoomView = { room_id: string, host_pubkey: string, title: string
 
 export type MetaverseRoomEventView = { envelope_id: string, content: MetaverseRoomEventEnvelopeContentV1, envelope: Record<string, unknown>, received_at: number, source_peer: string, };
 
+export type Pubkey = string;
+
+export type TopicId = string;
+
+export type ChannelId = string;
+
+export type ChannelRef = { "kind": "public" } | { "kind": "private_channel", channel_id: ChannelId, };
+
+export type TimelineScope = { "kind": "public" } | { "kind": "all_joined" } | { "kind": "channel", channel_id: ChannelId, };
+
+export type SeedPeer = { endpoint_id: string, addr_hint?: string | null, };
+
+export type Profile = { pubkey: Pubkey, name?: string | null, display_name?: string | null, about?: string | null, picture?: string | null, picture_asset?: ProfileAssetView | null, updated_at: number, };
+
+export type PrivateChannelInvitePreview = { channel_id: ChannelId, topic_id: TopicId, channel_label: string, inviter_pubkey: Pubkey, owner_pubkey: Pubkey, epoch_id: string, expires_at?: number | null, namespace_secret_hex: string, };
+
+export type FriendOnlyGrantPreview = { channel_id: ChannelId, topic_id: TopicId, channel_label: string, owner_pubkey: Pubkey, epoch_id: string, expires_at?: number | null, namespace_secret_hex: string, };
+
+export type FriendPlusSharePreview = { channel_id: ChannelId, topic_id: TopicId, channel_label: string, owner_pubkey: Pubkey, sponsor_pubkey: Pubkey, epoch_id: string, expires_at?: number | null, namespace_secret_hex: string, share_token_id: string, };
+

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -9,12 +9,15 @@ import type {
   ChannelAccessTokenExport,
   ChannelAccessTokenPreview,
   ChannelAudienceKind,
+  ChannelRef,
   ConnectMode,
   CustomReactionAssetView,
   DirectMessageConversationView,
   DirectMessageStatusView,
   DirectMessageTimelineView,
   DiscoveryMode,
+  FriendOnlyGrantPreview,
+  FriendPlusSharePreview,
   GameRoomStatus,
   GameRoomView,
   GameScoreView,
@@ -27,12 +30,15 @@ import type {
   NotificationStatusView,
   NotificationView,
   PostView as WirePostView,
-  ProfileAssetView,
+  PrivateChannelInvitePreview,
+  Profile,
   ReactionStateView,
   RecentReactionView,
+  SeedPeer,
   SocialConnectionKind,
   SyncStatus,
   TimelineCursor,
+  TimelineScope,
   TimelineView,
 } from './types.generated';
 
@@ -45,15 +51,6 @@ export type PostView = WirePostView & {
   local_draft?: LocalPostDraft | null;
   local_draft_media_items?: LocalDraftMediaItem[] | null;
 };
-
-export type ChannelRef =
-  | { kind: 'public' }
-  | { kind: 'private_channel'; channel_id: string };
-
-export type TimelineScope =
-  | { kind: 'public' }
-  | { kind: 'all_joined' }
-  | { kind: 'channel'; channel_id: string };
 
 // Tauri コマンドの構造化エラー封筒(src-tauri の CommandError と対、WP-C3)。
 // invoke reject の payload 形状であり views fixture(S4 codegen)の対象外。
@@ -119,16 +116,6 @@ export type CustomReactionCropRect = {
   size: number;
 };
 
-export type Profile = {
-  pubkey: string;
-  name?: string | null;
-  display_name?: string | null;
-  about?: string | null;
-  picture?: string | null;
-  picture_asset?: ProfileAssetView | null;
-  updated_at: number;
-};
-
 export type ProfileInput = {
   name?: string | null;
   display_name?: string | null;
@@ -151,11 +138,6 @@ export type CreateRepostInput = {
   source_topic: string;
   source_object_id: string;
   commentary?: string | null;
-};
-
-export type SeedPeer = {
-  endpoint_id: string;
-  addr_hint?: string | null;
 };
 
 export type DiscoveryConfig = {
@@ -292,39 +274,6 @@ export type SubmitCommunityNodeReportStatus = 'submitted';
 export type SubmitCommunityNodeReportResult = {
   status: SubmitCommunityNodeReportStatus;
   reference_id?: string | null;
-};
-
-export type PrivateChannelInvitePreview = {
-  channel_id: string;
-  topic_id: string;
-  channel_label: string;
-  inviter_pubkey: string;
-  owner_pubkey: string;
-  epoch_id: string;
-  expires_at?: number | null;
-  namespace_secret_hex: string;
-};
-
-export type FriendOnlyGrantPreview = {
-  channel_id: string;
-  topic_id: string;
-  channel_label: string;
-  owner_pubkey: string;
-  epoch_id: string;
-  expires_at?: number | null;
-  namespace_secret_hex: string;
-};
-
-export type FriendPlusSharePreview = {
-  channel_id: string;
-  topic_id: string;
-  channel_label: string;
-  owner_pubkey: string;
-  sponsor_pubkey: string;
-  epoch_id: string;
-  expires_at?: number | null;
-  namespace_secret_hex: string;
-  share_token_id: string;
 };
 
 export interface DesktopApi {

--- a/crates/app-api/src/ipc_ts_export.rs
+++ b/crates/app-api/src/ipc_ts_export.rs
@@ -26,14 +26,15 @@ fn emit<T: TS>(cfg: &ts_rs::Config, out: &mut String) {
 fn export_ipc_types() {
     use crate::views::*;
     use kukuri_core::{
-        ChannelAudienceKind, ChannelSharingState, GameRoomKind, GameRoomStatus, LiveSessionStatus,
+        ChannelAudienceKind, ChannelId, ChannelRef, ChannelSharingState, FriendOnlyGrantPreview,
+        FriendPlusSharePreview, GameRoomKind, GameRoomStatus, LiveSessionStatus,
         MetaverseAssetKind, MetaverseAssetRef, MetaverseAvatarTransformV1, MetaversePrimitive,
         MetaverseRoomChatMessageV1, MetaverseRoomEventEnvelopeContentV1, MetaverseRoomEventV1,
         MetaverseRoomPresenceV1, MetaverseRoomSceneV1, MetaverseRoomSpawnV1, MetaverseRoomStateV1,
-        SharedRoomObjectV1,
+        PrivateChannelInvitePreview, Profile, Pubkey, SharedRoomObjectV1, TimelineScope, TopicId,
     };
     use kukuri_store::{NotificationKind, TimelineCursor};
-    use kukuri_transport::{ConnectMode, ConnectionPath, DiscoveryMode};
+    use kukuri_transport::{ConnectMode, ConnectionPath, DiscoveryMode, SeedPeer};
 
     let cfg = ts_rs::Config::from_env();
     let mut out = String::from(HEADER);
@@ -104,6 +105,17 @@ fn export_ipc_types() {
         MetaverseRoomStateV1,
         GameRoomView,
         MetaverseRoomEventView,
+        // Stage 3a: core / transport の残り型 + newtype(string)
+        Pubkey,
+        TopicId,
+        ChannelId,
+        ChannelRef,
+        TimelineScope,
+        SeedPeer,
+        Profile,
+        PrivateChannelInvitePreview,
+        FriendOnlyGrantPreview,
+        FriendPlusSharePreview,
     );
 
     let path = concat!(

--- a/crates/core/src/ids.rs
+++ b/crates/core/src/ids.rs
@@ -23,6 +23,7 @@ impl From<&str> for EnvelopeId {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(transparent)]
 pub struct Pubkey(pub String);
 
@@ -45,6 +46,7 @@ impl From<&str> for Pubkey {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(transparent)]
 pub struct TopicId(pub String);
 
@@ -63,6 +65,7 @@ pub fn author_profile_topic_id(author_pubkey: &str) -> TopicId {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(transparent)]
 pub struct ChannelId(pub String);
 

--- a/crates/core/src/posts.rs
+++ b/crates/core/src/posts.rs
@@ -38,6 +38,7 @@ pub enum ObjectStatus {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ChannelRef {
     #[default]
@@ -64,6 +65,7 @@ impl ChannelRef {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TimelineScope {
     #[default]

--- a/crates/core/src/private_channels.rs
+++ b/crates/core/src/private_channels.rs
@@ -107,6 +107,8 @@ pub struct PrivateChannelInviteTokenV1 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct PrivateChannelInvitePreview {
     pub channel_id: ChannelId,
     pub topic_id: TopicId,
@@ -135,6 +137,8 @@ pub struct FriendOnlyGrantTokenV1 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct FriendOnlyGrantPreview {
     pub channel_id: ChannelId,
     pub topic_id: TopicId,
@@ -163,6 +167,8 @@ pub struct FriendPlusShareTokenV1 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct FriendPlusSharePreview {
     pub channel_id: ChannelId,
     pub topic_id: TopicId,

--- a/crates/core/src/profile.rs
+++ b/crates/core/src/profile.rs
@@ -8,17 +8,22 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct Profile {
     pub pubkey: Pubkey,
     pub name: Option<String>,
     pub display_name: Option<String>,
     pub about: Option<String>,
     pub picture: Option<String>,
+    // serialize_with で wire は ProfileAssetView 形状(views.rs で生成済み)。
+    // AssetRef を直接生成せず、現行 types.ts と同じ `?: ProfileAssetView | null` にする。
     #[serde(
         default,
         serialize_with = "serialize_profile_asset_ref",
         deserialize_with = "deserialize_profile_asset_ref"
     )]
+    #[cfg_attr(feature = "ts", ts(optional, type = "ProfileAssetView | null"))]
     pub picture_asset: Option<AssetRef>,
     pub updated_at: i64,
 }

--- a/crates/transport/src/config.rs
+++ b/crates/transport/src/config.rs
@@ -90,6 +90,8 @@ impl TransportRelayConfig {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SeedPeer {
     pub endpoint_id: String,
     pub addr_hint: Option<String>,


### PR DESCRIPTION
## 概要

WP-H7 PR3 の Stage 3a。app-api の生成器から**到達可能な** core / transport の残り型を生成対象へ広げる(community-node 系は app-api の上流にあるため Stage 3b で生成器を移設して対応)。

- **core**: `Profile` / `ChannelRef` / `TimelineScope` / `PrivateChannelInvitePreview` / `FriendOnlyGrantPreview` / `FriendPlusSharePreview` に `derive(TS)`
- **core の ID newtype**(`Pubkey` / `TopicId` / `ChannelId`)に `derive(TS)`。`#[serde(transparent)]` の single-field tuple struct なので ts-rs は `type Pubkey = string` を生成し、ChannelRef / TimelineScope / preview の newtype フィールドが自動で string 化される(per-field override 不要)
- **transport**: `SeedPeer` に `derive(TS)`
- `ipc_ts_export.rs` の emit に 10 型を追加、`types.ts` の該当手書き 7 型を除去して再輸出へ

## 種別

refactor(挙動不変)。serde 表現は不変。

## 現行 TS との整合

- `ChannelRef` / `TimelineScope` は `#[serde(tag = "kind", rename_all = "snake_case")]` がそのまま `{ kind: "public" } | { kind: "private_channel", channel_id: ChannelId }` に(現行と等価)
- `Profile.picture_asset` は `serialize_with` で wire が `ProfileAssetView` 形状のため `ts(optional, type = "ProfileAssetView | null")` を付与し、現行の `?: ProfileAssetView | null` に一致

## 検証

- `pnpm typecheck` / `pnpm lint` green(**消費側の型修正はゼロ**)
- `pnpm test` 545 / `cargo test`(core 52 + transport 39 + app-api 162)green。S4 fixture golden 継続
- `cargo fmt --check` / `cargo clippy`(core / transport / app-api)green
- `cargo xtask ipc-types --check` 冪等(生成差分は 10 型の純増のみ)
- `cargo xtask desktop-ui-check` green(Storybook / ブラウザ E2E 10 / visual 14)

## リスク

- 低。feature-gate で production 無影響。乖離は CI 再生成 diff + S4 fixture で二重検出

## 後続(最終)

- **Stage 3b**: community-node 系(`DiscoveryConfig` / `CommunityNodeConfig` / `CommunityNodeNodeStatus` / `CommunityNodeManifest` など約 15 型)。これらは app-api の**上流**(desktop-runtime / cn-protocol)にあり、生成器を desktop-runtime へ移設して生成する。完了で全型表面の生成物化が完了(残る手書きは front 専用の入力型・エラー型・DesktopApi interface のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)