### PR TITLE
[refactor] Rust dead: key_kind() と app-api の test 専用糖衣ラッパー 2 件を削除 (WP-Q1 PR5)

### DIFF
--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -202,10 +202,6 @@ pub(crate) use timeline_view_support::{
 // テストからのみ参照される再輸出(依存の可視化。WP-H5 PR1)。
 #[cfg(test)]
 pub(crate) use object_persistence_support::custom_reaction_asset_view_from_snapshot;
-#[cfg(test)]
-pub(crate) use profile_docs_support::{
-    snapshot_follow_notification_baseline, snapshot_object_notification_baseline,
-};
 
 pub(crate) async fn maybe_restart_replica_sync_with_cooldown(
     docs_sync: &dyn DocsSync,

--- a/crates/app-api/src/service/profile_docs_support.rs
+++ b/crates/app-api/src/service/profile_docs_support.rs
@@ -574,19 +574,6 @@ pub(crate) async fn load_profile_reposts_from_author_replica_with_policy(
     Ok(items)
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) async fn snapshot_object_notification_baseline(
-    docs_sync: &dyn DocsSync,
-    replica: &ReplicaId,
-) -> Result<NotificationDocEventBaseline> {
-    snapshot_object_notification_baseline_with_policy(
-        docs_sync,
-        replica,
-        DocFetchPolicy::LocalThenRemote,
-    )
-    .await
-}
-
 pub(crate) async fn snapshot_object_notification_baseline_with_policy(
     docs_sync: &dyn DocsSync,
     replica: &ReplicaId,
@@ -605,19 +592,6 @@ pub(crate) async fn snapshot_object_notification_baseline_with_policy(
             .filter(|record| record.key.ends_with("/state"))
             .collect::<Vec<_>>(),
     ))
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) async fn snapshot_follow_notification_baseline(
-    docs_sync: &dyn DocsSync,
-    replica: &ReplicaId,
-) -> Result<NotificationDocEventBaseline> {
-    snapshot_follow_notification_baseline_with_policy(
-        docs_sync,
-        replica,
-        DocFetchPolicy::LocalThenRemote,
-    )
-    .await
 }
 
 pub(crate) async fn snapshot_follow_notification_baseline_with_policy(

--- a/crates/app-api/src/tests/notifications.rs
+++ b/crates/app-api/src/tests/notifications.rs
@@ -313,9 +313,13 @@ async fn repost_notification_survives_hydration_before_live_doc_event() {
         .create_post(topic.as_str(), "source post", None)
         .await
         .expect("create source post");
-    let baseline = snapshot_object_notification_baseline(docs_sync.as_ref(), &replica)
-        .await
-        .expect("snapshot object baseline");
+    let baseline = snapshot_object_notification_baseline_with_policy(
+        docs_sync.as_ref(),
+        &replica,
+        DocFetchPolicy::LocalThenRemote,
+    )
+    .await
+    .expect("snapshot object baseline");
     let remote_keys = generate_keys();
     let repost_source = app
         .resolve_repost_source(topic.as_str(), source_object_id.as_str())
@@ -390,9 +394,13 @@ async fn quote_repost_notification_survives_hydration_before_live_doc_event() {
         .create_post(topic.as_str(), "quoted source", None)
         .await
         .expect("create source post");
-    let baseline = snapshot_object_notification_baseline(docs_sync.as_ref(), &replica)
-        .await
-        .expect("snapshot object baseline");
+    let baseline = snapshot_object_notification_baseline_with_policy(
+        docs_sync.as_ref(),
+        &replica,
+        DocFetchPolicy::LocalThenRemote,
+    )
+    .await
+    .expect("snapshot object baseline");
     let remote_keys = generate_keys();
     let repost_source = app
         .resolve_repost_source(topic.as_str(), source_object_id.as_str())
@@ -573,9 +581,13 @@ async fn follow_notification_survives_hydration_before_live_doc_event() {
     let remote_keys = generate_keys();
     let remote_pubkey = remote_keys.public_key_hex();
     let replica = author_replica_id(remote_pubkey.as_str());
-    let baseline = snapshot_follow_notification_baseline(docs_sync.as_ref(), &replica)
-        .await
-        .expect("snapshot follow baseline");
+    let baseline = snapshot_follow_notification_baseline_with_policy(
+        docs_sync.as_ref(),
+        &replica,
+        DocFetchPolicy::LocalThenRemote,
+    )
+    .await
+    .expect("snapshot follow baseline");
     let envelope = build_follow_edge_envelope(
         &remote_keys,
         &Pubkey::from(local_author_pubkey.as_str()),
@@ -647,9 +659,13 @@ async fn initial_follow_baseline_prevents_backfill_notification() {
     persist_follow_edge_doc(docs_sync.as_ref(), &edge, &envelope)
         .await
         .expect("persist follow edge doc");
-    let baseline = snapshot_follow_notification_baseline(docs_sync.as_ref(), &replica)
-        .await
-        .expect("snapshot follow baseline");
+    let baseline = snapshot_follow_notification_baseline_with_policy(
+        docs_sync.as_ref(),
+        &replica,
+        DocFetchPolicy::LocalThenRemote,
+    )
+    .await
+    .expect("snapshot follow baseline");
 
     hydrate_author_state_with_services(
         docs_sync.as_ref(),
@@ -790,9 +806,13 @@ async fn restart_or_manual_hydration_does_not_backfill_or_duplicate_notification
         .to_post_object()
         .expect("parse existing reply")
         .expect("existing reply object");
-    let baseline = snapshot_object_notification_baseline(docs_sync.as_ref(), &replica)
-        .await
-        .expect("snapshot object baseline");
+    let baseline = snapshot_object_notification_baseline_with_policy(
+        docs_sync.as_ref(),
+        &replica,
+        DocFetchPolicy::LocalThenRemote,
+    )
+    .await
+    .expect("snapshot object baseline");
     hydrate_subscription_state_with_services(
         docs_sync.as_ref(),
         blob_service.as_ref(),

--- a/crates/core/src/reactions.rs
+++ b/crates/core/src/reactions.rs
@@ -59,13 +59,6 @@ impl ReactionKeyV1 {
             }
         }
     }
-
-    pub fn key_kind(&self) -> ReactionKeyKind {
-        match self {
-            Self::Emoji { .. } => ReactionKeyKind::Emoji,
-            Self::CustomAsset { .. } => ReactionKeyKind::CustomAsset,
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## 概要

WP-Q1(dead code 削除バッチ)PR5。production 参照 0 の Rust dead code を削除する。挙動不変。

> 注: プランの PR5 対象のうち `endpoint_publish_task` / `dht_options` の vestigial 配管は、現地確認の結果「戻り値契約の簡約」を伴う別 intent の中規模リファクタと判明したため **PR5b に分離**した(本 PR には含めない)。

## 変更

### core: `ReactionKeyV1::key_kind()` 削除
- `.key_kind()` の method 呼び出しは全 crate で **0 件**。残る `reaction_key_kind` 参照は同名の別物(フィールド)で無関係。

### app-api: test 専用糖衣ラッパー 2 件削除
- `snapshot_object_notification_baseline` / `snapshot_follow_notification_baseline` を削除。これらは `_with_policy` に既定 `DocFetchPolicy::LocalThenRemote` を渡すだけの test 専用糖衣で、非 test では `#[cfg_attr(not(test), allow(dead_code))]` が付く dead code だった。
- テスト 5 箇所(object×3 / follow×2)を `_with_policy(.., LocalThenRemote)` の直呼びへ置換し、`service/mod.rs` の `#[cfg(test)]` 再輸出も除去。
- production で使う `_with_policy` 版(`private_channels_support` / `social_runtime_support`)はそのまま維持。

## 無害性の検証

- `.key_kind()` 呼び出し grep 0 / 糖衣ラッパー参照は test 5 箇所のみ(置換済み)
- `cargo fmt --check` 緑 / `cargo clippy -p kukuri-core -p kukuri-app-api --all-targets` 緑 / `cargo test -p kukuri-core -p kukuri-app-api` 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)