### PR TITLE
[refactor] vestigial な endpoint_publish_task / dht_options 配管を除去 (WP-Q1 PR5b)

### DIFF
--- a/crates/iroh-node/src/node.rs
+++ b/crates/iroh-node/src/node.rs
@@ -19,7 +19,6 @@ use kukuri_transport::{
     build_endpoint_builder, prepare_endpoint_for_discovery, sync_endpoint_relay_config,
 };
 use serde::{Deserialize, Serialize};
-use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tracing::warn;
 
@@ -146,7 +145,6 @@ pub struct IrohDocsNode {
     router: Arc<Router>,
     docs: DocsApi,
     blobs: BlobStore,
-    endpoint_publish_task: Option<JoinHandle<()>>,
     shutdown_started: AtomicBool,
 }
 
@@ -257,9 +255,7 @@ impl IrohDocsNode {
         if let Some(root) = root.as_deref() {
             save_endpoint_secret(root, endpoint.secret_key())?;
         }
-        let endpoint_publish_task =
-            prepare_endpoint_for_discovery(&endpoint, &discovery, &dht_options, &relay_config)
-                .await?;
+        prepare_endpoint_for_discovery(&endpoint, &discovery, &relay_config).await?;
         let gossip = Gossip::builder().spawn(endpoint.clone());
         let docs = match spawn_docs(
             root.as_deref(),
@@ -286,9 +282,6 @@ impl IrohDocsNode {
                 match error {
                     Ok(docs) => docs,
                     Err(error) => {
-                        if let Some(task) = &endpoint_publish_task {
-                            task.abort();
-                        }
                         endpoint.close().await;
                         let _ = blobs.shutdown().await;
                         return Err(error);
@@ -313,7 +306,6 @@ impl IrohDocsNode {
             router: Arc::new(router),
             docs: docs.api().clone(),
             blobs,
-            endpoint_publish_task,
             shutdown_started: AtomicBool::new(false),
         });
         if relay_config.connect_mode() == ConnectMode::DirectOrRelay {
@@ -413,9 +405,6 @@ impl IrohDocsNode {
         if self.shutdown_started.swap(true, Ordering::AcqRel) {
             return Ok(());
         }
-        if let Some(task) = &self.endpoint_publish_task {
-            task.abort();
-        }
         match timeout(router_shutdown_timeout(), self.router.shutdown()).await {
             Ok(Ok(())) => {}
             Ok(Err(error)) => {
@@ -436,9 +425,6 @@ impl IrohDocsNode {
 
 impl Drop for IrohDocsNode {
     fn drop(&mut self) {
-        if let Some(task) = self.endpoint_publish_task.take() {
-            task.abort();
-        }
         if self.shutdown_started.swap(true, Ordering::AcqRel) {
             return;
         }

--- a/crates/transport/src/discovery.rs
+++ b/crates/transport/src/discovery.rs
@@ -6,20 +6,18 @@ use std::time::Duration;
 use anyhow::Result;
 use iroh::Endpoint;
 use iroh::address_lookup::MemoryLookup;
-use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tracing::debug;
 
-use crate::config::{ConnectMode, DhtDiscoveryOptions, TransportRelayConfig};
+use crate::config::{ConnectMode, TransportRelayConfig};
 
 const RELAY_ONLINE_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub async fn prepare_endpoint_for_discovery(
     endpoint: &Endpoint,
     discovery: &Arc<MemoryLookup>,
-    dht_options: &DhtDiscoveryOptions,
     relay_config: &TransportRelayConfig,
-) -> Result<Option<JoinHandle<()>>> {
+) -> Result<()> {
     let relay_backed = relay_config.connect_mode() == ConnectMode::DirectOrRelay;
     if relay_backed {
         let endpoint = endpoint.clone();
@@ -44,8 +42,7 @@ pub async fn prepare_endpoint_for_discovery(
     }
     discovery.add_endpoint_info(endpoint.addr());
 
-    let _ = dht_options;
-    Ok(None)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -58,6 +55,7 @@ mod tests {
     use iroh_mainline_address_lookup::DhtAddressLookup;
     use n0_mainline::{DhtBuilder, Testnet};
 
+    use crate::config::DhtDiscoveryOptions;
     use crate::iroh::bind_endpoint_with_options;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -74,7 +72,7 @@ mod tests {
         let relay_urls = Arc::new(StdRwLock::new(
             relay_config.parsed_relay_urls().expect("relay urls"),
         ));
-        let (endpoint, _discovery, _publish_task) = bind_endpoint_with_options(
+        let (endpoint, _discovery) = bind_endpoint_with_options(
             std::net::SocketAddr::V4(std::net::SocketAddrV4::new(
                 std::net::Ipv4Addr::LOCALHOST,
                 0,

--- a/crates/transport/src/iroh/endpoint.rs
+++ b/crates/transport/src/iroh/endpoint.rs
@@ -17,7 +17,7 @@ impl IrohGossipTransport {
     ) -> Result<Self> {
         let relay_config = relay_config.normalized();
         let relay_urls = Arc::new(StdRwLock::new(relay_config.parsed_relay_urls()?));
-        let (endpoint, discovery, publish_task) = bind_endpoint_with_options(
+        let (endpoint, discovery) = bind_endpoint_with_options(
             network_config.bind_addr,
             &dht_options,
             &relay_config,
@@ -35,7 +35,6 @@ impl IrohGossipTransport {
             endpoint,
             gossip,
             _router: Some(router),
-            _endpoint_publish_task: publish_task,
             discovery,
             network_config,
             configured_seed_peers: Arc::new(Mutex::new(BTreeMap::new())),
@@ -73,7 +72,6 @@ impl IrohGossipTransport {
             endpoint,
             gossip,
             _router: None,
-            _endpoint_publish_task: None,
             discovery,
             network_config,
             configured_seed_peers: Arc::new(Mutex::new(BTreeMap::new())),
@@ -105,7 +103,7 @@ pub(crate) async fn bind_endpoint_with_options(
     relay_config: &TransportRelayConfig,
     relay_urls: Arc<StdRwLock<Vec<RelayUrl>>>,
     secret_key: Option<SecretKey>,
-) -> Result<(Endpoint, Arc<MemoryLookup>, Option<JoinHandle<()>>)> {
+) -> Result<(Endpoint, Arc<MemoryLookup>)> {
     let discovery = Arc::new(MemoryLookup::new());
     let mut builder = build_endpoint_builder(
         EndpointBuilder::new(presets::Minimal).relay_mode(relay_config.relay_mode()?),
@@ -125,9 +123,8 @@ pub(crate) async fn bind_endpoint_with_options(
         .bind()
         .await
         .context("failed to bind iroh endpoint")?;
-    let publish_task =
-        prepare_endpoint_for_discovery(&endpoint, &discovery, dht_options, relay_config).await?;
-    Ok((endpoint, discovery, publish_task))
+    prepare_endpoint_for_discovery(&endpoint, &discovery, relay_config).await?;
+    Ok((endpoint, discovery))
 }
 fn apply_bind(builder: EndpointBuilder, bind_addr: SocketAddr) -> Result<EndpointBuilder> {
     match bind_addr {

--- a/crates/transport/src/iroh/mod.rs
+++ b/crates/transport/src/iroh/mod.rs
@@ -88,7 +88,6 @@ pub struct IrohGossipTransport {
     endpoint: Endpoint,
     gossip: Gossip,
     _router: Option<Router>,
-    _endpoint_publish_task: Option<JoinHandle<()>>,
     discovery: Arc<MemoryLookup>,
     network_config: TransportNetworkConfig,
     configured_seed_peers: Arc<Mutex<BTreeMap<String, EndpointAddr>>>,
@@ -120,9 +119,6 @@ pub(crate) use topics::{initial_topic_join_timeout, topic_to_gossip_id};
 
 impl Drop for IrohGossipTransport {
     fn drop(&mut self) {
-        if let Some(task) = self._endpoint_publish_task.take() {
-            task.abort();
-        }
         if let Ok(mut topics) = self.topic_states.try_lock() {
             for (_, state) in topics.drain() {
                 state._receiver_task.abort();


### PR DESCRIPTION
## 概要

WP-Q1(dead code 削除バッチ)PR5b。PR5 から分離した vestigial 配管の除去。`discovery` 経路の実装変更(#391 系)以降、`prepare_endpoint_for_discovery` は `dht_options` を `let _ =` で捨て**常に `Ok(None)`** を返しており、その戻り値を格納する `publish_task` 系フィールドは全経路で `None`・abort 分岐は no-op だった。挙動不変で戻り値契約を簡約する。

## 変更

### transport
- **discovery.rs**: `prepare_endpoint_for_discovery` の未使用引数 `dht_options` を削除し、戻り値を `Result<Option<JoinHandle<()>>>` → `Result<()>` に簡約(`Ok(None)`→`Ok(())`)。未使用化した `JoinHandle` import と、非 test で未使用化する `DhtDiscoveryOptions` を config import から外し、後者はテストモジュール側の import に移設。
- **iroh/endpoint.rs**: `bind_endpoint_with_options` の戻り値 tuple から `Option<JoinHandle<()>>` を削除。`bind_with_options` / `from_shared_parts` の `_endpoint_publish_task` フィールド初期化を削除。
- **iroh/mod.rs**: `IrohGossipTransport` の `_endpoint_publish_task` フィールドと Drop 内の該当 abort 分岐を削除(`topic_states` の abort 等は維持)。

### iroh-node
- **node.rs**: `IrohDocsNode` の `endpoint_publish_task` フィールドを削除し、生成・struct 初期化・docs spawn 失敗経路 / `shutdown()` / Drop の no-op abort 分岐を除去。未使用化した `JoinHandle` import を削除。`dht_options` は `build_endpoint_builder` で現役のため残す。

## 無害性の検証

- `cargo fmt --check` 緑 / `cargo clippy -p kukuri-transport -p kukuri-iroh-node --all-targets` 緑
- `cargo test -p kukuri-transport -p kukuri-iroh-node` 緑(transport 7+39 = DHT publish 実機テスト含む)
- 残存 `endpoint_publish_task` 参照 grep 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)