### PR TITLE
refactor: extract metaverse room view

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.stories.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.stories.tsx
@@ -1,0 +1,201 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import type { GameRoomView, SyncStatus } from '@/lib/api';
+import { createDesktopMockApi } from '@/mocks/desktopApiMock';
+import { MetaverseRoomPanel } from './MetaverseRoomPanel';
+import { DEFAULT_SHARED_OBJECT } from './MetaverseSceneModel';
+import { MetaverseRoomDiscovery } from './metaverse/MetaverseRoomDiscovery';
+import { MetaverseRoomView } from './metaverse/MetaverseRoomView';
+
+const meta = {
+  title: 'Extended/MetaverseRoomPanel',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const STORY_TIMESTAMP = 1_742_860_800_000;
+const LOCAL_PUBKEY = 'f'.repeat(64);
+
+const room: GameRoomView = {
+  room_id: 'metaverse-room-1',
+  host_pubkey: LOCAL_PUBKEY,
+  title: 'Atrium',
+  description: 'Small social space',
+  status: 'Waiting',
+  phase_label: 'metaverse-mvp',
+  scores: [],
+  room_kind: 'metaverse_room',
+  metaverse: {
+    world_version: 1,
+    max_peers: 8,
+    scene: {
+      ground: 'default',
+      shared_object: DEFAULT_SHARED_OBJECT,
+    },
+    default_spawn: {
+      position: [0, 0, 260],
+      rotation: [0, 180, 0],
+    },
+    asset_refs: [],
+    chat_history: [],
+  },
+  manifest_blob_hash: 'mock-metaverse-room-1',
+  updated_at: STORY_TIMESTAMP,
+  channel_id: null,
+  audience_label: 'Public',
+};
+
+const syncStatus: SyncStatus = {
+  connected: true,
+  delivery_state: 'Live',
+  peer_count: 1,
+  pending_events: 0,
+  status_detail: 'connected',
+  configured_peers: [],
+  subscribed_topics: ['kukuri:topic:demo'],
+  active_path: 'direct_p2p',
+  fallback_peer_ids: [],
+  topic_diagnostics: [],
+  local_author_pubkey: LOCAL_PUBKEY,
+  discovery: {
+    mode: 'seeded_dht',
+    connect_mode: 'direct_only',
+    active_path: 'direct_p2p',
+    fallback_peer_ids: [],
+    env_locked: false,
+    configured_seed_peer_ids: [],
+    bootstrap_seed_peer_ids: ['community-node'],
+    manual_ticket_peer_ids: [],
+    connected_peer_ids: [],
+    docs_assist_peer_ids: [],
+    blob_assist_peer_ids: [],
+    local_endpoint_id: 'local-endpoint-a',
+  },
+  gossip_disabled_topics: [],
+  gossip_disabled_channels: [],
+};
+
+function StoryFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ maxWidth: 1180, margin: '0 auto', padding: 24 }}>
+      <div className='shell-main-stack'>{children}</div>
+    </div>
+  );
+}
+
+function panel(rooms: GameRoomView[]) {
+  return (
+    <StoryFrame>
+      <MetaverseRoomPanel
+        api={createDesktopMockApi()}
+        activeTopic='kukuri:topic:demo'
+        activeComposeChannel={{ kind: 'public' }}
+        rooms={rooms}
+        syncStatus={syncStatus}
+        locale='en'
+        localProfile={{
+          pubkey: LOCAL_PUBKEY,
+          name: 'host',
+          display_name: 'Host Author',
+          about: null,
+          picture: null,
+          picture_asset: null,
+          updated_at: STORY_TIMESTAMP,
+        }}
+        onRefresh={async () => undefined}
+      />
+    </StoryFrame>
+  );
+}
+
+function selectedRoom(initialHudOpen = true, initialChatOpen = true) {
+  return (
+    <StoryFrame>
+      <MetaverseRoomView
+        room={room}
+        activeTopic='kukuri:topic:demo'
+        localPeerId='local-endpoint-a:story'
+        remoteTransforms={{}}
+        peerPresence={{}}
+        sharedObject={DEFAULT_SHARED_OBJECT}
+        avatarAssetUrl={null}
+        latestChatByPeer={{}}
+        connectionState='live'
+        now={STORY_TIMESTAMP}
+        knownPeerCount={2}
+        lastSentSeq={12}
+        lastReceivedAt={STORY_TIMESTAMP - 1_000}
+        remoteAnimationSummary='remote-pe:walk'
+        avatarAssetStatus='sample-vrm'
+        localAvatarAssetRef={null}
+        communityAssistAvailable={true}
+        locale='en'
+        pending={false}
+        messages={[
+          {
+            roomId: room.room_id,
+            messageId: 'story-message-1',
+            authorPeerId: 'remote-peer',
+            displayName: 'Remote Friend',
+            body: 'Welcome to the room.',
+            createdAt: STORY_TIMESTAMP - 2_000,
+          },
+        ]}
+        messageDraft=''
+        initialHudOpen={initialHudOpen}
+        initialHudDebugOpen={initialHudOpen}
+        initialChatOpen={initialChatOpen}
+        onLocalTransform={() => undefined}
+        onAvatarAssetStatus={() => undefined}
+        onLeaveRoom={() => undefined}
+        onImportAvatar={() => undefined}
+        onImportDefaultAvatar={() => undefined}
+        onMoveSharedObject={() => undefined}
+        onMessageDraftChange={() => undefined}
+        onSendMessage={(event) => event.preventDefault()}
+      />
+    </StoryFrame>
+  );
+}
+
+export const EmptyRooms: Story = {
+  render: () => panel([]),
+};
+
+export const RoomList: Story = {
+  render: () => panel([room]),
+};
+
+export const DiscoveryError: Story = {
+  render: () => (
+    <StoryFrame>
+      <MetaverseRoomDiscovery
+        rooms={[room]}
+        selectedRoomId={null}
+        joinedRoomIds={new Set()}
+        pending={false}
+        error='Room connectivity is unavailable'
+        locale='en'
+        localAuthorPubkey={LOCAL_PUBKEY}
+        localProfile={null}
+        knownAuthorsByPubkey={{}}
+        mediaObjectUrls={{}}
+        onCreateRoom={async () => false}
+        onJoinRoom={() => undefined}
+      />
+    </StoryFrame>
+  ),
+};
+
+export const SelectedHudAndChat: Story = {
+  render: () => selectedRoom(),
+};
+
+export const SelectedCollapsed: Story = {
+  render: () => selectedRoom(false, false),
+};

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -1,5 +1,4 @@
 ﻿import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
-import { Card } from '@/components/ui/card';
 import type {
   ChannelRef,
   DesktopApi,
@@ -14,12 +13,11 @@ import type {
 } from '@/lib/api';
 import type { SupportedLocale } from '@/i18n';
 import { blobToBase64 } from '@/lib/attachments';
-import { MetaverseScene } from './MetaverseScene';
 import {
   MetaverseRoomDiscovery,
   type CreateMetaverseRoomInput,
 } from './metaverse/MetaverseRoomDiscovery';
-import { MetaverseRoomControls } from './metaverse/MetaverseRoomControls';
+import { MetaverseRoomView } from './metaverse/MetaverseRoomView';
 import {
   DEFAULT_AVATAR_ASSET_NAME,
   DEFAULT_AVATAR_ASSET_URL,
@@ -92,14 +90,6 @@ function latestChatBubbleFromMessage(message: RoomChatMessage, now = Date.now())
   };
 }
 
-function isEditableTarget(target: EventTarget | null) {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-  const tagName = target.tagName.toLowerCase();
-  return tagName === 'input' || tagName === 'textarea' || tagName === 'select' || target.isContentEditable;
-}
-
 export function MetaverseRoomPanel({
   api,
   activeTopic,
@@ -116,9 +106,6 @@ export function MetaverseRoomPanel({
   const [pending, setPending] = useState(false);
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const [joinedRoomIds, setJoinedRoomIds] = useState<Set<string>>(() => new Set());
-  const [hudOpen, setHudOpen] = useState(true);
-  const [chatOpen, setChatOpen] = useState(true);
-  const [hudDebugOpen, setHudDebugOpen] = useState(false);
   const [remoteTransforms, setRemoteTransforms] = useState<Record<string, AvatarTransform>>({});
   const [peerPresence, setPeerPresence] = useState<Record<string, PeerPresence>>({});
   const [messages, setMessages] = useState<RoomChatMessage[]>([]);
@@ -138,7 +125,6 @@ export function MetaverseRoomPanel({
   const lastRecoveryAtRef = useRef(0);
   const pendingCreatedRoomIdRef = useRef<string | null>(null);
   const sharedObjectRef = useRef<SharedRoomObjectV1>(DEFAULT_SHARED_OBJECT);
-  const messageInputRef = useRef<HTMLInputElement | null>(null);
   const localPeerSeed = useId().replaceAll(':', '');
   const localPeerId = `${syncStatus.discovery.local_endpoint_id || syncStatus.local_author_pubkey || 'local'}:${localPeerSeed}`;
   const lastSentTransformRef = useRef<AvatarTransform | null>(null);
@@ -735,33 +721,6 @@ export function MetaverseRoomPanel({
     persistSharedObject(nextObject, room);
   }
 
-  useEffect(() => {
-    if (!selectedRoom) {
-      return;
-    }
-    let focusFrameId = 0;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Enter' || isEditableTarget(event.target)) {
-        return;
-      }
-      event.preventDefault();
-      setChatOpen(true);
-      if (focusFrameId) {
-        window.cancelAnimationFrame(focusFrameId);
-      }
-      focusFrameId = window.requestAnimationFrame(() => {
-        messageInputRef.current?.focus();
-      });
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-      if (focusFrameId) {
-        window.cancelAnimationFrame(focusFrameId);
-      }
-    };
-  }, [selectedRoom]);
-
   return (
     <div className='metaverse-panel'>
       <MetaverseRoomDiscovery
@@ -779,58 +738,37 @@ export function MetaverseRoomPanel({
         onJoinRoom={handleJoinRoom}
       />
 
-      {selectedRoom ? (
-        <Card className='shell-workspace-card metaverse-room-view'>
-          <div className='metaverse-room-stage'>
-            <MetaverseScene
-              room={selectedRoom}
-              localPeerId={localPeerId}
-              remoteTransforms={remoteTransforms}
-              peerPresence={peerPresence}
-              sharedObject={sharedObject}
-              avatarAssetUrl={localAvatarAssetUrl}
-              latestChatByPeer={latestChatByPeer}
-              connectionState={roomConnectionState}
-              now={clockNow}
-              onLocalTransform={handleLocalTransform}
-              onAvatarAssetStatus={setAvatarAssetStatus}
-              hud={(
-                <MetaverseRoomControls
-                  room={selectedRoom}
-                  activeTopic={activeTopic}
-                  localPeerId={localPeerId}
-                  knownPeerCount={knownPeerCount}
-                  lastSentSeq={lastSentSeq}
-                  lastReceivedAt={lastReceivedAt}
-                  remoteAnimationSummary={remoteAnimationSummary}
-                  avatarAssetStatus={avatarAssetStatus}
-                  localAvatarAssetRef={localAvatarAssetRef}
-                  communityAssistAvailable={syncStatus.discovery.bootstrap_seed_peer_ids.length > 0}
-                  connectionState={roomConnectionState}
-                  locale={locale}
-                  pending={pending}
-                  hudOpen={hudOpen}
-                  hudDebugOpen={hudDebugOpen}
-                  chatOpen={chatOpen}
-                  messages={messages}
-                  messageDraft={messageDraft}
-                  messageInputRef={messageInputRef}
-                  onLeaveRoom={handleLeaveRoom}
-                  onToggleHud={() => setHudOpen((open) => !open)}
-                  onToggleHudDebug={() => setHudDebugOpen((open) => !open)}
-                  onImportAvatar={(file) => void importAvatarBlob(file, file.name)}
-                  onImportDefaultAvatar={() => void handleSampleAvatarImport()}
-                  onMoveSharedObject={(delta) => void moveSharedObject(delta)}
-                  onCloseChat={() => setChatOpen(false)}
-                  onOpenChat={() => setChatOpen(true)}
-                  onMessageDraftChange={setMessageDraft}
-                  onSendMessage={handleSendMessage}
-                />
-              )}
-            />
-          </div>
-        </Card>
-      ) : null}
+      <MetaverseRoomView
+        room={selectedRoom}
+        activeTopic={activeTopic}
+        localPeerId={localPeerId}
+        remoteTransforms={remoteTransforms}
+        peerPresence={peerPresence}
+        sharedObject={sharedObject}
+        avatarAssetUrl={localAvatarAssetUrl}
+        latestChatByPeer={latestChatByPeer}
+        connectionState={roomConnectionState}
+        now={clockNow}
+        knownPeerCount={knownPeerCount}
+        lastSentSeq={lastSentSeq}
+        lastReceivedAt={lastReceivedAt}
+        remoteAnimationSummary={remoteAnimationSummary}
+        avatarAssetStatus={avatarAssetStatus}
+        localAvatarAssetRef={localAvatarAssetRef}
+        communityAssistAvailable={syncStatus.discovery.bootstrap_seed_peer_ids.length > 0}
+        locale={locale}
+        pending={pending}
+        messages={messages}
+        messageDraft={messageDraft}
+        onLocalTransform={handleLocalTransform}
+        onAvatarAssetStatus={setAvatarAssetStatus}
+        onLeaveRoom={handleLeaveRoom}
+        onImportAvatar={(file) => void importAvatarBlob(file, file.name)}
+        onImportDefaultAvatar={() => void handleSampleAvatarImport()}
+        onMoveSharedObject={(delta) => void moveSharedObject(delta)}
+        onMessageDraftChange={setMessageDraft}
+        onSendMessage={handleSendMessage}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomView.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomView.test.tsx
@@ -1,0 +1,155 @@
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import type { GameRoomView, SharedRoomObjectV1 } from '@/lib/api';
+import { MetaverseRoomView } from './MetaverseRoomView';
+
+vi.mock('../MetaverseScene', () => ({
+  MetaverseScene: (props: {
+    room: GameRoomView;
+    localPeerId: string;
+    sharedObject: SharedRoomObjectV1;
+    connectionState: string;
+    hud: ReactNode;
+  }) => (
+    <div aria-label='Metaverse room viewport'>
+      <span>{`Scene room: ${props.room.room_id}`}</span>
+      <span>{`Scene peer: ${props.localPeerId}`}</span>
+      <span>{`Scene object: ${props.sharedObject.object_id}`}</span>
+      <span>{`Scene connection: ${props.connectionState}`}</span>
+      {props.hud}
+    </div>
+  ),
+}));
+
+const room: GameRoomView = {
+  room_id: 'metaverse-room-1',
+  host_pubkey: 'f'.repeat(64),
+  title: 'Atrium',
+  description: 'Small social space',
+  status: 'Waiting',
+  phase_label: 'metaverse-mvp',
+  scores: [],
+  room_kind: 'metaverse_room',
+  metaverse: null,
+  manifest_blob_hash: 'manifest-1',
+  updated_at: 1,
+  channel_id: null,
+  audience_label: 'Public',
+};
+
+const sharedObject: SharedRoomObjectV1 = {
+  object_id: 'shared-object-1',
+  asset_ref: null,
+  primitive_fallback: 'cube',
+  position: [0, 0, 0],
+  rotation: [0, 0, 0],
+  scale: [100, 100, 100],
+  updated_by: 'local-peer',
+  updated_at: 1,
+};
+
+function viewProps(
+  overrides: Partial<Parameters<typeof MetaverseRoomView>[0]> = {}
+): Parameters<typeof MetaverseRoomView>[0] {
+  return {
+    room,
+    activeTopic: 'kukuri:topic:demo',
+    localPeerId: 'local-peer',
+    remoteTransforms: {},
+    peerPresence: {},
+    sharedObject,
+    avatarAssetUrl: null,
+    latestChatByPeer: {},
+    connectionState: 'live',
+    now: 1,
+    knownPeerCount: 0,
+    lastSentSeq: 0,
+    lastReceivedAt: null,
+    remoteAnimationSummary: '',
+    avatarAssetStatus: 'sample-vrm',
+    localAvatarAssetRef: null,
+    communityAssistAvailable: true,
+    locale: 'en',
+    pending: false,
+    messages: [],
+    messageDraft: '',
+    onLocalTransform: vi.fn(),
+    onAvatarAssetStatus: vi.fn(),
+    onLeaveRoom: vi.fn(),
+    onImportAvatar: vi.fn(),
+    onImportDefaultAvatar: vi.fn(),
+    onMoveSharedObject: vi.fn(),
+    onMessageDraftChange: vi.fn(),
+    onSendMessage: vi.fn((event) => event.preventDefault()),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('MetaverseRoomView', () => {
+  test('passes room session state into the scene and composes HUD/chat controls', () => {
+    render(<MetaverseRoomView {...viewProps()} />);
+
+    expect(screen.getByText('Scene room: metaverse-room-1')).toBeInTheDocument();
+    expect(screen.getByText('Scene peer: local-peer')).toBeInTheDocument();
+    expect(screen.getByText('Scene object: shared-object-1')).toBeInTheDocument();
+    expect(screen.getByText('Scene connection: live')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide room HUD' })).toBeInTheDocument();
+    expect(screen.getByLabelText('ROOM Chat')).toBeInTheDocument();
+  });
+
+  test('opens chat and focuses its input when Enter is pressed outside an editable target', async () => {
+    render(<MetaverseRoomView {...viewProps({ initialChatOpen: false })} />);
+    expect(screen.getByRole('button', { name: 'Open room chat' })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    const input = await screen.findByLabelText('Room chat message');
+    await waitFor(() => expect(input).toHaveFocus());
+  });
+
+  test('does not capture Enter from an editable target', () => {
+    render(<MetaverseRoomView {...viewProps({ initialChatOpen: false })} />);
+
+    fireEvent.keyDown(screen.getByLabelText('VRM file'), { key: 'Enter' });
+
+    expect(screen.getByRole('button', { name: 'Open room chat' })).toBeInTheDocument();
+  });
+
+  test('preserves HUD and chat state while the selected room is temporarily absent', async () => {
+    const user = userEvent.setup();
+    const props = viewProps();
+    const view = render(<MetaverseRoomView {...props} />);
+    await user.click(screen.getByRole('button', { name: 'Hide room HUD' }));
+    await user.click(screen.getByRole('button', { name: 'Hide room chat' }));
+
+    view.rerender(<MetaverseRoomView {...props} room={null} />);
+    expect(screen.queryByLabelText('Metaverse room viewport')).not.toBeInTheDocument();
+    view.rerender(<MetaverseRoomView {...props} />);
+
+    expect(screen.getByRole('button', { name: 'Open room HUD' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Open room chat' })).toBeInTheDocument();
+  });
+
+  test('removes the key listener and cancels a pending focus frame on cleanup', () => {
+    const removeEventListener = vi.spyOn(window, 'removeEventListener');
+    const requestAnimationFrame = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 17);
+    const cancelAnimationFrame = vi.spyOn(window, 'cancelAnimationFrame');
+    const view = render(<MetaverseRoomView {...viewProps({ initialChatOpen: false })} />);
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+    view.unmount();
+
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(17);
+    expect(removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
+  });
+});

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomView.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomView.tsx
@@ -1,0 +1,188 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type FormEventHandler,
+} from 'react';
+
+import { Card } from '@/components/ui/card';
+import type { SupportedLocale } from '@/i18n';
+import type { GameRoomView, MetaverseAssetRef, SharedRoomObjectV1 } from '@/lib/api';
+import { MetaverseScene } from '../MetaverseScene';
+import type {
+  AvatarAssetStatus,
+  AvatarTransform,
+  LatestChatBubble,
+  MetaverseRoomConnectionState,
+  MetaverseVec3,
+  PeerPresence,
+  RoomChatMessage,
+} from '../MetaverseSceneModel';
+import { MetaverseRoomControls } from './MetaverseRoomControls';
+
+export type MetaverseRoomViewProps = {
+  room: GameRoomView | null;
+  activeTopic: string;
+  localPeerId: string;
+  remoteTransforms: Record<string, AvatarTransform>;
+  peerPresence: Record<string, PeerPresence>;
+  sharedObject: SharedRoomObjectV1;
+  avatarAssetUrl: string | null;
+  latestChatByPeer: Record<string, LatestChatBubble>;
+  connectionState: MetaverseRoomConnectionState;
+  now: number;
+  knownPeerCount: number;
+  lastSentSeq: number;
+  lastReceivedAt: number | null;
+  remoteAnimationSummary: string;
+  avatarAssetStatus: AvatarAssetStatus;
+  localAvatarAssetRef: MetaverseAssetRef | null;
+  communityAssistAvailable: boolean;
+  locale: SupportedLocale;
+  pending: boolean;
+  messages: RoomChatMessage[];
+  messageDraft: string;
+  initialHudOpen?: boolean;
+  initialHudDebugOpen?: boolean;
+  initialChatOpen?: boolean;
+  onLocalTransform: (transform: AvatarTransform) => void;
+  onAvatarAssetStatus: (status: AvatarAssetStatus) => void;
+  onLeaveRoom: () => void;
+  onImportAvatar: (file: File) => void;
+  onImportDefaultAvatar: () => void;
+  onMoveSharedObject: (delta: MetaverseVec3) => void;
+  onMessageDraftChange: (value: string) => void;
+  onSendMessage: FormEventHandler<HTMLFormElement>;
+};
+
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = target.tagName.toLowerCase();
+  return tagName === 'input' || tagName === 'textarea' || tagName === 'select' || target.isContentEditable;
+}
+
+export function MetaverseRoomView({
+  room,
+  activeTopic,
+  localPeerId,
+  remoteTransforms,
+  peerPresence,
+  sharedObject,
+  avatarAssetUrl,
+  latestChatByPeer,
+  connectionState,
+  now,
+  knownPeerCount,
+  lastSentSeq,
+  lastReceivedAt,
+  remoteAnimationSummary,
+  avatarAssetStatus,
+  localAvatarAssetRef,
+  communityAssistAvailable,
+  locale,
+  pending,
+  messages,
+  messageDraft,
+  initialHudOpen = true,
+  initialHudDebugOpen = false,
+  initialChatOpen = true,
+  onLocalTransform,
+  onAvatarAssetStatus,
+  onLeaveRoom,
+  onImportAvatar,
+  onImportDefaultAvatar,
+  onMoveSharedObject,
+  onMessageDraftChange,
+  onSendMessage,
+}: MetaverseRoomViewProps) {
+  const [hudOpen, setHudOpen] = useState(initialHudOpen);
+  const [hudDebugOpen, setHudDebugOpen] = useState(initialHudDebugOpen);
+  const [chatOpen, setChatOpen] = useState(initialChatOpen);
+  const messageInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!room) {
+      return;
+    }
+    let focusFrameId = 0;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter' || isEditableTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      setChatOpen(true);
+      if (focusFrameId) {
+        window.cancelAnimationFrame(focusFrameId);
+      }
+      focusFrameId = window.requestAnimationFrame(() => {
+        messageInputRef.current?.focus();
+      });
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      if (focusFrameId) {
+        window.cancelAnimationFrame(focusFrameId);
+      }
+    };
+  }, [room]);
+
+  if (!room) {
+    return null;
+  }
+
+  return (
+    <Card className='shell-workspace-card metaverse-room-view'>
+      <div className='metaverse-room-stage'>
+        <MetaverseScene
+          room={room}
+          localPeerId={localPeerId}
+          remoteTransforms={remoteTransforms}
+          peerPresence={peerPresence}
+          sharedObject={sharedObject}
+          avatarAssetUrl={avatarAssetUrl}
+          latestChatByPeer={latestChatByPeer}
+          connectionState={connectionState}
+          now={now}
+          onLocalTransform={onLocalTransform}
+          onAvatarAssetStatus={onAvatarAssetStatus}
+          hud={(
+            <MetaverseRoomControls
+              room={room}
+              activeTopic={activeTopic}
+              localPeerId={localPeerId}
+              knownPeerCount={knownPeerCount}
+              lastSentSeq={lastSentSeq}
+              lastReceivedAt={lastReceivedAt}
+              remoteAnimationSummary={remoteAnimationSummary}
+              avatarAssetStatus={avatarAssetStatus}
+              localAvatarAssetRef={localAvatarAssetRef}
+              communityAssistAvailable={communityAssistAvailable}
+              connectionState={connectionState}
+              locale={locale}
+              pending={pending}
+              hudOpen={hudOpen}
+              hudDebugOpen={hudDebugOpen}
+              chatOpen={chatOpen}
+              messages={messages}
+              messageDraft={messageDraft}
+              messageInputRef={messageInputRef}
+              onLeaveRoom={onLeaveRoom}
+              onToggleHud={() => setHudOpen((open) => !open)}
+              onToggleHudDebug={() => setHudDebugOpen((open) => !open)}
+              onImportAvatar={onImportAvatar}
+              onImportDefaultAvatar={onImportDefaultAvatar}
+              onMoveSharedObject={onMoveSharedObject}
+              onCloseChat={() => setChatOpen(false)}
+              onOpenChat={() => setChatOpen(true)}
+              onMessageDraftChange={onMessageDraftChange}
+              onSendMessage={onSendMessage}
+            />
+          )}
+        />
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- extract Scene + controls composition into `MetaverseRoomView`
- move HUD/chat/debug state and Enter-to-focus ownership into the view while preserving state across temporary room absence
- add focused listener/rAF cleanup contracts and five Storybook states for empty/list/error/selected/collapsed surfaces

## Validation
- focused view + panel tests: 30 passed
- `cargo xtask desktop-ui-check` (69 files / 584 tests, Storybook, browser 10, visual 14)
- `cargo xtask oversized-files`
- verified `MetaverseRoomView` has no DesktopApi, BroadcastChannel, or session timer references