### PR TITLE
refactor: extract metaverse room discovery

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -2,14 +2,12 @@
 import {
   Box,
   ChevronDown,
-  Cuboid,
   LogOut,
   MessageSquare,
   MonitorPause,
   Move3D,
   PanelRightClose,
   PanelRightOpen,
-  Play,
   RefreshCw,
   Send,
   Wifi,
@@ -17,13 +15,10 @@ import {
   X,
 } from 'lucide-react';
 
-import { AuthorAvatar } from '@/components/core/AuthorAvatar';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Notice } from '@/components/ui/notice';
-import { Textarea } from '@/components/ui/textarea';
 import type {
   ChannelRef,
   DesktopApi,
@@ -36,10 +31,14 @@ import type {
   SharedRoomObjectV1,
   SyncStatus,
 } from '@/lib/api';
-import { formatLocalizedTime } from '@/i18n/format';
 import type { SupportedLocale } from '@/i18n';
+import { formatLocalizedTime } from '@/i18n/format';
 import { blobToBase64 } from '@/lib/attachments';
 import { MetaverseScene } from './MetaverseScene';
+import {
+  MetaverseRoomDiscovery,
+  type CreateMetaverseRoomInput,
+} from './metaverse/MetaverseRoomDiscovery';
 import {
   DEFAULT_AVATAR_ASSET_NAME,
   DEFAULT_AVATAR_ASSET_URL,
@@ -171,10 +170,6 @@ export function MetaverseRoomPanel({
   mediaObjectUrls = {},
   onRefresh,
 }: MetaverseRoomPanelProps) {
-  const [createOpen, setCreateOpen] = useState(false);
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
-  const [maxPeers, setMaxPeers] = useState('8');
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
@@ -618,32 +613,25 @@ export function MetaverseRoomPanel({
     });
   }, [onRefresh, roomConnectionState, selectedRoom]);
 
-  async function handleCreateRoom(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!title.trim()) {
-      setError('Room title is required');
-      return;
-    }
+  async function handleCreateRoom(input: CreateMetaverseRoomInput) {
     setPending(true);
     try {
-      const parsedMaxPeers = Number.parseInt(maxPeers, 10);
       const roomId = await api.createMetaverseRoom(
         activeTopic,
-        title.trim(),
-        description.trim(),
-        Number.isNaN(parsedMaxPeers) ? null : parsedMaxPeers,
+        input.title,
+        input.description,
+        input.maxPeers,
         activeComposeChannel
       );
-      setTitle('');
-      setDescription('');
-      setMaxPeers('8');
       setError(null);
       pendingCreatedRoomIdRef.current = roomId;
       setJoinedRoomIds((current) => new Set(current).add(roomId));
       setSelectedRoomId(roomId);
       await onRefresh();
+      return true;
     } catch (createError) {
       setError(createError instanceof Error ? createError.message : 'Failed to create metaverse room');
+      return false;
     } finally {
       setPending(false);
     }
@@ -692,26 +680,6 @@ export function MetaverseRoomPanel({
     });
     setSelectedRoomId(null);
     resetRoomRuntimeState();
-  }
-
-  function hostAuthor(room: GameRoomView): Profile | AuthorSocialView | null {
-    return room.host_pubkey === syncStatus.local_author_pubkey
-      ? localProfile
-      : knownAuthorsByPubkey[room.host_pubkey] ?? null;
-  }
-
-  function hostLabel(room: GameRoomView) {
-    const host = hostAuthor(room);
-    return host?.display_name?.trim() || host?.name?.trim() || room.host_pubkey.slice(0, 10);
-  }
-
-  function hostPicture(room: GameRoomView) {
-    const host = hostAuthor(room);
-    const pictureAssetHash = host?.picture_asset?.hash;
-    if (pictureAssetHash && typeof mediaObjectUrls[pictureAssetHash] === 'string') {
-      return mediaObjectUrls[pictureAssetHash];
-    }
-    return host?.picture ?? null;
   }
 
   function handleLocalTransform(transform: AvatarTransform) {
@@ -854,100 +822,20 @@ export function MetaverseRoomPanel({
 
   return (
     <div className='metaverse-panel'>
-      <Card className='shell-workspace-card metaverse-discovery-card'>
-        <div className='panel-header'>
-          <div>
-            <h3>Metaverse Rooms</h3>
-            <small>{rooms.length} room{rooms.length === 1 ? '' : 's'} in this topic</small>
-          </div>
-        </div>
-        {error ? <Notice tone='destructive'>{error}</Notice> : null}
-        <section className='shell-nav-accordion metaverse-create-accordion' data-open={createOpen}>
-          <button
-            className='shell-nav-accordion-trigger'
-            type='button'
-            aria-expanded={createOpen}
-            onClick={() => setCreateOpen((current) => !current)}
-          >
-            <Cuboid className='size-4' aria-hidden='true' />
-            <span className='shell-nav-accordion-title'>Create metaverse room</span>
-            <ChevronDown className='shell-nav-accordion-icon size-4' aria-hidden='true' />
-          </button>
-          {createOpen ? (
-            <form className='composer composer-compact metaverse-create-form' onSubmit={handleCreateRoom}>
-              <div className='metaverse-create-form-primary'>
-                <Label>
-                  <span>Room title</span>
-                  <Input
-                    value={title}
-                    placeholder='Atrium'
-                    disabled={pending}
-                    onChange={(event) => setTitle(event.target.value)}
-                  />
-                </Label>
-                <Label>
-                  <span>Max peers</span>
-                  <Input
-                    value={maxPeers}
-                    disabled={pending}
-                    onChange={(event) => setMaxPeers(event.target.value)}
-                  />
-                </Label>
-              </div>
-              <Label className='metaverse-create-form-description'>
-                <span>Description</span>
-                <Textarea
-                  value={description}
-                  placeholder='Small social space'
-                  disabled={pending}
-                  onChange={(event) => setDescription(event.target.value)}
-                />
-              </Label>
-              <div className='metaverse-create-form-actions'>
-                <Button type='submit' disabled={pending}>
-                  <Cuboid className='size-4' aria-hidden='true' />
-                  Create metaverse room
-                </Button>
-              </div>
-            </form>
-          ) : null}
-        </section>
-        {rooms.length === 0 ? <p className='empty-state'>No metaverse rooms in this topic.</p> : null}
-        <ul className='metaverse-room-grid'>
-          {rooms.map((room) => (
-            <li key={room.room_id}>
-              <article className={`metaverse-room-card${selectedRoom?.room_id === room.room_id ? ' metaverse-room-card-active' : ''}`}>
-                <div className='post-meta'>
-                  <span>{room.title}</span>
-                  <span>{room.status}</span>
-                  <span className='reply-chip'>{room.audience_label}</span>
-                </div>
-                <p>{room.description || 'No description'}</p>
-                <div className='metaverse-room-host'>
-                  <AuthorAvatar label={hostLabel(room)} picture={hostPicture(room)} size='sm' />
-                  <span>Host: {hostLabel(room)}</span>
-                </div>
-                <div className='topic-diagnostic topic-diagnostic-secondary'>
-                  <span>Updated: {formatLocalizedTime(room.updated_at, locale)}</span>
-                  <span>{joinedRoomIds.has(room.room_id) ? 'Joined' : 'Not joined'}</span>
-                </div>
-                <div className='topic-diagnostic topic-diagnostic-secondary'>
-                  <span>Manifest: {room.manifest_blob_hash ?? 'pending'}</span>
-                  <span>World: {room.metaverse?.world_version ?? 1}</span>
-                </div>
-                <Button
-                  variant='secondary'
-                  type='button'
-                  onClick={() => handleJoinRoom(room.room_id)}
-                >
-                  <Play className='size-4' aria-hidden='true' />
-                  Join Room
-                </Button>
-              </article>
-            </li>
-          ))}
-        </ul>
-      </Card>
+      <MetaverseRoomDiscovery
+        rooms={rooms}
+        selectedRoomId={selectedRoomId}
+        joinedRoomIds={joinedRoomIds}
+        pending={pending}
+        error={error}
+        locale={locale}
+        localAuthorPubkey={syncStatus.local_author_pubkey}
+        localProfile={localProfile}
+        knownAuthorsByPubkey={knownAuthorsByPubkey}
+        mediaObjectUrls={mediaObjectUrls}
+        onCreateRoom={handleCreateRoom}
+        onJoinRoom={handleJoinRoom}
+      />
 
       {selectedRoom ? (
         <Card className='shell-workspace-card metaverse-room-view'>

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import type { GameRoomView } from '@/lib/api';
+import { MetaverseRoomDiscovery } from './MetaverseRoomDiscovery';
+
+const room: GameRoomView = {
+  room_id: 'metaverse-room-1',
+  host_pubkey: 'f'.repeat(64),
+  title: 'Atrium',
+  description: 'Small social space',
+  status: 'Waiting',
+  phase_label: 'metaverse-mvp',
+  scores: [],
+  room_kind: 'metaverse_room',
+  metaverse: {
+    world_version: 1,
+    max_peers: 8,
+    scene: {
+      ground: 'default',
+      shared_object: {
+        object_id: 'mvp-object-1',
+        asset_ref: null,
+        primitive_fallback: 'cube',
+        position: [0, 50, -240],
+        rotation: [0, 0, 0],
+        scale: [100, 100, 100],
+        updated_by: 'f'.repeat(64),
+        updated_at: 1,
+      },
+    },
+    default_spawn: {
+      position: [0, 0, 260],
+      rotation: [0, 180, 0],
+    },
+    asset_refs: [],
+  },
+  manifest_blob_hash: 'mock-metaverse-room-1',
+  updated_at: 1,
+  channel_id: null,
+  audience_label: 'Public',
+};
+
+function renderDiscovery(
+  overrides: Partial<Parameters<typeof MetaverseRoomDiscovery>[0]> = {}
+) {
+  const props: Parameters<typeof MetaverseRoomDiscovery>[0] = {
+    rooms: [room],
+    selectedRoomId: null,
+    joinedRoomIds: new Set(),
+    pending: false,
+    error: null,
+    locale: 'en',
+    localAuthorPubkey: room.host_pubkey,
+    localProfile: null,
+    knownAuthorsByPubkey: {},
+    mediaObjectUrls: {},
+    onCreateRoom: vi.fn().mockResolvedValue(true),
+    onJoinRoom: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<MetaverseRoomDiscovery {...props} />), props };
+}
+
+describe('MetaverseRoomDiscovery', () => {
+  test('shows the empty state and an action error without an API dependency', () => {
+    renderDiscovery({ rooms: [], error: 'Room action failed' });
+
+    expect(screen.getByText('0 rooms in this topic')).toBeInTheDocument();
+    expect(screen.getByText('No metaverse rooms in this topic.')).toBeInTheDocument();
+    expect(screen.getByText('Room action failed')).toBeInTheDocument();
+  });
+
+  test('validates and normalizes the create-room callback input', async () => {
+    const user = userEvent.setup();
+    const onCreateRoom = vi.fn().mockResolvedValue(true);
+    renderDiscovery({ rooms: [], onCreateRoom });
+
+    await user.click(screen.getByRole('button', { name: 'Create metaverse room' }));
+    await user.click(screen.getAllByRole('button', { name: 'Create metaverse room' })[1]);
+    expect(screen.getByText('Room title is required')).toBeInTheDocument();
+    expect(onCreateRoom).not.toHaveBeenCalled();
+
+    await user.type(screen.getByPlaceholderText('Atrium'), '  Contract room  ');
+    await user.type(screen.getByPlaceholderText('Small social space'), '  Contract space  ');
+    const maxPeersInput = screen.getByLabelText('Max peers');
+    await user.clear(maxPeersInput);
+    await user.type(maxPeersInput, '12');
+    await user.click(screen.getAllByRole('button', { name: 'Create metaverse room' })[1]);
+
+    expect(onCreateRoom).toHaveBeenCalledWith({
+      title: 'Contract room',
+      description: 'Contract space',
+      maxPeers: 12,
+    });
+    expect(screen.getByPlaceholderText('Atrium')).toHaveValue('');
+    expect(maxPeersInput).toHaveValue('8');
+  });
+
+  test('preserves room card host fallback, selected/joined state, and Join callback', async () => {
+    const user = userEvent.setup();
+    const onJoinRoom = vi.fn();
+    renderDiscovery({
+      selectedRoomId: room.room_id,
+      joinedRoomIds: new Set([room.room_id]),
+      onJoinRoom,
+    });
+
+    expect(screen.getByText('1 room in this topic')).toBeInTheDocument();
+    expect(screen.getByText(`Host: ${room.host_pubkey.slice(0, 10)}`)).toBeInTheDocument();
+    expect(screen.getByText('Joined')).toBeInTheDocument();
+    expect(screen.getByText(room.title).closest('article')).toHaveClass('metaverse-room-card-active');
+
+    await user.click(screen.getByRole('button', { name: 'Join Room' }));
+    expect(onJoinRoom).toHaveBeenCalledWith(room.room_id);
+  });
+
+  test('disables all create controls while an action is pending', async () => {
+    const user = userEvent.setup();
+    renderDiscovery({ rooms: [], pending: true });
+
+    await user.click(screen.getByRole('button', { name: 'Create metaverse room' }));
+    expect(screen.getByPlaceholderText('Atrium')).toBeDisabled();
+    expect(screen.getByLabelText('Max peers')).toBeDisabled();
+    expect(screen.getByPlaceholderText('Small social space')).toBeDisabled();
+    expect(screen.getAllByRole('button', { name: 'Create metaverse room' })[1]).toBeDisabled();
+  });
+});

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.tsx
@@ -1,0 +1,178 @@
+import { useState, type FormEvent } from 'react';
+import { ChevronDown, Cuboid, Play } from 'lucide-react';
+
+import { AuthorAvatar } from '@/components/core/AuthorAvatar';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Notice } from '@/components/ui/notice';
+import { Textarea } from '@/components/ui/textarea';
+import type { SupportedLocale } from '@/i18n';
+import { formatLocalizedTime } from '@/i18n/format';
+import type { AuthorSocialView, GameRoomView, Profile } from '@/lib/api';
+
+export type CreateMetaverseRoomInput = {
+  title: string;
+  description: string;
+  maxPeers: number | null;
+};
+
+type MetaverseRoomDiscoveryProps = {
+  rooms: GameRoomView[];
+  selectedRoomId: string | null;
+  joinedRoomIds: ReadonlySet<string>;
+  pending: boolean;
+  error: string | null;
+  locale: SupportedLocale;
+  localAuthorPubkey: string;
+  localProfile: Profile | null;
+  knownAuthorsByPubkey: Record<string, AuthorSocialView>;
+  mediaObjectUrls: Record<string, string | null>;
+  onCreateRoom: (input: CreateMetaverseRoomInput) => Promise<boolean>;
+  onJoinRoom: (roomId: string) => void;
+};
+
+export function MetaverseRoomDiscovery({
+  rooms,
+  selectedRoomId,
+  joinedRoomIds,
+  pending,
+  error,
+  locale,
+  localAuthorPubkey,
+  localProfile,
+  knownAuthorsByPubkey,
+  mediaObjectUrls,
+  onCreateRoom,
+  onJoinRoom,
+}: MetaverseRoomDiscoveryProps) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [maxPeers, setMaxPeers] = useState('8');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  function hostAuthor(room: GameRoomView): Profile | AuthorSocialView | null {
+    return room.host_pubkey === localAuthorPubkey
+      ? localProfile
+      : knownAuthorsByPubkey[room.host_pubkey] ?? null;
+  }
+
+  function hostLabel(room: GameRoomView) {
+    const host = hostAuthor(room);
+    return host?.display_name?.trim() || host?.name?.trim() || room.host_pubkey.slice(0, 10);
+  }
+
+  function hostPicture(room: GameRoomView) {
+    const host = hostAuthor(room);
+    const pictureAssetHash = host?.picture_asset?.hash;
+    if (pictureAssetHash && typeof mediaObjectUrls[pictureAssetHash] === 'string') {
+      return mediaObjectUrls[pictureAssetHash];
+    }
+    return host?.picture ?? null;
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!title.trim()) {
+      setValidationError('Room title is required');
+      return;
+    }
+    setValidationError(null);
+    const parsedMaxPeers = Number.parseInt(maxPeers, 10);
+    const created = await onCreateRoom({
+      title: title.trim(),
+      description: description.trim(),
+      maxPeers: Number.isNaN(parsedMaxPeers) ? null : parsedMaxPeers,
+    });
+    if (!created) {
+      return;
+    }
+    setTitle('');
+    setDescription('');
+    setMaxPeers('8');
+    setValidationError(null);
+  }
+
+  return (
+    <Card className='shell-workspace-card metaverse-discovery-card'>
+      <div className='panel-header'>
+        <div>
+          <h3>Metaverse Rooms</h3>
+          <small>{rooms.length} room{rooms.length === 1 ? '' : 's'} in this topic</small>
+        </div>
+      </div>
+      {validationError || error ? (
+        <Notice tone='destructive'>{validationError ?? error}</Notice>
+      ) : null}
+      <section className='shell-nav-accordion metaverse-create-accordion' data-open={createOpen}>
+        <button
+          className='shell-nav-accordion-trigger'
+          type='button'
+          aria-expanded={createOpen}
+          onClick={() => setCreateOpen((current) => !current)}
+        >
+          <Cuboid className='size-4' aria-hidden='true' />
+          <span className='shell-nav-accordion-title'>Create metaverse room</span>
+          <ChevronDown className='shell-nav-accordion-icon size-4' aria-hidden='true' />
+        </button>
+        {createOpen ? (
+          <form className='composer composer-compact metaverse-create-form' onSubmit={handleSubmit}>
+            <div className='metaverse-create-form-primary'>
+              <Label>
+                <span>Room title</span>
+                <Input value={title} placeholder='Atrium' disabled={pending} onChange={(event) => setTitle(event.target.value)} />
+              </Label>
+              <Label>
+                <span>Max peers</span>
+                <Input value={maxPeers} disabled={pending} onChange={(event) => setMaxPeers(event.target.value)} />
+              </Label>
+            </div>
+            <Label className='metaverse-create-form-description'>
+              <span>Description</span>
+              <Textarea value={description} placeholder='Small social space' disabled={pending} onChange={(event) => setDescription(event.target.value)} />
+            </Label>
+            <div className='metaverse-create-form-actions'>
+              <Button type='submit' disabled={pending}>
+                <Cuboid className='size-4' aria-hidden='true' />
+                Create metaverse room
+              </Button>
+            </div>
+          </form>
+        ) : null}
+      </section>
+      {rooms.length === 0 ? <p className='empty-state'>No metaverse rooms in this topic.</p> : null}
+      <ul className='metaverse-room-grid'>
+        {rooms.map((room) => (
+          <li key={room.room_id}>
+            <article className={`metaverse-room-card${selectedRoomId === room.room_id ? ' metaverse-room-card-active' : ''}`}>
+              <div className='post-meta'>
+                <span>{room.title}</span>
+                <span>{room.status}</span>
+                <span className='reply-chip'>{room.audience_label}</span>
+              </div>
+              <p>{room.description || 'No description'}</p>
+              <div className='metaverse-room-host'>
+                <AuthorAvatar label={hostLabel(room)} picture={hostPicture(room)} size='sm' />
+                <span>Host: {hostLabel(room)}</span>
+              </div>
+              <div className='topic-diagnostic topic-diagnostic-secondary'>
+                <span>Updated: {formatLocalizedTime(room.updated_at, locale)}</span>
+                <span>{joinedRoomIds.has(room.room_id) ? 'Joined' : 'Not joined'}</span>
+              </div>
+              <div className='topic-diagnostic topic-diagnostic-secondary'>
+                <span>Manifest: {room.manifest_blob_hash ?? 'pending'}</span>
+                <span>World: {room.metaverse?.world_version ?? 1}</span>
+              </div>
+              <Button variant='secondary' type='button' onClick={() => onJoinRoom(room.room_id)}>
+                <Play className='size-4' aria-hidden='true' />
+                Join Room
+              </Button>
+            </article>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -1,10 +1,6 @@
 {
   "files": [
     {
-      "lines": 1155,
-      "path": "apps/desktop/src/components/extended/MetaverseRoomPanel.tsx"
-    },
-    {
       "lines": 1087,
       "path": "crates/app-api/src/service/private_channels_support.rs"
     },
@@ -15,6 +11,10 @@
     {
       "lines": 1079,
       "path": "crates/app-api/src/private_channels.rs"
+    },
+    {
+      "lines": 1043,
+      "path": "apps/desktop/src/components/extended/MetaverseRoomPanel.tsx"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extract the metaverse create accordion, room list, host metadata, and join action into an API-independent component
- keep room creation effects and session ownership in `MetaverseRoomPanel`
- add focused discovery contracts and ratchet the panel oversized baseline from 1155 to 1043 lines

## Validation
- focused metaverse tests: 29 passed
- `cargo xtask desktop-ui-check` (67 files / 572 tests, Storybook, browser 10, visual 14)
- `cargo xtask oversized-files`
- verified `MetaverseRoomDiscovery` has no DesktopApi, timer, or BroadcastChannel references