### PR TITLE
[refactor] .gitmodules 削除と .gitignore 旧レイアウト残骸の掃除 (WP-Q1 PR1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
 # Tauri
-kukuri-tauri/src-tauri/target/
-kukuri-tauri/src-tauri/WixTools/
-kukuri-tauri/src-tauri/gen/
 apps/desktop/src-tauri/gen/
-
-kukuri-cli/target/
 
 # Node
 node_modules/
@@ -58,16 +53,12 @@ apps/desktop/storybook-static/
 **/*.rs.bk
 Cargo.lock
 !Cargo.lock
-!kukuri-tauri/src-tauri/Cargo.lock
-!kukuri-cli/Cargo.lock
-!kukuri-community-node/Cargo.lock
 
 # SQLite
 *.db
 *.db-journal
 *.db-wal
 *.db-shm
-!kukuri-tauri/testdata/e2e_seed.db
 
 # Test coverage
 coverage/
@@ -77,8 +68,6 @@ coverage/
 
 # Test results
 test-results/
-kukuri-tauri/tests/e2e/output/
-!kukuri-tauri/tests/e2e/output/.gitkeep
 
 # Temporary files
 *.tmp
@@ -123,7 +112,6 @@ docs/apis/
 build.err
 
 # Optional local bootstrap config (override via UI)
-kukuri-tauri/src-tauri/bootstrap_nodes.json
 
 # kamui
 .kamui/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "docs/nips"]
-	path = docs/nips
-	url = https://github.com/nostr-protocol/nips.git
-[submodule "pkarr"]
-	path = pkarr
-	url = https://github.com/Pubky/pkarr


### PR DESCRIPTION
## 概要

WP-Q1(dead code 削除バッチ)PR1。リポジトリ衛生のみの変更で、公開 API・挙動・ビルド成果物に一切影響しない。

## 変更

### `.gitmodules` 削除
- `docs/nips`・`pkarr` の submodule 宣言があるが、**gitlink 無し・ディレクトリ不在・`git submodule status` 空**の実体のない dead 宣言。
- ソース内に `docs/nips` / `pkarr` へのパス参照も無いことを `git grep` で確認済み。

### `.gitignore` 旧レイアウト残骸の掃除(11 行削除)
現在のツリーに存在しない旧ディレクトリ(`kukuri-tauri/` / `kukuri-cli/` / `kukuri-community-node/`)を指す行を削除:

\`\`\`
kukuri-tauri/src-tauri/target/
kukuri-tauri/src-tauri/WixTools/
kukuri-tauri/src-tauri/gen/
kukuri-cli/target/
!kukuri-tauri/src-tauri/Cargo.lock
!kukuri-cli/Cargo.lock
!kukuri-community-node/Cargo.lock
!kukuri-tauri/testdata/e2e_seed.db
kukuri-tauri/tests/e2e/output/
!kukuri-tauri/tests/e2e/output/.gitkeep
kukuri-tauri/src-tauri/bootstrap_nodes.json
\`\`\`

## 無害性の検証

- 削除対象パスは全て不在(`kukuri-tauri` / `kukuri-cli` / `kukuri-community-node`)。
- 掃除前後で `git status --ignored -uall` の ignore 対象ファイル集合は **385,808 件で完全一致**(実ファイルの ignore 状態は不変)。
- root `Cargo.lock` の negation(`!Cargo.lock`)は維持し、追跡対象のまま(`git ls-files --error-unmatch Cargo.lock` OK)。
- 現行の `apps/desktop/src-tauri/gen/` 除外は保持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)