### PR TITLE
[refactor] 起動エラー分類を typed downcast へ (WP-Q2 PR3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3275,6 +3275,7 @@ dependencies = [
  "sha2 0.10.9",
  "sqlx",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "ts-rs",
 ]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -107,12 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arcstr"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,7 +384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -404,61 +397,6 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core",
- "base64 0.22.1",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sha1",
- "sync_wrapper",
- "tokio",
- "tokio-tungstenite",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -920,11 +858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
- "futures-core",
  "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -3633,24 +3567,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "10.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
-dependencies = [
- "aws-lc-rs",
- "base64 0.22.1",
- "getrandom 0.2.17",
- "js-sys",
- "pem",
- "serde",
- "serde_json",
- "signature 2.2.0",
- "simple_asn1",
- "zeroize",
-]
-
-[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3705,7 +3621,7 @@ dependencies = [
  "iroh",
  "iroh-blobs",
  "kukuri-core",
- "kukuri-docs-sync",
+ "kukuri-iroh-node",
  "kukuri-transport",
  "serde",
  "tokio",
@@ -3713,66 +3629,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "kukuri-cn-core"
+name = "kukuri-cn-protocol"
 version = "0.1.2"
 dependencies = [
  "anyhow",
- "async-trait",
- "axum",
- "chacha20poly1305",
- "chrono",
- "hex",
- "jsonwebtoken",
- "kukuri-cn-safety",
- "kukuri-cn-safety-runtime",
- "kukuri-cn-trust",
  "kukuri-core",
- "redis",
- "secp256k1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
- "sqlx",
- "tokio",
- "tracing",
  "url",
- "uuid",
-]
-
-[[package]]
-name = "kukuri-cn-safety"
-version = "0.1.2"
-dependencies = [
- "async-trait",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "kukuri-cn-safety-runtime"
-version = "0.1.2"
-dependencies = [
- "chrono",
- "hex",
- "kukuri-cn-safety",
- "kukuri-core",
- "secp256k1",
- "serde",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "uuid",
-]
-
-[[package]]
-name = "kukuri-cn-trust"
-version = "0.1.2"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "kukuri-cn-safety",
- "serde",
 ]
 
 [[package]]
@@ -3805,9 +3669,10 @@ dependencies = [
  "keyring",
  "kukuri-app-api",
  "kukuri-blob-service",
- "kukuri-cn-core",
+ "kukuri-cn-protocol",
  "kukuri-core",
  "kukuri-docs-sync",
+ "kukuri-iroh-node",
  "kukuri-store",
  "kukuri-transport",
  "reqwest 0.13.4",
@@ -3855,11 +3720,30 @@ dependencies = [
  "iroh-docs",
  "iroh-gossip",
  "kukuri-core",
+ "kukuri-iroh-node",
  "kukuri-transport",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "kukuri-iroh-node"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "hex",
+ "iroh",
+ "iroh-blobs",
+ "iroh-docs",
+ "iroh-gossip",
+ "kukuri-transport",
+ "serde",
+ "serde_json",
+ "tokio",
  "tracing",
 ]
 
@@ -3873,6 +3757,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -4117,12 +4002,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -5835,29 +5714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6b5f4d8ef33944e833e2b1859ad478deab6e431d7337b30ee2efe21f7543"
-dependencies = [
- "arcstr",
- "async-lock",
- "bytes",
- "cfg-if",
- "combine",
- "futures-util",
- "itoa",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "socket2",
- "tokio",
- "tokio-util",
- "url",
- "xxhash-rust",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6041,7 +5897,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -6186,7 +6042,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -6473,17 +6329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6715,18 +6560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
 dependencies = [
  "bitflags 2.11.1",
-]
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.18",
- "time",
 ]
 
 [[package]]
@@ -7820,18 +7653,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8001,7 +7822,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -8125,22 +7945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "sha1",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8252,12 +8056,6 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -9556,12 +9354,6 @@ checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
 dependencies = [
  "xml-rs",
 ]
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yasna"

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -4,7 +4,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use kukuri_desktop_runtime::{DesktopRuntime, resolve_db_path_from_env};
+use kukuri_desktop_runtime::{DesktopRuntime, StoreStartupError, resolve_db_path_from_env};
 use serde::{Deserialize, Serialize};
 use tauri::Manager;
 
@@ -51,6 +51,39 @@ pub(crate) enum DesktopStartupErrorKind {
     Unknown,
 }
 
+/// 起動失敗の内部表現。分類済みの `kind` と表示用 `message` を持ち、`build_desktop_state`
+/// の Err として src-tauri 内を流れる。`kind` は anyhow エラーの typed downcast で
+/// 決まる(WP-Q2、従来の文字列 contains 判定を置換)。
+#[derive(Debug)]
+pub(crate) struct StartupError {
+    pub(crate) kind: DesktopStartupErrorKind,
+    pub(crate) message: String,
+}
+
+impl StartupError {
+    /// 分類できない起動失敗(db パス解決失敗など)。
+    fn unknown(message: String) -> Self {
+        Self {
+            kind: DesktopStartupErrorKind::Unknown,
+            message,
+        }
+    }
+
+    /// runtime 構築時の anyhow エラーを typed 分類して包む。
+    fn from_runtime_error(error: anyhow::Error) -> Self {
+        Self {
+            kind: classify_startup_error(&error),
+            message: error_message(error),
+        }
+    }
+}
+
+impl std::fmt::Display for StartupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
 pub(crate) struct DesktopStartupState {
     status: Mutex<DesktopStartupStatus>,
 }
@@ -74,7 +107,7 @@ impl DesktopStartupState {
         }
     }
 
-    pub(crate) fn failed(error: String, db_path: Option<PathBuf>) -> Self {
+    pub(crate) fn failed(error: StartupError, db_path: Option<PathBuf>) -> Self {
         Self {
             status: Mutex::new(failed_status(error, db_path)),
         }
@@ -92,12 +125,12 @@ impl DesktopStartupState {
     }
 }
 
-pub(crate) fn failed_status(error: String, db_path: Option<PathBuf>) -> DesktopStartupStatus {
+pub(crate) fn failed_status(error: StartupError, db_path: Option<PathBuf>) -> DesktopStartupStatus {
     DesktopStartupStatus::Failed {
         error: DesktopStartupErrorView {
-            kind: classify_startup_error(&error),
+            kind: error.kind,
             message: "kukuri could not open the local app database.".to_string(),
-            detail: error,
+            detail: error.message,
             db_path: db_path.map(|path| path.display().to_string()),
         },
     }
@@ -148,10 +181,12 @@ pub(crate) fn resolve_db_path(app_handle: &tauri::AppHandle) -> Result<PathBuf, 
     resolve_db_path_from_env(&app_data_dir).map_err(error_message)
 }
 
-pub(crate) fn build_desktop_state(app_handle: &tauri::AppHandle) -> Result<DesktopState, String> {
-    let db_path = resolve_db_path(app_handle)?;
-    let runtime =
-        tauri::async_runtime::block_on(DesktopRuntime::from_env(db_path)).map_err(error_message)?;
+pub(crate) fn build_desktop_state(
+    app_handle: &tauri::AppHandle,
+) -> Result<DesktopState, StartupError> {
+    let db_path = resolve_db_path(app_handle).map_err(StartupError::unknown)?;
+    let runtime = tauri::async_runtime::block_on(DesktopRuntime::from_env(db_path))
+        .map_err(StartupError::from_runtime_error)?;
     let runtime = Arc::new(runtime);
     // トレイ常駐中はフロントのポーリング(hidden で停止)が CN セッションを維持できないため、
     // runtime 常駐のセッション維持スケジューラをここで起動する(停止は shutdown / プロセス終了)。
@@ -198,18 +233,16 @@ pub(crate) fn current_unix_seconds() -> i64 {
         .unwrap_or(0)
 }
 
-fn classify_startup_error(error: &str) -> DesktopStartupErrorKind {
-    let normalized = error.to_lowercase();
-    if normalized.contains("migration") || normalized.contains("_sqlx_migrations") {
-        return DesktopStartupErrorKind::DatabaseMigration;
+/// 起動時の anyhow エラーを typed に分類する(WP-Q2)。store が返す
+/// `StoreStartupError`(接続 / migration を区別)を downcast で判定する。
+/// anyhow の downcast は `.context()` を跨いでチェーンを辿るため、途中で文脈が
+/// 付与されても root の typed variant に到達する。store 由来でないエラーは Unknown。
+fn classify_startup_error(error: &anyhow::Error) -> DesktopStartupErrorKind {
+    match error.downcast_ref::<StoreStartupError>() {
+        Some(StoreStartupError::Migration(_)) => DesktopStartupErrorKind::DatabaseMigration,
+        Some(StoreStartupError::Open { .. }) => DesktopStartupErrorKind::DatabaseOpen,
+        None => DesktopStartupErrorKind::Unknown,
     }
-    if normalized.contains("failed to connect sqlite database")
-        || normalized.contains("sqlite")
-        || normalized.contains("database")
-    {
-        return DesktopStartupErrorKind::DatabaseOpen;
-    }
-    DesktopStartupErrorKind::Unknown
 }
 
 #[cfg(test)]
@@ -275,5 +308,26 @@ mod tests {
         ));
         state.set_status(DesktopStartupStatus::Ready);
         assert!(matches!(state.status(), DesktopStartupStatus::Ready));
+    }
+
+    // WP-Q2: store 由来でないエラーは、message に "migration"/"sqlite"/"database" を
+    // 含んでいても Unknown に分類される(= 旧実装の文字列判定による誤分類が起きない)。
+    // Open/Migration の typed 分類は store 側の connect_file_*_is_typed_as_* テストが担保。
+    #[test]
+    fn classify_startup_error_ignores_message_strings_for_non_store_errors() {
+        for message in [
+            "some unrelated database noise",
+            "migration-like wording in an unrelated failure",
+            "failed to connect sqlite database (but not a StoreStartupError)",
+        ] {
+            let error = anyhow::anyhow!(message);
+            assert!(
+                matches!(
+                    classify_startup_error(&error),
+                    DesktopStartupErrorKind::Unknown
+                ),
+                "non-store error must classify as Unknown regardless of message: {message}"
+            );
+        }
     }
 }

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -22,6 +22,8 @@ pub use community_node::{
     SubmitCommunityNodeReportStatus,
 };
 pub use discovery::{DiscoveryConfig, SetDiscoverySeedsRequest};
+// 起動エラーの typed 分類(WP-Q2)。src-tauri は downcast で DatabaseOpen/Migration を判定する。
+pub use kukuri_store::StoreStartupError;
 pub use paths::resolve_db_path_from_env;
 pub use requests::{
     AuthorRequest, BookmarkCustomReactionRequest, BookmarkPostRequest, CreateAttachmentRequest,

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -10,6 +10,7 @@ async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 kukuri-core = { path = "../core" }
 ts-rs = { workspace = true, optional = true }

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -16,7 +16,7 @@ pub use models::{
     LiveSessionProjectionRow, MutedAuthorRow, NotificationKind, NotificationRow,
     ObjectProjectionRow, Page, ReactionProjectionRow, TimelineCursor,
 };
-pub use sqlite::SqliteStore;
+pub use sqlite::{SqliteStore, StoreStartupError};
 pub use traits::{
     BlobCacheStore, DirectMessageStore, LiveGameProjectionStore, NotificationStore,
     ObjectProjectionStore, ProjectionStore, ReactionBookmarkStore, SocialProjectionStore, Store,

--- a/crates/store/src/sqlite/connection.rs
+++ b/crates/store/src/sqlite/connection.rs
@@ -2,6 +2,26 @@ use super::*;
 
 pub(crate) static STORE_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
+/// 起動時(SQLite 接続 / migration 適用)の失敗を型で区別するエラー。
+///
+/// desktop の起動 Failed 画面は、この variant を downcast して DatabaseOpen /
+/// DatabaseMigration に分類する(WP-Q2、従来のエラー文字列 contains 判定を置換)。
+/// `Display`(および anyhow の `{:#}`)は従来と同じ message + source を出すため、
+/// 表示・ログ・文字列アサーションは不変。
+#[derive(Debug, thiserror::Error)]
+pub enum StoreStartupError {
+    /// SQLite データベースへの接続 / オープン失敗。
+    #[error("failed to connect sqlite database: {path}")]
+    Open {
+        path: String,
+        #[source]
+        source: sqlx::Error,
+    },
+    /// embedded migration の適用失敗(checksum 不一致・未知世代など)。
+    #[error("failed to run sqlite migrations")]
+    Migration(#[source] sqlx::migrate::MigrateError),
+}
+
 impl SqliteStore {
     pub async fn connect(database_url: &str) -> Result<Self> {
         let pool = sqlite_pool_options(
@@ -14,7 +34,10 @@ impl SqliteStore {
         )
         .connect(database_url)
         .await
-        .with_context(|| format!("failed to connect sqlite database: {database_url}"))?;
+        .map_err(|source| StoreStartupError::Open {
+            path: database_url.to_string(),
+            source,
+        })?;
 
         run_store_migrations(&pool).await?;
 
@@ -28,7 +51,10 @@ impl SqliteStore {
         let pool = sqlite_pool_options(4, true)
             .connect_with(options)
             .await
-            .with_context(|| format!("failed to connect sqlite database: {}", path.display()))?;
+            .map_err(|source| StoreStartupError::Open {
+                path: path.display().to_string(),
+                source,
+            })?;
 
         run_store_migrations(&pool).await?;
 
@@ -74,6 +100,9 @@ fn sqlite_pool_options(max_connections: u32, enable_wal: bool) -> SqlitePoolOpti
 // DatabaseMigration として通知される。かつての接続毎 CRLF 自己修復(#211)は
 // WP-C6 で撤去済み — 根本原因は .gitattributes (*.sql text eol=lf、#211 同梱)で解消済み。
 async fn run_store_migrations(pool: &Pool<Sqlite>) -> Result<()> {
-    STORE_MIGRATOR.run(pool).await?;
+    STORE_MIGRATOR
+        .run(pool)
+        .await
+        .map_err(StoreStartupError::Migration)?;
     Ok(())
 }

--- a/crates/store/src/sqlite/mod.rs
+++ b/crates/store/src/sqlite/mod.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use async_trait::async_trait;
 use kukuri_core::{
     BlobHash, EnvelopeId, FollowEdge, KukuriEnvelope, Profile, ReplicaId, ThreadRef,
@@ -42,6 +42,8 @@ mod live_game;
 mod notifications;
 mod projections;
 mod social;
+
+pub use connection::StoreStartupError;
 
 #[derive(Clone)]
 pub struct SqliteStore {

--- a/crates/store/src/tests/migrations.rs
+++ b/crates/store/src/tests/migrations.rs
@@ -65,6 +65,83 @@ async fn connect_file_fails_loudly_on_line_ending_variant_migration_checksums() 
 }
 
 #[tokio::test]
+async fn connect_file_migration_failure_is_typed_as_migration_error() {
+    // WP-Q2: 起動 Failed 画面のエラー分類を文字列 contains から typed downcast に
+    // 移すため、migration 失敗が StoreStartupError::Migration として downcast できることを固定する。
+    use crate::StoreStartupError;
+
+    let tempdir = tempdir().expect("tempdir");
+    let db_path = tempdir.path().join("store.db");
+    let store = SqliteStore::connect_file(&db_path)
+        .await
+        .expect("initialize sqlite store");
+    store.close().await;
+
+    // 適用済み migration の checksum を書き換えて version mismatch を誘発する。
+    let database_url = format!("sqlite://{}", db_path.display());
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(&database_url)
+        .await
+        .expect("reopen sqlite db");
+    let version = 20260319000000_i64;
+    let migration = STORE_MIGRATOR
+        .iter()
+        .find(|migration| {
+            migration.version == version && !migration.migration_type.is_down_migration()
+        })
+        .expect("embedded store migration");
+    sqlx::query("UPDATE _sqlx_migrations SET checksum = ?1 WHERE version = ?2")
+        .bind(crlf_variant_checksum(migration.sql.as_ref()))
+        .bind(version)
+        .execute(&pool)
+        .await
+        .expect("rewrite migration checksum");
+    pool.close().await;
+
+    let error = match SqliteStore::connect_file(&db_path).await {
+        Ok(_) => panic!("checksum mismatch must fail"),
+        Err(error) => error,
+    };
+    let typed = error
+        .downcast_ref::<StoreStartupError>()
+        .expect("startup error must be typed as StoreStartupError");
+    assert!(
+        matches!(typed, StoreStartupError::Migration(_)),
+        "expected Migration variant, got {typed:?}"
+    );
+    // message は従来と同一(表示・ログ・既存文字列アサーションは不変)。
+    assert!(
+        format!("{error:#}").contains("was previously applied but has been modified"),
+        "migration source message must survive typing: {error:#}"
+    );
+}
+
+#[tokio::test]
+async fn connect_file_open_failure_is_typed_as_open_error() {
+    // 存在しない親ディレクトリ配下のパスは create_if_missing でも作成できず接続失敗する。
+    use crate::StoreStartupError;
+
+    let tempdir = tempdir().expect("tempdir");
+    let db_path = tempdir.path().join("missing-parent").join("store.db");
+    let error = match SqliteStore::connect_file(&db_path).await {
+        Ok(_) => panic!("connecting under a missing parent dir must fail"),
+        Err(error) => error,
+    };
+    let typed = error
+        .downcast_ref::<StoreStartupError>()
+        .expect("startup error must be typed as StoreStartupError");
+    assert!(
+        matches!(typed, StoreStartupError::Open { .. }),
+        "expected Open variant, got {typed:?}"
+    );
+    assert!(
+        format!("{error:#}").contains("failed to connect sqlite database"),
+        "open error message must survive typing: {error:#}"
+    );
+}
+
+#[tokio::test]
 async fn connect_file_applies_unfiltered_projection_indexes() {
     let tempdir = tempdir().expect("tempdir");
     let db_path = tempdir.path().join("store.db");


### PR DESCRIPTION
## Summary
- store に `StoreStartupError` (Open / Migration) を `thiserror` で導入し、`connect()` / `run_store_migrations()` の `.with_context()` を `.map_err()` に置換
- `desktop-runtime` → `src-tauri` へ re-export チェーンを敷設
- `src-tauri` の `classify_startup_error` を `anyhow::downcast_ref::<StoreStartupError>()` による typed 分類に置換（旧: error message の文字列 contains）
- `StartupError` 構造体を導入し、`build_desktop_state` / `failed_status` の戻り値を型安全に

## Test plan
- [x] store migration テスト 9 件 green（うち 2 件が新規: `connect_file_migration_failure_is_typed_as_migration_error`, `connect_file_open_failure_is_typed_as_open_error`）
- [x] src-tauri テスト 13 件 green（`classify_startup_error_ignores_message_strings_for_non_store_errors` が新規）
- [x] `cargo check` src-tauri 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)