### PR TITLE
[refactor] 通知ステータスを event push で即時反映 (WP-Q2 PR5)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/background_notifications.rs
+++ b/apps/desktop/src-tauri/src/commands/background_notifications.rs
@@ -20,7 +20,7 @@ use tracing::{debug, warn};
 
 use crate::{commands::os_notification::show_platform_notification, state::DesktopState};
 
-const POLL_INTERVAL: Duration = Duration::from_secs(15);
+const FALLBACK_POLL_INTERVAL: Duration = Duration::from_secs(60);
 
 /// User-facing OS notification preferences. Mirrors the `OsNotificationSettings`
 /// type the frontend persists in `localStorage` (camelCase keys on the wire).
@@ -123,11 +123,26 @@ pub fn set_os_notification_settings(
     state.replace_settings(settings);
 }
 
-/// Start the background poll loop. Call once after the runtime is ready.
+/// Start the background notification dispatcher. Subscribes to runtime events
+/// for instant dispatch and falls back to a 60-second poll for resilience.
 pub fn spawn(app: AppHandle) {
+    if let Some(state) = app.try_state::<DesktopState>() {
+        let mut rx = state.runtime.subscribe_events();
+        let event_app = app.clone();
+        tauri::async_runtime::spawn(async move {
+            while let Ok(event) = rx.recv().await {
+                if matches!(event, kukuri_desktop_runtime::RuntimeEvent::NotificationStatusChanged) {
+                    if let Err(error) = poll_once(&event_app).await {
+                        debug!(%error, "event-driven notification poll skipped");
+                    }
+                }
+            }
+        });
+    }
+
     tauri::async_runtime::spawn(async move {
         loop {
-            tokio::time::sleep(POLL_INTERVAL).await;
+            tokio::time::sleep(FALLBACK_POLL_INTERVAL).await;
             if let Err(error) = poll_once(&app).await {
                 debug!(%error, "background notification poll skipped");
             }

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -6,7 +6,7 @@ use std::{
 
 use kukuri_desktop_runtime::{DesktopRuntime, StoreStartupError, resolve_db_path_from_env};
 use serde::{Deserialize, Serialize};
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 pub(crate) struct DesktopState {
     pub(crate) runtime: Arc<DesktopRuntime>,
@@ -192,7 +192,19 @@ pub(crate) fn build_desktop_state(
     // runtime 常駐のセッション維持スケジューラをここで起動する(停止は shutdown / プロセス終了)。
     tauri::async_runtime::block_on(runtime.start_community_node_session_scheduler());
 
+    spawn_runtime_event_bridge(app_handle, &runtime);
+
     Ok(DesktopState { runtime })
+}
+
+fn spawn_runtime_event_bridge(app_handle: &tauri::AppHandle, runtime: &Arc<DesktopRuntime>) {
+    let mut rx = runtime.subscribe_events();
+    let app = app_handle.clone();
+    tauri::async_runtime::spawn(async move {
+        while let Ok(event) = rx.recv().await {
+            let _ = app.emit("kukuri://runtime-event", &event);
+        }
+    });
 }
 
 fn app_consent_path(db_path: &Path) -> PathBuf {

--- a/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
+++ b/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
@@ -1,5 +1,6 @@
 import {
   startTransition,
+  useCallback,
   useEffect,
   type MutableRefObject,
 } from 'react';
@@ -31,6 +32,7 @@ import {
   messageFromError,
   profileInputFromProfile,
 } from '@/shell/selectors';
+import { useRuntimeEventBridge } from '@/shell/data/useRuntimeEventBridge';
 
 type Setter<K extends keyof DesktopShellState> = (
   value: DesktopShellStateValue<K>
@@ -182,46 +184,38 @@ export function useDesktopShellDataEffects({
     };
   }, [activeTopic, refreshVisibleShellData, selectedThread, visibleRefreshInFlightRef]);
 
-  useEffect(() => {
-    let disposed = false;
-
-    const refreshStatus = async () => {
+  const refreshNotificationStatus = useCallback(async () => {
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+      return;
+    }
+    try {
+      const status = await api.getNotificationStatus();
+      setNotificationStatus(status);
       if (
-        disposed ||
-        (typeof document !== 'undefined' && document.visibilityState === 'hidden')
+        status.unread_count > 0 &&
+        shellChromeState.activePrimarySection !== 'notifications'
       ) {
-        return;
+        const notificationItems = await api.listNotifications();
+        startTransition(() => {
+          setNotifications(notificationItems);
+        });
       }
-      try {
-        const status = await api.getNotificationStatus();
-        if (!disposed) {
-          setNotificationStatus(status);
-        }
-        if (
-          status.unread_count > 0 &&
-          shellChromeState.activePrimarySection !== 'notifications'
-        ) {
-          const notificationItems = await api.listNotifications();
-          if (!disposed) {
-            startTransition(() => {
-              setNotifications(notificationItems);
-            });
-          }
-        }
-      } catch {
-        // best effort badge refresh
-      }
-    };
+    } catch {
+      // best effort badge refresh
+    }
+  }, [api, setNotificationStatus, setNotifications, shellChromeState.activePrimarySection]);
 
-    void refreshStatus();
+  useRuntimeEventBridge(refreshNotificationStatus);
+
+  useEffect(() => {
+    void refreshNotificationStatus();
     const intervalId = window.setInterval(() => {
-      void refreshStatus();
+      void refreshNotificationStatus();
     }, STATUS_REFRESH_INTERVAL_MS);
     return () => {
-      disposed = true;
       window.clearInterval(intervalId);
     };
-  }, [api, setNotificationStatus, setNotifications, shellChromeState.activePrimarySection]);
+  }, [refreshNotificationStatus]);
 
   useEffect(() => {
     let disposed = false;

--- a/apps/desktop/src/shell/data/useRuntimeEventBridge.ts
+++ b/apps/desktop/src/shell/data/useRuntimeEventBridge.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+import { isTauriRuntime } from '@/lib/releaseReadiness';
+
+type RuntimeEventPayload = {
+  type: string;
+};
+
+export function useRuntimeEventBridge(
+  onNotificationStatusChanged: () => void
+): void {
+  const callbackRef = useRef(onNotificationStatusChanged);
+
+  useEffect(() => {
+    callbackRef.current = onNotificationStatusChanged;
+  }, [onNotificationStatusChanged]);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    let unlisten: UnlistenFn | undefined;
+    let cancelled = false;
+
+    void (async () => {
+      const dispose = await listen<RuntimeEventPayload>(
+        'kukuri://runtime-event',
+        (event) => {
+          switch (event.payload?.type) {
+            case 'notification_status_changed':
+              callbackRef.current();
+              break;
+          }
+        }
+      );
+      if (cancelled) {
+        dispose();
+        return;
+      }
+      unlisten = dispose;
+    })();
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+}

--- a/apps/desktop/src/shell/store.ts
+++ b/apps/desktop/src/shell/store.ts
@@ -70,7 +70,7 @@ export type DesktopShellPageProps = AppProps & {
 };
 
 export const REFRESH_INTERVAL_MS = 3000;
-export const STATUS_REFRESH_INTERVAL_MS = 10000;
+export const STATUS_REFRESH_INTERVAL_MS = 60000;
 export const VIDEO_POSTER_TIMEOUT_MS = 5000;
 export const MEDIA_DEBUG_STORAGE_KEY = 'kukuri:media-debug';
 export const SHELL_WORKSPACE_ID = 'shell-primary-workspace';

--- a/crates/app-api/src/service/direct_messages_subscription_support.rs
+++ b/crates/app-api/src/service/direct_messages_subscription_support.rs
@@ -21,6 +21,7 @@ impl AppService {
             Arc::clone(&self.keys),
             Arc::clone(&self.last_sync_ts),
             Arc::clone(&self.subscription_registry.direct_message_subscriptions),
+            Arc::clone(&self.notification_inserted_notify),
             self.current_author_pubkey().as_str(),
         )
         .await
@@ -274,6 +275,7 @@ impl AppService {
             Arc::clone(&self.transport),
             Arc::clone(&self.keys),
             Arc::clone(&self.last_sync_ts),
+            Arc::clone(&self.notification_inserted_notify),
             self.current_author_pubkey().as_str(),
             peer_pubkey.as_str(),
         )
@@ -302,6 +304,7 @@ impl AppService {
             Arc::clone(&self.transport),
             Arc::clone(&self.keys),
             Arc::clone(&self.last_sync_ts),
+            Arc::clone(&self.notification_inserted_notify),
             self.current_author_pubkey().as_str(),
             peer_pubkey.as_str(),
         )
@@ -375,6 +378,7 @@ impl AppService {
         transport: Arc<dyn Transport>,
         keys: Arc<KukuriKeys>,
         last_sync: Arc<Mutex<Option<i64>>>,
+        notification_inserted: Arc<tokio::sync::Notify>,
         local_author_pubkey: &str,
         peer_pubkey: &str,
     ) -> Result<()> {
@@ -451,6 +455,7 @@ impl AppService {
                         ).await {
                             Ok(true) => {
                                 *last_sync.lock().await = Some(Utc::now().timestamp_millis());
+                                notification_inserted.notify_waiters();
                             }
                             Ok(false) => {}
                             Err(error) => {

--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -335,6 +335,7 @@ pub struct AppService {
     pub(crate) private_channel_capability_persist:
         std::sync::OnceLock<PrivateChannelCapabilityPersist>,
     pub(crate) private_channel_capability_persist_guard: Arc<Mutex<()>>,
+    pub(crate) notification_inserted_notify: Arc<tokio::sync::Notify>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -483,6 +484,7 @@ impl AppService {
             gossip_disabled_channels: Arc::new(Mutex::new(HashSet::new())),
             private_channel_capability_persist: std::sync::OnceLock::new(),
             private_channel_capability_persist_guard: Arc::new(Mutex::new(())),
+            notification_inserted_notify: Arc::new(tokio::sync::Notify::new()),
         }
     }
 
@@ -493,6 +495,10 @@ impl AppService {
     /// 復元前に接続すると復元途中の部分リストが永続化される。
     pub fn set_private_channel_capability_persist(&self, persist: PrivateChannelCapabilityPersist) {
         let _ = self.private_channel_capability_persist.set(persist);
+    }
+
+    pub fn notification_inserted_notify(&self) -> Arc<tokio::sync::Notify> {
+        Arc::clone(&self.notification_inserted_notify)
     }
 
     pub(crate) async fn resolve_repost_source(

--- a/crates/app-api/src/service/private_channels_support.rs
+++ b/crates/app-api/src/service/private_channels_support.rs
@@ -632,6 +632,7 @@ impl AppService {
         let transport = Arc::clone(&self.transport);
         let metaverse_room_events = Arc::clone(&self.metaverse_room_events);
         let last_sync = Arc::clone(&self.last_sync_ts);
+        let notification_inserted = Arc::clone(&self.notification_inserted_notify);
         let public_topic_delivery = Arc::clone(&self.public_topic_delivery);
         let topic = topic_id.to_string();
         let storage_channel_id = channel_storage_id(channel_id.as_ref());
@@ -727,6 +728,7 @@ impl AppService {
                             ).await {
                                 Ok(true) => {
                                     *last_sync.lock().await = Some(now);
+                                    notification_inserted.notify_waiters();
                                 }
                                 Ok(false) => {}
                                 Err(error) => {

--- a/crates/app-api/src/service/social_helpers.rs
+++ b/crates/app-api/src/service/social_helpers.rs
@@ -50,6 +50,7 @@ pub(crate) fn schedule_direct_message_reconcile_with_services(
     keys: Arc<KukuriKeys>,
     last_sync: Arc<Mutex<Option<i64>>>,
     direct_message_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
+    notification_inserted: Arc<tokio::sync::Notify>,
     local_author_pubkey: String,
     author_pubkey: String,
 ) {
@@ -63,6 +64,7 @@ pub(crate) fn schedule_direct_message_reconcile_with_services(
             keys,
             last_sync,
             direct_message_subscriptions,
+            notification_inserted,
             local_author_pubkey.as_str(),
         )
         .await
@@ -86,6 +88,7 @@ pub(crate) async fn reconcile_direct_message_subscriptions_with_services(
     keys: Arc<KukuriKeys>,
     last_sync: Arc<Mutex<Option<i64>>>,
     direct_message_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
+    notification_inserted: Arc<tokio::sync::Notify>,
     local_author_pubkey: &str,
 ) -> Result<()> {
     let desired_peers =
@@ -119,6 +122,7 @@ pub(crate) async fn reconcile_direct_message_subscriptions_with_services(
             Arc::clone(&transport),
             Arc::clone(&keys),
             Arc::clone(&last_sync),
+            Arc::clone(&notification_inserted),
             local_author_pubkey,
             peer_pubkey.as_str(),
         )

--- a/crates/app-api/src/service/social_runtime_support.rs
+++ b/crates/app-api/src/service/social_runtime_support.rs
@@ -158,6 +158,7 @@ impl AppService {
         let transport = Arc::clone(&self.transport);
         let keys = Arc::clone(&self.keys);
         let last_sync = Arc::clone(&self.last_sync_ts);
+        let notification_inserted = Arc::clone(&self.notification_inserted_notify);
         let direct_message_subscriptions =
             Arc::clone(&self.subscription_registry.direct_message_subscriptions);
         let author_key = normalize_author_pubkey(author_pubkey)?;
@@ -205,6 +206,7 @@ impl AppService {
                         Arc::clone(&keys),
                         Arc::clone(&last_sync),
                         Arc::clone(&direct_message_subscriptions),
+                        Arc::clone(&notification_inserted),
                         local_author_pubkey.clone(),
                         author_key_for_task.clone(),
                     );
@@ -226,6 +228,7 @@ impl AppService {
             let recovery_transport = Arc::clone(&transport);
             let recovery_keys = Arc::clone(&keys);
             let recovery_last_sync = Arc::clone(&last_sync);
+            let recovery_notification_inserted = Arc::clone(&notification_inserted);
             let recovery_direct_message_subscriptions = Arc::clone(&direct_message_subscriptions);
             let recovery_local_author_pubkey = local_author_pubkey.clone();
             let recovery_author_pubkey = author_key_for_task.clone();
@@ -253,6 +256,7 @@ impl AppService {
                             Arc::clone(&recovery_keys),
                             Arc::clone(&recovery_last_sync),
                             Arc::clone(&recovery_direct_message_subscriptions),
+                            Arc::clone(&recovery_notification_inserted),
                             recovery_local_author_pubkey,
                             recovery_author_pubkey,
                         );
@@ -309,6 +313,7 @@ impl AppService {
                             ).await {
                                 Ok(true) => {
                                     *last_sync.lock().await = Some(Utc::now().timestamp_millis());
+                                    notification_inserted.notify_waiters();
                                 }
                                 Ok(false) => {}
                                 Err(error) => {
@@ -340,6 +345,7 @@ impl AppService {
                                 Arc::clone(&keys),
                                 Arc::clone(&last_sync),
                                 Arc::clone(&direct_message_subscriptions),
+                                Arc::clone(&notification_inserted),
                                 local_author_pubkey.clone(),
                                 author_key_for_task.clone(),
                             );

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -45,4 +45,4 @@ pub use requests::{
     SetMyProfileRequest, SetTopicGossipEnabledRequest, ToggleReactionRequest,
     UnsubscribeTopicRequest, UpdateGameRoomRequest, UpdateMetaverseRoomRequest,
 };
-pub use runtime::DesktopRuntime;
+pub use runtime::{DesktopRuntime, RuntimeEvent};

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -64,6 +64,12 @@ pub(crate) const PRIVATE_CHANNEL_CAPABILITIES_KEY: &str = "registry";
 pub(crate) const GOSSIP_SUBSCRIPTION_STATE_PURPOSE: &str = "gossip-subscription-state";
 pub(crate) const GOSSIP_SUBSCRIPTION_STATE_KEY: &str = "registry";
 
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RuntimeEvent {
+    NotificationStatusChanged,
+}
+
 pub struct DesktopRuntime {
     pub(crate) app_service: AppService,
     pub(crate) author_keys: Arc<KukuriKeys>,
@@ -86,6 +92,7 @@ pub struct DesktopRuntime {
         Arc<Mutex<Option<crate::community_node::EffectiveSeedPeerApplyState>>>,
     pub(crate) runtime_connectivity_apply_version: Arc<AtomicU64>,
     pub(crate) effective_seed_peer_apply_version: Arc<AtomicU64>,
+    event_sender: tokio::sync::broadcast::Sender<RuntimeEvent>,
 }
 
 fn load_private_channel_capabilities(
@@ -277,6 +284,18 @@ impl DesktopRuntime {
         app_service.warm_social_graph().await?;
         app_service.resume_direct_message_state().await?;
 
+        let (event_sender, _) = tokio::sync::broadcast::channel(64);
+        {
+            let notify = app_service.notification_inserted_notify();
+            let sender = event_sender.clone();
+            tokio::spawn(async move {
+                loop {
+                    notify.notified().await;
+                    let _ = sender.send(RuntimeEvent::NotificationStatusChanged);
+                }
+            });
+        }
+
         Ok(Self {
             app_service,
             author_keys,
@@ -303,6 +322,7 @@ impl DesktopRuntime {
             ))),
             runtime_connectivity_apply_version: Arc::new(AtomicU64::new(0)),
             effective_seed_peer_apply_version: Arc::new(AtomicU64::new(0)),
+            event_sender,
         })
     }
 
@@ -326,6 +346,14 @@ impl DesktopRuntime {
 
     pub fn db_path(&self) -> &Path {
         &self.db_path
+    }
+
+    pub fn subscribe_events(&self) -> tokio::sync::broadcast::Receiver<RuntimeEvent> {
+        self.event_sender.subscribe()
+    }
+
+    pub(crate) fn emit_event(&self, event: RuntimeEvent) {
+        let _ = self.event_sender.send(event);
     }
 
     pub(crate) async fn persist_gossip_subscription_state_from_app(&self) -> Result<()> {

--- a/crates/desktop-runtime/src/runtime/notifications_messages_api.rs
+++ b/crates/desktop-runtime/src/runtime/notifications_messages_api.rs
@@ -9,13 +9,18 @@ impl DesktopRuntime {
         &self,
         request: NotificationIdRequest,
     ) -> Result<NotificationStatusView> {
-        self.app_service
+        let status = self
+            .app_service
             .mark_notification_read(request.notification_id.as_str())
-            .await
+            .await?;
+        self.emit_event(RuntimeEvent::NotificationStatusChanged);
+        Ok(status)
     }
 
     pub async fn mark_all_notifications_read(&self) -> Result<NotificationStatusView> {
-        self.app_service.mark_all_notifications_read().await
+        let status = self.app_service.mark_all_notifications_read().await?;
+        self.emit_event(RuntimeEvent::NotificationStatusChanged);
+        Ok(status)
     }
 
     pub async fn get_notification_status(&self) -> Result<NotificationStatusView> {

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -14,11 +14,11 @@
     },
     {
       "lines": 1087,
-      "path": "crates/harness/src/scenarios/community_node.rs"
+      "path": "crates/app-api/src/service/private_channels_support.rs"
     },
     {
-      "lines": 1085,
-      "path": "crates/app-api/src/service/private_channels_support.rs"
+      "lines": 1087,
+      "path": "crates/harness/src/scenarios/community_node.rs"
     },
     {
       "lines": 1079,


### PR DESCRIPTION
## Summary
- app-api に `notification_inserted_notify` (`Arc<tokio::sync::Notify>`) を追加し、通知挿入の 3 経路（object event / follow event / DM hint）すべてで `notify_waiters()` を発火
- desktop-runtime に `RuntimeEvent` enum + `tokio::sync::broadcast` channel を追加し、notification relay task で `Notify` → `broadcast` を橋渡し
- src-tauri に `spawn_runtime_event_bridge` を追加し、`broadcast` → `app.emit("kukuri://runtime-event")` で Tauri イベントとしてフロントへ push
- フロント `useRuntimeEventBridge` hook で `event.type` を switch 分岐し、`notification_status_changed` で即時リフレッシュ
- `mark_notification_read` / `mark_all_notifications_read` でも `RuntimeEvent::NotificationStatusChanged` を emit
- ポーリング間隔を 10s → 60s に緩和（フォールバック用途に変更）
- `background_notifications.rs` のトレイ通知ループも event-driven dispatch に変更

## Test plan
- [ ] デスクトップアプリ起動 → 通知受信時にベルアイコンが即時更新されること
- [ ] 通知を既読にした時にステータスが即時反映されること
- [ ] トレイ最小化中に通知を受信したらシステム通知が表示されること
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` green
- [ ] `tsc --noEmit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)