### PR TITLE
[refactor] Cargo 未使用依存 3 件の宣言削除 (WP-Q1 PR2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,7 +3006,6 @@ dependencies = [
  "kukuri-cn-trust",
  "kukuri-core",
  "kukuri-docs-sync",
- "kukuri-transport",
  "reqwest 0.13.4",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ futures-util = "0.3.32"
 hex = "0.4.3"
 hkdf = "0.12.4"
 hmac = "0.12.1"
-httpdate = "1.0.3"
 image = { version = "0.25.10", default-features = false, features = ["png", "gif", "jpeg", "webp"] }
 iroh = "1.0.0"
 iroh-docs = "0.101.0"
@@ -69,7 +68,6 @@ sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "postg
 thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "sync", "time", "fs"] }
 tokio-stream = { version = "0.1.18", features = ["sync"] }
-tokio-tungstenite = "0.29.0"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tempfile = "3.27.0"

--- a/crates/cn-indexer/Cargo.toml
+++ b/crates/cn-indexer/Cargo.toml
@@ -27,7 +27,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 kukuri-core = { path = "../core" }
 kukuri-docs-sync = { path = "../docs-sync" }
-kukuri-transport = { path = "../transport" }
 # safety-mock-provider: 本番 provider 未使用構成でも runtime 構築（provider 実装名 `mock`）と
 # contract test を成立させるため有効化する。mock provider は operator が env で明示指定しない
 # 限り構成されず、未知の provider 名は fail-closed で Err になる。


### PR DESCRIPTION
## 概要

WP-Q1(dead code 削除バッチ)PR2。参照経路調査で production 参照 0 と確認した Cargo 依存宣言 3 件を削除する。解決グラフ・挙動は不変(宣言衛生のみ)。

## 変更

### 1. cn-indexer → kukuri-transport の直接依存を削除
- `crates/cn-indexer/Cargo.toml` の `kukuri-transport = { path = "../transport" }` を削除。
- `cn-indexer/src/**` に `kukuri_transport` の参照は無い(grep 0)。
- `kukuri-transport` は `docs-sync → cn-indexer` の推移依存として引き続き解決される:
  \`\`\`
  $ cargo tree -p kukuri-cn-indexer -i kukuri-transport
  kukuri-transport
  ├── kukuri-docs-sync
  │   └── kukuri-cn-indexer
  └── kukuri-iroh-node
      └── kukuri-docs-sync (*)
  \`\`\`

### 2. workspace.dependencies の httpdate / tokio-tungstenite を削除
- root `Cargo.toml` の `[workspace.dependencies]` から `httpdate` / `tokio-tungstenite` の version pin を削除。
- どの member crate も `.workspace = true` で消費しておらず(全 `Cargo.toml` grep 0)、`src/**` 実参照も 0 の dead な pin だった。
- 両 crate は `axum`/`hyper`/`iroh` の推移依存として `Cargo.lock` に残るため、宣言削除で解決グラフは変化しない。

## 無害性の検証

- `cargo build --workspace --all-targets` → 緑(exit 0)
- `cargo clippy --workspace --all-targets` → 緑(exit 0)
- `Cargo.lock` の実 diff は cn-indexer の `"kukuri-transport"` **1 行削除のみ**(httpdate/tokio-tungstenite の推移コピーは無傷)

🤖 Generated with [Claude Code](https://claude.com/claude-code)