### PR TITLE
[fix] 同期ステータスを event push で即時反映 (WP-Q2b)

### DIFF
--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -193,6 +193,7 @@ pub(crate) fn build_desktop_state(
     tauri::async_runtime::block_on(runtime.start_community_node_session_scheduler());
 
     spawn_runtime_event_bridge(app_handle, &runtime);
+    tauri::async_runtime::block_on(runtime.start_sync_status_observer());
 
     Ok(DesktopState { runtime })
 }

--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -225,3 +225,5 @@ export type SubmitCommunityNodeReportResult = { status: SubmitCommunityNodeRepor
  */
 reference_id?: string | null, };
 
+export type RuntimeEvent = { "type": "notification_status_changed" } | { "type": "sync_status_changed", sync_status?: SyncStatus | null, community_node_statuses?: Array<CommunityNodeNodeStatus> | null, };
+

--- a/apps/desktop/src/shell/data/useConnectivityStatusRefresh.ts
+++ b/apps/desktop/src/shell/data/useConnectivityStatusRefresh.ts
@@ -1,0 +1,32 @@
+import { startTransition, useCallback } from 'react';
+
+import type { DesktopApi } from '@/lib/api';
+import { mergeCommunityNodeStatuses } from '@/shell/selectors';
+import type { DesktopShellState, DesktopShellStateValue } from '@/shell/store';
+
+type Setter<K extends keyof DesktopShellState> = (
+  value: DesktopShellStateValue<K>
+) => void;
+
+export function useConnectivityStatusRefresh(
+  api: DesktopApi,
+  setSyncStatus: Setter<'syncStatus'>,
+  setCommunityNodeStatuses: Setter<'communityNodeStatuses'>
+): () => Promise<void> {
+  return useCallback(async () => {
+    const [syncStatusResult, communityNodeStatusesResult] = await Promise.allSettled([
+      api.getSyncStatus(),
+      api.getCommunityNodeStatuses(),
+    ]);
+    startTransition(() => {
+      if (syncStatusResult.status === 'fulfilled') {
+        setSyncStatus(syncStatusResult.value);
+      }
+      if (communityNodeStatusesResult.status === 'fulfilled') {
+        setCommunityNodeStatuses((current) =>
+          mergeCommunityNodeStatuses(current, communityNodeStatusesResult.value)
+        );
+      }
+    });
+  }, [api, setCommunityNodeStatuses, setSyncStatus]);
+}

--- a/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
+++ b/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
@@ -7,7 +7,9 @@ import {
 
 import type {
   AttachmentView,
+  CommunityNodeNodeStatus,
   DesktopApi,
+  SyncStatus,
 } from '@/lib/api';
 
 import {
@@ -17,6 +19,7 @@ import {
 import {
   PUBLIC_CHANNEL_REF,
   PUBLIC_TIMELINE_SCOPE,
+  CONNECTIVITY_STATUS_FALLBACK_INTERVAL_MS,
   REFRESH_INTERVAL_MS,
   STATUS_REFRESH_INTERVAL_MS,
   type DesktopShellState,
@@ -28,11 +31,13 @@ import { VISIBLE_TIMELINE_LIMIT } from '@/shell/pagination';
 import {
   authorViewFromDirectMessageConversation,
   createGameEditorDraft,
+  mergeCommunityNodeStatuses,
   mergeKnownAuthors,
   messageFromError,
   profileInputFromProfile,
 } from '@/shell/selectors';
 import { useRuntimeEventBridge } from '@/shell/data/useRuntimeEventBridge';
+import { isTauriRuntime } from '@/lib/releaseReadiness';
 
 type Setter<K extends keyof DesktopShellState> = (
   value: DesktopShellStateValue<K>
@@ -63,7 +68,10 @@ type UseDesktopShellDataEffectsArgs = {
     currentThread: string | null,
     mode?: 'apply' | 'buffer'
   ) => Promise<void>;
+  refreshConnectivityStatus: () => Promise<void>;
   setNotificationStatus: Setter<'notificationStatus'>;
+  setCommunityNodeStatuses: Setter<'communityNodeStatuses'>;
+  setSyncStatus: Setter<'syncStatus'>;
   setLocalProfile: Setter<'localProfile'>;
   setProfileDraft: Setter<'profileDraft'>;
   setKnownAuthorsByPubkey: Setter<'knownAuthorsByPubkey'>;
@@ -113,7 +121,10 @@ export function useDesktopShellDataEffects({
   visibleRefreshInFlightRef,
   loadTopics,
   refreshVisibleShellData,
+  refreshConnectivityStatus,
   setNotificationStatus,
+  setCommunityNodeStatuses,
+  setSyncStatus,
   setLocalProfile,
   setProfileDraft,
   setKnownAuthorsByPubkey,
@@ -205,7 +216,39 @@ export function useDesktopShellDataEffects({
     }
   }, [api, setNotificationStatus, setNotifications, shellChromeState.activePrimarySection]);
 
-  useRuntimeEventBridge(refreshNotificationStatus);
+  const applySyncStatusChange = useCallback(
+    (
+      syncStatus: SyncStatus | null,
+      communityNodeStatuses: CommunityNodeNodeStatus[] | null
+    ) => {
+      startTransition(() => {
+        if (syncStatus) {
+          setSyncStatus(syncStatus);
+        }
+        if (communityNodeStatuses) {
+          setCommunityNodeStatuses((current) =>
+            mergeCommunityNodeStatuses(current, communityNodeStatuses)
+          );
+        }
+      });
+    },
+    [setCommunityNodeStatuses, setSyncStatus]
+  );
+
+  useRuntimeEventBridge(refreshNotificationStatus, applySyncStatusChange);
+
+  useEffect(() => {
+    void refreshConnectivityStatus();
+    const intervalMs = isTauriRuntime()
+      ? CONNECTIVITY_STATUS_FALLBACK_INTERVAL_MS
+      : REFRESH_INTERVAL_MS;
+    const intervalId = window.setInterval(() => {
+      void refreshConnectivityStatus();
+    }, intervalMs);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [refreshConnectivityStatus]);
 
   useEffect(() => {
     void refreshNotificationStatus();

--- a/apps/desktop/src/shell/data/useRuntimeEventBridge.test.ts
+++ b/apps/desktop/src/shell/data/useRuntimeEventBridge.test.ts
@@ -1,0 +1,90 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { RuntimeEvent } from '@/lib/api';
+import { createDesktopMockApi } from '@/mocks/desktopApiMock';
+
+const listenMock = vi.fn();
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
+}));
+
+import { useRuntimeEventBridge } from './useRuntimeEventBridge';
+
+type EventCallback = (event: { payload: RuntimeEvent }) => void;
+
+describe('useRuntimeEventBridge', () => {
+  beforeEach(() => {
+    listenMock.mockReset();
+    listenMock.mockResolvedValue(() => undefined);
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+  });
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+  });
+
+  test('does not subscribe outside the Tauri runtime', () => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    renderHook(() => useRuntimeEventBridge(vi.fn(), vi.fn()));
+    expect(listenMock).not.toHaveBeenCalled();
+  });
+
+  test('dispatches notification and partial sync status events without API calls', async () => {
+    let capturedCallback: EventCallback | undefined;
+    listenMock.mockImplementation(async (_event: string, callback: EventCallback) => {
+      capturedCallback = callback;
+      return () => undefined;
+    });
+    const onNotificationStatusChanged = vi.fn();
+    const onSyncStatusChanged = vi.fn();
+    const api = createDesktopMockApi();
+    const syncStatus = await api.getSyncStatus();
+    const communityNodeStatuses = await api.getCommunityNodeStatuses();
+
+    renderHook(() =>
+      useRuntimeEventBridge(onNotificationStatusChanged, onSyncStatusChanged)
+    );
+    await vi.waitFor(() => expect(capturedCallback).toBeDefined());
+
+    capturedCallback?.({ payload: { type: 'notification_status_changed' } });
+    expect(onNotificationStatusChanged).toHaveBeenCalledTimes(1);
+
+    capturedCallback?.({
+      payload: {
+        type: 'sync_status_changed',
+        sync_status: syncStatus,
+        community_node_statuses: null,
+      },
+    });
+    capturedCallback?.({
+      payload: {
+        type: 'sync_status_changed',
+        sync_status: null,
+        community_node_statuses: communityNodeStatuses,
+      },
+    });
+    expect(onSyncStatusChanged).toHaveBeenNthCalledWith(1, syncStatus, null);
+    expect(onSyncStatusChanged).toHaveBeenNthCalledWith(2, null, communityNodeStatuses);
+  });
+
+  test('ignores unknown runtime event types', async () => {
+    let capturedCallback: EventCallback | undefined;
+    listenMock.mockImplementation(async (_event: string, callback: EventCallback) => {
+      capturedCallback = callback;
+      return () => undefined;
+    });
+    const onNotificationStatusChanged = vi.fn();
+    const onSyncStatusChanged = vi.fn();
+
+    renderHook(() =>
+      useRuntimeEventBridge(onNotificationStatusChanged, onSyncStatusChanged)
+    );
+    await vi.waitFor(() => expect(capturedCallback).toBeDefined());
+
+    capturedCallback?.({ payload: { type: 'future_event' } as unknown as RuntimeEvent });
+    expect(onNotificationStatusChanged).not.toHaveBeenCalled();
+    expect(onSyncStatusChanged).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/shell/data/useRuntimeEventBridge.ts
+++ b/apps/desktop/src/shell/data/useRuntimeEventBridge.ts
@@ -1,20 +1,26 @@
 import { useEffect, useRef } from 'react';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 
+import type { CommunityNodeNodeStatus, RuntimeEvent, SyncStatus } from '@/lib/api';
 import { isTauriRuntime } from '@/lib/releaseReadiness';
 
-type RuntimeEventPayload = {
-  type: string;
-};
-
 export function useRuntimeEventBridge(
-  onNotificationStatusChanged: () => void
+  onNotificationStatusChanged: () => void,
+  onSyncStatusChanged: (
+    syncStatus: SyncStatus | null,
+    communityNodeStatuses: CommunityNodeNodeStatus[] | null
+  ) => void
 ): void {
-  const callbackRef = useRef(onNotificationStatusChanged);
+  const notificationCallbackRef = useRef(onNotificationStatusChanged);
+  const syncStatusCallbackRef = useRef(onSyncStatusChanged);
 
   useEffect(() => {
-    callbackRef.current = onNotificationStatusChanged;
+    notificationCallbackRef.current = onNotificationStatusChanged;
   }, [onNotificationStatusChanged]);
+
+  useEffect(() => {
+    syncStatusCallbackRef.current = onSyncStatusChanged;
+  }, [onSyncStatusChanged]);
 
   useEffect(() => {
     if (!isTauriRuntime()) {
@@ -25,12 +31,18 @@ export function useRuntimeEventBridge(
     let cancelled = false;
 
     void (async () => {
-      const dispose = await listen<RuntimeEventPayload>(
+      const dispose = await listen<RuntimeEvent>(
         'kukuri://runtime-event',
         (event) => {
           switch (event.payload?.type) {
             case 'notification_status_changed':
-              callbackRef.current();
+              notificationCallbackRef.current();
+              break;
+            case 'sync_status_changed':
+              syncStatusCallbackRef.current(
+                event.payload.sync_status ?? null,
+                event.payload.community_node_statuses ?? null
+              );
               break;
           }
         }

--- a/apps/desktop/src/shell/renderIsolation.smoke.test.tsx
+++ b/apps/desktop/src/shell/renderIsolation.smoke.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/shell/store';
 
 // 購読の分離 smoke(WP-H6 PR2)。
-// 3 秒ポーリングが更新するフィールド(syncStatus / communityNodeStatuses)を
+// runtime event push / fallback が更新するフィールド(syncStatus / communityNodeStatuses)を
 // setState しても、それを選択していない購読者が再レンダーされないことを固定する。
 // selector なしの全ストア購読(useDesktopShellStore())ではこの分離が成立しない。
 
@@ -31,7 +31,7 @@ function RelatedProbe() {
 }
 
 describe('shell 購読の分離(レンダー回数 smoke)', () => {
-  it('ポーリング更新フィールドを選択しない購読者は再レンダーされない', () => {
+  it('接続状態の更新フィールドを選択しない購読者は再レンダーされない', () => {
     const store = createDesktopShellStore();
     renderLog.length = 0;
     render(
@@ -43,7 +43,7 @@ describe('shell 購読の分離(レンダー回数 smoke)', () => {
     expect(countRenders('unrelated')).toBe(1);
     expect(countRenders('related')).toBe(1);
 
-    // ポーリング 1 周期相当: syncStatus を新しいオブジェクトで更新する
+    // runtime event push 相当: syncStatus を新しいオブジェクトで更新する
     act(() => {
       const current = store.getState().syncStatus;
       store.setState({

--- a/apps/desktop/src/shell/store.ts
+++ b/apps/desktop/src/shell/store.ts
@@ -70,6 +70,7 @@ export type DesktopShellPageProps = AppProps & {
 };
 
 export const REFRESH_INTERVAL_MS = 3000;
+export const CONNECTIVITY_STATUS_FALLBACK_INTERVAL_MS = 60000;
 export const STATUS_REFRESH_INTERVAL_MS = 60000;
 export const VIDEO_POSTER_TIMEOUT_MS = 5000;
 export const MEDIA_DEBUG_STORAGE_KEY = 'kukuri:media-debug';

--- a/apps/desktop/src/shell/useDesktopShellData.test.tsx
+++ b/apps/desktop/src/shell/useDesktopShellData.test.tsx
@@ -21,6 +21,12 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+const { listenMock } = vi.hoisted(() => ({ listenMock: vi.fn() }));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
+}));
+
 import type {
   DesktopApi,
   JoinedPrivateChannelView,
@@ -31,7 +37,10 @@ import type {
   TimelineView,
 } from '@/lib/api';
 import { createDesktopMockApi } from '@/mocks/desktopApiMock';
-import { REFRESH_INTERVAL_MS } from '@/shell/store';
+import {
+  CONNECTIVITY_STATUS_FALLBACK_INTERVAL_MS,
+  REFRESH_INTERVAL_MS,
+} from '@/shell/store';
 import { useDesktopShellData } from '@/shell/useDesktopShellData';
 import {
   actPatchState,
@@ -176,6 +185,9 @@ beforeEach(() => {
   // mount 直後からポーリングが走るため renderHook 前に必ず fake timers。
   // (afterEach の useRealTimers は setup.ts が行う)
   vi.useFakeTimers();
+  listenMock.mockReset();
+  listenMock.mockResolvedValue(() => undefined);
+  delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
 });
 
 describe('useDesktopShellData characterization', () => {
@@ -307,6 +319,43 @@ describe('useDesktopShellData characterization', () => {
     ).toEqual(['post-new', 'post-old']);
 
     view.unmount();
+  });
+
+  test('connectivity status uses mount bootstrap and 60 second fallback, not the 3 second refresh', async () => {
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    const baseApi = createDesktopMockApi();
+    const getSyncStatus = vi.fn(baseApi.getSyncStatus);
+    const getCommunityNodeStatuses = vi.fn(baseApi.getCommunityNodeStatuses);
+    const api: DesktopApi = {
+      ...baseApi,
+      getSyncStatus,
+      getCommunityNodeStatuses,
+    };
+
+    const { view } = renderDataHook(api);
+    await flushAsyncWork();
+    expect(getSyncStatus).toHaveBeenCalledTimes(1);
+    expect(getCommunityNodeStatuses).toHaveBeenCalledTimes(1);
+
+    getSyncStatus.mockClear();
+    getCommunityNodeStatuses.mockClear();
+    await advanceTimersAsync(REFRESH_INTERVAL_MS);
+    expect(getSyncStatus).not.toHaveBeenCalled();
+    expect(getCommunityNodeStatuses).not.toHaveBeenCalled();
+
+    act(() => window.dispatchEvent(new Event('focus')));
+    await flushAsyncWork();
+    expect(getSyncStatus).not.toHaveBeenCalled();
+    expect(getCommunityNodeStatuses).not.toHaveBeenCalled();
+
+    await advanceTimersAsync(
+      CONNECTIVITY_STATUS_FALLBACK_INTERVAL_MS - REFRESH_INTERVAL_MS
+    );
+    expect(getSyncStatus).toHaveBeenCalledTimes(1);
+    expect(getCommunityNodeStatuses).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
   });
 
   test('refreshTimelineFeed applies pending posts without api calls and clears the pending buffers', async () => {

--- a/apps/desktop/src/shell/useDesktopShellData.ts
+++ b/apps/desktop/src/shell/useDesktopShellData.ts
@@ -16,6 +16,7 @@ import type {
 } from '@/lib/api';
 
 import { removeRecordEntry, setRecordEntry, updateRecordEntry } from '@/shell/stateUpdates';
+import { useConnectivityStatusRefresh } from '@/shell/data/useConnectivityStatusRefresh';
 import { useDesktopShellDataEffects } from '@/shell/data/useDesktopShellDataEffects';
 import { useDraftMediaHelpers } from '@/shell/data/useDraftMediaHelpers';
 import { useQueuedLoadTopics } from '@/shell/data/useQueuedLoadTopics';
@@ -913,22 +914,11 @@ export function useDesktopShellData({
     ]
   );
 
-  const refreshConnectivityStatus = useCallback(async () => {
-    const [syncStatusResult, communityNodeStatusesResult] = await Promise.allSettled([
-      api.getSyncStatus(),
-      api.getCommunityNodeStatuses(),
-    ]);
-    startTransition(() => {
-      if (syncStatusResult.status === 'fulfilled') {
-        setSyncStatus(syncStatusResult.value);
-      }
-      if (communityNodeStatusesResult.status === 'fulfilled') {
-        setCommunityNodeStatuses((current) =>
-          mergeCommunityNodeStatuses(current, communityNodeStatusesResult.value)
-        );
-      }
-    });
-  }, [api, setCommunityNodeStatuses, setSyncStatus]);
+  const refreshConnectivityStatus = useConnectivityStatusRefresh(
+    api,
+    setSyncStatus,
+    setCommunityNodeStatuses
+  );
 
   const queuedLoadTopics = useQueuedLoadTopics(runLoadTopics);
   const loadTopics = useCallback(

--- a/apps/desktop/src/shell/useDesktopShellData.ts
+++ b/apps/desktop/src/shell/useDesktopShellData.ts
@@ -317,18 +317,14 @@ export function useDesktopShellData({
         publicTimelineResult,
         joinedChannelsResult,
         threadViewResult,
-        statusResult,
-        communityNodeStatusesResult,
       ] = await Promise.allSettled([
-          api.listTimeline(topic, null, VISIBLE_TIMELINE_LIMIT, timelineScope),
-          api.listTimeline(topic, null, VISIBLE_TIMELINE_LIMIT, PUBLIC_TIMELINE_SCOPE),
-          api.listJoinedPrivateChannels(topic),
-          currentThread
-            ? api.listThread(topic, currentThread, null, THREAD_TIMELINE_LIMIT)
-            : Promise.resolve(null),
-          api.getSyncStatus(),
-          api.getCommunityNodeStatuses(),
-        ]);
+        api.listTimeline(topic, null, VISIBLE_TIMELINE_LIMIT, timelineScope),
+        api.listTimeline(topic, null, VISIBLE_TIMELINE_LIMIT, PUBLIC_TIMELINE_SCOPE),
+        api.listJoinedPrivateChannels(topic),
+        currentThread
+          ? api.listThread(topic, currentThread, null, THREAD_TIMELINE_LIMIT)
+          : Promise.resolve(null),
+      ]);
 
       if (requestId !== loadTopicsRequestRef.current) {
         return;
@@ -339,7 +335,6 @@ export function useDesktopShellData({
         publicTimelineResult,
         joinedChannelsResult,
         threadViewResult,
-        statusResult,
       ].find((result) => result.status === 'rejected');
 
       startTransition(() => {
@@ -436,16 +431,6 @@ export function useDesktopShellData({
           setThread([]);
         }
 
-        if (statusResult.status === 'fulfilled') {
-          setSyncStatus(statusResult.value);
-        }
-
-        if (communityNodeStatusesResult.status === 'fulfilled') {
-          setCommunityNodeStatuses((current) =>
-            mergeCommunityNodeStatuses(current, communityNodeStatusesResult.value)
-          );
-        }
-
         setError(
           firstCoreFailure && firstCoreFailure.status === 'rejected'
             ? messageFromError(firstCoreFailure.reason, translate('common:errors.failedToLoadTopic'))
@@ -457,7 +442,6 @@ export function useDesktopShellData({
       api,
       clearPendingTimeline,
       loadTopicsRequestRef,
-      setCommunityNodeStatuses,
       setError,
       setChannelPanelStateByTopic,
       setJoinedChannelsByTopic,
@@ -466,7 +450,6 @@ export function useDesktopShellData({
       setPendingTimelineSnapshotsByKey,
       setPublicTimelineNextCursorByTopic,
       setPublicTimelinesByTopic,
-      setSyncStatus,
       setThread,
       setThreadNextCursorById,
       setTimelineNextCursorByKey,
@@ -930,7 +913,31 @@ export function useDesktopShellData({
     ]
   );
 
-  const loadTopics = useQueuedLoadTopics(runLoadTopics);
+  const refreshConnectivityStatus = useCallback(async () => {
+    const [syncStatusResult, communityNodeStatusesResult] = await Promise.allSettled([
+      api.getSyncStatus(),
+      api.getCommunityNodeStatuses(),
+    ]);
+    startTransition(() => {
+      if (syncStatusResult.status === 'fulfilled') {
+        setSyncStatus(syncStatusResult.value);
+      }
+      if (communityNodeStatusesResult.status === 'fulfilled') {
+        setCommunityNodeStatuses((current) =>
+          mergeCommunityNodeStatuses(current, communityNodeStatusesResult.value)
+        );
+      }
+    });
+  }, [api, setCommunityNodeStatuses, setSyncStatus]);
+
+  const queuedLoadTopics = useQueuedLoadTopics(runLoadTopics);
+  const loadTopics = useCallback(
+    async (topics: string[], currentActiveTopic: string, currentThread: string | null) => {
+      await queuedLoadTopics(topics, currentActiveTopic, currentThread);
+      await refreshConnectivityStatus();
+    },
+    [queuedLoadTopics, refreshConnectivityStatus]
+  );
 
   const refreshVisibleTimelineAfterPublish = useCallback(
     async (topic: string, currentThread: string | null) => {
@@ -970,7 +977,10 @@ export function useDesktopShellData({
     visibleRefreshInFlightRef,
     loadTopics,
     refreshVisibleShellData,
+    refreshConnectivityStatus,
     setNotificationStatus,
+    setCommunityNodeStatuses,
+    setSyncStatus,
     setLocalProfile,
     setProfileDraft,
     setKnownAuthorsByPubkey,

--- a/crates/desktop-runtime/src/ipc_ts_export.rs
+++ b/crates/desktop-runtime/src/ipc_ts_export.rs
@@ -30,7 +30,7 @@ fn export_ipc_types() {
         CommunityNodeAuthState, CommunityNodeAuthorityScope, CommunityNodeCapabilityScope,
         CommunityNodeConfig, CommunityNodeManifest, CommunityNodeManifestFetch,
         CommunityNodeManifestFetchStatus, CommunityNodeNodeConfig, CommunityNodeNodeStatus,
-        CommunityNodeP2pBoundary, CommunityNodeSessionPhase, DiscoveryConfig,
+        CommunityNodeP2pBoundary, CommunityNodeSessionPhase, DiscoveryConfig, RuntimeEvent,
         SubmitCommunityNodeReportRequest, SubmitCommunityNodeReportResult,
         SubmitCommunityNodeReportStatus,
     };
@@ -150,6 +150,7 @@ fn export_ipc_types() {
         SubmitCommunityNodeReportRequest,
         SubmitCommunityNodeReportStatus,
         SubmitCommunityNodeReportResult,
+        RuntimeEvent,
     );
 
     let path = concat!(

--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -290,6 +290,10 @@ impl DesktopRuntime {
     }
 
     pub async fn shutdown(&self) {
+        if let Some(handle) = self.sync_status_observer_task.lock().await.take() {
+            handle.abort();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        }
         if let Some(handle) = self.community_node_scheduler_task.lock().await.take() {
             handle.abort();
             let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -58,16 +58,23 @@ mod content_profile_api;
 mod notifications_messages_api;
 mod private_channels_game_api;
 mod sync_live_api;
+mod sync_status_observer;
 
 pub(crate) const PRIVATE_CHANNEL_CAPABILITIES_PURPOSE: &str = "private-channel-capabilities";
 pub(crate) const PRIVATE_CHANNEL_CAPABILITIES_KEY: &str = "registry";
 pub(crate) const GOSSIP_SUBSCRIPTION_STATE_PURPOSE: &str = "gossip-subscription-state";
 pub(crate) const GOSSIP_SUBSCRIPTION_STATE_KEY: &str = "registry";
 
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RuntimeEvent {
     NotificationStatusChanged,
+    SyncStatusChanged {
+        sync_status: Option<Box<SyncStatus>>,
+        community_node_statuses: Option<Vec<CommunityNodeNodeStatus>>,
+    },
 }
 
 pub struct DesktopRuntime {
@@ -85,6 +92,7 @@ pub struct DesktopRuntime {
     pub(crate) community_node_reconnect_state: Arc<Mutex<CommunityNodeReconnectState>>,
     pub(crate) community_node_reconnect_guard: Arc<Mutex<()>>,
     pub(crate) community_node_scheduler_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    pub(crate) sync_status_observer_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
     pub(crate) active_connectivity_urls: Arc<Mutex<Vec<String>>>,
     pub(crate) last_runtime_connectivity_assist_state:
         Arc<Mutex<Option<crate::community_node::RuntimeConnectivityAssistState>>>,
@@ -313,6 +321,7 @@ impl DesktopRuntime {
             )),
             community_node_reconnect_guard: Arc::new(Mutex::new(())),
             community_node_scheduler_task: Mutex::new(None),
+            sync_status_observer_task: Mutex::new(None),
             active_connectivity_urls: Arc::new(Mutex::new(relay_config.iroh_relay_urls.clone())),
             last_runtime_connectivity_assist_state: Arc::new(Mutex::new(Some(
                 initial_runtime_connectivity_state,

--- a/crates/desktop-runtime/src/runtime/sync_status_observer.rs
+++ b/crates/desktop-runtime/src/runtime/sync_status_observer.rs
@@ -1,0 +1,137 @@
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use tokio::time::MissedTickBehavior;
+use tracing::{info, warn};
+
+use super::*;
+
+const SYNC_STATUS_OBSERVER_INTERVAL: Duration = Duration::from_secs(3);
+
+#[derive(Default)]
+struct SyncStatusEventSnapshot {
+    sync_status: Option<SyncStatus>,
+    community_node_statuses: Option<Vec<CommunityNodeNodeStatus>>,
+    sync_error: Option<String>,
+    community_node_error: Option<String>,
+}
+
+impl SyncStatusEventSnapshot {
+    fn update_sync_status(&mut self, result: Result<SyncStatus>) -> Option<SyncStatus> {
+        match result {
+            Ok(next) => {
+                if self.sync_error.take().is_some() {
+                    info!("sync status observer recovered");
+                }
+                if self.sync_status.as_ref() == Some(&next) {
+                    return None;
+                }
+                self.sync_status = Some(next.clone());
+                Some(next)
+            }
+            Err(error) => {
+                let message = format!("{error:#}");
+                if self.sync_error.as_deref() != Some(message.as_str()) {
+                    warn!(error = %message, "sync status observer failed to load sync status");
+                    self.sync_error = Some(message);
+                }
+                None
+            }
+        }
+    }
+
+    fn update_community_node_statuses(
+        &mut self,
+        result: Result<Vec<CommunityNodeNodeStatus>>,
+    ) -> Option<Vec<CommunityNodeNodeStatus>> {
+        match result {
+            Ok(next) => {
+                if self.community_node_error.take().is_some() {
+                    info!("sync status observer recovered community-node status");
+                }
+                if self.community_node_statuses.as_ref() == Some(&next) {
+                    return None;
+                }
+                self.community_node_statuses = Some(next.clone());
+                Some(next)
+            }
+            Err(error) => {
+                let message = format!("{error:#}");
+                if self.community_node_error.as_deref() != Some(message.as_str()) {
+                    warn!(error = %message, "sync status observer failed to load community-node status");
+                    self.community_node_error = Some(message);
+                }
+                None
+            }
+        }
+    }
+}
+
+impl DesktopRuntime {
+    async fn observe_sync_status_once(&self, snapshot: &mut SyncStatusEventSnapshot) {
+        let (sync_status, community_node_statuses) =
+            tokio::join!(self.get_sync_status(), self.get_community_node_statuses());
+        let sync_status = snapshot.update_sync_status(sync_status);
+        let community_node_statuses =
+            snapshot.update_community_node_statuses(community_node_statuses);
+        if sync_status.is_some() || community_node_statuses.is_some() {
+            self.emit_event(RuntimeEvent::SyncStatusChanged {
+                sync_status: sync_status.map(Box::new),
+                community_node_statuses,
+            });
+        }
+    }
+
+    pub async fn start_sync_status_observer(self: &Arc<Self>) {
+        self.start_sync_status_observer_with_interval(SYNC_STATUS_OBSERVER_INTERVAL)
+            .await;
+    }
+
+    pub(crate) async fn start_sync_status_observer_with_interval(self: &Arc<Self>, tick: Duration) {
+        let mut task = self.sync_status_observer_task.lock().await;
+        if task.as_ref().is_some_and(|handle| !handle.is_finished()) {
+            return;
+        }
+
+        let weak: Weak<Self> = Arc::downgrade(self);
+        *task = Some(tokio::spawn(async move {
+            let mut interval = tokio::time::interval(tick);
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            let mut snapshot = SyncStatusEventSnapshot::default();
+            loop {
+                interval.tick().await;
+                let Some(runtime) = weak.upgrade() else {
+                    return;
+                };
+                runtime.observe_sync_status_once(&mut snapshot).await;
+                drop(runtime);
+            }
+        }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_updates_each_status_source_independently() {
+        let mut snapshot = SyncStatusEventSnapshot::default();
+
+        assert!(
+            snapshot
+                .update_sync_status(Err(anyhow!("sync unavailable")))
+                .is_none()
+        );
+        assert_eq!(
+            snapshot.update_community_node_statuses(Ok(Vec::new())),
+            Some(Vec::new())
+        );
+        assert!(
+            snapshot
+                .update_community_node_statuses(Ok(Vec::new()))
+                .is_none(),
+            "an unchanged successful source must be suppressed"
+        );
+    }
+}

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -58,5 +58,6 @@ mod identity_restart;
 mod media_blob_restore;
 mod private_channels;
 mod replication_heuristics;
+mod runtime_events;
 mod seeded_dht;
 mod static_peer;

--- a/crates/desktop-runtime/src/tests/runtime_events.rs
+++ b/crates/desktop-runtime/src/tests/runtime_events.rs
@@ -1,0 +1,118 @@
+use super::*;
+
+#[test]
+fn sync_status_changed_event_wire_shape_is_stable() {
+    let event = RuntimeEvent::SyncStatusChanged {
+        sync_status: None,
+        community_node_statuses: None,
+    };
+
+    assert_eq!(
+        serde_json::to_value(event).expect("serialize runtime event"),
+        serde_json::json!({
+            "type": "sync_status_changed",
+            "sync_status": null,
+            "community_node_statuses": null,
+        })
+    );
+}
+
+#[tokio::test]
+async fn sync_status_observer_emits_only_changed_snapshot_parts_and_stops_on_shutdown() {
+    let _serial = acquire_async_test_lock().await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("runtime-events.db");
+    let runtime = Arc::new(
+        DesktopRuntime::new_with_config_and_identity(
+            &db_path,
+            TransportNetworkConfig::loopback(),
+            IdentityStorageMode::FileOnly,
+        )
+        .await
+        .expect("runtime"),
+    );
+    let mut events = runtime.subscribe_events();
+
+    runtime
+        .start_sync_status_observer_with_interval(Duration::from_millis(25))
+        .await;
+    runtime
+        .start_sync_status_observer_with_interval(Duration::from_millis(25))
+        .await;
+
+    let first = timeout(Duration::from_secs(5), events.recv())
+        .await
+        .expect("initial event timeout")
+        .expect("initial event");
+    match first {
+        RuntimeEvent::SyncStatusChanged {
+            sync_status,
+            community_node_statuses,
+        } => {
+            assert!(sync_status.is_some());
+            assert_eq!(community_node_statuses, Some(Vec::new()));
+        }
+        other => panic!("unexpected initial event: {other:?}"),
+    }
+
+    assert!(
+        timeout(Duration::from_millis(150), events.recv())
+            .await
+            .is_err(),
+        "unchanged snapshots and a duplicate start must not emit"
+    );
+
+    runtime
+        .set_topic_gossip_enabled(SetTopicGossipEnabledRequest {
+            topic: "kukuri:topic:q2b-observer".to_string(),
+            enabled: false,
+        })
+        .await
+        .expect("disable topic gossip");
+    let sync_changed = timeout(Duration::from_secs(5), events.recv())
+        .await
+        .expect("sync change timeout")
+        .expect("sync change event");
+    match sync_changed {
+        RuntimeEvent::SyncStatusChanged {
+            sync_status,
+            community_node_statuses,
+        } => {
+            assert!(
+                sync_status
+                    .expect("changed sync status")
+                    .gossip_disabled_topics
+                    .contains(&"kukuri:topic:q2b-observer".to_string())
+            );
+            assert!(community_node_statuses.is_none());
+        }
+        other => panic!("unexpected sync event: {other:?}"),
+    }
+
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: "http://127.0.0.1:9".to_string(),
+            auto_approve: false,
+            resolved_urls: None,
+        }],
+    };
+    let community_node_changed = timeout(Duration::from_secs(5), events.recv())
+        .await
+        .expect("community-node change timeout")
+        .expect("community-node change event");
+    match community_node_changed {
+        RuntimeEvent::SyncStatusChanged {
+            sync_status,
+            community_node_statuses,
+        } => {
+            assert!(sync_status.is_none());
+            let statuses = community_node_statuses.expect("changed community-node statuses");
+            assert_eq!(statuses.len(), 1);
+            assert_eq!(statuses[0].base_url, "http://127.0.0.1:9");
+        }
+        other => panic!("unexpected community-node event: {other:?}"),
+    }
+
+    runtime.shutdown().await;
+    assert!(runtime.sync_status_observer_task.lock().await.is_none());
+}


### PR DESCRIPTION
## Summary
- `DesktopRuntime` に3秒間隔の差分 observer と型付き `sync_status_changed` runtime event を追加
- frontend は generated `RuntimeEvent` をdispatchし、同期/CN状態をpushでstoreへ反映
- 3秒のvisible refreshから状態getterを外し、mount時取得 + 60秒fallbackへ分離
- observerの重複起動防止、独立エラー処理、shutdown停止とfrontend回帰テストを追加

## Validation
- `cargo xtask check`
- `cargo xtask ipc-types --check`
- `cargo test -p kukuri-desktop-runtime runtime_events -- --nocapture`
- `cargo xtask desktop-test` (62 files / 547 tests)
- `cargo xtask tauri-check`
- `cargo xtask e2e-smoke`
- `cargo xtask desktop-ui-check` (Storybook build, browser E2E 10, visual smoke 14を含む)
- Windows実機2インスタンス: Aをトレイ常駐させ、B停止後約17秒で `connected: no / peers: 0`、B再起動後約23秒で `connected: yes / peers: 1` を確認（いずれも60秒fallback前）

## Local environment note
- `cargo xtask rust-test` は docs-sync の既存custom relay依存2件がWindows環境で90秒timeoutし、個別serial再実行でも同じ結果。Q2b対象テストと上記validationは成功しており、Linux CIを最終判定とする。