### PR TITLE
refactor: centralize shell route state

### DIFF
--- a/apps/desktop/src/shell/routes.test.tsx
+++ b/apps/desktop/src/shell/routes.test.tsx
@@ -62,7 +62,7 @@ test('hash-backed route resolution preserves hash query during router hydration 
     '/#/timeline?topic=kukuri%3Atopic%3Ademo&settings=appearance'
   );
 
-  expect(resolveHashBackedRouteLocation('/', '')).toEqual({
+  expect(resolveHashBackedRouteLocation('/', '', window.location.hash)).toEqual({
     pathname: '/timeline',
     search: '?topic=kukuri%3Atopic%3Ademo&settings=appearance',
   });

--- a/apps/desktop/src/shell/routes.ts
+++ b/apps/desktop/src/shell/routes.ts
@@ -139,6 +139,25 @@ export type HashRouteLocation = {
   search: string;
 };
 
+export type ParsedRouteState = {
+  primarySection: PrimarySection | null;
+  requestedTopic: string | null;
+  requestedChannel: string | null;
+  requestedTimelineView: string | null;
+  requestedTimelineScope: string | null;
+  requestedComposeTarget: string | null;
+  requestedSettingsSection: string | null;
+  requestedContext: string | null;
+  requestedProfileMode: string | null;
+  requestedConnectionsView: string | null;
+  requestedThreadId: string | null;
+  requestedFocusObjectId: string | null;
+  requestedAuthorPubkey: string | null;
+  requestedPeerPubkey: string | null;
+  requestedSessionId: string | null;
+  requestedRoomId: string | null;
+};
+
 export function parseHashRouteLocation(hash: string): HashRouteLocation {
   const normalizedHash = hash.startsWith('#') ? hash.slice(1) : hash;
   if (!normalizedHash) {
@@ -162,18 +181,34 @@ export function parseHashRouteLocation(hash: string): HashRouteLocation {
   };
 }
 
+export function parseShellRouteState(location: HashRouteLocation): ParsedRouteState {
+  const params = new URLSearchParams(location.search);
+  return {
+    primarySection: parsePrimarySectionPath(location.pathname),
+    requestedTopic: params.get('topic')?.trim() || null,
+    requestedChannel: params.get('channel')?.trim() || null,
+    requestedTimelineView: params.get('timelineView'),
+    requestedTimelineScope: params.get('timelineScope'),
+    requestedComposeTarget: params.get('composeTarget'),
+    requestedSettingsSection: params.get('settings'),
+    requestedContext: params.get('context'),
+    requestedProfileMode: params.get('profileMode'),
+    requestedConnectionsView: params.get('connectionsView'),
+    requestedThreadId: params.get('threadId'),
+    requestedFocusObjectId: params.get('focusObjectId')?.trim() || null,
+    requestedAuthorPubkey: params.get('authorPubkey'),
+    requestedPeerPubkey: params.get('peerPubkey'),
+    requestedSessionId: params.get('sessionId')?.trim() || null,
+    requestedRoomId: params.get('roomId')?.trim() || null,
+  };
+}
+
 export function resolveHashBackedRouteLocation(
   pathname: string,
-  search: string
+  search: string,
+  hash: string
 ): HashRouteLocation {
-  if (typeof window === 'undefined') {
-    return {
-      pathname,
-      search,
-    };
-  }
-
-  const hashRouteLocation = parseHashRouteLocation(window.location.hash);
+  const hashRouteLocation = parseHashRouteLocation(hash);
   const shouldUseHashPathname =
     parsePrimarySectionPath(pathname) === null ||
     (pathname === '/' && hashRouteLocation.pathname !== '/');
@@ -199,7 +234,7 @@ export function parseLegacyRequestedChannel(
     .find((value): value is string => value !== null) ?? null;
 }
 
-export type BuildShellUrlOptions = {
+export type RouteState = {
   activeTopic: string;
   primarySection: PrimarySection;
   timelineView: TimelineWorkspaceView;
@@ -216,7 +251,7 @@ export type BuildShellUrlOptions = {
   selectedGameRoomId: string | null;
 };
 
-export function buildShellUrl(options: BuildShellUrlOptions): string {
+export function buildShellUrl(options: RouteState): string {
   const search = new URLSearchParams();
   search.set('topic', options.activeTopic);
 

--- a/apps/desktop/src/shell/routes.unit.test.ts
+++ b/apps/desktop/src/shell/routes.unit.test.ts
@@ -18,7 +18,8 @@ import {
   parseHashRouteLocation,
   parseLegacyRequestedChannel,
   parsePrimarySectionPath,
-  type BuildShellUrlOptions,
+  parseShellRouteState,
+  type RouteState,
 } from './routes';
 
 // 各テストを独立させる(setup.ts は hash を掃除しない)。
@@ -128,6 +129,52 @@ describe('parseHashRouteLocation', () => {
   });
 });
 
+describe('parseShellRouteState', () => {
+  test('parses every persisted route field without reading window state', () => {
+    expect(
+      parseShellRouteState({
+        pathname: '/messages',
+        search:
+          '?topic=topic-a&channel=channel-a&context=dm&peerPubkey=peer-a&authorPubkey=author-a&settings=appearance',
+      })
+    ).toMatchObject({
+      primarySection: 'messages',
+      requestedTopic: 'topic-a',
+      requestedChannel: 'channel-a',
+      requestedContext: 'dm',
+      requestedPeerPubkey: 'peer-a',
+      requestedAuthorPubkey: 'author-a',
+      requestedSettingsSection: 'appearance',
+    });
+  });
+
+  test('round-trips canonical messages state through the URL', () => {
+    const url = buildShellUrl({
+      activeTopic: 'topic-a',
+      primarySection: 'messages',
+      timelineView: 'feed',
+      profileMode: 'overview',
+      profileConnectionsView: 'following',
+      selectedThread: null,
+      focusedObjectId: null,
+      selectedAuthorPubkey: 'a'.repeat(64),
+      selectedDirectMessagePeerPubkey: 'b'.repeat(64),
+      settingsOpen: false,
+      settingsSection: 'about',
+      selectedChannelId: null,
+      selectedLiveSessionId: null,
+      selectedGameRoomId: null,
+    });
+    const parsed = parseShellRouteState(parseHashRouteLocation(`#${url}`));
+    expect(parsed).toMatchObject({
+      primarySection: 'messages',
+      requestedTopic: 'topic-a',
+      requestedAuthorPubkey: 'a'.repeat(64),
+      requestedPeerPubkey: 'b'.repeat(64),
+    });
+  });
+});
+
 describe('parseLegacyRequestedChannel', () => {
   // 引数順は (timelineScope, composeTarget)。compose target 側が優先される。
   const cases: Array<{
@@ -188,7 +235,7 @@ describe('parseLegacyRequestedChannel', () => {
 
 describe('buildShellUrl', () => {
   // 全フィールド必須のため fixture でデフォルトを埋め、期待 URL は生リテラルで固定する。
-  function buildOptions(overrides: Partial<BuildShellUrlOptions> = {}): BuildShellUrlOptions {
+  function buildOptions(overrides: Partial<RouteState> = {}): RouteState {
     return {
       activeTopic: 'kukuri:topic:demo',
       primarySection: 'timeline',
@@ -210,7 +257,7 @@ describe('buildShellUrl', () => {
 
   const cases: Array<{
     name: string;
-    overrides: Partial<BuildShellUrlOptions>;
+    overrides: Partial<RouteState>;
     expected: string;
   }> = [
     {

--- a/apps/desktop/src/shell/routing/useRouteSynchronization.ts
+++ b/apps/desktop/src/shell/routing/useRouteSynchronization.ts
@@ -8,6 +8,7 @@ import {
   isProfileConnectionsView,
   isSettingsSection,
   parseLegacyRequestedChannel,
+  parseShellRouteState,
   parsePrimarySectionPath,
   type DesktopShellRouteOverrides,
   type HashRouteLocation,
@@ -159,22 +160,26 @@ export function useRouteSynchronization({
       return;
     }
 
-    const params = new URLSearchParams(resolvedRouteLocation.search);
-    const requestedTopic = params.get('topic')?.trim() ?? null;
-    const requestedChannelParam = params.get('channel')?.trim() ?? null;
-    const requestedTimelineView = params.get('timelineView');
-    const requestedTimelineScopeValue = params.get('timelineScope');
-    const requestedComposeTargetValue = params.get('composeTarget');
-    const requestedSettingsSection = params.get('settings');
-    const requestedContext = params.get('context');
-    const requestedProfileMode = params.get('profileMode');
-    const requestedConnectionsView = params.get('connectionsView');
-    const requestedThreadId = params.get('threadId');
-    const requestedFocusObjectId = params.get('focusObjectId')?.trim() ?? null;
-    const requestedAuthorPubkey = params.get('authorPubkey');
-    const requestedPeerPubkey = params.get('peerPubkey');
-    const requestedSessionId = params.get('sessionId')?.trim() ?? null;
-    const requestedRoomId = params.get('roomId')?.trim() ?? null;
+    const {
+      requestedTopic,
+      requestedChannel: requestedChannelParam,
+      requestedTimelineView,
+      requestedTimelineScope: requestedTimelineScopeValue,
+      requestedComposeTarget: requestedComposeTargetValue,
+      requestedSettingsSection,
+      requestedContext,
+      requestedProfileMode,
+      requestedConnectionsView,
+      requestedThreadId,
+      requestedFocusObjectId,
+      requestedAuthorPubkey,
+      requestedPeerPubkey,
+      requestedSessionId,
+      requestedRoomId,
+    } = parseShellRouteState({
+      pathname: resolvedRouteLocation.pathname,
+      search: resolvedRouteLocation.search,
+    });
 
     let nextTopic = activeTopic;
     let shouldReload = false;

--- a/apps/desktop/src/shell/useDesktopShellRouting.ts
+++ b/apps/desktop/src/shell/useDesktopShellRouting.ts
@@ -99,7 +99,12 @@ export function useDesktopShellRouting({
   const setLastNonNotificationsRoute = useDesktopShellFieldSetter('lastNonNotificationsRoute');
   const setShellChromeState = useDesktopShellFieldSetter('shellChromeState');
   const resolvedRouteLocation = useMemo(
-    () => resolveHashBackedRouteLocation(location.pathname, location.search),
+    () =>
+      resolveHashBackedRouteLocation(
+        location.pathname,
+        location.search,
+        typeof window === 'undefined' ? '' : window.location.hash
+      ),
     [location.pathname, location.search]
   );
 


### PR DESCRIPTION
## What changed

- introduce canonical `RouteState` for URL serialization
- add pure `parseShellRouteState` for pathname/query decoding
- move all URLSearchParams field extraction out of the synchronization effect
- make hash-backed location resolution pure by passing the hash explicitly
- add full-field parse and canonical messages build/parse round-trip tests

The existing URL/query schema and effect-side API/store validation remain unchanged.

## Validation

- route unit/integration/hooks: 109 green
- Playwright hash routing: 2 green, including back/forward
- `cargo xtask desktop-ui-check` (558 tests, Storybook, browser, visual)
- `cargo xtask oversized-files`