### PR TITLE
refactor: split shell section loaders

### DIFF
--- a/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.test.tsx
+++ b/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.test.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { createDesktopMockApi } from '@/mocks/desktopApiMock';
+import { useDesktopShellSectionLoaders } from '@/shell/data/loaders/useDesktopShellSectionLoaders';
+import { privateTimelineScope } from '@/shell/selectors';
+import {
+  createDesktopShellStore,
+  DesktopShellStoreContext,
+} from '@/shell/store';
+
+function setup() {
+  const api = createDesktopMockApi();
+  const store = createDesktopShellStore();
+  const loadReactionCatalogData = vi.fn().mockResolvedValue(undefined);
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <DesktopShellStoreContext.Provider value={store}>{children}</DesktopShellStoreContext.Provider>
+  );
+  const hook = renderHook(
+    () =>
+      useDesktopShellSectionLoaders({
+        api,
+        loadReactionCatalogData,
+        storeApi: store,
+        translate: (key) => key,
+      }),
+    { wrapper }
+  );
+  return { api, hook, store };
+}
+
+describe('useDesktopShellSectionLoaders', () => {
+  test('loads only the active live section with the selected channel scope', async () => {
+    const { api, hook, store } = setup();
+    const listLiveSessions = vi.spyOn(api, 'listLiveSessions').mockResolvedValue([]);
+    const listGameRooms = vi.spyOn(api, 'listGameRooms');
+    store.setState((state) => ({
+      selectedChannelIdByTopic: { topic: 'channel-a' },
+      shellChromeState: { ...state.shellChromeState, activePrimarySection: 'live' },
+    }));
+
+    await act(async () => hook.result.current('topic'));
+
+    expect(listLiveSessions).toHaveBeenCalledWith(
+      'topic',
+      privateTimelineScope('channel-a')
+    );
+    expect(store.getState().livePanelStateByTopic.topic).toEqual({
+      status: 'ready',
+      error: null,
+    });
+    expect(listGameRooms).not.toHaveBeenCalled();
+  });
+
+  test('keeps fulfilled DM status when the timeline branch fails', async () => {
+    const { api, hook, store } = setup();
+    const peer = 'b'.repeat(64);
+    const status = await api.getDirectMessageStatus(peer);
+    store.setState((state) => ({
+      selectedDirectMessagePeerPubkey: peer,
+      shellChromeState: { ...state.shellChromeState, activePrimarySection: 'messages' },
+    }));
+    vi.spyOn(api, 'listDirectMessages').mockResolvedValue([]);
+    vi.spyOn(api, 'listDirectMessageMessages').mockRejectedValue(new Error('timeline failed'));
+    vi.spyOn(api, 'getDirectMessageStatus').mockResolvedValue(status);
+
+    await act(async () => hook.result.current('topic'));
+
+    expect(store.getState().directMessageStatusByPeer[peer]).toEqual(status);
+    expect(store.getState().directMessageError).toBe('timeline failed');
+  });
+
+  test('refreshes discovery config without overwriting a dirty editor', async () => {
+    const { api, hook, store } = setup();
+    const config = await api.getDiscoveryConfig();
+    store.setState((state) => ({
+      discoveryEditorDirty: true,
+      discoverySeedInput: 'keep-local-editor',
+      shellChromeState: {
+        ...state.shellChromeState,
+        settingsOpen: true,
+        activeSettingsSection: 'discovery',
+      },
+    }));
+    vi.spyOn(api, 'getDiscoveryConfig').mockResolvedValue(config);
+
+    await act(async () => hook.result.current('topic'));
+
+    expect(store.getState().discoveryConfig).toEqual(config);
+    expect(store.getState().discoverySeedInput).toBe('keep-local-editor');
+  });
+});

--- a/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts
+++ b/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts
@@ -1,0 +1,499 @@
+import { startTransition, useCallback } from 'react';
+
+import type { DesktopApi, NotificationView } from '@/lib/api';
+import { VISIBLE_TIMELINE_LIMIT } from '@/shell/pagination';
+import {
+  authorViewFromDirectMessageConversation,
+  communityNodesToDraftNodes,
+  mergeCommunityNodeStatuses,
+  mergeKnownAuthors,
+  messageFromError,
+  privateTimelineScope,
+  profileInputFromProfile,
+  seedPeersToEditorValue,
+} from '@/shell/selectors';
+import { setRecordEntry } from '@/shell/stateUpdates';
+import {
+  useDesktopShellFieldSetter,
+  type DesktopShellStoreApi,
+} from '@/shell/store';
+
+type UseDesktopShellSectionLoadersArgs = {
+  api: DesktopApi;
+  loadReactionCatalogData: () => Promise<void>;
+  storeApi: DesktopShellStoreApi;
+  translate: (key: string, options?: Record<string, unknown>) => string;
+};
+
+export function useDesktopShellSectionLoaders({
+  api,
+  loadReactionCatalogData,
+  storeApi,
+  translate,
+}: UseDesktopShellSectionLoadersArgs) {
+  const setAuthorError = useDesktopShellFieldSetter('authorError');
+  const setBookmarkedPosts = useDesktopShellFieldSetter('bookmarkedPosts');
+  const setCommunityNodeConfig = useDesktopShellFieldSetter('communityNodeConfig');
+  const setCommunityNodeError = useDesktopShellFieldSetter('communityNodeError');
+  const setCommunityNodeInput = useDesktopShellFieldSetter('communityNodeInput');
+  const setCommunityNodeManifests = useDesktopShellFieldSetter('communityNodeManifests');
+  const setCommunityNodeStatuses = useDesktopShellFieldSetter('communityNodeStatuses');
+  const setDirectMessageError = useDesktopShellFieldSetter('directMessageError');
+  const setDirectMessages = useDesktopShellFieldSetter('directMessages');
+  const setDirectMessageStatusByPeer = useDesktopShellFieldSetter('directMessageStatusByPeer');
+  const setDirectMessageTimelineByPeer = useDesktopShellFieldSetter(
+    'directMessageTimelineByPeer'
+  );
+  const setDirectMessageTimelineNextCursorByPeer = useDesktopShellFieldSetter(
+    'directMessageTimelineNextCursorByPeer'
+  );
+  const setDiscoveryConfig = useDesktopShellFieldSetter('discoveryConfig');
+  const setDiscoveryError = useDesktopShellFieldSetter('discoveryError');
+  const setDiscoverySeedInput = useDesktopShellFieldSetter('discoverySeedInput');
+  const setGamePanelStateByTopic = useDesktopShellFieldSetter('gamePanelStateByTopic');
+  const setGameRoomsByTopic = useDesktopShellFieldSetter('gameRoomsByTopic');
+  const setKnownAuthorsByPubkey = useDesktopShellFieldSetter('knownAuthorsByPubkey');
+  const setLivePanelStateByTopic = useDesktopShellFieldSetter('livePanelStateByTopic');
+  const setLiveSessionsByTopic = useDesktopShellFieldSetter('liveSessionsByTopic');
+  const setLocalPeerTicket = useDesktopShellFieldSetter('localPeerTicket');
+  const setLocalProfile = useDesktopShellFieldSetter('localProfile');
+  const setNotificationAutoReadError = useDesktopShellFieldSetter(
+    'notificationAutoReadError'
+  );
+  const setNotificationPanelState = useDesktopShellFieldSetter('notificationPanelState');
+  const setNotifications = useDesktopShellFieldSetter('notifications');
+  const setNotificationStatus = useDesktopShellFieldSetter('notificationStatus');
+  const setProfileDraft = useDesktopShellFieldSetter('profileDraft');
+  const setProfileError = useDesktopShellFieldSetter('profileError');
+  const setProfilePanelState = useDesktopShellFieldSetter('profilePanelState');
+  const setProfileTimeline = useDesktopShellFieldSetter('profileTimeline');
+  const setProfileTimelineNextCursor = useDesktopShellFieldSetter(
+    'profileTimelineNextCursor'
+  );
+  const setReactionPanelState = useDesktopShellFieldSetter('reactionPanelState');
+  const setSelectedAuthor = useDesktopShellFieldSetter('selectedAuthor');
+  const setSelectedAuthorTimeline = useDesktopShellFieldSetter('selectedAuthorTimeline');
+  const setSelectedAuthorTimelineNextCursor = useDesktopShellFieldSetter(
+    'selectedAuthorTimelineNextCursor'
+  );
+  const setSocialConnections = useDesktopShellFieldSetter('socialConnections');
+  const setSocialConnectionsPanelState = useDesktopShellFieldSetter(
+    'socialConnectionsPanelState'
+  );
+
+  const loadLiveSection = useCallback(
+    async (topic: string, selectedChannelId: string | null) => {
+      try {
+        const sessions = await api.listLiveSessions(
+          topic,
+          privateTimelineScope(selectedChannelId)
+        );
+        startTransition(() => {
+          setLiveSessionsByTopic(setRecordEntry(topic, sessions));
+          setLivePanelStateByTopic(
+            setRecordEntry(topic, { status: 'ready', error: null })
+          );
+        });
+      } catch (error) {
+        setLivePanelStateByTopic(
+          setRecordEntry(topic, {
+            status: 'error',
+            error: messageFromError(
+              error,
+              translate('common:errors.failedToLoadLiveSessions')
+            ),
+          })
+        );
+      }
+    },
+    [api, setLivePanelStateByTopic, setLiveSessionsByTopic, translate]
+  );
+
+  const loadGameSection = useCallback(
+    async (topic: string, selectedChannelId: string | null) => {
+      try {
+        const rooms = await api.listGameRooms(topic, privateTimelineScope(selectedChannelId));
+        startTransition(() => {
+          setGameRoomsByTopic(setRecordEntry(topic, rooms));
+          setGamePanelStateByTopic(
+            setRecordEntry(topic, { status: 'ready', error: null })
+          );
+        });
+      } catch (error) {
+        setGamePanelStateByTopic(
+          setRecordEntry(topic, {
+            status: 'error',
+            error: messageFromError(error, translate('common:errors.failedToLoadGameRooms')),
+          })
+        );
+      }
+    },
+    [api, setGamePanelStateByTopic, setGameRoomsByTopic, translate]
+  );
+
+  const loadProfileSection = useCallback(async () => {
+    try {
+      const [profile, following, followed, muted] = await Promise.all([
+        api.getMyProfile(),
+        api.listSocialConnections('following'),
+        api.listSocialConnections('followed'),
+        api.listSocialConnections('muted'),
+      ]);
+      const timeline = await api.listProfileTimeline(
+        profile.pubkey,
+        null,
+        VISIBLE_TIMELINE_LIMIT
+      );
+      startTransition(() => {
+        setLocalProfile(profile);
+        if (!storeApi.getState().profileDirty) {
+          setProfileDraft(profileInputFromProfile(profile));
+        }
+        setProfileTimeline(timeline.items);
+        setProfileTimelineNextCursor(timeline.next_cursor ?? null);
+        setProfileError(null);
+        setProfilePanelState({ status: 'ready', error: null });
+        setSocialConnections({ following, followed, muted });
+        setKnownAuthorsByPubkey((current) =>
+          mergeKnownAuthors(current, [...following, ...followed, ...muted])
+        );
+        setSocialConnectionsPanelState({ status: 'ready', error: null });
+      });
+    } catch (error) {
+      const message = messageFromError(
+        error,
+        translate('common:errors.failedToLoadProfile')
+      );
+      setProfileError(message);
+      setProfilePanelState({ status: 'error', error: message });
+    }
+  }, [
+    api,
+    setKnownAuthorsByPubkey,
+    setLocalProfile,
+    setProfileDraft,
+    setProfileError,
+    setProfilePanelState,
+    setProfileTimeline,
+    setProfileTimelineNextCursor,
+    setSocialConnections,
+    setSocialConnectionsPanelState,
+    storeApi,
+    translate,
+  ]);
+
+  const loadAuthorSection = useCallback(
+    async (pubkey: string) => {
+      try {
+        const [author, timeline] = await Promise.all([
+          api.getAuthorSocialView(pubkey),
+          api.listProfileTimeline(pubkey, null, VISIBLE_TIMELINE_LIMIT),
+        ]);
+        startTransition(() => {
+          setSelectedAuthor(author);
+          setSelectedAuthorTimeline(timeline.items);
+          setSelectedAuthorTimelineNextCursor(timeline.next_cursor ?? null);
+          setAuthorError(null);
+          if (author) {
+            setKnownAuthorsByPubkey((current) => mergeKnownAuthors(current, [author]));
+          }
+        });
+      } catch (error) {
+        setAuthorError(
+          messageFromError(error, translate('common:errors.failedToLoadAuthor'))
+        );
+      }
+    },
+    [
+      api,
+      setAuthorError,
+      setKnownAuthorsByPubkey,
+      setSelectedAuthor,
+      setSelectedAuthorTimeline,
+      setSelectedAuthorTimelineNextCursor,
+      translate,
+    ]
+  );
+
+  const loadMessagesSection = useCallback(async () => {
+    try {
+      const directMessages = await api.listDirectMessages();
+      startTransition(() => {
+        setDirectMessages(directMessages);
+        setKnownAuthorsByPubkey((current) =>
+          mergeKnownAuthors(
+            current,
+            directMessages.map(authorViewFromDirectMessageConversation)
+          )
+        );
+      });
+      const selectedPeerPubkey = storeApi.getState().selectedDirectMessagePeerPubkey;
+      if (!selectedPeerPubkey) {
+        setDirectMessageError(null);
+        return;
+      }
+      const [timelineResult, statusResult] = await Promise.allSettled([
+        api.listDirectMessageMessages(selectedPeerPubkey, null, VISIBLE_TIMELINE_LIMIT),
+        api.getDirectMessageStatus(selectedPeerPubkey),
+      ]);
+      startTransition(() => {
+        if (timelineResult.status === 'fulfilled') {
+          setDirectMessageTimelineByPeer(
+            setRecordEntry(selectedPeerPubkey, timelineResult.value.items)
+          );
+          setDirectMessageTimelineNextCursorByPeer(
+            setRecordEntry(selectedPeerPubkey, timelineResult.value.next_cursor ?? null)
+          );
+        }
+        if (statusResult.status === 'fulfilled') {
+          setDirectMessageStatusByPeer(
+            setRecordEntry(selectedPeerPubkey, statusResult.value)
+          );
+        }
+        setDirectMessageError(
+          timelineResult.status === 'fulfilled' && statusResult.status === 'fulfilled'
+            ? null
+            : messageFromError(
+                timelineResult.status === 'rejected'
+                  ? timelineResult.reason
+                  : statusResult.status === 'rejected'
+                    ? statusResult.reason
+                    : null,
+                'failed to load direct messages'
+              )
+        );
+      });
+    } catch (error) {
+      setDirectMessageError(messageFromError(error, 'failed to load direct messages'));
+    }
+  }, [
+    api,
+    setDirectMessageError,
+    setDirectMessages,
+    setDirectMessageStatusByPeer,
+    setDirectMessageTimelineByPeer,
+    setDirectMessageTimelineNextCursorByPeer,
+    setKnownAuthorsByPubkey,
+    storeApi,
+  ]);
+
+  const loadNotificationsSection = useCallback(async () => {
+    try {
+      const [status, notificationItems] = await Promise.all([
+        api.getNotificationStatus(),
+        api.listNotifications(),
+      ]);
+      let nextNotifications: NotificationView[] = notificationItems;
+      let nextStatus = status;
+      if (notificationItems.some((notification) => !notification.read_at)) {
+        try {
+          nextStatus = await api.markAllNotificationsRead();
+          const readAt = Date.now();
+          nextNotifications = notificationItems.map((notification) =>
+            notification.read_at ? notification : { ...notification, read_at: readAt }
+          );
+          setNotificationAutoReadError(null);
+        } catch (notificationReadError) {
+          setNotificationAutoReadError(
+            messageFromError(
+              notificationReadError,
+              translate('shell:notifications.errors.failedAutoRead')
+            )
+          );
+        }
+      }
+      startTransition(() => {
+        setNotificationStatus(nextStatus);
+        setNotifications(nextNotifications);
+        setNotificationPanelState({ status: 'ready', error: null });
+      });
+    } catch (error) {
+      setNotificationPanelState({
+        status: 'error',
+        error: messageFromError(
+          error,
+          translate('shell:notifications.errors.failedToLoad')
+        ),
+      });
+    }
+  }, [
+    api,
+    setNotificationAutoReadError,
+    setNotificationPanelState,
+    setNotifications,
+    setNotificationStatus,
+    translate,
+  ]);
+
+  const loadBookmarksSection = useCallback(async () => {
+    try {
+      setBookmarkedPosts(await api.listBookmarkedPosts());
+    } catch {
+      // best effort refresh
+    }
+  }, [api, setBookmarkedPosts]);
+
+  const loadSettingsSection = useCallback(async () => {
+    const { activeSettingsSection } = storeApi.getState().shellChromeState;
+    if (activeSettingsSection === 'connectivity') {
+      try {
+        setLocalPeerTicket(await api.getLocalPeerTicket());
+      } catch {
+        // best effort refresh
+      }
+      return;
+    }
+    if (activeSettingsSection === 'discovery') {
+      try {
+        const config = await api.getDiscoveryConfig();
+        setDiscoveryConfig(config);
+        if (!storeApi.getState().discoveryEditorDirty) {
+          setDiscoverySeedInput(seedPeersToEditorValue(config));
+        }
+        setDiscoveryError(null);
+      } catch (error) {
+        setDiscoveryError(
+          messageFromError(error, translate('common:errors.failedToLoadSettings'))
+        );
+      }
+      return;
+    }
+    if (activeSettingsSection === 'community-node') {
+      try {
+        const [config, statuses] = await Promise.all([
+          api.getCommunityNodeConfig(),
+          api.getCommunityNodeStatuses(),
+        ]);
+        startTransition(() => {
+          setCommunityNodeConfig(config);
+          if (!storeApi.getState().communityNodeEditorDirty) {
+            setCommunityNodeInput(communityNodesToDraftNodes(config));
+          }
+          setCommunityNodeStatuses((current) =>
+            mergeCommunityNodeStatuses(current, statuses)
+          );
+          setCommunityNodeError(null);
+        });
+        const baseUrls = config.nodes
+          .map((node) => node.base_url)
+          .filter((baseUrl) => baseUrl.trim().length > 0);
+        if (baseUrls.length > 0) {
+          setCommunityNodeManifests((current) => {
+            const next = { ...current };
+            for (const baseUrl of baseUrls) {
+              next[baseUrl] = { status: 'loading' };
+            }
+            return next;
+          });
+          for (const baseUrl of baseUrls) {
+            void api
+              .fetchCommunityNodeManifest(baseUrl)
+              .then((result) => {
+                setCommunityNodeManifests(
+                  setRecordEntry(
+                    baseUrl,
+                    result.status === 'ok' && result.manifest
+                      ? { status: 'ok', manifest: result.manifest }
+                      : { status: 'absent' }
+                  )
+                );
+              })
+              .catch((error) => {
+                setCommunityNodeManifests(
+                  setRecordEntry(baseUrl, {
+                    status: 'error',
+                    error: messageFromError(
+                      error,
+                      translate('common:errors.failedToLoadSettings')
+                    ),
+                  })
+                );
+              });
+          }
+        }
+      } catch (error) {
+        setCommunityNodeError(
+          messageFromError(error, translate('common:errors.failedToLoadSettings'))
+        );
+      }
+      return;
+    }
+    if (activeSettingsSection === 'reactions') {
+      try {
+        const [bookmarkedPosts] = await Promise.all([
+          api.listBookmarkedPosts(),
+          loadReactionCatalogData(),
+        ]);
+        startTransition(() => setBookmarkedPosts(bookmarkedPosts));
+      } catch (error) {
+        setReactionPanelState({
+          status: 'error',
+          error: messageFromError(error, translate('common:errors.failedToLoadSettings')),
+        });
+      }
+    }
+  }, [
+    api,
+    loadReactionCatalogData,
+    setBookmarkedPosts,
+    setCommunityNodeConfig,
+    setCommunityNodeError,
+    setCommunityNodeInput,
+    setCommunityNodeManifests,
+    setCommunityNodeStatuses,
+    setDiscoveryConfig,
+    setDiscoveryError,
+    setDiscoverySeedInput,
+    setLocalPeerTicket,
+    setReactionPanelState,
+    storeApi,
+    translate,
+  ]);
+
+  return useCallback(
+    async (topic: string) => {
+      const state = storeApi.getState();
+      const selectedChannelId = state.selectedChannelIdByTopic[topic] ?? null;
+      const selectedAuthorPubkey = state.selectedAuthorPubkey;
+      const { activePrimarySection, settingsOpen, timelineView } = state.shellChromeState;
+      const tasks: Promise<void>[] = [];
+
+      if (activePrimarySection === 'live') {
+        tasks.push(loadLiveSection(topic, selectedChannelId));
+      }
+      if (activePrimarySection === 'game') {
+        tasks.push(loadGameSection(topic, selectedChannelId));
+      }
+      if (activePrimarySection === 'profile') {
+        tasks.push(loadProfileSection());
+      }
+      if (selectedAuthorPubkey) {
+        tasks.push(loadAuthorSection(selectedAuthorPubkey));
+      }
+      if (activePrimarySection === 'messages' || state.directMessagePaneOpen) {
+        tasks.push(loadMessagesSection());
+      }
+      if (activePrimarySection === 'notifications') {
+        tasks.push(loadNotificationsSection());
+      }
+      if (activePrimarySection === 'timeline' && timelineView === 'bookmarks') {
+        tasks.push(loadBookmarksSection());
+      }
+      if (settingsOpen) {
+        tasks.push(loadSettingsSection());
+      }
+      await Promise.allSettled(tasks);
+    },
+    [
+      loadAuthorSection,
+      loadBookmarksSection,
+      loadGameSection,
+      loadLiveSection,
+      loadMessagesSection,
+      loadNotificationsSection,
+      loadProfileSection,
+      loadSettingsSection,
+      storeApi,
+    ]
+  );
+}

--- a/apps/desktop/src/shell/useDesktopShellData.ts
+++ b/apps/desktop/src/shell/useDesktopShellData.ts
@@ -11,7 +11,6 @@ import type {
   DirectMessageMessageView,
   GameRoomView,
   JoinedPrivateChannelView,
-  NotificationView,
   PostView,
 } from '@/lib/api';
 
@@ -19,6 +18,7 @@ import { removeRecordEntry, setRecordEntry, updateRecordEntry } from '@/shell/st
 import { useConnectivityStatusRefresh } from '@/shell/data/useConnectivityStatusRefresh';
 import { useDesktopShellDataEffects } from '@/shell/data/useDesktopShellDataEffects';
 import { useDraftMediaHelpers } from '@/shell/data/useDraftMediaHelpers';
+import { useDesktopShellSectionLoaders } from '@/shell/data/loaders/useDesktopShellSectionLoaders';
 import { useQueuedLoadTopics } from '@/shell/data/useQueuedLoadTopics';
 import {
   hasLoadedOlderAuthoritativePosts,
@@ -39,14 +39,9 @@ import {
 import { THREAD_TIMELINE_LIMIT, VISIBLE_TIMELINE_LIMIT } from '@/shell/pagination';
 import { useShallow } from 'zustand/react/shallow';
 import {
-  authorViewFromDirectMessageConversation,
-  communityNodesToDraftNodes,
-  mergeCommunityNodeStatuses,
   mergeKnownAuthors,
   messageFromError,
   privateTimelineScope,
-  profileInputFromProfile,
-  seedPeersToEditorValue,
   selectShellDataSlice,
 } from '@/shell/selectors';
 
@@ -123,8 +118,6 @@ export function useDesktopShellData({
   const setPublicTimelineNextCursorByTopic = useDesktopShellFieldSetter(
     'publicTimelineNextCursorByTopic'
   );
-  const setLiveSessionsByTopic = useDesktopShellFieldSetter('liveSessionsByTopic');
-  const setGameRoomsByTopic = useDesktopShellFieldSetter('gameRoomsByTopic');
   const setJoinedChannelsByTopic = useDesktopShellFieldSetter('joinedChannelsByTopic');
   const setChannelPanelStateByTopic = useDesktopShellFieldSetter('channelPanelStateByTopic');
   const setSelectedChannelIdByTopic = useDesktopShellFieldSetter('selectedChannelIdByTopic');
@@ -133,15 +126,7 @@ export function useDesktopShellData({
   const setThread = useDesktopShellFieldSetter('thread');
   const setThreadNextCursorById = useDesktopShellFieldSetter('threadNextCursorById');
   const setThreadLoadingMoreById = useDesktopShellFieldSetter('threadLoadingMoreById');
-  const setLocalPeerTicket = useDesktopShellFieldSetter('localPeerTicket');
-  const setDiscoveryConfig = useDesktopShellFieldSetter('discoveryConfig');
-  const setDiscoverySeedInput = useDesktopShellFieldSetter('discoverySeedInput');
-  const setDiscoveryError = useDesktopShellFieldSetter('discoveryError');
-  const setCommunityNodeConfig = useDesktopShellFieldSetter('communityNodeConfig');
   const setCommunityNodeStatuses = useDesktopShellFieldSetter('communityNodeStatuses');
-  const setCommunityNodeManifests = useDesktopShellFieldSetter('communityNodeManifests');
-  const setCommunityNodeInput = useDesktopShellFieldSetter('communityNodeInput');
-  const setCommunityNodeError = useDesktopShellFieldSetter('communityNodeError');
   const setMediaObjectUrls = useDesktopShellFieldSetter('mediaObjectUrls');
   const setSyncStatus = useDesktopShellFieldSetter('syncStatus');
   const setLocalProfile = useDesktopShellFieldSetter('localProfile');
@@ -152,7 +137,6 @@ export function useDesktopShellData({
   const setSocialConnectionsPanelState = useDesktopShellFieldSetter('socialConnectionsPanelState');
   const setOwnedReactionAssets = useDesktopShellFieldSetter('ownedReactionAssets');
   const setBookmarkedReactionAssets = useDesktopShellFieldSetter('bookmarkedReactionAssets');
-  const setBookmarkedPosts = useDesktopShellFieldSetter('bookmarkedPosts');
   const setRecentReactions = useDesktopShellFieldSetter('recentReactions');
   const setProfileDraft = useDesktopShellFieldSetter('profileDraft');
   const setProfileError = useDesktopShellFieldSetter('profileError');
@@ -174,8 +158,6 @@ export function useDesktopShellData({
   );
   const setDirectMessageStatusByPeer = useDesktopShellFieldSetter('directMessageStatusByPeer');
   const setDirectMessageError = useDesktopShellFieldSetter('directMessageError');
-  const setLivePanelStateByTopic = useDesktopShellFieldSetter('livePanelStateByTopic');
-  const setGamePanelStateByTopic = useDesktopShellFieldSetter('gamePanelStateByTopic');
   const setGameDrafts = useDesktopShellFieldSetter('gameDrafts');
   const setReactionPanelState = useDesktopShellFieldSetter('reactionPanelState');
   const setError = useDesktopShellFieldSetter('error');
@@ -549,369 +531,18 @@ export function useDesktopShellData({
     translate,
   ]);
 
+  const loadShellSections = useDesktopShellSectionLoaders({
+    api,
+    loadReactionCatalogData,
+    storeApi,
+    translate,
+  });
   const runLoadTopics = useCallback(
     async (_currentTopics: string[], currentActiveTopic: string, currentThread: string | null) => {
       await refreshVisibleShellData(currentActiveTopic, currentThread, 'apply');
-
-      const currentState = storeApi.getState();
-      const selectedChannelId = currentState.selectedChannelIdByTopic[currentActiveTopic] ?? null;
-      const selectedAuthorPubkey = currentState.selectedAuthorPubkey;
-      const {
-        activePrimarySection,
-        activeSettingsSection,
-        settingsOpen,
-        timelineView,
-      } = currentState.shellChromeState;
-
-      const tasks: Promise<void>[] = [];
-
-      if (activePrimarySection === 'live') {
-        tasks.push(
-          api
-            .listLiveSessions(currentActiveTopic, privateTimelineScope(selectedChannelId))
-            .then((sessions) => {
-              startTransition(() => {
-                setLiveSessionsByTopic(setRecordEntry(currentActiveTopic, sessions));
-                setLivePanelStateByTopic(setRecordEntry(currentActiveTopic, { status: 'ready', error: null }));
-              });
-            })
-            .catch((error) => {
-              setLivePanelStateByTopic(setRecordEntry(currentActiveTopic, {
-                  status: 'error',
-                  error: messageFromError(
-                    error,
-                    translate('common:errors.failedToLoadLiveSessions')
-                  ),
-                }));
-            })
-        );
-      }
-
-      if (activePrimarySection === 'game') {
-        tasks.push(
-          api
-            .listGameRooms(currentActiveTopic, privateTimelineScope(selectedChannelId))
-            .then((rooms) => {
-              startTransition(() => {
-                setGameRoomsByTopic(setRecordEntry(currentActiveTopic, rooms));
-                setGamePanelStateByTopic(setRecordEntry(currentActiveTopic, { status: 'ready', error: null }));
-              });
-            })
-            .catch((error) => {
-              setGamePanelStateByTopic(setRecordEntry(currentActiveTopic, {
-                  status: 'error',
-                  error: messageFromError(error, translate('common:errors.failedToLoadGameRooms')),
-                }));
-            })
-        );
-      }
-
-      if (activePrimarySection === 'profile') {
-        tasks.push(
-          Promise.all([
-            api.getMyProfile(),
-            api.listSocialConnections('following'),
-            api.listSocialConnections('followed'),
-            api.listSocialConnections('muted'),
-          ])
-            .then(async ([profile, following, followed, muted]) => {
-              const timeline = await api.listProfileTimeline(profile.pubkey, null, VISIBLE_TIMELINE_LIMIT);
-              startTransition(() => {
-                setLocalProfile(profile);
-                if (!storeApi.getState().profileDirty) {
-                  setProfileDraft(profileInputFromProfile(profile));
-                }
-                setProfileTimeline(timeline.items);
-                setProfileTimelineNextCursor(timeline.next_cursor ?? null);
-                setProfileError(null);
-                setProfilePanelState({ status: 'ready', error: null });
-                setSocialConnections({ following, followed, muted });
-                setKnownAuthorsByPubkey((current) =>
-                  mergeKnownAuthors(current, [...following, ...followed, ...muted])
-                );
-                setSocialConnectionsPanelState({ status: 'ready', error: null });
-              });
-            })
-            .catch((error) => {
-              const message = messageFromError(error, translate('common:errors.failedToLoadProfile'));
-              setProfileError(message);
-              setProfilePanelState({ status: 'error', error: message });
-            })
-        );
-      }
-
-      if (selectedAuthorPubkey) {
-        tasks.push(
-          Promise.all([
-            api.getAuthorSocialView(selectedAuthorPubkey),
-            api.listProfileTimeline(selectedAuthorPubkey, null, VISIBLE_TIMELINE_LIMIT),
-          ])
-            .then(([author, timeline]) => {
-              startTransition(() => {
-                setSelectedAuthor(author);
-                setSelectedAuthorTimeline(timeline.items);
-                setSelectedAuthorTimelineNextCursor(timeline.next_cursor ?? null);
-                setAuthorError(null);
-                if (author) {
-                  setKnownAuthorsByPubkey((current) => mergeKnownAuthors(current, [author]));
-                }
-              });
-            })
-            .catch((error) => {
-              setAuthorError(messageFromError(error, translate('common:errors.failedToLoadAuthor')));
-            })
-        );
-      }
-
-      if (activePrimarySection === 'messages' || currentState.directMessagePaneOpen) {
-        tasks.push(
-          api
-            .listDirectMessages()
-            .then(async (directMessages) => {
-              startTransition(() => {
-                setDirectMessages(directMessages);
-                setKnownAuthorsByPubkey((current) =>
-                  mergeKnownAuthors(
-                    current,
-                    directMessages.map(authorViewFromDirectMessageConversation)
-                  )
-                );
-              });
-              const selectedPeerPubkey = storeApi.getState().selectedDirectMessagePeerPubkey;
-              if (!selectedPeerPubkey) {
-                setDirectMessageError(null);
-                return;
-              }
-              const [timelineResult, statusResult] = await Promise.allSettled([
-                api.listDirectMessageMessages(selectedPeerPubkey, null, VISIBLE_TIMELINE_LIMIT),
-                api.getDirectMessageStatus(selectedPeerPubkey),
-              ]);
-              startTransition(() => {
-                if (timelineResult.status === 'fulfilled') {
-                  setDirectMessageTimelineByPeer(setRecordEntry(selectedPeerPubkey, timelineResult.value.items));
-                  setDirectMessageTimelineNextCursorByPeer(setRecordEntry(selectedPeerPubkey, timelineResult.value.next_cursor ?? null));
-                }
-                if (statusResult.status === 'fulfilled') {
-                  setDirectMessageStatusByPeer(setRecordEntry(selectedPeerPubkey, statusResult.value));
-                }
-                setDirectMessageError(
-                  timelineResult.status === 'fulfilled' && statusResult.status === 'fulfilled'
-                    ? null
-                    : messageFromError(
-                        timelineResult.status === 'rejected'
-                          ? timelineResult.reason
-                          : statusResult.status === 'rejected'
-                            ? statusResult.reason
-                            : null,
-                        'failed to load direct messages'
-                      )
-                );
-              });
-            })
-            .catch((error) => {
-              setDirectMessageError(messageFromError(error, 'failed to load direct messages'));
-            })
-        );
-      }
-
-      if (activePrimarySection === 'notifications') {
-        tasks.push(
-          Promise.all([api.getNotificationStatus(), api.listNotifications()])
-            .then(async ([status, notificationItems]) => {
-              let nextNotifications: NotificationView[] = notificationItems;
-              let nextStatus = status;
-              if (notificationItems.some((notification) => !notification.read_at)) {
-                try {
-                  nextStatus = await api.markAllNotificationsRead();
-                  const readAt = Date.now();
-                  nextNotifications = notificationItems.map((notification) =>
-                    notification.read_at ? notification : { ...notification, read_at: readAt }
-                  );
-                  setNotificationAutoReadError(null);
-                } catch (notificationReadError) {
-                  setNotificationAutoReadError(
-                    messageFromError(
-                      notificationReadError,
-                      translate('shell:notifications.errors.failedAutoRead')
-                    )
-                  );
-                }
-              }
-              startTransition(() => {
-                setNotificationStatus(nextStatus);
-                setNotifications(nextNotifications);
-                setNotificationPanelState({ status: 'ready', error: null });
-              });
-            })
-            .catch((error) => {
-              setNotificationPanelState({
-                status: 'error',
-                error: messageFromError(error, translate('shell:notifications.errors.failedToLoad')),
-              });
-            })
-        );
-      }
-
-      if (activePrimarySection === 'timeline' && timelineView === 'bookmarks') {
-        tasks.push(
-          api
-            .listBookmarkedPosts()
-            .then((bookmarks) => {
-              setBookmarkedPosts(bookmarks);
-            })
-            .catch(() => undefined)
-        );
-      }
-
-      if (settingsOpen) {
-        if (activeSettingsSection === 'connectivity') {
-          tasks.push(
-            api
-              .getLocalPeerTicket()
-              .then((ticket) => {
-                setLocalPeerTicket(ticket);
-              })
-              .catch(() => undefined)
-          );
-        }
-
-        if (activeSettingsSection === 'discovery') {
-          tasks.push(
-            api
-              .getDiscoveryConfig()
-              .then((config) => {
-                setDiscoveryConfig(config);
-                if (!storeApi.getState().discoveryEditorDirty) {
-                  setDiscoverySeedInput(seedPeersToEditorValue(config));
-                }
-                setDiscoveryError(null);
-              })
-              .catch((error) => {
-                setDiscoveryError(
-                  messageFromError(error, translate('common:errors.failedToLoadSettings'))
-                );
-              })
-          );
-        }
-
-        if (activeSettingsSection === 'community-node') {
-          tasks.push(
-            Promise.all([api.getCommunityNodeConfig(), api.getCommunityNodeStatuses()])
-              .then(([config, statuses]) => {
-                startTransition(() => {
-                  setCommunityNodeConfig(config);
-                  if (!storeApi.getState().communityNodeEditorDirty) {
-                    setCommunityNodeInput(communityNodesToDraftNodes(config));
-                  }
-                  setCommunityNodeStatuses((current) =>
-                    mergeCommunityNodeStatuses(current, statuses)
-                  );
-                  setCommunityNodeError(null);
-                });
-                // public manifest endpoint (#356) から dependency 情報を best-effort 取得する。
-                const baseUrls = config.nodes
-                  .map((node) => node.base_url)
-                  .filter((baseUrl) => baseUrl.trim().length > 0);
-                if (baseUrls.length > 0) {
-                  setCommunityNodeManifests((current) => {
-                    const next = { ...current };
-                    for (const baseUrl of baseUrls) {
-                      next[baseUrl] = { status: 'loading' };
-                    }
-                    return next;
-                  });
-                  for (const baseUrl of baseUrls) {
-                    void api
-                      .fetchCommunityNodeManifest(baseUrl)
-                      .then((result) => {
-                        setCommunityNodeManifests(setRecordEntry(baseUrl, result.status === 'ok' && result.manifest
-                              ? { status: 'ok', manifest: result.manifest }
-                              : { status: 'absent' }));
-                      })
-                      .catch((error) => {
-                        setCommunityNodeManifests(setRecordEntry(baseUrl, {
-                            status: 'error',
-                            error: messageFromError(
-                              error,
-                              translate('common:errors.failedToLoadSettings')
-                            ),
-                          }));
-                      });
-                  }
-                }
-              })
-              .catch((error) => {
-                setCommunityNodeError(
-                  messageFromError(error, translate('common:errors.failedToLoadSettings'))
-                );
-              })
-          );
-        }
-
-        if (activeSettingsSection === 'reactions') {
-          tasks.push(
-            Promise.all([api.listBookmarkedPosts(), loadReactionCatalogData()])
-              .then(([bookmarkedPosts]) => {
-                startTransition(() => {
-                  setBookmarkedPosts(bookmarkedPosts);
-                });
-              })
-              .catch((error) => {
-                setReactionPanelState({
-                  status: 'error',
-                  error: messageFromError(error, translate('common:errors.failedToLoadSettings')),
-                });
-              })
-          );
-        }
-      }
-
-      await Promise.allSettled(tasks);
+      await loadShellSections(currentActiveTopic);
     },
-    [
-      api,
-      setAuthorError,
-      setBookmarkedPosts,
-      setCommunityNodeConfig,
-      setCommunityNodeError,
-      setCommunityNodeInput,
-      setCommunityNodeManifests,
-      setCommunityNodeStatuses,
-      setDirectMessages,
-      setDirectMessageError,
-      setDirectMessageTimelineNextCursorByPeer,
-      setDirectMessageTimelineByPeer,
-      setDirectMessageStatusByPeer,
-      setDiscoveryConfig,
-      setDiscoveryError,
-      setDiscoverySeedInput,
-      setGamePanelStateByTopic,
-      setGameRoomsByTopic,
-      setKnownAuthorsByPubkey,
-      setLivePanelStateByTopic,
-      setLiveSessionsByTopic,
-      setLocalPeerTicket,
-      setLocalProfile,
-      setNotifications,
-      setNotificationAutoReadError,
-      setNotificationPanelState,
-      setNotificationStatus,
-      setProfileDraft,
-      setProfileError,
-      setProfilePanelState,
-      setProfileTimelineNextCursor,
-      setProfileTimeline,
-      setReactionPanelState,
-      setSelectedAuthor,
-      setSelectedAuthorTimelineNextCursor,
-      setSelectedAuthorTimeline,
-      setSocialConnections,
-      setSocialConnectionsPanelState,
-      loadReactionCatalogData,
-      refreshVisibleShellData,
-      storeApi,
-      translate,
-    ]
+    [loadShellSections, refreshVisibleShellData]
   );
 
   const refreshConnectivityStatus = useConnectivityStatusRefresh(

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -19,10 +19,6 @@
     {
       "lines": 1079,
       "path": "crates/app-api/src/private_channels.rs"
-    },
-    {
-      "lines": 1035,
-      "path": "apps/desktop/src/shell/useDesktopShellData.ts"
     }
   ]
 }


### PR DESCRIPTION
## What changed

- split the 400-line `runLoadTopics` branch body into live, game, profile, author, messages, notifications, bookmarks, and settings loaders
- keep `useDesktopShellData` as core refresh + loader orchestration
- preserve section selection, dirty-editor protection, partial DM success, notification auto-read, and best-effort branches
- reduce `useDesktopShellData.ts` from 1,035 to 666 lines and remove it from the oversized baseline
- add loader characterization for live scope, DM partial failure, and dirty discovery editors

## Validation

- focused loader/data tests: 11 green
- `pnpm typecheck` and lint
- `cargo xtask desktop-ui-check` (556 tests, Storybook, browser, visual)
- `cargo xtask oversized-files`