### PR TITLE
refactor: unify shell focus scrolling

### DIFF
--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -61,6 +61,7 @@ import {
 import { DesktopShellOverlays } from '@/shell/page/DesktopShellOverlays';
 import { DesktopShellPrimaryWorkspace } from '@/shell/page/DesktopShellPrimaryWorkspace';
 import { DesktopShellSettingsDrawer } from '@/shell/page/DesktopShellSettingsDrawer';
+import { useFocusScroll } from '@/shell/page/useFocusScroll';
 import { useSharePreview } from '@/shell/page/useSharePreview';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -117,9 +118,6 @@ export function DesktopShellPage({
   const previousPrimarySectionRef = useRef(shellChromeState.activePrimarySection);
   const previousTimelineViewRef = useRef(shellChromeState.timelineView);
   const clipboardToastTimeoutRef = useRef<number | null>(null);
-  const lastThreadFocusKeyRef = useRef<string | null>(null);
-  const lastLiveFocusKeyRef = useRef<string | null>(null);
-  const lastGameFocusKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     document.documentElement.lang = locale;
@@ -543,61 +541,25 @@ export function DesktopShellPage({
   const threadFocusKey = selectedThread && focusedObjectId
     ? `${selectedThread}:${focusedObjectId}`
     : null;
-  useEffect(() => {
-    if (!threadFocusKey || lastThreadFocusKeyRef.current === threadFocusKey) {
-      return;
-    }
-    const frameId = window.requestAnimationFrame(() => {
-      const selector = `[data-post-object-id="${focusedObjectId}"]`;
-      const target = document.querySelector(selector);
-      if (target instanceof HTMLElement) {
-        if (typeof target.scrollIntoView === 'function') {
-          target.scrollIntoView({ block: 'center' });
-        }
-        target.focus({ preventScroll: true });
-        lastThreadFocusKeyRef.current = threadFocusKey;
-      }
-    });
-    return () => window.cancelAnimationFrame(frameId);
-  }, [focusedObjectId, threadFocusKey, threadPostViews.length]);
+  useFocusScroll({
+    focusKey: threadFocusKey,
+    readinessKey: threadPostViews.length,
+    selector: focusedObjectId ? `[data-post-object-id="${focusedObjectId}"]` : null,
+  });
   const liveFocusKey =
     shellChromeState.activePrimarySection === 'live' ? selectedLiveSessionId : null;
-  useEffect(() => {
-    if (!liveFocusKey || lastLiveFocusKeyRef.current === liveFocusKey) {
-      return;
-    }
-    const frameId = window.requestAnimationFrame(() => {
-      const selector = `[data-live-session-id="${liveFocusKey}"]`;
-      const target = document.querySelector(selector);
-      if (target instanceof HTMLElement) {
-        if (typeof target.scrollIntoView === 'function') {
-          target.scrollIntoView({ block: 'center' });
-        }
-        target.focus({ preventScroll: true });
-        lastLiveFocusKeyRef.current = liveFocusKey;
-      }
-    });
-    return () => window.cancelAnimationFrame(frameId);
-  }, [liveFocusKey, liveSessionListItems.length]);
+  useFocusScroll({
+    focusKey: liveFocusKey,
+    readinessKey: liveSessionListItems.length,
+    selector: liveFocusKey ? `[data-live-session-id="${liveFocusKey}"]` : null,
+  });
   const gameFocusKey =
     shellChromeState.activePrimarySection === 'game' ? selectedGameRoomId : null;
-  useEffect(() => {
-    if (!gameFocusKey || lastGameFocusKeyRef.current === gameFocusKey) {
-      return;
-    }
-    const frameId = window.requestAnimationFrame(() => {
-      const selector = `[data-game-room-id="${gameFocusKey}"]`;
-      const target = document.querySelector(selector);
-      if (target instanceof HTMLElement) {
-        if (typeof target.scrollIntoView === 'function') {
-          target.scrollIntoView({ block: 'center' });
-        }
-        target.focus({ preventScroll: true });
-        lastGameFocusKeyRef.current = gameFocusKey;
-      }
-    });
-    return () => window.cancelAnimationFrame(frameId);
-  }, [activeGameRooms.length, gameFocusKey]);
+  useFocusScroll({
+    focusKey: gameFocusKey,
+    readinessKey: activeGameRooms.length,
+    selector: gameFocusKey ? `[data-game-room-id="${gameFocusKey}"]` : null,
+  });
   useEffect(() => {
     if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) {
       return;

--- a/apps/desktop/src/shell/page/useFocusScroll.test.tsx
+++ b/apps/desktop/src/shell/page/useFocusScroll.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { useFocusScroll } from '@/shell/page/useFocusScroll';
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe('useFocusScroll', () => {
+  test('retries after readiness changes, then focuses a key only once', () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+    const scrollIntoView = vi.fn();
+    const focus = vi.fn();
+
+    const hook = renderHook(
+      ({ focusKey, readinessKey }) =>
+        useFocusScroll({
+          focusKey,
+          readinessKey,
+          selector: '[data-focus-target="target"]',
+        }),
+      { initialProps: { focusKey: 'thread:post', readinessKey: 0 } }
+    );
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    const target = document.createElement('button');
+    target.dataset.focusTarget = 'target';
+    target.scrollIntoView = scrollIntoView;
+    target.focus = focus;
+    document.body.append(target);
+    hook.rerender({ focusKey: 'thread:post', readinessKey: 1 });
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'center' });
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+    hook.rerender({ focusKey: 'thread:post', readinessKey: 2 });
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    hook.rerender({ focusKey: 'thread:other-post', readinessKey: 2 });
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  test('cancels a pending frame on cleanup', () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(42);
+    const cancelAnimationFrame = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => {});
+
+    const hook = renderHook(() =>
+      useFocusScroll({
+        focusKey: 'live-session',
+        readinessKey: 1,
+        selector: '[data-live-session-id="live-session"]',
+      })
+    );
+    hook.unmount();
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(42);
+  });
+});

--- a/apps/desktop/src/shell/page/useFocusScroll.ts
+++ b/apps/desktop/src/shell/page/useFocusScroll.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+
+type UseFocusScrollArgs = {
+  focusKey: string | null;
+  readinessKey: unknown;
+  selector: string | null;
+};
+
+export function useFocusScroll({
+  focusKey,
+  readinessKey,
+  selector,
+}: UseFocusScrollArgs): void {
+  const lastFocusedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!focusKey || !selector || lastFocusedKeyRef.current === focusKey) {
+      return;
+    }
+    const frameId = window.requestAnimationFrame(() => {
+      const target = document.querySelector(selector);
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+      if (typeof target.scrollIntoView === 'function') {
+        target.scrollIntoView({ block: 'center' });
+      }
+      target.focus({ preventScroll: true });
+      lastFocusedKeyRef.current = focusKey;
+    });
+    return () => window.cancelAnimationFrame(frameId);
+  }, [focusKey, readinessKey, selector]);
+}

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -23,10 +23,6 @@
     {
       "lines": 1035,
       "path": "apps/desktop/src/shell/useDesktopShellData.ts"
-    },
-    {
-      "lines": 1002,
-      "path": "apps/desktop/src/shell/DesktopShellPage.tsx"
     }
   ]
 }


### PR DESCRIPTION
## What changed

- replace the three thread/live/game focus effects with a shared `useFocusScroll` hook
- preserve retry-until-found and focus-once-per-key behavior
- add hook tests for retry, deduplication, key changes, and frame cleanup
- reduce `DesktopShellPage.tsx` to 964 lines and remove it from the oversized baseline

## Validation

- focused Vitest: 7 tests green
- `pnpm typecheck`
- `cargo xtask desktop-ui-check` (551 tests, Storybook, browser, visual)
- `cargo xtask oversized-files`