### PR TITLE
[refactor] shell-phase1-legacy.css を shell-scoped-overrides.css へ改名 (WP-H8 PR2)

### DIFF
--- a/apps/desktop/src/styles/css-vars.test.ts
+++ b/apps/desktop/src/styles/css-vars.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 // Shell stylesheets that ship together (see index.css). Any `var(--token)` they
 // reference must resolve to a custom property defined in the same bundle,
 // otherwise the value silently falls back to nothing at runtime.
-const CSS_FILES = ['tokens.css', 'base.css', 'shell-phase1.css', 'shell-phase1-legacy.css'] as const;
+const CSS_FILES = ['tokens.css', 'base.css', 'shell-phase1.css', 'shell-scoped-overrides.css'] as const;
 
 // Custom properties intentionally injected at runtime (inline style / JS) rather
 // than declared in the static stylesheets. Tailwind owns the `--tw-*` space.

--- a/apps/desktop/src/styles/index.css
+++ b/apps/desktop/src/styles/index.css
@@ -2,4 +2,4 @@
 @import "./tokens.css";
 @import "./base.css";
 @import "./shell-phase1.css";
-@import "./shell-phase1-legacy.css";
+@import "./shell-scoped-overrides.css";

--- a/apps/desktop/src/styles/shell-scoped-overrides.css
+++ b/apps/desktop/src/styles/shell-scoped-overrides.css
@@ -1,3 +1,12 @@
+/*
+ * shell-scoped-overrides.css
+ *
+ * 全規則が `.shell-phase1` スコープ付き(ShellFrame のルート div に付与)。
+ * アプリ shell 配下では shell-phase1.css の同名セレクタを specificity で上書きし、
+ * body 直下の Radix portal(dialog / tooltip / dropdown 等)には効かない層。
+ * shell 固有スタイルもここに置く。index.css で shell-phase1.css の後に @import する。
+ * (旧名 shell-phase1-legacy.css。WP-H8 PR2 で実態に合わせて改名)
+ */
 .shell-phase1 .shell {
   max-width: 1200px;
   margin: 0 auto;

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -29,12 +29,12 @@
       "path": "crates/app-api/src/private_channels.rs"
     },
     {
-      "lines": 1035,
-      "path": "apps/desktop/src/shell/useDesktopShellData.ts"
+      "lines": 1044,
+      "path": "apps/desktop/src/styles/shell-scoped-overrides.css"
     },
     {
       "lines": 1035,
-      "path": "apps/desktop/src/styles/shell-phase1-legacy.css"
+      "path": "apps/desktop/src/shell/useDesktopShellData.ts"
     }
   ]
 }


### PR DESCRIPTION
## 概要

WP-H8 の PR2。実態が不明瞭な `shell-phase1-legacy.css` を、役割を表す `shell-scoped-overrides.css` へ改名する。

- このファイルの全 175 規則は `.shell-phase1` スコープ付き(ShellFrame のルート div に付与)。**アプリ shell 配下では shell-phase1.css の同名セレクタを specificity で上書きし、body 直下の Radix portal には効かない**「shell スコープ上書き層 + shell 固有スタイル」という実態を名前に反映
- ファイル先頭に役割コメントを付与
- `index.css` の @import と `css-vars.test.ts` の `CSS_FILES` を追随
- **oversized baseline のエントリ**を旧パス → 新パス(`shell-scoped-overrides.css` 1044 行)へ更新。改名でパスが変わり baseline の旧キーと一致しなくなるため(ファイルは PR1 で既に baseline 登録済みの既存ファイルで、行数増はコメント 9 行のみ)

## 種別

refactor:rename(挙動不変)。git は rename(97% 類似)として検出。中身の実スタイル変更はコメント追加のみ。

## 検証

- 旧名の残存参照 = 0(コメントの改名記録を除く)
- `css-vars.test.ts` green(ファイル名リスト追随)
- `cargo xtask oversized-files` green(baseline のパス更新後)
- `cargo xtask desktop-ui-check` green(視覚回帰 14 面・Storybook・ブラウザ E2E 含む)

## リスク

- 低。改名 + import/テスト/baseline 追随のみ

## 後続

- PR3: shell-phase1.css ↔ shell-scoped-overrides.css の重複宣言統合(宣言同一の機械削除 + 相違 20 件の portal 到達性判定)
- PR4: コンポーネント単位分割 + 層ルール文書化

🤖 Generated with [Claude Code](https://claude.com/claude-code)