### PR TITLE
[refactor] community-node 型を ts-rs で生成物化・生成器を desktop-runtime へ移設 (WP-H7 PR3 / Stage 3b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,6 +3054,7 @@ dependencies = [
  "kukuri-core",
  "serde",
  "serde_json",
+ "ts-rs",
  "url",
 ]
 
@@ -3194,6 +3195,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "ts-rs",
  "url",
 ]
 

--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -141,3 +141,87 @@ export type FriendOnlyGrantPreview = { channel_id: ChannelId, topic_id: TopicId,
 
 export type FriendPlusSharePreview = { channel_id: ChannelId, topic_id: TopicId, channel_label: string, owner_pubkey: Pubkey, sponsor_pubkey: Pubkey, epoch_id: string, expires_at?: number | null, namespace_secret_hex: string, share_token_id: string, };
 
+export type DiscoveryConfig = { mode: DiscoveryMode, connect_mode: ConnectMode, env_locked: boolean, seed_peers: Array<SeedPeer>, };
+
+export type CommunityNodeSeedPeer = { endpoint_id: string, addr_hint?: string | null, };
+
+export type CommunityNodeResolvedUrls = { public_base_url: string, connectivity_urls: Array<string>, seed_peers?: Array<CommunityNodeSeedPeer> | null, };
+
+export type CommunityNodeNodeConfig = { base_url: string, auto_approve?: boolean | null, resolved_urls?: CommunityNodeResolvedUrls | null, };
+
+export type CommunityNodeConfig = { nodes: Array<CommunityNodeNodeConfig>, };
+
+export type CommunityNodeAuthState = { authenticated: boolean, expires_at?: number | null, };
+
+export type CommunityNodeConsentItem = { policy_slug: string, policy_version: number, title: string, body?: string | null, required: boolean, accepted_at?: number | null, 
+/**
+ * その policy_slug で過去に同意した最大 version（version 不問）。
+ * `accepted_at` が None でこれが Some なら、版が上がって再同意が必要な「更新」を意味する。
+ */
+previously_accepted_version?: number | null, };
+
+export type CommunityNodeConsentStatus = { all_required_accepted: boolean, items: Array<CommunityNodeConsentItem>, };
+
+export type CommunityNodeSessionPhase = "idle" | "connecting" | "authenticating" | "accepting" | "refreshing" | "ready" | "retrying";
+
+export type CommunityNodeNodeStatus = { base_url: string, auto_approve?: boolean | null, auth_state: CommunityNodeAuthState, consent_state?: CommunityNodeConsentStatus | null, resolved_urls?: CommunityNodeResolvedUrls | null, last_error?: string | null, session_phase?: CommunityNodeSessionPhase | null, retry_after?: number | null, restart_required: boolean, };
+
+export type CommunityNodeCapabilityScope = { available_enabled: Array<string>, planned_enabled: Array<string>, };
+
+export type CommunityNodeAuthorityScope = { applies_to: Array<string>, does_not_apply_to: Array<string>, };
+
+export type CommunityNodeP2pBoundary = { identity_authority: boolean, profile_canonical_store: boolean, social_graph_canonical_store: boolean, content_truth_source: boolean, network_wide_authority: boolean, };
+
+export type CommunityNodeManifest = { node_id: string, node_name: string, node_role: string, server_name: string, manifest_version: string, capability_scope: CommunityNodeCapabilityScope, authority_scope: CommunityNodeAuthorityScope, p2p_boundary: CommunityNodeP2pBoundary, abuse_contact: string, 
+/**
+ * node が公開する通報受付 endpoint(#310)。未公開の場合は空文字。
+ * client は空なら `abuse_contact` を mailto / copyable contact として案内する。
+ */
+report_endpoint: string, terms_url: string, privacy_url: string, moderation_policy_url: string, };
+
+export type CommunityNodeManifestFetchStatus = "ok" | "absent";
+
+export type CommunityNodeManifestFetch = { status: CommunityNodeManifestFetchStatus, manifest?: CommunityNodeManifest | null, };
+
+export type SubmitCommunityNodeReportRequest = { 
+/**
+ * 通報先 node の base url（記録・表示用）。
+ */
+node_base_url: string, 
+/**
+ * node manifest が公開する通報受付 endpoint（絶対 http(s) URL）。
+ */
+report_endpoint: string, 
+/**
+ * 通報対象の種別（post / profile / media / search_result / recommendation 等）。
+ */
+subject_kind: string, 
+/**
+ * 通報対象の識別子（post id / pubkey / object id 等）。
+ */
+subject_id: string, 
+/**
+ * 通報先となった node capability（community_index / moderation / media_cache 等）。
+ */
+capability: string, 
+/**
+ * 通報理由カテゴリ。
+ */
+reason: string, 
+/**
+ * 任意の補足説明。
+ */
+details?: string | null, 
+/**
+ * 任意の通報者連絡先（node が follow-up に使える）。
+ */
+reporter_contact?: string | null, };
+
+export type SubmitCommunityNodeReportStatus = "submitted";
+
+export type SubmitCommunityNodeReportResult = { status: SubmitCommunityNodeReportStatus, 
+/**
+ * node が返した受付参照 ID（任意）。
+ */
+reference_id?: string | null, };
+

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -10,12 +10,14 @@ import type {
   ChannelAccessTokenPreview,
   ChannelAudienceKind,
   ChannelRef,
-  ConnectMode,
+  CommunityNodeConfig,
+  CommunityNodeManifestFetch,
+  CommunityNodeNodeStatus,
   CustomReactionAssetView,
   DirectMessageConversationView,
   DirectMessageStatusView,
   DirectMessageTimelineView,
-  DiscoveryMode,
+  DiscoveryConfig,
   FriendOnlyGrantPreview,
   FriendPlusSharePreview,
   GameRoomStatus,
@@ -34,8 +36,9 @@ import type {
   Profile,
   ReactionStateView,
   RecentReactionView,
-  SeedPeer,
   SocialConnectionKind,
+  SubmitCommunityNodeReportRequest,
+  SubmitCommunityNodeReportResult,
   SyncStatus,
   TimelineCursor,
   TimelineScope,
@@ -140,70 +143,6 @@ export type CreateRepostInput = {
   commentary?: string | null;
 };
 
-export type DiscoveryConfig = {
-  mode: DiscoveryMode;
-  connect_mode: ConnectMode;
-  env_locked: boolean;
-  seed_peers: SeedPeer[];
-};
-
-export type CommunityNodeResolvedUrls = {
-  public_base_url: string;
-  connectivity_urls: string[];
-  seed_peers?: SeedPeer[];
-};
-
-export type CommunityNodeNodeConfig = {
-  base_url: string;
-  auto_approve?: boolean;
-  resolved_urls?: CommunityNodeResolvedUrls | null;
-};
-
-export type CommunityNodeConfig = {
-  nodes: CommunityNodeNodeConfig[];
-};
-
-export type CommunityNodeAuthState = {
-  authenticated: boolean;
-  expires_at?: number | null;
-};
-
-export type CommunityNodeConsentItem = {
-  policy_slug: string;
-  policy_version: number;
-  title: string;
-  body?: string;
-  required: boolean;
-  accepted_at?: number | null;
-  previously_accepted_version?: number | null;
-};
-
-export type CommunityNodeConsentStatus = {
-  all_required_accepted: boolean;
-  items: CommunityNodeConsentItem[];
-};
-
-export type CommunityNodeSessionPhase =
-  | 'idle'
-  | 'connecting'
-  | 'authenticating'
-  | 'accepting'
-  | 'refreshing'
-  | 'ready'
-  | 'retrying';
-
-export type CommunityNodeNodeStatus = {
-  base_url: string;
-  auto_approve?: boolean;
-  auth_state: CommunityNodeAuthState;
-  consent_state?: CommunityNodeConsentStatus | null;
-  resolved_urls?: CommunityNodeResolvedUrls | null;
-  last_error?: string | null;
-  session_phase?: CommunityNodeSessionPhase;
-  retry_after?: number | null;
-  restart_required: boolean;
-};
-
 export type CommunityNodeConfigInput = {
   base_url: string;
   auto_approve: boolean;
@@ -211,71 +150,10 @@ export type CommunityNodeConfigInput = {
 
 // community node manifest (#355/#356) の client 側表現。public manifest endpoint から取得し、
 // dependency 表示 (#357) に使う。snake_case は Rust 由来の JSON 形状に合わせる。
-export type CommunityNodeCapabilityScope = {
-  available_enabled: string[];
-  planned_enabled: string[];
-};
-
-export type CommunityNodeAuthorityScope = {
-  applies_to: string[];
-  does_not_apply_to: string[];
-};
-
-export type CommunityNodeP2pBoundary = {
-  identity_authority: boolean;
-  profile_canonical_store: boolean;
-  social_graph_canonical_store: boolean;
-  content_truth_source: boolean;
-  network_wide_authority: boolean;
-};
-
-export type CommunityNodeManifest = {
-  node_id: string;
-  node_name: string;
-  node_role: string;
-  server_name: string;
-  manifest_version: string;
-  capability_scope: CommunityNodeCapabilityScope;
-  authority_scope: CommunityNodeAuthorityScope;
-  p2p_boundary: CommunityNodeP2pBoundary;
-  abuse_contact: string;
-  // node が公開する通報受付 endpoint (#310)。未公開なら空文字。
-  // client は空なら abuse_contact を mailto / copyable contact として案内する。
-  report_endpoint: string;
-  terms_url: string;
-  privacy_url: string;
-  moderation_policy_url: string;
-};
-
 // manifest fetch 状態。'ok' は取得成功、'absent' は node が未公開 (404)。
 // 'error' は fetch 失敗、'loading' は取得中（client 側で付与）。
-export type CommunityNodeManifestFetchStatus = 'ok' | 'absent';
-
-export type CommunityNodeManifestFetch = {
-  status: CommunityNodeManifestFetchStatus;
-  manifest?: CommunityNodeManifest | null;
-};
-
 // 分散通報ルーティング (#310) の送信リクエスト。通報先は client が provenance + manifest
 // から解決し、その report_endpoint を載せて渡す。snake_case は Rust 由来の JSON 形状。
-export type SubmitCommunityNodeReportRequest = {
-  node_base_url: string;
-  report_endpoint: string;
-  subject_kind: string;
-  subject_id: string;
-  capability: string;
-  reason: string;
-  details?: string | null;
-  reporter_contact?: string | null;
-};
-
-export type SubmitCommunityNodeReportStatus = 'submitted';
-
-export type SubmitCommunityNodeReportResult = {
-  status: SubmitCommunityNodeReportStatus;
-  reference_id?: string | null;
-};
-
 export interface DesktopApi {
   createPost(
     topic: string,

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -1,7 +1,5 @@
 mod direct_messages;
 mod game;
-#[cfg(feature = "ts")]
-mod ipc_ts_export;
 mod live;
 mod media;
 mod notifications;

--- a/crates/cn-protocol/Cargo.toml
+++ b/crates/cn-protocol/Cargo.toml
@@ -10,6 +10,11 @@ serde.workspace = true
 serde_json.workspace = true
 url.workspace = true
 kukuri-core = { path = "../core" }
+ts-rs = { workspace = true, optional = true }
+
+[features]
+# IPC 型の TypeScript 生成専用(codegen 時のみ有効)。
+ts = ["dep:ts-rs", "kukuri-core/ts"]
 
 [lints]
 workspace = true

--- a/crates/cn-protocol/src/manifest.rs
+++ b/crates/cn-protocol/src/manifest.rs
@@ -8,6 +8,8 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeManifest {
     #[serde(default)]
     pub node_id: String,
@@ -40,6 +42,8 @@ pub struct CommunityNodeManifest {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeCapabilityScope {
     #[serde(default)]
     pub available_enabled: Vec<String>,
@@ -48,6 +52,8 @@ pub struct CommunityNodeCapabilityScope {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeAuthorityScope {
     #[serde(default)]
     pub applies_to: Vec<String>,
@@ -56,6 +62,8 @@ pub struct CommunityNodeAuthorityScope {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeP2pBoundary {
     #[serde(default)]
     pub identity_authority: bool,

--- a/crates/cn-protocol/src/models.rs
+++ b/crates/cn-protocol/src/models.rs
@@ -6,14 +6,20 @@ use serde::{Deserialize, Serialize};
 use crate::normalize::{normalize_http_url, normalize_http_url_list};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeResolvedUrls {
     pub public_base_url: String,
     pub connectivity_urls: Vec<String>,
+    // 現行 types.ts と同じく任意(#[serde(default)])。
     #[serde(default)]
+    #[cfg_attr(feature = "ts", ts(as = "Option<Vec<CommunityNodeSeedPeer>>"))]
     pub seed_peers: Vec<CommunityNodeSeedPeer>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeSeedPeer {
     pub endpoint_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -97,11 +103,14 @@ pub struct BootstrapHeartbeatResponse {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeConsentItem {
     pub policy_slug: String,
     pub policy_version: i32,
     pub title: String,
     #[serde(default)]
+    #[cfg_attr(feature = "ts", ts(as = "Option<String>"))]
     pub body: String,
     pub required: bool,
     pub accepted_at: Option<i64>,
@@ -112,6 +121,8 @@ pub struct CommunityNodeConsentItem {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeConsentStatus {
     pub all_required_accepted: bool,
     pub items: Vec<CommunityNodeConsentItem>,

--- a/crates/desktop-runtime/Cargo.toml
+++ b/crates/desktop-runtime/Cargo.toml
@@ -25,6 +25,19 @@ kukuri-docs-sync = { path = "../docs-sync" }
 kukuri-iroh-node = { path = "../iroh-node" }
 kukuri-store = { path = "../store" }
 kukuri-transport = { path = "../transport" }
+ts-rs = { workspace = true, optional = true }
+
+[features]
+# IPC 型の TypeScript 生成専用(codegen 時のみ有効。生成器はこの crate に置く
+# — client 依存グラフの頂点で全 IPC 型に到達できるため)。
+ts = [
+  "dep:ts-rs",
+  "kukuri-app-api/ts",
+  "kukuri-core/ts",
+  "kukuri-store/ts",
+  "kukuri-transport/ts",
+  "kukuri-cn-protocol/ts",
+]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { workspace = true, features = ["sync-secret-service"] }

--- a/crates/desktop-runtime/src/community_node/manifest_support.rs
+++ b/crates/desktop-runtime/src/community_node/manifest_support.rs
@@ -9,6 +9,7 @@ pub use kukuri_cn_protocol::{
 
 /// manifest fetch の結果状態。error は command の Err として返すため含めない。
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(rename_all = "snake_case")]
 pub enum CommunityNodeManifestFetchStatus {
     /// manifest を取得・解析できた。
@@ -19,6 +20,8 @@ pub enum CommunityNodeManifestFetchStatus {
 
 /// manifest fetch の結果。
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeManifestFetch {
     pub status: CommunityNodeManifestFetchStatus,
     #[serde(default)]

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -73,15 +73,20 @@ pub(crate) const COMMUNITY_NODE_RECONNECT_BACKOFF_SECONDS: [i64; 3] = [30, 60, 1
 pub(crate) const COMMUNITY_NODE_SESSION_SCHEDULER_TICK_SECONDS: u64 = 15;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeNodeConfig {
     pub base_url: String,
     #[serde(default)]
+    #[cfg_attr(feature = "ts", ts(as = "Option<bool>"))]
     pub auto_approve: bool,
     #[serde(default)]
     pub resolved_urls: Option<CommunityNodeResolvedUrls>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeConfig {
     #[serde(default)]
     pub nodes: Vec<CommunityNodeNodeConfig>,
@@ -138,6 +143,8 @@ pub struct AcceptCommunityNodeConsentsRequest {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeAuthState {
     pub authenticated: bool,
     pub expires_at: Option<i64>,
@@ -168,6 +175,7 @@ pub(crate) struct CommunityNodeReconnectState {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(rename_all = "snake_case")]
 pub enum CommunityNodeSessionPhase {
     #[default]
@@ -181,15 +189,20 @@ pub enum CommunityNodeSessionPhase {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeNodeStatus {
     pub base_url: String,
+    // 現行 types.ts と同じく任意(#[serde(default)])。
     #[serde(default)]
+    #[cfg_attr(feature = "ts", ts(as = "Option<bool>"))]
     pub auto_approve: bool,
     pub auth_state: CommunityNodeAuthState,
     pub consent_state: Option<CommunityNodeConsentStatus>,
     pub resolved_urls: Option<CommunityNodeResolvedUrls>,
     pub last_error: Option<String>,
     #[serde(default)]
+    #[cfg_attr(feature = "ts", ts(as = "Option<CommunityNodeSessionPhase>"))]
     pub session_phase: CommunityNodeSessionPhase,
     pub retry_after: Option<i64>,
     pub restart_required: bool,

--- a/crates/desktop-runtime/src/community_node/report_routing_support.rs
+++ b/crates/desktop-runtime/src/community_node/report_routing_support.rs
@@ -8,6 +8,8 @@ use super::*;
 /// この request に載せて渡す。endpoint が無い node は client 側で `abuse_contact`
 /// 案内に切り替えるため、この command には到達しない。
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 #[serde(rename_all = "snake_case")]
 pub struct SubmitCommunityNodeReportRequest {
     /// 通報先 node の base url（記録・表示用）。
@@ -32,6 +34,7 @@ pub struct SubmitCommunityNodeReportRequest {
 
 /// 通報送信結果の状態。
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[serde(rename_all = "snake_case")]
 pub enum SubmitCommunityNodeReportStatus {
     /// node が通報を受理した（2xx）。
@@ -40,6 +43,8 @@ pub enum SubmitCommunityNodeReportStatus {
 
 /// 通報送信結果。
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SubmitCommunityNodeReportResult {
     pub status: SubmitCommunityNodeReportStatus,
     /// node が返した受付参照 ID（任意）。

--- a/crates/desktop-runtime/src/discovery.rs
+++ b/crates/desktop-runtime/src/discovery.rs
@@ -11,6 +11,8 @@ pub(crate) const DISCOVERY_MODE_ENV: &str = "KUKURI_DISCOVERY_MODE";
 pub(crate) const DISCOVERY_SEEDS_ENV: &str = "KUKURI_DISCOVERY_SEEDS";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct DiscoveryConfig {
     pub mode: DiscoveryMode,
     pub connect_mode: ConnectMode,

--- a/crates/desktop-runtime/src/ipc_ts_export.rs
+++ b/crates/desktop-runtime/src/ipc_ts_export.rs
@@ -1,14 +1,16 @@
 //! IPC 型の TypeScript 生成(WP-H7 PR3。`ts` feature 時のみ)。
 //!
-//! `cargo test -p kukuri-app-api --features ts export_ipc_types` で
-//! `apps/desktop/src/lib/api/types.generated.ts` を再生成する。
-//! xtask `ipc-types` が `TS_RS_LARGE_INT=number` を設定してこれを実行し、
-//! 続けて prettier を掛ける。CI は再生成後に `git diff --exit-code` で
-//! Rust と TS の乖離(手動同期漏れ)を検出する。
+//! 生成器は client 依存グラフの頂点である desktop-runtime に置く。ここからは
+//! app-api(views)/ core / store / transport / cn-protocol / 自 crate の
+//! community-node 型まで全 IPC 型に到達できる。
 //!
-//! Stage 1 の生成対象は app-api の view サブグラフ(metaverse/game/live は
-//! 後続ステージ)。front 専用型・入力型・DesktopApi interface は
-//! 手書きの types.ts 側に残す。
+//! `cargo test -p kukuri-desktop-runtime --features ts export_ipc_types` で
+//! `apps/desktop/src/lib/api/types.generated.ts` を再生成する。xtask `ipc-types`
+//! が `TS_RS_LARGE_INT=number` を設定して実行し、CI は再生成後の
+//! `git diff --exit-code` で Rust と TS の乖離を検出する。
+//!
+//! front 専用型(入力 DTO / エラー型 / DesktopApi interface)は手書きの
+//! types.ts 側に残す。
 #![cfg(feature = "ts")]
 
 use ts_rs::TS;
@@ -24,7 +26,19 @@ fn emit<T: TS>(cfg: &ts_rs::Config, out: &mut String) {
 
 #[test]
 fn export_ipc_types() {
-    use crate::views::*;
+    use crate::{
+        CommunityNodeAuthState, CommunityNodeAuthorityScope, CommunityNodeCapabilityScope,
+        CommunityNodeConfig, CommunityNodeManifest, CommunityNodeManifestFetch,
+        CommunityNodeManifestFetchStatus, CommunityNodeNodeConfig, CommunityNodeNodeStatus,
+        CommunityNodeP2pBoundary, CommunityNodeSessionPhase, DiscoveryConfig,
+        SubmitCommunityNodeReportRequest, SubmitCommunityNodeReportResult,
+        SubmitCommunityNodeReportStatus,
+    };
+    use kukuri_app_api::*;
+    use kukuri_cn_protocol::{
+        CommunityNodeConsentItem, CommunityNodeConsentStatus, CommunityNodeResolvedUrls,
+        CommunityNodeSeedPeer,
+    };
     use kukuri_core::{
         ChannelAudienceKind, ChannelId, ChannelRef, ChannelSharingState, FriendOnlyGrantPreview,
         FriendPlusSharePreview, GameRoomKind, GameRoomStatus, LiveSessionStatus,
@@ -33,7 +47,7 @@ fn export_ipc_types() {
         MetaverseRoomPresenceV1, MetaverseRoomSceneV1, MetaverseRoomSpawnV1, MetaverseRoomStateV1,
         PrivateChannelInvitePreview, Profile, Pubkey, SharedRoomObjectV1, TimelineScope, TopicId,
     };
-    use kukuri_store::{NotificationKind, TimelineCursor};
+    use kukuri_store::TimelineCursor;
     use kukuri_transport::{ConnectMode, ConnectionPath, DiscoveryMode, SeedPeer};
 
     let cfg = ts_rs::Config::from_env();
@@ -85,7 +99,7 @@ fn export_ipc_types() {
         TopicSyncStatus,
         DiscoveryStatus,
         SyncStatus,
-        // Stage 2: metaverse / game / live
+        // metaverse / game / live
         LiveSessionStatus,
         LiveSessionView,
         GameRoomStatus,
@@ -105,7 +119,7 @@ fn export_ipc_types() {
         MetaverseRoomStateV1,
         GameRoomView,
         MetaverseRoomEventView,
-        // Stage 3a: core / transport の残り型 + newtype(string)
+        // core / transport の残り + newtype(string)
         Pubkey,
         TopicId,
         ChannelId,
@@ -116,6 +130,26 @@ fn export_ipc_types() {
         PrivateChannelInvitePreview,
         FriendOnlyGrantPreview,
         FriendPlusSharePreview,
+        // community-node(desktop-runtime / cn-protocol)
+        DiscoveryConfig,
+        CommunityNodeSeedPeer,
+        CommunityNodeResolvedUrls,
+        CommunityNodeNodeConfig,
+        CommunityNodeConfig,
+        CommunityNodeAuthState,
+        CommunityNodeConsentItem,
+        CommunityNodeConsentStatus,
+        CommunityNodeSessionPhase,
+        CommunityNodeNodeStatus,
+        CommunityNodeCapabilityScope,
+        CommunityNodeAuthorityScope,
+        CommunityNodeP2pBoundary,
+        CommunityNodeManifest,
+        CommunityNodeManifestFetchStatus,
+        CommunityNodeManifestFetch,
+        SubmitCommunityNodeReportRequest,
+        SubmitCommunityNodeReportStatus,
+        SubmitCommunityNodeReportResult,
     );
 
     let path = concat!(

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -2,6 +2,8 @@ mod attachments;
 mod community_node;
 mod discovery;
 mod identity;
+#[cfg(feature = "ts")]
+mod ipc_ts_export;
 mod paths;
 mod requests;
 mod runtime;

--- a/xtask/src/ipc.rs
+++ b/xtask/src/ipc.rs
@@ -19,7 +19,7 @@ pub(crate) fn ipc_types(check: bool) -> Result<()> {
         [
             "test",
             "-p",
-            "kukuri-app-api",
+            "kukuri-desktop-runtime",
             "--features",
             "ts",
             "export_ipc_types",


### PR DESCRIPTION
## 概要

WP-H7 PR3 の最終段(Stage 3b)。**全型表面の生成物化を完了**する。生成器を app-api から **client 依存グラフの頂点である desktop-runtime へ移設**し、app-api(views)/ core / store / transport / cn-protocol / 自 crate の community-node 型まで全 IPC 型に到達できるようにした。

- **生成器移設**: `crates/app-api/src/ipc_ts_export.rs` → `crates/desktop-runtime/src/ipc_ts_export.rs`。view 型は `kukuri_app_api::*` 経由で参照。app-api の `ts` feature(derive 用)は存置
- **desktop-runtime / cn-protocol に `ts` feature** を追加。community-node 18 型(`DiscoveryConfig` / `CommunityNode*` / `SubmitCommunityNodeReport*` / manifest 系 / ConsentItem・Status / ResolvedUrls・SeedPeer)に `derive(TS)`。`xtask ipc-types` の対象 crate を desktop-runtime へ変更
- `types.ts` の該当手書き 18 型を除去して `types.generated.ts` からの再輸出へ

**これで計 89 型が Rust から生成**され、残る手書きは front 専用の入力 DTO・エラー型・`DesktopApi` interface のみ。

## 種別

refactor(挙動不変)。serde 表現は不変。

## 現行 TS との整合

- `#[serde(default)]` の非 Option フィールド(`auto_approve` / `session_phase` / `body`)と `Vec` は `ts(as = "Option<..>")` で現行 types.ts の optional に一致させ、characterization テスト(selectors.test.ts)を**無変更で維持**
- `CommunityNodeSeedPeer` は構造的に `SeedPeer` と同一(endpoint_id + addr_hint?)

## 検証

- `pnpm typecheck` / `pnpm lint` green(**消費側の型修正はゼロ**)
- `pnpm test` 545 / `cargo test`(core 52 + app-api 162 + desktop-runtime 含む cn 92）green。S4 fixture golden 継続
- `cargo fmt --check` / `cargo clippy`(cn-protocol / desktop-runtime）green
- `cargo xtask ipc-types --check` 冪等(生成器移設後も再生成 diff ゼロ）
- `cargo xtask desktop-ui-check` green(Storybook / ブラウザ E2E 10 / visual 14）

## リスク

- 生成器移設は codegen 経路のみ(cfg-gated feature)。production ビルド・依存ツリーは無影響。乖離は CI 再生成 diff + S4 fixture で二重検出

## WP-H7 完了

- PR1 [#504](https://github.com/KingYoSun/kukuri/pull/504)= mock 分岐集約 / PR2 [#505](https://github.com/KingYoSun/kukuri/pull/505)= desktopApiMock 分割 / PR3 Stage1〜3b(#506/#507/#508/本PR)= 全型表面の ts-rs 生成物化
- **手動ミラー(views.rs ↔ types.ts)の保守作業が解消**。今後は Rust を変更して `xtask ipc-types` で再生成、CI が乖離を検出する

🤖 Generated with [Claude Code](https://claude.com/claude-code)