### PR TITLE
[fix] get_community_node_statuses を読み取り専用化 (WP-Q2 PR2)

### DIFF
--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -5,24 +5,15 @@ impl DesktopRuntime {
         Ok(self.community_node_config.lock().await.clone())
     }
 
+    /// 読み取り専用。CN セッションの establish/refresh・self-heal は
+    /// セッション維持スケジューラ(`run_community_node_session_maintenance_once`)が
+    /// 担い、getter は副作用(registration refresh のネットワーク I/O)を持たない(WP-Q2)。
+    /// config は tick 側が resolved_urls を書き戻すため、ここで読んだ node が最新。
     pub async fn get_community_node_statuses(&self) -> Result<Vec<CommunityNodeNodeStatus>> {
         let config = self.community_node_config.lock().await.clone();
         let mut statuses = Vec::with_capacity(config.nodes.len());
         for node in config.nodes {
-            let base_url = node.base_url.clone();
-            let _ = self
-                .refresh_community_node_registration_if_due(base_url.as_str())
-                .await;
-            let current_node = self
-                .community_node_config
-                .lock()
-                .await
-                .nodes
-                .iter()
-                .find(|candidate| candidate.base_url == base_url)
-                .cloned()
-                .unwrap_or(node);
-            statuses.push(self.community_node_status(current_node, None, None).await?);
+            statuses.push(self.community_node_status(node, None, None).await?);
         }
         Ok(statuses)
     }
@@ -71,6 +62,10 @@ impl DesktopRuntime {
         *self.community_node_reconnect_state.lock().await = Default::default();
         self.apply_runtime_connectivity_assist().await?;
         self.apply_effective_seed_peers().await?;
+        // getter を読取専用化した(WP-Q2)ため、config 変更直後の登録はここで 1 tick 即時実行する。
+        // これが無いと新規 auto_approve ノードの bootstrap がスケジューラ次 tick(最大 15 秒)まで
+        // 遅延する。tick は deadline ゲート済みの冪等設計で、直後の scheduler tick と二重でも安全。
+        self.run_community_node_session_maintenance_once().await;
         Ok(next_config)
     }
 

--- a/crates/desktop-runtime/src/tests/community_node/connectivity.rs
+++ b/crates/desktop-runtime/src/tests/community_node/connectivity.rs
@@ -732,6 +732,11 @@ async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_
         kukuri_app_api::DeliveryState::Offline | kukuri_app_api::DeliveryState::DurableRecovering
     ));
 
+    // WP-Q2: 到達不能ノードへの registration refresh 試行(→ last_error 記録)は
+    // スケジューラ tick が駆動し、getter は読み取り専用。
+    runtime_a
+        .run_community_node_session_maintenance_once()
+        .await;
     let community_statuses = runtime_a
         .get_community_node_statuses()
         .await

--- a/crates/desktop-runtime/src/tests/community_node/metadata.rs
+++ b/crates/desktop-runtime/src/tests/community_node/metadata.rs
@@ -60,6 +60,8 @@ async fn community_node_status_refresh_updates_bootstrap_seed_peers() {
         }],
     };
 
+    // WP-Q2: registration refresh はスケジューラ tick が駆動し、getter は読み取り専用。
+    runtime.run_community_node_session_maintenance_once().await;
     let statuses = runtime
         .get_community_node_statuses()
         .await
@@ -544,6 +546,8 @@ async fn community_node_status_retries_bootstrap_metadata_when_seed_peers_are_em
         }],
     };
 
+    // WP-Q2: metadata refresh はスケジューラ tick が駆動し、getter は読み取り専用。
+    runtime.run_community_node_session_maintenance_once().await;
     let initial_statuses = runtime
         .get_community_node_statuses()
         .await
@@ -574,6 +578,7 @@ async fn community_node_status_retries_bootstrap_metadata_when_seed_peers_are_em
         .await
         .insert(base_url.clone(), Utc::now().timestamp() - 1);
 
+    runtime.run_community_node_session_maintenance_once().await;
     let refreshed_statuses = runtime
         .get_community_node_statuses()
         .await

--- a/crates/desktop-runtime/src/tests/community_node/session.rs
+++ b/crates/desktop-runtime/src/tests/community_node/session.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 
 #[tokio::test]
-async fn auto_approve_node_bootstraps_session_on_status_refresh() {
+async fn auto_approve_node_bootstraps_session_on_maintenance_tick() {
     let _serial = acquire_async_test_lock().await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-auto-approve-session.db");
@@ -61,6 +61,8 @@ async fn auto_approve_node_bootstraps_session_on_status_refresh() {
         }],
     };
 
+    // WP-Q2: セッション確立はスケジューラ tick が駆動し、getter は読み取り専用。
+    runtime.run_community_node_session_maintenance_once().await;
     let statuses = runtime
         .get_community_node_statuses()
         .await
@@ -93,6 +95,99 @@ async fn auto_approve_node_bootstraps_session_on_status_refresh() {
             .expect("resolved urls")
             .seed_peers,
         vec![seed_peer]
+    );
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn status_getter_is_read_only_and_does_not_bootstrap_session() {
+    // WP-Q2: get_community_node_statuses は読み取り専用。セッションの establish/refresh は
+    // セッション維持スケジューラ(run_community_node_session_maintenance_once)が担い、
+    // getter 単独では refresh 副作用(challenge/verify/heartbeat/bootstrap)を持たない。
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-getter-read-only.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let state = Arc::new(MockManagedCommunityNodeState {
+        base_url: base_url.clone(),
+        seed_peers: vec![],
+        consent_accepted: Arc::new(AtomicBool::new(false)),
+        current_token: Arc::new(Mutex::new(String::new())),
+        challenge_hits: Arc::new(AtomicUsize::new(0)),
+        verify_hits: Arc::new(AtomicUsize::new(0)),
+        consent_status_hits: Arc::new(AtomicUsize::new(0)),
+        consent_accept_hits: Arc::new(AtomicUsize::new(0)),
+        heartbeat_hits: Arc::new(AtomicUsize::new(0)),
+        bootstrap_hits: Arc::new(AtomicUsize::new(0)),
+        simulate_pending_update: Arc::new(AtomicBool::new(false)),
+    });
+    let app = Router::new()
+        .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
+        .route("/v1/auth/verify", post(mock_managed_auth_verify))
+        .route("/v1/consents/status", get(mock_managed_consent_status))
+        .route("/v1/consents", post(mock_managed_accept_consents))
+        .route(
+            "/v1/bootstrap/heartbeat",
+            post(mock_managed_bootstrap_heartbeat),
+        )
+        .route("/v1/bootstrap/nodes", get(mock_managed_bootstrap_nodes))
+        .with_state(state.clone());
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.clone(),
+            auto_approve: true,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
+                    .expect("resolved urls"),
+            ),
+        }],
+    };
+
+    // getter 単独では auto_approve でもセッションを bootstrap しない。
+    let statuses = runtime
+        .get_community_node_statuses()
+        .await
+        .expect("community node statuses");
+    assert_eq!(state.challenge_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.verify_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.bootstrap_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(
+        statuses[0].session_phase,
+        crate::CommunityNodeSessionPhase::Idle
+    );
+
+    // スケジューラ tick を回すとセッションが確立する。
+    runtime.run_community_node_session_maintenance_once().await;
+    let statuses = runtime
+        .get_community_node_statuses()
+        .await
+        .expect("community node statuses after maintenance tick");
+    assert_eq!(state.challenge_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(state.verify_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(state.bootstrap_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        statuses[0].session_phase,
+        crate::CommunityNodeSessionPhase::Ready
     );
 
     runtime.shutdown().await;
@@ -170,6 +265,8 @@ async fn near_expiry_token_triggers_proactive_community_node_reauthentication() 
         }],
     };
 
+    // WP-Q2: 近接失効トークンの proactive 再認証はスケジューラ tick が駆動する。
+    runtime.run_community_node_session_maintenance_once().await;
     let statuses = runtime
         .get_community_node_statuses()
         .await
@@ -265,6 +362,8 @@ async fn consent_required_node_without_auto_approve_stays_pending() {
         }],
     };
 
+    // WP-Q2: consent 確認を伴う registration refresh もスケジューラ tick が駆動する。
+    runtime.run_community_node_session_maintenance_once().await;
     let statuses = runtime
         .get_community_node_statuses()
         .await
@@ -445,6 +544,8 @@ async fn auto_approve_node_does_not_silently_reaccept_policy_update() {
         }],
     };
 
+    // WP-Q2: auto_approve の consent 判定もスケジューラ tick が駆動する。
+    runtime.run_community_node_session_maintenance_once().await;
     let statuses = runtime
         .get_community_node_statuses()
         .await


### PR DESCRIPTION
## 意図 (1 PR = 1 intent)

`fix` — 副作用付き getter `get_community_node_statuses` から registration refresh のネットワーク副作用を除去し、読み取り専用にする。

## 背景

E-1(CN セッション維持が UI ポーリング駆動)の訂正で、副作用付き getter は `get_sync_status`(WP-C1 で読取専用化済み)だけでなく `get_community_node_statuses` にも存在し、そちらは Q2 に残されていた。セッションの establish/refresh は WP-C1 で導入した維持スケジューラ(`run_community_node_session_maintenance_once`、15 秒 tick)が既に担っており、getter 側の refresh は重複していた。トレイ常駐中(フロントのポーリング停止)は getter が呼ばれないため、getter に副作用を持たせる意味はない。

出典: `.claude/plans/2026-07-09-refactor-q2-desktop-runtime.md` PR2 / 領域3b。

## 変更

- `get_community_node_statuses`: `refresh_community_node_registration_if_due` の呼び出しを削除し、config を読んで `community_node_status` を組むだけの読み取り専用に。
- `set_community_node_config`: 末尾で `run_community_node_session_maintenance_once()` を 1 回即時実行。getter 読取専用化により新規 auto_approve ノードの bootstrap がスケジューラ次 tick(最大 15 秒)まで遅延するのを防ぐ。tick は deadline ゲート済みの冪等設計で、直後の scheduler tick と二重でも安全。

## 挙動の変化(failing-test-first)

- 新規 `status_getter_is_read_only_and_does_not_bootstrap_session`: getter 単独では `challenge/verify/heartbeat/bootstrap` hits が 0 のまま `Idle`、maintenance tick 後に初めて `Ready` へ遷移することを固定(修正前は getter が bootstrap を駆動して赤)。
- getter が refresh を駆動する前提だった既存 characterization 8 箇所(session 4 / metadata 3 / connectivity 1)を maintenance tick 駆動へ更新。`auto_approve_node_bootstraps_session_on_status_refresh` は駆動元が変わったため `..._on_maintenance_tick` へ改名。

## 検証

- `cargo test -p kukuri-desktop-runtime --lib community_node::` 51 本 green
- `cargo clippy -p kukuri-desktop-runtime --all-targets` warning 0 / `cargo fmt --check` clean

path 別検証マトリクス: `crates/desktop-runtime/**` → `cargo xtask rust-test`(CI)+ CN セッション挙動変更のため `community_node_public_connectivity` scenario(CI の linux-community-node / linux-smoke で実行)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)