### PR TITLE
refactor: extract metaverse room controls

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -1,24 +1,5 @@
 ﻿import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
-import {
-  Box,
-  ChevronDown,
-  LogOut,
-  MessageSquare,
-  MonitorPause,
-  Move3D,
-  PanelRightClose,
-  PanelRightOpen,
-  RefreshCw,
-  Send,
-  Wifi,
-  WifiOff,
-  X,
-} from 'lucide-react';
-
-import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import type {
   ChannelRef,
   DesktopApi,
@@ -32,13 +13,13 @@ import type {
   SyncStatus,
 } from '@/lib/api';
 import type { SupportedLocale } from '@/i18n';
-import { formatLocalizedTime } from '@/i18n/format';
 import { blobToBase64 } from '@/lib/attachments';
 import { MetaverseScene } from './MetaverseScene';
 import {
   MetaverseRoomDiscovery,
   type CreateMetaverseRoomInput,
 } from './metaverse/MetaverseRoomDiscovery';
+import { MetaverseRoomControls } from './metaverse/MetaverseRoomControls';
 import {
   DEFAULT_AVATAR_ASSET_NAME,
   DEFAULT_AVATAR_ASSET_URL,
@@ -101,32 +82,6 @@ function topicDiagnosticFor(syncStatus: SyncStatus, topic: string) {
   );
 }
 
-function connectionStateLabel(state: MetaverseRoomConnectionState) {
-  if (state === 'live') {
-    return 'Live';
-  }
-  if (state === 'recovering') {
-    return 'Recovering';
-  }
-  if (state === 'stale') {
-    return 'Stale';
-  }
-  return 'Offline';
-}
-
-function connectionStateDetail(state: MetaverseRoomConnectionState) {
-  if (state === 'live') {
-    return 'Room events are flowing';
-  }
-  if (state === 'recovering') {
-    return 'Refreshing room connectivity';
-  }
-  if (state === 'stale') {
-    return 'No room activity recently';
-  }
-  return 'Peer connectivity is unavailable';
-}
-
 function latestChatBubbleFromMessage(message: RoomChatMessage, now = Date.now()): LatestChatBubble {
   return {
     peerId: message.authorPeerId,
@@ -143,19 +98,6 @@ function isEditableTarget(target: EventTarget | null) {
   }
   const tagName = target.tagName.toLowerCase();
   return tagName === 'input' || tagName === 'textarea' || tagName === 'select' || target.isContentEditable;
-}
-
-function ConnectionStateIcon({ state }: { state: MetaverseRoomConnectionState }) {
-  if (state === 'live') {
-    return <Wifi className='size-4' aria-hidden='true' />;
-  }
-  if (state === 'recovering') {
-    return <RefreshCw className='size-4' aria-hidden='true' />;
-  }
-  if (state === 'stale') {
-    return <MonitorPause className='size-4' aria-hidden='true' />;
-  }
-  return <WifiOff className='size-4' aria-hidden='true' />;
 }
 
 export function MetaverseRoomPanel({
@@ -853,186 +795,37 @@ export function MetaverseRoomPanel({
               onLocalTransform={handleLocalTransform}
               onAvatarAssetStatus={setAvatarAssetStatus}
               hud={(
-                <>
-                  <div
-                    className='metaverse-connection-badge'
-                    data-state={roomConnectionState}
-                    title={connectionStateDetail(roomConnectionState)}
-                  >
-                    <ConnectionStateIcon state={roomConnectionState} />
-                    <span>{connectionStateLabel(roomConnectionState)}</span>
-                  </div>
-                  <div className='metaverse-hud-toolbar' data-open={hudOpen}>
-                    <Button
-                      variant='ghost'
-                      size='icon'
-                      className='metaverse-hud-icon-button'
-                      type='button'
-                      aria-label='Leave room'
-                      onClick={handleLeaveRoom}
-                    >
-                      <LogOut className='size-4' aria-hidden='true' />
-                    </Button>
-                    <Button
-                      variant='ghost'
-                      size='icon'
-                      className='metaverse-hud-icon-button'
-                      type='button'
-                      aria-label={hudOpen ? 'Hide room HUD' : 'Open room HUD'}
-                      onClick={() => setHudOpen((open) => !open)}
-                    >
-                      {hudOpen ? (
-                        <PanelRightClose className='size-4' aria-hidden='true' />
-                      ) : (
-                        <PanelRightOpen className='size-4' aria-hidden='true' />
-                      )}
-                    </Button>
-                  </div>
-                  {hudOpen ? (
-                    <>
-                    <aside className='metaverse-room-hud'>
-                      <div className='panel-header metaverse-hud-header'>
-                        <div>
-                          <h3>{selectedRoom.title}</h3>
-                          <small>{selectedRoom.room_id}</small>
-                        </div>
-                      </div>
-                      <section className='metaverse-hud-accordion' data-open={hudDebugOpen}>
-                        <button
-                          type='button'
-                          className='metaverse-hud-accordion-trigger'
-                          aria-expanded={hudDebugOpen}
-                          onClick={() => setHudDebugOpen((open) => !open)}
-                        >
-                          <span>Debug details</span>
-                          <ChevronDown className='size-4' aria-hidden='true' />
-                        </button>
-                        {hudDebugOpen ? (
-                          <div className='metaverse-room-diagnostics'>
-                            <span>Topic: {activeTopic}</span>
-                            <span>Local peer: {localPeerId}</span>
-                            <span>Known peers: {knownPeerCount}</span>
-                            <span>Last sent seq: {lastSentSeq}</span>
-                            <span>Last received: {lastReceivedAt ? formatLocalizedTime(lastReceivedAt, locale) : 'none'}</span>
-                            <span>Remote animation: {remoteAnimationSummary || 'none'}</span>
-                            <span>
-                              Avatar asset:{' '}
-                              {avatarAssetStatus === 'sample-vrm'
-                                ? 'sample VRM loaded'
-                                : avatarAssetStatus === 'blob-vrm'
-                                  ? 'blob VRM loaded'
-                                  : avatarAssetStatus}
-                            </span>
-                            <span>Blob asset resolve: {localAvatarAssetRef?.blob_hash ?? 'public sample / fallback-ready'}</span>
-                            <span>Persistence: manifest blob {selectedRoom.manifest_blob_hash ?? 'pending'}</span>
-                            <span>Community assist: {syncStatus.discovery.bootstrap_seed_peer_ids.length > 0 ? 'available' : 'optional'}</span>
-                          </div>
-                        ) : null}
-                      </section>
-                      <div className='metaverse-object-controls'>
-                        <strong>Avatar asset</strong>
-                        <div className='metaverse-avatar-asset-controls'>
-                          <Label>
-                            <span className='sr-only'>VRM file</span>
-                            <Input
-                              type='file'
-                              accept='.vrm,model/vrm,application/octet-stream'
-                              disabled={pending}
-                              onChange={(event) => {
-                                const file = event.target.files?.[0];
-                                if (file) {
-                                  void importAvatarBlob(file, file.name);
-                                }
-                                event.currentTarget.value = '';
-                              }}
-                            />
-                          </Label>
-                          <Button size='sm' variant='secondary' type='button' disabled={pending} onClick={() => void handleSampleAvatarImport()}>
-                            Default
-                          </Button>
-                        </div>
-                      </div>
-                      <div className='metaverse-object-controls'>
-                        <strong>
-                          <Box className='size-4' aria-hidden='true' />
-                          Shared object
-                        </strong>
-                        <div className='metaverse-nudge-grid'>
-                          <Button size='sm' variant='secondary' type='button' onClick={() => void moveSharedObject([0, 0, -50])}>
-                            <Move3D className='size-4' aria-hidden='true' />
-                            Forward
-                          </Button>
-                          <Button size='sm' variant='secondary' type='button' onClick={() => void moveSharedObject([-50, 0, 0])}>Left</Button>
-                          <Button size='sm' variant='secondary' type='button' onClick={() => void moveSharedObject([50, 0, 0])}>Right</Button>
-                          <Button size='sm' variant='secondary' type='button' onClick={() => void moveSharedObject([0, 0, 50])}>Back</Button>
-                        </div>
-                      </div>
-                    </aside>
-                    <span className='metaverse-hud-scrollbar-indicator' aria-hidden='true'>
-                      <span />
-                    </span>
-                    </>
-                  ) : null}
-                  {chatOpen ? (
-                    <section className='metaverse-room-chat-log' aria-label='ROOM Chat'>
-                      <div className='metaverse-room-chat-log-header'>
-                        <span>
-                          <MessageSquare className='size-4' aria-hidden='true' />
-                          ROOM Chat
-                        </span>
-                        <Button
-                          variant='ghost'
-                          size='icon'
-                          className='metaverse-chat-close-button'
-                          type='button'
-                          aria-label='Hide room chat'
-                          onClick={() => setChatOpen(false)}
-                        >
-                          <X className='size-4' aria-hidden='true' />
-                        </Button>
-                      </div>
-                      <ul className='metaverse-chat-list'>
-                        {messages.map((message) => (
-                          <li key={message.messageId}>
-                            <strong>
-                              {message.authorPeerId === localPeerId
-                                ? 'You'
-                                : message.displayName || message.authorPeerId.slice(0, 12)}
-                              <small>{formatLocalizedTime(message.createdAt, locale)}</small>
-                            </strong>
-                            <span>{message.body}</span>
-                          </li>
-                        ))}
-                      </ul>
-                      <form className='metaverse-chat-form' onSubmit={handleSendMessage}>
-                        <Label>
-                          <span className='sr-only'>Room chat message</span>
-                          <Input
-                            ref={messageInputRef}
-                            value={messageDraft}
-                            placeholder='Say something in the room'
-                            onChange={(event) => setMessageDraft(event.target.value)}
-                          />
-                        </Label>
-                        <Button size='sm' type='submit'>
-                          <Send className='size-4' aria-hidden='true' />
-                          Send
-                        </Button>
-                      </form>
-                    </section>
-                  ) : (
-                    <Button
-                      variant='secondary'
-                      size='icon'
-                      className='metaverse-chat-toggle'
-                      type='button'
-                      aria-label='Open room chat'
-                      onClick={() => setChatOpen(true)}
-                    >
-                      <MessageSquare className='size-4' aria-hidden='true' />
-                    </Button>
-                  )}
-                </>
+                <MetaverseRoomControls
+                  room={selectedRoom}
+                  activeTopic={activeTopic}
+                  localPeerId={localPeerId}
+                  knownPeerCount={knownPeerCount}
+                  lastSentSeq={lastSentSeq}
+                  lastReceivedAt={lastReceivedAt}
+                  remoteAnimationSummary={remoteAnimationSummary}
+                  avatarAssetStatus={avatarAssetStatus}
+                  localAvatarAssetRef={localAvatarAssetRef}
+                  communityAssistAvailable={syncStatus.discovery.bootstrap_seed_peer_ids.length > 0}
+                  connectionState={roomConnectionState}
+                  locale={locale}
+                  pending={pending}
+                  hudOpen={hudOpen}
+                  hudDebugOpen={hudDebugOpen}
+                  chatOpen={chatOpen}
+                  messages={messages}
+                  messageDraft={messageDraft}
+                  messageInputRef={messageInputRef}
+                  onLeaveRoom={handleLeaveRoom}
+                  onToggleHud={() => setHudOpen((open) => !open)}
+                  onToggleHudDebug={() => setHudDebugOpen((open) => !open)}
+                  onImportAvatar={(file) => void importAvatarBlob(file, file.name)}
+                  onImportDefaultAvatar={() => void handleSampleAvatarImport()}
+                  onMoveSharedObject={(delta) => void moveSharedObject(delta)}
+                  onCloseChat={() => setChatOpen(false)}
+                  onOpenChat={() => setChatOpen(true)}
+                  onMessageDraftChange={setMessageDraft}
+                  onSendMessage={handleSendMessage}
+                />
               )}
             />
           </div>

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.test.tsx
@@ -1,0 +1,176 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi } from 'vitest';
+
+import type { GameRoomView } from '@/lib/api';
+import { MetaverseRoomControls } from './MetaverseRoomControls';
+
+const room: GameRoomView = {
+  room_id: 'metaverse-room-1',
+  host_pubkey: 'f'.repeat(64),
+  title: 'Atrium',
+  description: 'Small social space',
+  status: 'Waiting',
+  phase_label: 'metaverse-mvp',
+  scores: [],
+  room_kind: 'metaverse_room',
+  metaverse: null,
+  manifest_blob_hash: 'manifest-1',
+  updated_at: 1,
+  channel_id: null,
+  audience_label: 'Public',
+};
+
+function renderControls(
+  overrides: Partial<Parameters<typeof MetaverseRoomControls>[0]> = {}
+) {
+  const props: Parameters<typeof MetaverseRoomControls>[0] = {
+    room,
+    activeTopic: 'kukuri:topic:demo',
+    localPeerId: 'local-peer',
+    knownPeerCount: 2,
+    lastSentSeq: 7,
+    lastReceivedAt: null,
+    remoteAnimationSummary: '',
+    avatarAssetStatus: 'sample-vrm',
+    localAvatarAssetRef: null,
+    communityAssistAvailable: true,
+    connectionState: 'live',
+    locale: 'en',
+    pending: false,
+    hudOpen: true,
+    hudDebugOpen: false,
+    chatOpen: true,
+    messages: [],
+    messageDraft: '',
+    messageInputRef: createRef<HTMLInputElement>(),
+    onLeaveRoom: vi.fn(),
+    onToggleHud: vi.fn(),
+    onToggleHudDebug: vi.fn(),
+    onImportAvatar: vi.fn(),
+    onImportDefaultAvatar: vi.fn(),
+    onMoveSharedObject: vi.fn(),
+    onCloseChat: vi.fn(),
+    onOpenChat: vi.fn(),
+    onMessageDraftChange: vi.fn(),
+    onSendMessage: vi.fn((event) => event.preventDefault()),
+    ...overrides,
+  };
+  return { ...render(<MetaverseRoomControls {...props} />), props };
+}
+
+describe('MetaverseRoomControls', () => {
+  test.each([
+    ['live', 'Live', 'Room events are flowing'],
+    ['recovering', 'Recovering', 'Refreshing room connectivity'],
+    ['stale', 'Stale', 'No room activity recently'],
+    ['offline', 'Offline', 'Peer connectivity is unavailable'],
+  ] as const)('renders %s connection status and detail', (connectionState, label, detail) => {
+    renderControls({ connectionState, hudOpen: false, chatOpen: false });
+
+    expect(screen.getByText(label).closest('.metaverse-connection-badge')).toHaveAttribute(
+      'title',
+      detail
+    );
+  });
+
+  test('routes toolbar, avatar, and shared-object controls through callbacks', async () => {
+    const user = userEvent.setup();
+    const onLeaveRoom = vi.fn();
+    const onToggleHud = vi.fn();
+    const onToggleHudDebug = vi.fn();
+    const onImportAvatar = vi.fn();
+    const onImportDefaultAvatar = vi.fn();
+    const onMoveSharedObject = vi.fn();
+    renderControls({
+      hudDebugOpen: true,
+      onLeaveRoom,
+      onToggleHud,
+      onToggleHudDebug,
+      onImportAvatar,
+      onImportDefaultAvatar,
+      onMoveSharedObject,
+    });
+
+    expect(screen.getByText('Topic: kukuri:topic:demo')).toBeInTheDocument();
+    expect(screen.getByText('Community assist: available')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Leave room' }));
+    await user.click(screen.getByRole('button', { name: 'Hide room HUD' }));
+    await user.click(screen.getByRole('button', { name: 'Debug details' }));
+    await user.upload(
+      screen.getByLabelText('VRM file'),
+      new File(['avatar'], 'avatar.vrm', { type: 'model/vrm' })
+    );
+    await user.click(screen.getByRole('button', { name: 'Default' }));
+    for (const name of ['Forward', 'Left', 'Right', 'Back']) {
+      await user.click(screen.getByRole('button', { name }));
+    }
+
+    expect(onLeaveRoom).toHaveBeenCalledTimes(1);
+    expect(onToggleHud).toHaveBeenCalledTimes(1);
+    expect(onToggleHudDebug).toHaveBeenCalledTimes(1);
+    expect(onImportAvatar).toHaveBeenCalledWith(expect.objectContaining({ name: 'avatar.vrm' }));
+    expect(onImportDefaultAvatar).toHaveBeenCalledTimes(1);
+    expect(onMoveSharedObject.mock.calls).toEqual([
+      [[0, 0, -50]],
+      [[-50, 0, 0]],
+      [[50, 0, 0]],
+      [[0, 0, 50]],
+    ]);
+  });
+
+  test('renders chat authors and routes draft, submit, and close actions', async () => {
+    const user = userEvent.setup();
+    const onMessageDraftChange = vi.fn();
+    const onCloseChat = vi.fn();
+    const onSendMessage = vi.fn((event: React.FormEvent<HTMLFormElement>) =>
+      event.preventDefault()
+    );
+    renderControls({
+      messageDraft: 'hello',
+      messages: [
+        {
+          roomId: room.room_id,
+          messageId: 'local-message',
+          authorPeerId: 'local-peer',
+          displayName: null,
+          body: 'Local hello',
+          createdAt: 1,
+        },
+        {
+          roomId: room.room_id,
+          messageId: 'remote-message',
+          authorPeerId: 'remote-peer',
+          displayName: 'Remote Friend',
+          body: 'Remote hello',
+          createdAt: 2,
+        },
+      ],
+      onMessageDraftChange,
+      onCloseChat,
+      onSendMessage,
+    });
+
+    expect(screen.getByText('You')).toBeInTheDocument();
+    expect(screen.getByText('Remote Friend')).toBeInTheDocument();
+    const input = screen.getByLabelText('Room chat message');
+    await user.type(input, '!');
+    expect(onMessageDraftChange).toHaveBeenLastCalledWith('hello!');
+    await user.click(screen.getByRole('button', { name: 'Send' }));
+    await user.click(screen.getByRole('button', { name: 'Hide room chat' }));
+    expect(onSendMessage).toHaveBeenCalledTimes(1);
+    expect(onCloseChat).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows the chat reopen action and disables avatar inputs while pending', async () => {
+    const user = userEvent.setup();
+    const onOpenChat = vi.fn();
+    renderControls({ chatOpen: false, pending: true, onOpenChat });
+
+    expect(screen.getByLabelText('VRM file')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Default' })).toBeDisabled();
+    await user.click(screen.getByRole('button', { name: 'Open room chat' }));
+    expect(onOpenChat).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.tsx
@@ -1,0 +1,337 @@
+import type { FormEventHandler, RefObject } from 'react';
+import {
+  Box,
+  ChevronDown,
+  LogOut,
+  MessageSquare,
+  MonitorPause,
+  Move3D,
+  PanelRightClose,
+  PanelRightOpen,
+  RefreshCw,
+  Send,
+  Wifi,
+  WifiOff,
+  X,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { SupportedLocale } from '@/i18n';
+import { formatLocalizedTime } from '@/i18n/format';
+import type { GameRoomView, MetaverseAssetRef } from '@/lib/api';
+import type {
+  AvatarAssetStatus,
+  MetaverseRoomConnectionState,
+  MetaverseVec3,
+  RoomChatMessage,
+} from '../MetaverseSceneModel';
+
+type MetaverseRoomControlsProps = {
+  room: GameRoomView;
+  activeTopic: string;
+  localPeerId: string;
+  knownPeerCount: number;
+  lastSentSeq: number;
+  lastReceivedAt: number | null;
+  remoteAnimationSummary: string;
+  avatarAssetStatus: AvatarAssetStatus;
+  localAvatarAssetRef: MetaverseAssetRef | null;
+  communityAssistAvailable: boolean;
+  connectionState: MetaverseRoomConnectionState;
+  locale: SupportedLocale;
+  pending: boolean;
+  hudOpen: boolean;
+  hudDebugOpen: boolean;
+  chatOpen: boolean;
+  messages: RoomChatMessage[];
+  messageDraft: string;
+  messageInputRef: RefObject<HTMLInputElement | null>;
+  onLeaveRoom: () => void;
+  onToggleHud: () => void;
+  onToggleHudDebug: () => void;
+  onImportAvatar: (file: File) => void;
+  onImportDefaultAvatar: () => void;
+  onMoveSharedObject: (delta: MetaverseVec3) => void;
+  onCloseChat: () => void;
+  onOpenChat: () => void;
+  onMessageDraftChange: (value: string) => void;
+  onSendMessage: FormEventHandler<HTMLFormElement>;
+};
+
+function connectionStateLabel(state: MetaverseRoomConnectionState) {
+  if (state === 'live') {
+    return 'Live';
+  }
+  if (state === 'recovering') {
+    return 'Recovering';
+  }
+  if (state === 'stale') {
+    return 'Stale';
+  }
+  return 'Offline';
+}
+
+function connectionStateDetail(state: MetaverseRoomConnectionState) {
+  if (state === 'live') {
+    return 'Room events are flowing';
+  }
+  if (state === 'recovering') {
+    return 'Refreshing room connectivity';
+  }
+  if (state === 'stale') {
+    return 'No room activity recently';
+  }
+  return 'Peer connectivity is unavailable';
+}
+
+function ConnectionStateIcon({ state }: { state: MetaverseRoomConnectionState }) {
+  if (state === 'live') {
+    return <Wifi className='size-4' aria-hidden='true' />;
+  }
+  if (state === 'recovering') {
+    return <RefreshCw className='size-4' aria-hidden='true' />;
+  }
+  if (state === 'stale') {
+    return <MonitorPause className='size-4' aria-hidden='true' />;
+  }
+  return <WifiOff className='size-4' aria-hidden='true' />;
+}
+
+export function MetaverseRoomControls({
+  room,
+  activeTopic,
+  localPeerId,
+  knownPeerCount,
+  lastSentSeq,
+  lastReceivedAt,
+  remoteAnimationSummary,
+  avatarAssetStatus,
+  localAvatarAssetRef,
+  communityAssistAvailable,
+  connectionState,
+  locale,
+  pending,
+  hudOpen,
+  hudDebugOpen,
+  chatOpen,
+  messages,
+  messageDraft,
+  messageInputRef,
+  onLeaveRoom,
+  onToggleHud,
+  onToggleHudDebug,
+  onImportAvatar,
+  onImportDefaultAvatar,
+  onMoveSharedObject,
+  onCloseChat,
+  onOpenChat,
+  onMessageDraftChange,
+  onSendMessage,
+}: MetaverseRoomControlsProps) {
+  return (
+    <>
+      <div
+        className='metaverse-connection-badge'
+        data-state={connectionState}
+        title={connectionStateDetail(connectionState)}
+      >
+        <ConnectionStateIcon state={connectionState} />
+        <span>{connectionStateLabel(connectionState)}</span>
+      </div>
+      <div className='metaverse-hud-toolbar' data-open={hudOpen}>
+        <Button
+          variant='ghost'
+          size='icon'
+          className='metaverse-hud-icon-button'
+          type='button'
+          aria-label='Leave room'
+          onClick={onLeaveRoom}
+        >
+          <LogOut className='size-4' aria-hidden='true' />
+        </Button>
+        <Button
+          variant='ghost'
+          size='icon'
+          className='metaverse-hud-icon-button'
+          type='button'
+          aria-label={hudOpen ? 'Hide room HUD' : 'Open room HUD'}
+          onClick={onToggleHud}
+        >
+          {hudOpen ? (
+            <PanelRightClose className='size-4' aria-hidden='true' />
+          ) : (
+            <PanelRightOpen className='size-4' aria-hidden='true' />
+          )}
+        </Button>
+      </div>
+      {hudOpen ? (
+        <>
+          <aside className='metaverse-room-hud'>
+            <div className='panel-header metaverse-hud-header'>
+              <div>
+                <h3>{room.title}</h3>
+                <small>{room.room_id}</small>
+              </div>
+            </div>
+            <section className='metaverse-hud-accordion' data-open={hudDebugOpen}>
+              <button
+                type='button'
+                className='metaverse-hud-accordion-trigger'
+                aria-expanded={hudDebugOpen}
+                onClick={onToggleHudDebug}
+              >
+                <span>Debug details</span>
+                <ChevronDown className='size-4' aria-hidden='true' />
+              </button>
+              {hudDebugOpen ? (
+                <div className='metaverse-room-diagnostics'>
+                  <span>Topic: {activeTopic}</span>
+                  <span>Local peer: {localPeerId}</span>
+                  <span>Known peers: {knownPeerCount}</span>
+                  <span>Last sent seq: {lastSentSeq}</span>
+                  <span>
+                    Last received: {lastReceivedAt ? formatLocalizedTime(lastReceivedAt, locale) : 'none'}
+                  </span>
+                  <span>Remote animation: {remoteAnimationSummary || 'none'}</span>
+                  <span>
+                    Avatar asset:{' '}
+                    {avatarAssetStatus === 'sample-vrm'
+                      ? 'sample VRM loaded'
+                      : avatarAssetStatus === 'blob-vrm'
+                        ? 'blob VRM loaded'
+                        : avatarAssetStatus}
+                  </span>
+                  <span>
+                    Blob asset resolve:{' '}
+                    {localAvatarAssetRef?.blob_hash ?? 'public sample / fallback-ready'}
+                  </span>
+                  <span>Persistence: manifest blob {room.manifest_blob_hash ?? 'pending'}</span>
+                  <span>Community assist: {communityAssistAvailable ? 'available' : 'optional'}</span>
+                </div>
+              ) : null}
+            </section>
+            <div className='metaverse-object-controls'>
+              <strong>Avatar asset</strong>
+              <div className='metaverse-avatar-asset-controls'>
+                <Label>
+                  <span className='sr-only'>VRM file</span>
+                  <Input
+                    type='file'
+                    accept='.vrm,model/vrm,application/octet-stream'
+                    disabled={pending}
+                    onChange={(event) => {
+                      const file = event.target.files?.[0];
+                      if (file) {
+                        onImportAvatar(file);
+                      }
+                      event.currentTarget.value = '';
+                    }}
+                  />
+                </Label>
+                <Button
+                  size='sm'
+                  variant='secondary'
+                  type='button'
+                  disabled={pending}
+                  onClick={onImportDefaultAvatar}
+                >
+                  Default
+                </Button>
+              </div>
+            </div>
+            <div className='metaverse-object-controls'>
+              <strong>
+                <Box className='size-4' aria-hidden='true' />
+                Shared object
+              </strong>
+              <div className='metaverse-nudge-grid'>
+                <Button
+                  size='sm'
+                  variant='secondary'
+                  type='button'
+                  onClick={() => onMoveSharedObject([0, 0, -50])}
+                >
+                  <Move3D className='size-4' aria-hidden='true' />
+                  Forward
+                </Button>
+                <Button size='sm' variant='secondary' type='button' onClick={() => onMoveSharedObject([-50, 0, 0])}>
+                  Left
+                </Button>
+                <Button size='sm' variant='secondary' type='button' onClick={() => onMoveSharedObject([50, 0, 0])}>
+                  Right
+                </Button>
+                <Button size='sm' variant='secondary' type='button' onClick={() => onMoveSharedObject([0, 0, 50])}>
+                  Back
+                </Button>
+              </div>
+            </div>
+          </aside>
+          <span className='metaverse-hud-scrollbar-indicator' aria-hidden='true'>
+            <span />
+          </span>
+        </>
+      ) : null}
+      {chatOpen ? (
+        <section className='metaverse-room-chat-log' aria-label='ROOM Chat'>
+          <div className='metaverse-room-chat-log-header'>
+            <span>
+              <MessageSquare className='size-4' aria-hidden='true' />
+              ROOM Chat
+            </span>
+            <Button
+              variant='ghost'
+              size='icon'
+              className='metaverse-chat-close-button'
+              type='button'
+              aria-label='Hide room chat'
+              onClick={onCloseChat}
+            >
+              <X className='size-4' aria-hidden='true' />
+            </Button>
+          </div>
+          <ul className='metaverse-chat-list'>
+            {messages.map((message) => (
+              <li key={message.messageId}>
+                <strong>
+                  {message.authorPeerId === localPeerId
+                    ? 'You'
+                    : message.displayName || message.authorPeerId.slice(0, 12)}
+                  <small>{formatLocalizedTime(message.createdAt, locale)}</small>
+                </strong>
+                <span>{message.body}</span>
+              </li>
+            ))}
+          </ul>
+          <form className='metaverse-chat-form' onSubmit={onSendMessage}>
+            <Label>
+              <span className='sr-only'>Room chat message</span>
+              <Input
+                ref={messageInputRef}
+                value={messageDraft}
+                placeholder='Say something in the room'
+                onChange={(event) => onMessageDraftChange(event.target.value)}
+              />
+            </Label>
+            <Button size='sm' type='submit'>
+              <Send className='size-4' aria-hidden='true' />
+              Send
+            </Button>
+          </form>
+        </section>
+      ) : (
+        <Button
+          variant='secondary'
+          size='icon'
+          className='metaverse-chat-toggle'
+          type='button'
+          aria-label='Open room chat'
+          onClick={onOpenChat}
+        >
+          <MessageSquare className='size-4' aria-hidden='true' />
+        </Button>
+      )}
+    </>
+  );
+}

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -11,10 +11,6 @@
     {
       "lines": 1079,
       "path": "crates/app-api/src/private_channels.rs"
-    },
-    {
-      "lines": 1043,
-      "path": "apps/desktop/src/components/extended/MetaverseRoomPanel.tsx"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extract connection status, HUD/debug, avatar, shared-object, and chat controls into a callback-only component
- preserve panel-owned state, API calls, timers, and session effects
- add focused status/input/control contracts and remove the now-836-line panel from the oversized baseline

## Validation
- focused metaverse tests: 32 passed
- `cargo xtask desktop-ui-check` (68 files / 579 tests, Storybook, browser 10, visual 14)
- `cargo xtask oversized-files --update-baseline`
- verified `MetaverseRoomControls` has no DesktopApi, state, effect, timer, or BroadcastChannel references