### PR TITLE
[refactor] 未使用 CSS セレクタ 34 クラスを削除 (WP-H8 PR1)

### DIFF
--- a/apps/desktop/src/styles/shell-phase1-legacy.css
+++ b/apps/desktop/src/styles/shell-phase1-legacy.css
@@ -233,33 +233,6 @@
   border-radius: var(--radius-input);
 }
 
-.shell-phase1 .status-grid {
-  display: grid;
-  gap: var(--space-sm);
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin: 0 0 var(--space-md);
-}
-
-.shell-phase1 .status-grid-compact {
-  margin-bottom: var(--space-sm);
-}
-
-.shell-phase1 .status-grid div {
-  padding: var(--space-sm);
-  border-radius: var(--radius);
-  background: var(--surface-panel-muted);
-}
-
-.shell-phase1 .status-grid dt {
-  font-size: var(--text-caption);
-  color: var(--muted-foreground);
-}
-
-.shell-phase1 .status-grid dd {
-  margin: var(--space-2xs) 0 0;
-  font-size: var(--text-h2);
-}
-
 .shell-phase1 .topic-list {
   margin-top: var(--space-lg);
 }
@@ -319,25 +292,6 @@
   color: var(--destructive);
 }
 
-.shell-phase1 .diagnostic-block {
-  margin: var(--space-sm) 0;
-  color: var(--muted-foreground);
-}
-
-.shell-phase1 .diagnostic-block p {
-  margin: var(--space-2xs) 0 0;
-  word-break: break-all;
-  color: var(--muted-foreground-soft);
-}
-
-.shell-phase1 .discovery-panel {
-  margin: var(--space-md) 0;
-}
-
-.shell-phase1 .discovery-editor {
-  min-height: 120px;
-}
-
 .shell-phase1 .discovery-actions {
   display: flex;
   flex-wrap: wrap;
@@ -353,7 +307,7 @@
   color: var(--destructive) !important;
 }
 
-.shell-phase1 .post-list, .shell-phase1 .thread-list {
+.shell-phase1 .post-list {
   display: grid;
   gap: var(--space-sm);
   padding: 0;
@@ -497,7 +451,7 @@
   z-index: 1;
 }
 
-.shell-phase1 .media-status-badge, .shell-phase1 .media-type-badge, .shell-phase1 .media-count-badge {
+.shell-phase1 .media-type-badge, .shell-phase1 .media-count-badge {
   display: inline-flex;
   align-items: center;
   border-radius: var(--radius-pill);
@@ -506,11 +460,6 @@
   letter-spacing: 0.04em;
   text-transform: uppercase;
   border: 1px solid var(--border-subtle);
-}
-
-.shell-phase1 .media-status-badge {
-  color: var(--foreground-strong);
-  background: var(--surface-contrast);
 }
 
 .shell-phase1 .media-type-badge {
@@ -524,7 +473,7 @@
   background: var(--surface-warning-soft);
 }
 
-.shell-phase1 .media-skeleton, .shell-phase1 .media-ready-placeholder {
+.shell-phase1 .media-skeleton {
   display: grid;
   place-items: center;
   width: 100%;
@@ -534,13 +483,6 @@
 .shell-phase1 .media-skeleton {
   background: var(--surface-skeleton);
   animation: skeleton-pulse 1.8s ease-in-out infinite;
-}
-
-.shell-phase1 .media-ready-placeholder {
-  color: var(--muted-foreground);
-  font-size: var(--text-body);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
 }
 
 .shell-phase1 .media-preview {
@@ -748,22 +690,6 @@
   opacity: 0.55;
 }
 
-.shell-phase1 .post-reaction-tray {
-  display: grid;
-  gap: var(--space-sm);
-  margin-top: var(--space-sm);
-  padding: var(--space-sm);
-  border-radius: var(--radius);
-  background: var(--surface-panel-muted);
-}
-
-.shell-phase1 .post-reaction-picker-row {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: var(--space-xs);
-}
-
 .shell-phase1 .reactions-panel {
   display: grid;
   gap: var(--space-md);
@@ -774,23 +700,9 @@
   gap: var(--space-md);
 }
 
-.shell-phase1 .reactions-editor-source,
 .shell-phase1 .reactions-preview-card {
   display: grid;
   gap: var(--space-xs);
-}
-
-.shell-phase1 .reactions-editor-image {
-  width: min(100%, 16rem);
-  border-radius: var(--radius);
-  object-fit: contain;
-  background: var(--surface-panel-muted);
-}
-
-.shell-phase1 .reactions-crop-fields {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-sm);
 }
 
 .shell-phase1 .reactions-preview-thumb,
@@ -818,8 +730,7 @@
   gap: var(--space-sm);
 }
 
-.shell-phase1 .reactions-asset-card,
-.shell-phase1 .reactions-saved-card {
+.shell-phase1 .reactions-asset-card {
   display: grid;
   gap: var(--space-xs);
 }
@@ -881,11 +792,6 @@
   height: 1rem;
 }
 
-.shell-phase1 .active-topic-label {
-  color: var(--muted-foreground);
-  font-size: var(--text-caption);
-}
-
 .shell-phase1 .post-meta {
   display: flex;
   justify-content: space-between;
@@ -923,13 +829,6 @@
   color: var(--accent-foreground);
   background: var(--surface-accent-soft);
   line-height: 1.1;
-}
-
-.shell-phase1 .post-reply-flag {
-  display: inline-block;
-  margin-top: var(--space-xs);
-  font-style: normal;
-  color: var(--accent);
 }
 
 .shell-phase1 .author-link {
@@ -1092,16 +991,11 @@
   block-size: 1.15rem;
 }
 
-.shell-phase1 .post-card small, .shell-phase1 .thread-item small {
+.shell-phase1 .post-card small {
   display: block;
   margin-top: var(--space-xs);
   word-break: break-all;
   color: var(--muted-foreground-soft);
-}
-
-.shell-phase1 .thread-item {
-  border-left: 3px solid var(--border-accent);
-  padding-left: var(--space-sm);
 }
 
 .shell-phase1 .empty, .shell-phase1 .error {

--- a/apps/desktop/src/styles/shell-phase1.css
+++ b/apps/desktop/src/styles/shell-phase1.css
@@ -753,7 +753,6 @@
 }
 
 .post-list,
-.thread-list,
 .thread-tree {
   display: grid;
   gap: var(--space-sm);
@@ -988,8 +987,7 @@
   background: var(--surface-warning-soft);
 }
 
-.media-skeleton,
-.media-ready-placeholder {
+.media-skeleton {
   display: grid;
   place-items: center;
   width: 100%;
@@ -999,13 +997,6 @@
 .media-skeleton {
   background: var(--surface-skeleton);
   animation: skeleton-pulse 1.8s ease-in-out infinite;
-}
-
-.media-ready-placeholder {
-  color: var(--muted-foreground);
-  font-size: var(--text-body);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
 }
 
 .media-preview,
@@ -1303,23 +1294,9 @@
   gap: var(--space-md);
 }
 
-.reactions-editor-source,
 .reactions-preview-card {
   display: grid;
   gap: var(--space-xs);
-}
-
-.reactions-editor-image {
-  width: min(100%, 16rem);
-  border-radius: var(--radius);
-  object-fit: contain;
-  background: var(--surface-panel-muted);
-}
-
-.reactions-crop-fields {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-sm);
 }
 
 .reactions-preview-thumb,
@@ -1347,8 +1324,7 @@
   gap: var(--space-sm);
 }
 
-.reactions-asset-card,
-.reactions-saved-card {
+.reactions-asset-card {
   display: grid;
   gap: var(--space-xs);
 }
@@ -1530,11 +1506,6 @@
   color: var(--muted-foreground);
 }
 
-.post-reply-context-eyebrow {
-  color: var(--muted-foreground-soft);
-  font-size: var(--text-caption);
-}
-
 .post-reply-context-body {
   color: var(--muted-foreground);
   min-width: 0;
@@ -1587,19 +1558,13 @@
   color: var(--foreground);
 }
 
-.post-card small,
-.thread-item small {
+.post-card small {
   display: block;
   margin-top: var(--space-xs);
   white-space: normal;
   overflow-wrap: anywhere;
   word-break: break-word;
   color: var(--muted-foreground-soft);
-}
-
-.thread-item {
-  border-left: 3px solid var(--border-accent);
-  padding-left: var(--space-sm);
 }
 
 .shell-phase1 {
@@ -1643,18 +1608,11 @@
   min-width: 0;
 }
 
-.shell-topbar-copy,
 .shell-main,
 .shell-pane-heading,
 .shell-pane-copy,
 .shell-topbar-topic {
   min-width: 0;
-}
-
-.shell-topbar-heading {
-  margin: 0;
-  font-size: var(--text-display);
-  line-height: 0.94;
 }
 
 .shell-topbar-topic {
@@ -1669,17 +1627,11 @@
   white-space: nowrap;
 }
 
-.shell-topbar-meta,
-.shell-topbar-actions,
 .shell-status-badges {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-xs);
   align-items: center;
-}
-
-.shell-topbar-actions {
-  justify-content: flex-end;
 }
 
 .shell-nav-meta {
@@ -1786,21 +1738,6 @@
   margin-top: 0;
 }
 
-.extended-channel-grid {
-  display: grid;
-  gap: var(--space-md);
-  grid-template-columns: minmax(0, 1fr);
-}
-
-.extended-channel-card {
-  width: 100%;
-}
-
-.extended-channel-card-active {
-  border-color: var(--border-accent);
-  background: var(--surface-active);
-}
-
 .extended-channel-detail {
   min-width: 0;
 }
@@ -1879,7 +1816,6 @@
   gap: var(--space-xs);
 }
 
-.shell-primary-nav-item,
 .shell-settings-nav-item,
 .shell-tab {
   width: 100%;
@@ -1901,7 +1837,6 @@
   font-weight: 700;
 }
 
-.shell-primary-nav-item-active,
 .shell-settings-nav-item-active,
 .shell-tab-active {
   border-color: var(--border-accent);
@@ -1911,14 +1846,6 @@
 .shell-primary-nav-label {
   display: block;
   font-weight: 700;
-}
-
-.shell-primary-nav-copy {
-  display: block;
-  margin-top: var(--space-2xs);
-  color: var(--muted-foreground);
-  font-size: var(--text-body);
-  line-height: 1.45;
 }
 
 .shell-nav-topic-entry {
@@ -1982,16 +1909,6 @@
   color: var(--foreground-strong);
 }
 
-.shell-nav-accordion-summary {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  justify-self: end;
-  font-size: var(--text-body);
-  color: var(--muted-foreground);
-}
-
 .shell-nav-accordion-icon {
   color: var(--muted-foreground);
   transition: transform 160ms ease;
@@ -1999,11 +1916,6 @@
 
 .shell-nav-accordion[data-open='true'] .shell-nav-accordion-icon {
   transform: rotate(180deg);
-}
-
-.shell-nav-accordion-content {
-  display: grid;
-  gap: var(--space-sm);
 }
 
 .shell-nav-topic-list {
@@ -2237,16 +2149,6 @@
   grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
-.shell-workspace-controls {
-  display: grid;
-  gap: var(--space-sm);
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.shell-context-trigger {
-  display: none;
-}
-
 .shell-section {
   min-width: 0;
   display: grid;
@@ -2367,12 +2269,6 @@
 
 .shell-context {
   gap: var(--space-md);
-}
-
-.shell-tab-list {
-  display: grid;
-  gap: var(--space-xs);
-  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .shell-context-panel {
@@ -2884,11 +2780,6 @@
   overflow: hidden;
 }
 
-.shell-settings-current {
-  padding-bottom: var(--space-xs);
-  border-bottom: 1px solid var(--border-subtle);
-}
-
 .shell-settings-content {
   min-width: 0;
   min-height: 0;
@@ -2931,13 +2822,6 @@
   display: inline-flex;
 }
 
-@media (min-width: 900px) {
-  .extended-channel-grid {
-    grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
-    align-items: start;
-  }
-}
-
 @media (max-width: 1099px) {
   .shell-layout {
     grid-template-columns: minmax(260px, 280px) minmax(0, 1fr);
@@ -2968,10 +2852,6 @@
     visibility: visible;
     pointer-events: auto;
   }
-
-  .shell-context-trigger {
-    display: inline-flex;
-  }
 }
 
 @media (min-width: 1100px) {
@@ -2981,8 +2861,7 @@
 }
 
 @media (max-width: 899px) {
-  .shell-workspace-tabs,
-  .shell-workspace-controls {
+  .shell-workspace-tabs {
     grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -1,16 +1,12 @@
 {
   "files": [
     {
-      "lines": 3085,
+      "lines": 2964,
       "path": "apps/desktop/src/styles/shell-phase1.css"
     },
     {
       "lines": 1155,
       "path": "apps/desktop/src/components/extended/MetaverseRoomPanel.tsx"
-    },
-    {
-      "lines": 1141,
-      "path": "apps/desktop/src/styles/shell-phase1-legacy.css"
     },
     {
       "lines": 1140,
@@ -35,6 +31,10 @@
     {
       "lines": 1035,
       "path": "apps/desktop/src/shell/useDesktopShellData.ts"
+    },
+    {
+      "lines": 1035,
+      "path": "apps/desktop/src/styles/shell-phase1-legacy.css"
     }
   ]
 }


### PR DESCRIPTION
## 概要

WP-H8(CSS 負債解消)の PR1。shell の CSS から未使用セレクタ 34 クラスを削除する。

- `shell-phase1.css` / `shell-phase1-legacy.css` から、**全ソース(tsx/ts/html/tests)で不検出**かつ動的クラス生成経路(`base-${var}` 形)も否定した 34 クラスを参照する規則を **postcss AST** で削除
- グループセレクタは該当複合セレクタのみ抜き、使用中クラス(`media-type-badge` / `media-count-badge` / `post-list` / `post-card small` 等)は残置
- descendant セレクタ(`.shell-phase1 .discovery-panel` 等)も、scope の `.shell-phase1` が使用中でも右側の未使用クラスで規則全体が dead(どの要素にもマッチしない)のため削除

phase1 19 規則 + legacy 18 規則を除去。3,085 → 2,964 行 / 1,141 → 1,035 行。oversized baseline を ratchet down。

## 種別

refactor:delete(挙動不変 = 実効スタイル不変)。削除した規則はいずれも「参照クラスが全要素で不在 → マッチ 0」で、実際のレンダリングに影響しない。

## 検証

- 未使用クラス再実測 = 0(削除後)。使用中クラスの残存を個別確認(グループから抜いた `media-type-badge`/`post-list`/`post-card small` 等)
- `css-vars.test.ts` green(var() 参照の未定義なし)
- `cargo xtask desktop-ui-check` green(**視覚回帰 14 面**・Storybook・ブラウザ E2E 含む)
- `cargo xtask oversized-files` — 両ファイル縮小、baseline 更新

## リスク

- 低。削除対象は「どの要素にもマッチしない dead 規則」のみ。視覚回帰で実効スタイル不変を担保

## 後続

- PR2: shell-phase1-legacy.css を実態(shell スコープ上書き層)に合う名前へ改名
- PR3: phase1↔legacy の重複宣言統合 / PR4: コンポーネント単位分割 + 層ルール文書化

🤖 Generated with [Claude Code](https://claude.com/claude-code)