### PR TITLE
[refactor] TS OS 通知 dead 5 関数と buildGameLink を削除 (WP-Q1 PR4)

### DIFF
--- a/apps/desktop/src/lib/internalLinks.ts
+++ b/apps/desktop/src/lib/internalLinks.ts
@@ -139,20 +139,6 @@ export function buildLiveLink(
   return buildRoute('/live', params);
 }
 
-export function buildGameLink(
-  topic: string,
-  roomId: string,
-  channelId: string | null = null
-): string {
-  const params = new URLSearchParams();
-  params.set('topic', topic);
-  if (channelId) {
-    params.set('channel', channelId);
-  }
-  params.set('roomId', roomId);
-  return buildRoute('/game', params);
-}
-
 export function buildChannelAccessPreviewDeepLink(token: string): string {
   const params = new URLSearchParams();
   params.set('token', token);

--- a/apps/desktop/src/lib/releaseReadiness.test.ts
+++ b/apps/desktop/src/lib/releaseReadiness.test.ts
@@ -1,41 +1,13 @@
 import { beforeEach, describe, expect, test } from 'vitest';
 
-import type { NotificationView } from '@/lib/api';
 import {
   buildSafeDiagnosticReport,
   classifyUpdateError,
   DEFAULT_OS_NOTIFICATION_SETTINGS,
   loadOsNotificationSettings,
-  notificationBody,
   saveOsNotificationSettings,
-  shouldSendOsNotification,
   type OsNotificationSettings,
 } from './releaseReadiness';
-
-function notification(overrides: Partial<NotificationView> = {}): NotificationView {
-  return {
-    notification_id: 'notification-1',
-    kind: 'direct_message',
-    actor_pubkey: 'remote-author',
-    actor_name: null,
-    actor_display_name: null,
-    actor_picture: null,
-    actor_picture_asset: null,
-    source_envelope_id: null,
-    source_replica_id: null,
-    topic_id: 'kukuri:topic:demo',
-    channel_id: null,
-    object_id: null,
-    thread_root_object_id: null,
-    dm_id: 'dm-1',
-    message_id: 'message-1',
-    preview_text: 'private body',
-    created_at: 1,
-    received_at: 1,
-    read_at: null,
-    ...overrides,
-  };
-}
 
 describe('release readiness helpers', () => {
   beforeEach(() => {
@@ -110,45 +82,5 @@ describe('release readiness helpers', () => {
     saveOsNotificationSettings(settings);
 
     expect(loadOsNotificationSettings()).toEqual(settings);
-  });
-
-  test('OS notification filtering respects local author, read state, and kind settings', () => {
-    const settings: OsNotificationSettings = {
-      ...DEFAULT_OS_NOTIFICATION_SETTINGS,
-      enabled: true,
-      directMessages: true,
-      mentionsAndReplies: false,
-      followsAndReposts: false,
-    };
-
-    expect(shouldSendOsNotification(notification(), settings, 'local-author')).toBe(true);
-    expect(
-      shouldSendOsNotification(
-        notification({ actor_pubkey: 'local-author' }),
-        settings,
-        'local-author'
-      )
-    ).toBe(false);
-    expect(shouldSendOsNotification(notification({ read_at: 2 }), settings, 'local-author')).toBe(
-      false
-    );
-    expect(
-      shouldSendOsNotification(notification({ kind: 'mention' }), settings, 'local-author')
-    ).toBe(false);
-  });
-
-  test('private direct message bodies are hidden unless preview body is enabled', () => {
-    expect(
-      notificationBody(notification(), {
-        ...DEFAULT_OS_NOTIFICATION_SETTINGS,
-        previewBody: false,
-      })
-    ).toBe('Open kukuri to read this message.');
-    expect(
-      notificationBody(notification(), {
-        ...DEFAULT_OS_NOTIFICATION_SETTINGS,
-        previewBody: true,
-      })
-    ).toBe('private body');
   });
 });

--- a/apps/desktop/src/lib/releaseReadiness.ts
+++ b/apps/desktop/src/lib/releaseReadiness.ts
@@ -1,13 +1,9 @@
-import type { NotificationView } from '@/lib/api';
-
 export const RELEASE_CHANNEL = 'preview';
 export const RELEASE_MANIFEST_NAME = 'latest-preview.json';
 export const RELEASE_FEEDBACK_URL =
   'https://github.com/KingYoSun/kukuri/issues/new?template=preview-feedback.md';
 
 export const OS_NOTIFICATION_SETTINGS_STORAGE_KEY = 'kukuri:os-notification-settings:v1';
-const OS_NOTIFICATION_SEEN_STORAGE_KEY = 'kukuri:os-notification-seen:v1';
-const MAX_SEEN_NOTIFICATION_IDS = 128;
 
 export type UpdateStatus =
   | 'idle'
@@ -72,84 +68,6 @@ export function saveOsNotificationSettings(settings: OsNotificationSettings): vo
   }
   window.localStorage.setItem(OS_NOTIFICATION_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
   window.dispatchEvent(new Event(OS_NOTIFICATION_SETTINGS_STORAGE_KEY));
-}
-
-export function shouldSendOsNotification(
-  notification: NotificationView,
-  settings: OsNotificationSettings,
-  localAuthorPubkey: string
-): boolean {
-  if (!settings.enabled || settings.quietMode || notification.read_at) {
-    return false;
-  }
-  if (notification.actor_pubkey === localAuthorPubkey) {
-    return false;
-  }
-  if (notification.kind === 'direct_message') {
-    return settings.directMessages;
-  }
-  if (notification.kind === 'mention' || notification.kind === 'reply') {
-    return settings.mentionsAndReplies;
-  }
-  if (
-    notification.kind === 'followed' ||
-    notification.kind === 'repost' ||
-    notification.kind === 'quote_repost'
-  ) {
-    return settings.followsAndReposts;
-  }
-  return false;
-}
-
-export function notificationTitle(notification: NotificationView): string {
-  switch (notification.kind) {
-    case 'direct_message':
-      return 'Direct message';
-    case 'mention':
-      return 'Mention';
-    case 'reply':
-      return 'Reply';
-    case 'followed':
-      return 'New follower';
-    case 'quote_repost':
-      return 'Quote repost';
-    case 'repost':
-      return 'Repost';
-  }
-}
-
-export function notificationBody(
-  notification: NotificationView,
-  settings: OsNotificationSettings
-): string | undefined {
-  if (!settings.previewBody) {
-    return notification.kind === 'direct_message'
-      ? 'Open kukuri to read this message.'
-      : 'Open kukuri to view this activity.';
-  }
-  return notification.preview_text ?? undefined;
-}
-
-export function readSeenOsNotificationIds(): Set<string> {
-  if (typeof window === 'undefined') {
-    return new Set();
-  }
-  try {
-    const parsed = JSON.parse(
-      window.localStorage.getItem(OS_NOTIFICATION_SEEN_STORAGE_KEY) ?? '[]'
-    ) as string[];
-    return new Set(parsed.filter((value) => typeof value === 'string'));
-  } catch {
-    return new Set();
-  }
-}
-
-export function writeSeenOsNotificationIds(values: Set<string>): void {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  const nextValues = Array.from(values).slice(-MAX_SEEN_NOTIFICATION_IDS);
-  window.localStorage.setItem(OS_NOTIFICATION_SEEN_STORAGE_KEY, JSON.stringify(nextValues));
 }
 
 export function isTauriRuntime(): boolean {


### PR DESCRIPTION
## 概要

WP-Q1(dead code 削除バッチ)PR4。production 参照 0 の TS dead code を削除する。#304 で OS 通知は Rust 側へ移管済みで、TS 側の判定・整形・既読管理関数は呼ばれなくなっていた。

## 変更

### `releaseReadiness.ts`
- OS 通知 dead 5 関数を削除: `shouldSendOsNotification` / `notificationTitle` / `notificationBody` / `readSeenOsNotificationIds` / `writeSeenOsNotificationIds`
- 5 関数専用だった `import type { NotificationView }` と、read/write 専用の定数 `OS_NOTIFICATION_SEEN_STORAGE_KEY` / `MAX_SEEN_NOTIFICATION_IDS` も dead 化するため同時削除
- `loadOsNotificationSettings` / `saveOsNotificationSettings` は `ReleasePanel` / `useOsNotificationBridge` で現役のため**残す**

### `internalLinks.ts`
- `buildGameLink`(builder)を削除。`GameLinkReference` 型は parse 側(`InternalSmartReference` union)で現役のため**残す**

### `releaseReadiness.test.ts`
- 該当 2 テスト(OS notification filtering / private direct message bodies)と、それ専用の `notification()` ヘルパ・`NotificationView` import を削除
- 残る 3 テスト(diagnostic report / update error classify / settings persist)は維持

## 無害性の検証

- 6 関数(5 + buildGameLink)の残存参照 → **grep 0**
- 削除した 2 定数の残存参照 → 0
- Rust 側に上記 TS 関数を Mirror する doc は存在せず(grep 0)→ **Rust 変更は不要**
- `pnpm typecheck` → 緑 / 該当ユニット 5 pass / `cargo xtask desktop-ui-check` → 緑(視覚回帰 14 面 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)