### PR TITLE
refactor: extract shell share preview hook

### DIFF
--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -18,12 +18,11 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-import { type ChannelAccessTokenPreview, runtimeApi } from '@/lib/api';
+import { runtimeApi } from '@/lib/api';
 import i18n from '@/i18n';
 import { getResolvedLocale } from '@/i18n/format';
 import {
   buildTopicLink,
-  parseChannelAccessPreviewDeepLink,
   type InternalSmartReference,
 } from '@/lib/internalLinks';
 import { CLIPBOARD_COPY_EVENT, copyTextToClipboard } from '@/lib/utils';
@@ -40,7 +39,6 @@ import {
 import {
   formatCount,
   mergeKnownAuthors,
-  messageFromError,
   privateComposeTarget,
   privateTimelineScope,
   syncStatusBadgeLabel,
@@ -63,6 +61,7 @@ import {
 import { DesktopShellOverlays } from '@/shell/page/DesktopShellOverlays';
 import { DesktopShellPrimaryWorkspace } from '@/shell/page/DesktopShellPrimaryWorkspace';
 import { DesktopShellSettingsDrawer } from '@/shell/page/DesktopShellSettingsDrawer';
+import { useSharePreview } from '@/shell/page/useSharePreview';
 import { useShallow } from 'zustand/react/shallow';
 
 const CLIPBOARD_TOAST_TIMEOUT_MS = 2200;
@@ -114,12 +113,6 @@ export function DesktopShellPage({
   const [profileAvatarCropFile, setProfileAvatarCropFile] = useState<File | null>(null);
   const [profileAvatarCropOpen, setProfileAvatarCropOpen] = useState(false);
   const [profileAvatarInputKey, setProfileAvatarInputKey] = useState(0);
-  const [sharePreviewOpen, setSharePreviewOpen] = useState(false);
-  const [sharePreviewToken, setSharePreviewToken] = useState<string | null>(null);
-  const [sharePreviewData, setSharePreviewData] = useState<ChannelAccessTokenPreview | null>(null);
-  const [sharePreviewLoading, setSharePreviewLoading] = useState(false);
-  const [sharePreviewError, setSharePreviewError] = useState<string | null>(null);
-  const [shareImportPending, setShareImportPending] = useState(false);
   const [clipboardToastId, setClipboardToastId] = useState(0);
   const previousPrimarySectionRef = useRef(shellChromeState.activePrimarySection);
   const previousTimelineViewRef = useRef(shellChromeState.timelineView);
@@ -444,90 +437,12 @@ export function DesktopShellPage({
   const handleCopyInternalLink = useCallback((link: string) => {
     void copyTextToClipboard(link);
   }, []);
-  const handleOpenSharePreview = useCallback(
-    async (token: string) => {
-      setSharePreviewOpen(true);
-      setSharePreviewToken(token);
-      setSharePreviewData(null);
-      setSharePreviewError(null);
-      setSharePreviewLoading(true);
-      try {
-        const preview = await api.previewChannelAccessToken(token);
-        setSharePreviewData(preview);
-      } catch (error) {
-        setSharePreviewError(
-          messageFromError(error, translate('channels:errors.failedPreviewToken'))
-        );
-      } finally {
-        setSharePreviewLoading(false);
-      }
-    },
-    [api, translate]
-  );
-  const handleAccessPreviewDeepLink = useCallback(
-    async (url: string) => {
-      const reference = parseChannelAccessPreviewDeepLink(url);
-      if (!reference) {
-        return;
-      }
-      await handleOpenSharePreview(reference.token);
-    },
-    [handleOpenSharePreview]
-  );
-  useEffect(() => {
-    const handleBrowserEvent = (event: Event) => {
-      const url =
-        event instanceof CustomEvent && typeof event.detail?.url === 'string'
-          ? event.detail.url
-          : null;
-      if (url) {
-        void handleAccessPreviewDeepLink(url);
-      }
-    };
-    window.addEventListener('kukuri:open-url', handleBrowserEvent);
-
-    let disposed = false;
-    let unlisten: (() => void) | undefined;
-    void import('@tauri-apps/plugin-deep-link')
-      .then(async ({ getCurrent, onOpenUrl }) => {
-        if (disposed) {
-          return;
-        }
-        const currentUrls = await getCurrent();
-        if (!disposed) {
-          for (const url of currentUrls ?? []) {
-            await handleAccessPreviewDeepLink(url);
-          }
-        }
-        unlisten = await onOpenUrl((urls) => {
-          for (const url of urls) {
-            void handleAccessPreviewDeepLink(url);
-          }
-        });
-      })
-      .catch(() => undefined);
-
-    return () => {
-      disposed = true;
-      window.removeEventListener('kukuri:open-url', handleBrowserEvent);
-      unlisten?.();
-    };
-  }, [handleAccessPreviewDeepLink]);
-  const handleConfirmShareImport = useCallback(async () => {
-    if (!sharePreviewToken) {
-      return;
-    }
-    setShareImportPending(true);
-    setSharePreviewError(null);
-    try {
-      await handleImportChannelAccessToken(sharePreviewToken);
-      setSharePreviewOpen(false);
-    } catch (error) {
-      setSharePreviewError(messageFromError(error, translate('channels:errors.failedJoinChannel')));
-    } finally {
-      setShareImportPending(false);
-    }
-  }, [handleImportChannelAccessToken, sharePreviewToken, translate]);
+  const sharePreview = useSharePreview({
+    api,
+    importChannelAccessToken: handleImportChannelAccessToken,
+    translate,
+  });
+  const handleOpenSharePreview = sharePreview.openPreview;
   const handleActivateReference = useCallback(
     async (reference: InternalSmartReference) => {
       if (reference.kind === 'share_token') {
@@ -1033,17 +948,14 @@ export function DesktopShellPage({
           setLeaveChannelDialogOpen(false);
           setPendingLeaveChannel(null);
         }}
-        sharePreviewOpen={sharePreviewOpen}
-        setSharePreviewOpen={setSharePreviewOpen}
-        sharePreviewToken={sharePreviewToken}
-        setSharePreviewToken={setSharePreviewToken}
-        sharePreviewData={sharePreviewData}
-        setSharePreviewData={setSharePreviewData}
-        sharePreviewLoading={sharePreviewLoading}
-        sharePreviewError={sharePreviewError}
-        setSharePreviewError={setSharePreviewError}
-        shareImportPending={shareImportPending}
-        handleConfirmShareImport={handleConfirmShareImport}
+        sharePreviewOpen={sharePreview.open}
+        handleSharePreviewOpenChange={sharePreview.handleOpenChange}
+        sharePreviewToken={sharePreview.token}
+        sharePreviewData={sharePreview.data}
+        sharePreviewLoading={sharePreview.loading}
+        sharePreviewError={sharePreview.error}
+        shareImportPending={sharePreview.importPending}
+        handleConfirmShareImport={sharePreview.confirmImport}
         handleCreatePrivateChannel={handleCreatePrivateChannel}
         handleJoinChannelAccess={handleJoinChannelAccess}
         handleShareChannelAccess={handleShareChannelAccess}

--- a/apps/desktop/src/shell/page/DesktopShellOverlays.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellOverlays.tsx
@@ -64,14 +64,11 @@ type DesktopShellOverlaysProps = {
   setLeaveChannelDialogOpen: (open: boolean) => void;
   handleConfirmLeaveChannel: () => Promise<void>;
   sharePreviewOpen: boolean;
-  setSharePreviewOpen: Dispatch<SetStateAction<boolean>>;
+  handleSharePreviewOpenChange: (open: boolean) => void;
   sharePreviewToken: string | null;
-  setSharePreviewToken: Dispatch<SetStateAction<string | null>>;
   sharePreviewData: ChannelAccessTokenPreview | null;
-  setSharePreviewData: Dispatch<SetStateAction<ChannelAccessTokenPreview | null>>;
   sharePreviewLoading: boolean;
   sharePreviewError: string | null;
-  setSharePreviewError: Dispatch<SetStateAction<string | null>>;
   shareImportPending: boolean;
   handleConfirmShareImport: () => Promise<void>;
   handleCreatePrivateChannel: (event: FormEvent<HTMLFormElement>) => Promise<void>;
@@ -135,14 +132,11 @@ export function DesktopShellOverlays({
   setLeaveChannelDialogOpen,
   handleConfirmLeaveChannel,
   sharePreviewOpen,
-  setSharePreviewOpen,
+  handleSharePreviewOpenChange,
   sharePreviewToken,
-  setSharePreviewToken,
   sharePreviewData,
-  setSharePreviewData,
   sharePreviewLoading,
   sharePreviewError,
-  setSharePreviewError,
   shareImportPending,
   handleConfirmShareImport,
   handleCreatePrivateChannel,
@@ -366,14 +360,7 @@ export function DesktopShellOverlays({
 
       <Dialog
         open={sharePreviewOpen}
-        onOpenChange={(open) => {
-          setSharePreviewOpen(open);
-          if (!open) {
-            setSharePreviewError(null);
-            setSharePreviewData(null);
-            setSharePreviewToken(null);
-          }
-        }}
+        onOpenChange={handleSharePreviewOpenChange}
       >
         <DialogContent>
           <DialogHeader>
@@ -419,7 +406,7 @@ export function DesktopShellOverlays({
               <Button
                 variant='secondary'
                 type='button'
-                onClick={() => setSharePreviewOpen(false)}
+                onClick={() => handleSharePreviewOpenChange(false)}
               >
                 {t('common:actions.cancel')}
               </Button>

--- a/apps/desktop/src/shell/page/useSharePreview.test.tsx
+++ b/apps/desktop/src/shell/page/useSharePreview.test.tsx
@@ -1,0 +1,98 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { buildChannelAccessPreviewDeepLink } from '@/lib/internalLinks';
+import { createDesktopMockApi } from '@/mocks/desktopApiMock';
+import { useSharePreview } from '@/shell/page/useSharePreview';
+
+const deepLinkMock = vi.hoisted(() => ({
+  currentUrls: [] as string[],
+  onOpenUrl: vi.fn(),
+  unlisten: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-deep-link', () => ({
+  getCurrent: vi.fn(async () => deepLinkMock.currentUrls),
+  onOpenUrl: deepLinkMock.onOpenUrl,
+}));
+
+const preview = {
+  channel_id: 'channel-imported',
+  topic_id: 'kukuri:topic:private-imported',
+  channel_label: 'Imported',
+  inviter_pubkey: 'f'.repeat(64),
+  owner_pubkey: 'f'.repeat(64),
+  epoch_id: 'epoch-imported-1',
+  expires_at: null,
+  namespace_secret_hex: 'a'.repeat(64),
+  kind: 'invite' as const,
+};
+
+function setup() {
+  const api = createDesktopMockApi({ invitePreview: preview });
+  const importChannelAccessToken = vi.fn().mockResolvedValue(undefined);
+  const translate = vi.fn((key: string) => key);
+  const hook = renderHook(() =>
+    useSharePreview({ api, importChannelAccessToken, translate })
+  );
+  return { api, hook, importChannelAccessToken };
+}
+
+afterEach(() => {
+  deepLinkMock.currentUrls = [];
+  deepLinkMock.onOpenUrl.mockReset();
+  deepLinkMock.unlisten.mockReset();
+});
+
+describe('useSharePreview', () => {
+  test('opens a preview from a browser deep-link event and imports only after confirmation', async () => {
+    deepLinkMock.onOpenUrl.mockResolvedValue(deepLinkMock.unlisten);
+    const { api, hook, importChannelAccessToken } = setup();
+    const previewSpy = vi.spyOn(api, 'previewChannelAccessToken');
+    const token = 'invite:encoded-token';
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('kukuri:open-url', {
+          detail: { url: buildChannelAccessPreviewDeepLink(token) },
+        })
+      );
+    });
+
+    await waitFor(() =>
+      expect(hook.result.current.data).toMatchObject({
+        channel_id: preview.channel_id,
+        kind: preview.kind,
+        topic_id: preview.topic_id,
+      })
+    );
+    expect(previewSpy).toHaveBeenCalledWith(token);
+    expect(importChannelAccessToken).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await hook.result.current.confirmImport();
+    });
+    expect(importChannelAccessToken).toHaveBeenCalledWith(token);
+    expect(hook.result.current.open).toBe(false);
+    expect(hook.result.current.token).toBeNull();
+  });
+
+  test('consumes current Tauri URLs and releases both listeners on unmount', async () => {
+    const token = 'invite:startup-token';
+    deepLinkMock.currentUrls = [buildChannelAccessPreviewDeepLink(token)];
+    deepLinkMock.onOpenUrl.mockResolvedValue(deepLinkMock.unlisten);
+    const { api, hook } = setup();
+    const previewSpy = vi.spyOn(api, 'previewChannelAccessToken');
+
+    await waitFor(() => expect(previewSpy).toHaveBeenCalledWith(token));
+    hook.unmount();
+    expect(deepLinkMock.unlisten).toHaveBeenCalled();
+
+    window.dispatchEvent(
+      new CustomEvent('kukuri:open-url', {
+        detail: { url: buildChannelAccessPreviewDeepLink('invite:after-unmount') },
+      })
+    );
+    expect(previewSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/shell/page/useSharePreview.ts
+++ b/apps/desktop/src/shell/page/useSharePreview.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import type { ChannelAccessTokenPreview, DesktopApi } from '@/lib/api';
+import { parseChannelAccessPreviewDeepLink } from '@/lib/internalLinks';
+import type { Translate } from '@/shell/actions/shared';
+import { messageFromError } from '@/shell/selectors';
+
+type UseSharePreviewArgs = {
+  api: DesktopApi;
+  importChannelAccessToken: (token: string) => Promise<void>;
+  translate: Translate;
+};
+
+export function useSharePreview({
+  api,
+  importChannelAccessToken,
+  translate,
+}: UseSharePreviewArgs) {
+  const [open, setOpen] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
+  const [data, setData] = useState<ChannelAccessTokenPreview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [importPending, setImportPending] = useState(false);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setError(null);
+      setData(null);
+      setToken(null);
+    }
+  }, []);
+
+  const openPreview = useCallback(
+    async (nextToken: string) => {
+      setOpen(true);
+      setToken(nextToken);
+      setData(null);
+      setError(null);
+      setLoading(true);
+      try {
+        const preview = await api.previewChannelAccessToken(nextToken);
+        setData(preview);
+      } catch (previewError) {
+        setError(
+          messageFromError(previewError, translate('channels:errors.failedPreviewToken'))
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [api, translate]
+  );
+
+  const openPreviewFromUrl = useCallback(
+    async (url: string) => {
+      const reference = parseChannelAccessPreviewDeepLink(url);
+      if (reference) {
+        await openPreview(reference.token);
+      }
+    },
+    [openPreview]
+  );
+
+  useEffect(() => {
+    const handleBrowserEvent = (event: Event) => {
+      const url =
+        event instanceof CustomEvent && typeof event.detail?.url === 'string'
+          ? event.detail.url
+          : null;
+      if (url) {
+        void openPreviewFromUrl(url);
+      }
+    };
+    window.addEventListener('kukuri:open-url', handleBrowserEvent);
+
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    void import('@tauri-apps/plugin-deep-link')
+      .then(async ({ getCurrent, onOpenUrl }) => {
+        if (disposed) {
+          return;
+        }
+        const currentUrls = await getCurrent();
+        if (!disposed) {
+          for (const url of currentUrls ?? []) {
+            await openPreviewFromUrl(url);
+          }
+        }
+        unlisten = await onOpenUrl((urls) => {
+          for (const url of urls) {
+            void openPreviewFromUrl(url);
+          }
+        });
+      })
+      .catch(() => undefined);
+
+    return () => {
+      disposed = true;
+      window.removeEventListener('kukuri:open-url', handleBrowserEvent);
+      unlisten?.();
+    };
+  }, [openPreviewFromUrl]);
+
+  const confirmImport = useCallback(async () => {
+    if (!token) {
+      return;
+    }
+    setImportPending(true);
+    setError(null);
+    try {
+      await importChannelAccessToken(token);
+      handleOpenChange(false);
+    } catch (importError) {
+      setError(messageFromError(importError, translate('channels:errors.failedJoinChannel')));
+    } finally {
+      setImportPending(false);
+    }
+  }, [handleOpenChange, importChannelAccessToken, token, translate]);
+
+  return {
+    data,
+    error,
+    handleOpenChange,
+    importPending,
+    loading,
+    open,
+    openPreview,
+    confirmImport,
+    token,
+  };
+}

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -9,10 +9,6 @@
       "path": "apps/desktop/src/shell/useDesktopShellViewModels.ts"
     },
     {
-      "lines": 1090,
-      "path": "apps/desktop/src/shell/DesktopShellPage.tsx"
-    },
-    {
       "lines": 1087,
       "path": "crates/app-api/src/service/private_channels_support.rs"
     },
@@ -27,6 +23,10 @@
     {
       "lines": 1035,
       "path": "apps/desktop/src/shell/useDesktopShellData.ts"
+    },
+    {
+      "lines": 1002,
+      "path": "apps/desktop/src/shell/DesktopShellPage.tsx"
     }
   ]
 }


### PR DESCRIPTION
## What changed

- move share preview state, preview loading, import confirmation, and reset behavior into `useSharePreview`
- move browser and Tauri deep-link listeners into the hook with cleanup
- reduce `DesktopShellPage.tsx` from 1,090 to 1,002 lines and ratchet the oversized baseline
- add hook characterization for browser events, startup URLs, confirmation, and listener cleanup

## Why

Q3 reduces the desktop shell orchestration surface without changing UI or route behavior. Share preview was a self-contained lifecycle embedded in the page.

## Validation

- focused Vitest: 13 tests green
- `pnpm typecheck`
- `cargo xtask desktop-ui-check` (549 unit/integration, Storybook build, 10 browser, 14 visual)
- `cargo xtask oversized-files`