### PR TITLE
refactor: extract metaverse room session

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -1,14 +1,12 @@
-﻿import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
+import { useState } from 'react';
+
 import type {
+  AuthorSocialView,
   ChannelRef,
   DesktopApi,
   GameRoomView,
   MetaverseAssetRef,
-  MetaverseRoomEventView,
-  MetaverseRoomEventV1,
-  AuthorSocialView,
   Profile,
-  SharedRoomObjectV1,
   SyncStatus,
 } from '@/lib/api';
 import type { SupportedLocale } from '@/i18n';
@@ -18,25 +16,11 @@ import {
   type CreateMetaverseRoomInput,
 } from './metaverse/MetaverseRoomDiscovery';
 import { MetaverseRoomView } from './metaverse/MetaverseRoomView';
+import { useMetaverseRoomSession } from './metaverse/useMetaverseRoomSession';
 import {
   DEFAULT_AVATAR_ASSET_NAME,
   DEFAULT_AVATAR_ASSET_URL,
-  DEFAULT_SHARED_OBJECT,
-  METAVERSE_CHAT_BUBBLE_TTL_MS,
-  METAVERSE_ROOM_HEARTBEAT_MS,
-  METAVERSE_ROOM_RECOVERY_MS,
-  METAVERSE_ROOM_STALE_MS,
-  isNewerSharedObject,
-  mergeRoomChatMessages,
-  normalizeAvatarAnimationState,
   type AvatarAssetStatus,
-  type AvatarTransform,
-  type LatestChatBubble,
-  type MetaverseRoomConnectionState,
-  type MetaverseRoomEvent,
-  type MetaverseVec3,
-  type PeerPresence,
-  type RoomChatMessage,
 } from './MetaverseSceneModel';
 
 type MetaverseRoomPanelProps = {
@@ -52,44 +36,6 @@ type MetaverseRoomPanelProps = {
   onRefresh: () => Promise<void>;
 };
 
-const EMPTY_ROOM_CHAT_HISTORY: NonNullable<
-  NonNullable<GameRoomView['metaverse']>['chat_history']
-> = [];
-
-function chatMessageFromApi(message: {
-  room_id: string;
-  message_id: string;
-  author_peer_id: string;
-  display_name?: string | null;
-  body: string;
-  created_at: number;
-}): RoomChatMessage {
-  return {
-    roomId: message.room_id,
-    messageId: message.message_id,
-    authorPeerId: message.author_peer_id,
-    displayName: message.display_name ?? null,
-    body: message.body,
-    createdAt: message.created_at,
-  };
-}
-
-function topicDiagnosticFor(syncStatus: SyncStatus, topic: string) {
-  return syncStatus.topic_diagnostics.find(
-    (diagnostic) => diagnostic.topic === topic || diagnostic.topic === `hint/${topic}`
-  );
-}
-
-function latestChatBubbleFromMessage(message: RoomChatMessage, now = Date.now()): LatestChatBubble {
-  return {
-    peerId: message.authorPeerId,
-    displayName: message.displayName ?? null,
-    body: message.body,
-    createdAt: message.createdAt,
-    expiresAt: now + METAVERSE_CHAT_BUBBLE_TTL_MS,
-  };
-}
-
 export function MetaverseRoomPanel({
   api,
   activeTopic,
@@ -104,260 +50,46 @@ export function MetaverseRoomPanel({
 }: MetaverseRoomPanelProps) {
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
-  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
-  const [joinedRoomIds, setJoinedRoomIds] = useState<Set<string>>(() => new Set());
-  const [remoteTransforms, setRemoteTransforms] = useState<Record<string, AvatarTransform>>({});
-  const [peerPresence, setPeerPresence] = useState<Record<string, PeerPresence>>({});
-  const [messages, setMessages] = useState<RoomChatMessage[]>([]);
-  const [latestChatByPeer, setLatestChatByPeer] = useState<Record<string, LatestChatBubble>>({});
-  const [messageDraft, setMessageDraft] = useState('');
-  const [sharedObject, setSharedObject] = useState<SharedRoomObjectV1>(DEFAULT_SHARED_OBJECT);
-  const [lastSentSeq, setLastSentSeq] = useState(0);
   const [avatarAssetStatus, setAvatarAssetStatus] = useState<AvatarAssetStatus>('loading');
   const [localAvatarAssetRef, setLocalAvatarAssetRef] = useState<MetaverseAssetRef | null>(null);
   const [localAvatarAssetUrl, setLocalAvatarAssetUrl] = useState<string | null>(null);
-  const [pollErrorCount, setPollErrorCount] = useState(0);
-  const [lastRoomActivityAt, setLastRoomActivityAt] = useState(() => Date.now());
-  const [recoveringUntil, setRecoveringUntil] = useState(0);
-  const [clockNow, setClockNow] = useState(() => Date.now());
-  const channelRef = useRef<BroadcastChannel | null>(null);
-  const lastBackendEventEnvelopeIdRef = useRef<string | null>(null);
-  const lastRecoveryAtRef = useRef(0);
-  const pendingCreatedRoomIdRef = useRef<string | null>(null);
-  const sharedObjectRef = useRef<SharedRoomObjectV1>(DEFAULT_SHARED_OBJECT);
-  const localPeerSeed = useId().replaceAll(':', '');
-  const localPeerId = `${syncStatus.discovery.local_endpoint_id || syncStatus.local_author_pubkey || 'local'}:${localPeerSeed}`;
-  const lastSentTransformRef = useRef<AvatarTransform | null>(null);
-  const lastReceivedAt = useMemo(() => {
-    const values = Object.values(remoteTransforms).map((transform) => transform.sentAt);
-    return values.length ? Math.max(...values) : null;
-  }, [remoteTransforms]);
-  const remoteAnimationSummary = useMemo(
-    () =>
-      Object.values(remoteTransforms)
-        .map((transform) => `${transform.peerId.slice(0, 8)}:${transform.animation}`)
-        .join(', '),
-    [remoteTransforms]
-  );
-
-  const selectedRoom = selectedRoomId
-    ? rooms.find((room) => room.room_id === selectedRoomId) ?? null
-    : null;
-  const selectedRoomRoomId = selectedRoom?.room_id ?? null;
-  const selectedRoomSharedObject = selectedRoom?.metaverse?.scene.shared_object ?? null;
-  const selectedRoomChatHistory = selectedRoom?.metaverse?.chat_history ?? EMPTY_ROOM_CHAT_HISTORY;
-  const activeTopicDiagnostic = useMemo(
-    () => topicDiagnosticFor(syncStatus, activeTopic),
-    [activeTopic, syncStatus]
-  );
-  const roomConnectionState: MetaverseRoomConnectionState = useMemo(() => {
-    if (!selectedRoom) {
-      return 'offline';
-    }
-    if (recoveringUntil > clockNow) {
-      return 'recovering';
-    }
-    const topicPeerCount = activeTopicDiagnostic?.peer_count ?? syncStatus.peer_count;
-    const topicError = activeTopicDiagnostic?.last_error ?? syncStatus.last_error ?? null;
-    if (
-      !syncStatus.connected ||
-      syncStatus.delivery_state === 'Offline' ||
-      topicPeerCount === 0 ||
-      pollErrorCount >= 3 ||
-      topicError
-    ) {
-      return 'offline';
-    }
-    if (clockNow - lastRoomActivityAt > METAVERSE_ROOM_STALE_MS) {
-      return 'stale';
-    }
-    return 'live';
-  }, [
-    activeTopicDiagnostic,
-    clockNow,
-    lastRoomActivityAt,
-    pollErrorCount,
-    recoveringUntil,
-    selectedRoom,
-    syncStatus,
-  ]);
-  const knownPeerCount = Object.keys(remoteTransforms).length;
   const localDisplayName = localProfile?.display_name?.trim() || localProfile?.name?.trim() || null;
-
-  useEffect(() => {
-    sharedObjectRef.current = sharedObject;
-  }, [sharedObject]);
-
-  useEffect(() => {
-    if (!selectedRoomId) {
-      return;
-    }
-    if (rooms.some((room) => room.room_id === selectedRoomId)) {
-      if (pendingCreatedRoomIdRef.current === selectedRoomId) {
-        pendingCreatedRoomIdRef.current = null;
-      }
-      return;
-    }
-    if (pendingCreatedRoomIdRef.current !== selectedRoomId) {
-      setSelectedRoomId(null);
-    }
-  }, [rooms, selectedRoomId]);
-
-  useEffect(() => {
-    const intervalId = window.setInterval(() => {
-      const now = Date.now();
-      setClockNow(now);
-      setLatestChatByPeer((current) => {
-        const next = Object.fromEntries(
-          Object.entries(current).filter(([, bubble]) => bubble.expiresAt > now)
-        );
-        return Object.keys(next).length === Object.keys(current).length ? current : next;
-      });
-    }, 1000);
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!selectedRoomRoomId) {
-      return;
-    }
-    sharedObjectRef.current = DEFAULT_SHARED_OBJECT;
-    setSharedObject(DEFAULT_SHARED_OBJECT);
-    setRemoteTransforms({});
-    setPeerPresence({});
-    setMessages([]);
-    setLatestChatByPeer({});
-    setPollErrorCount(0);
-    setLastRoomActivityAt(Date.now());
-    lastBackendEventEnvelopeIdRef.current = null;
-    if (typeof BroadcastChannel === 'undefined') {
-      return;
-    }
-    const channel = new BroadcastChannel(`kukuri-metaverse-room:${selectedRoomRoomId}`);
-    channelRef.current = channel;
-    channel.onmessage = (event: MessageEvent<MetaverseRoomEvent>) => {
-      const data = event.data;
-      if (!data || !('type' in data)) {
-        return;
-      }
-      setLastRoomActivityAt(Date.now());
-      if (data.type === 'presence.join' && data.presence.peerId !== localPeerId) {
-        setPeerPresence((current) => ({
-          ...current,
-          [data.presence.peerId]: data.presence,
-        }));
-      }
-      if (data.type === 'presence.leave' && data.peerId !== localPeerId) {
-        setPeerPresence((current) => {
-          const next = { ...current };
-          delete next[data.peerId];
-          return next;
-        });
-        setRemoteTransforms((current) => {
-          const next = { ...current };
-          delete next[data.peerId];
-          return next;
-        });
-        setLatestChatByPeer((current) => {
-          const next = { ...current };
-          delete next[data.peerId];
-          return next;
-        });
-      }
-      if (data.type === 'avatar.transform' && data.transform.peerId !== localPeerId) {
-        setRemoteTransforms((current) => ({
-          ...current,
-          [data.transform.peerId]: data.transform,
-        }));
-      }
-      if (data.type === 'chat.message') {
-        setMessages((current) => mergeRoomChatMessages(current, [data.message]));
-        setLatestChatByPeer((current) => ({
-          ...current,
-          [data.message.authorPeerId]: latestChatBubbleFromMessage(data.message),
-        }));
-      }
-      if (data.type === 'object.update' && data.object.updated_by !== localPeerId) {
-        setSharedObject((current) => {
-          if (!isNewerSharedObject(current, data.object)) {
-            return current;
-          }
-          sharedObjectRef.current = data.object;
-          return data.object;
-        });
-      }
-    };
-    return () => {
-      channel.close();
-      channelRef.current = null;
-    };
-  }, [localPeerId, selectedRoomRoomId]);
-
-  useEffect(() => {
-    const nextObject = selectedRoomSharedObject ?? DEFAULT_SHARED_OBJECT;
-    setSharedObject((current) => {
-      if (!isNewerSharedObject(current, nextObject)) {
-        return current;
-      }
-      sharedObjectRef.current = nextObject;
-      return nextObject;
-    });
-  }, [selectedRoomSharedObject]);
-
-  useEffect(() => {
-    const durableMessages = selectedRoomChatHistory.map(chatMessageFromApi);
-    setMessages((current) => mergeRoomChatMessages(current, durableMessages));
-  }, [selectedRoomChatHistory, selectedRoomRoomId]);
-
-  useEffect(() => {
-    if (!selectedRoom) {
-      return;
-    }
-    const joinedAt = Date.now();
-    const publishPresence = () => {
-      const now = Date.now();
-      const presence: PeerPresence = {
-        peerId: localPeerId,
-        displayName: localDisplayName,
-        avatarAssetRef: localAvatarAssetRef,
-        avatarAssetUrl: localAvatarAssetUrl,
-        joinedAt,
-        lastSeenAt: now,
-      };
-      emit({ type: 'presence.join', presence });
-      void api.publishMetaverseRoomEvent(activeTopic, selectedRoom.room_id, localPeerId, now, {
-        type: 'presence_join',
-        presence: {
-          room_id: selectedRoom.room_id,
-          peer_id: localPeerId,
-          display_name: localDisplayName,
-          avatar_asset_ref: localAvatarAssetRef,
-          joined_at: joinedAt,
-          last_seen_at: now,
-        },
-      }).catch(() => {
-        // Browser-only fallback is handled by the local scene.
-      });
-    };
-    publishPresence();
-    const intervalId = window.setInterval(publishPresence, METAVERSE_ROOM_HEARTBEAT_MS);
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [
-    activeTopic,
+  const session = useMetaverseRoomSession({
     api,
+    activeTopic,
+    rooms,
+    syncStatus,
+    localDisplayName,
     localAvatarAssetRef,
     localAvatarAssetUrl,
-    localDisplayName,
-    localPeerId,
-    selectedRoom,
-  ]);
+    onRefresh,
+    onError: setError,
+  });
+
+  async function handleCreateRoom(input: CreateMetaverseRoomInput) {
+    setPending(true);
+    try {
+      const roomId = await api.createMetaverseRoom(
+        activeTopic,
+        input.title,
+        input.description,
+        input.maxPeers,
+        activeComposeChannel
+      );
+      setError(null);
+      session.selectCreatedRoom(roomId);
+      await onRefresh();
+      return true;
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : 'Failed to create metaverse room');
+      return false;
+    } finally {
+      setPending(false);
+    }
+  }
 
   async function importAvatarBlob(blob: Blob, name: string) {
-    if (!selectedRoom) {
+    if (!session.selectedRoom) {
       return;
     }
     setPending(true);
@@ -366,7 +98,7 @@ export function MetaverseRoomPanel({
       const dataBase64 = await blobToBase64(blob);
       const assetRef = await api.importMetaverseRoomAsset(
         activeTopic,
-        selectedRoom.room_id,
+        session.selectedRoom.room_id,
         'vrm',
         mime,
         name,
@@ -393,340 +125,12 @@ export function MetaverseRoomPanel({
     await importAvatarBlob(await response.blob(), DEFAULT_AVATAR_ASSET_NAME);
   }
 
-  useEffect(() => {
-    if (!selectedRoom) {
-      return;
-    }
-    let cancelled = false;
-    let timeoutId = 0;
-    const applyBackendEvent = (view: MetaverseRoomEventView) => {
-      const event = view.content.event;
-      setLastRoomActivityAt(Date.now());
-      if (event.type === 'presence_join' && event.presence.peer_id !== localPeerId) {
-        const presence: PeerPresence = {
-          peerId: event.presence.peer_id,
-          displayName: event.presence.display_name ?? null,
-          avatarAssetRef: event.presence.avatar_asset_ref ?? null,
-          joinedAt: event.presence.joined_at,
-          lastSeenAt: event.presence.last_seen_at,
-        };
-        setPeerPresence((current) => ({
-          ...current,
-          [presence.peerId]: {
-            ...current[presence.peerId],
-            ...presence,
-          },
-        }));
-        if (presence.avatarAssetRef) {
-          void api
-            .getBlobPreviewUrl(
-              presence.avatarAssetRef.blob_hash,
-              presence.avatarAssetRef.mime_type ?? 'model/vrm'
-            )
-            .then((avatarAssetUrl) => {
-              if (!cancelled && avatarAssetUrl) {
-                setPeerPresence((current) => ({
-                  ...current,
-                  [presence.peerId]: {
-                    ...current[presence.peerId],
-                    avatarAssetUrl,
-                  },
-                }));
-              }
-            })
-            .catch(() => {
-              // Missing remote avatar blobs fall back to the bundled default VRM.
-            });
-        }
-      }
-      if (event.type === 'presence_leave' && event.peer_id !== localPeerId) {
-        setPeerPresence((current) => {
-          const next = { ...current };
-          delete next[event.peer_id];
-          return next;
-        });
-        setRemoteTransforms((current) => {
-          const next = { ...current };
-          delete next[event.peer_id];
-          return next;
-        });
-        setLatestChatByPeer((current) => {
-          const next = { ...current };
-          delete next[event.peer_id];
-          return next;
-        });
-      }
-      if (event.type === 'avatar_transform' && event.transform.peer_id !== localPeerId) {
-        setRemoteTransforms((current) => ({
-          ...current,
-          [event.transform.peer_id]: {
-            roomId: event.transform.room_id,
-            peerId: event.transform.peer_id,
-            seq: event.transform.seq,
-            position: event.transform.position,
-            rotation: event.transform.rotation,
-            animation: normalizeAvatarAnimationState(event.transform.animation),
-            sentAt: event.transform.sent_at,
-          },
-        }));
-      }
-      if (event.type === 'chat_message') {
-        const message = chatMessageFromApi(event.message);
-        setMessages((current) => mergeRoomChatMessages(current, [message]));
-        setLatestChatByPeer((current) => ({
-          ...current,
-          [message.authorPeerId]: latestChatBubbleFromMessage(message),
-        }));
-      }
-      if (event.type === 'object_update' && event.object.updated_by !== localPeerId) {
-        setSharedObject((current) => {
-          if (!isNewerSharedObject(current, event.object)) {
-            return current;
-          }
-          sharedObjectRef.current = event.object;
-          return event.object;
-        });
-      }
-    };
-    const poll = async () => {
-      try {
-        const events = await api.listMetaverseRoomEvents(
-          activeTopic,
-          selectedRoom.room_id,
-          lastBackendEventEnvelopeIdRef.current,
-          64
-        );
-        if (!cancelled && events.length > 0) {
-          for (const event of events) {
-            applyBackendEvent(event);
-          }
-          lastBackendEventEnvelopeIdRef.current = events[events.length - 1].envelope_id;
-        }
-        if (!cancelled) {
-          setPollErrorCount(0);
-        }
-      } catch {
-        if (!cancelled) {
-          setPollErrorCount((current) => current + 1);
-        }
-        // The browser-only dev shell has no Tauri backend. BroadcastChannel remains the local fallback.
-      } finally {
-        if (!cancelled) {
-          timeoutId = window.setTimeout(() => void poll(), 180);
-        }
-      }
-    };
-    void poll();
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timeoutId);
-    };
-  }, [activeTopic, api, localPeerId, selectedRoom]);
-
-  useEffect(() => {
-    if (!selectedRoom || (roomConnectionState !== 'stale' && roomConnectionState !== 'offline')) {
-      return;
-    }
-    const now = Date.now();
-    if (now - lastRecoveryAtRef.current < METAVERSE_ROOM_RECOVERY_MS) {
-      return;
-    }
-    lastRecoveryAtRef.current = now;
-    lastBackendEventEnvelopeIdRef.current = null;
-    if (roomConnectionState === 'stale') {
-      setRecoveringUntil(now + 3_000);
-    }
-    void Promise.resolve(onRefresh()).catch(() => {
-      setPollErrorCount((current) => current + 1);
-    });
-  }, [onRefresh, roomConnectionState, selectedRoom]);
-
-  async function handleCreateRoom(input: CreateMetaverseRoomInput) {
-    setPending(true);
-    try {
-      const roomId = await api.createMetaverseRoom(
-        activeTopic,
-        input.title,
-        input.description,
-        input.maxPeers,
-        activeComposeChannel
-      );
-      setError(null);
-      pendingCreatedRoomIdRef.current = roomId;
-      setJoinedRoomIds((current) => new Set(current).add(roomId));
-      setSelectedRoomId(roomId);
-      await onRefresh();
-      return true;
-    } catch (createError) {
-      setError(createError instanceof Error ? createError.message : 'Failed to create metaverse room');
-      return false;
-    } finally {
-      setPending(false);
-    }
-  }
-
-  function emit(event: MetaverseRoomEvent) {
-    channelRef.current?.postMessage(event);
-  }
-
-  function resetRoomRuntimeState() {
-    setRemoteTransforms({});
-    setPeerPresence({});
-    setLatestChatByPeer({});
-    setPollErrorCount(0);
-    setLastRoomActivityAt(Date.now());
-    setRecoveringUntil(0);
-    setLastSentSeq(0);
-    lastSentTransformRef.current = null;
-    lastBackendEventEnvelopeIdRef.current = null;
-  }
-
-  function handleJoinRoom(roomId: string) {
-    setJoinedRoomIds((current) => new Set(current).add(roomId));
-    setSelectedRoomId(roomId);
-  }
-
-  function handleLeaveRoom() {
-    if (!selectedRoom) {
-      return;
-    }
-    const roomId = selectedRoom.room_id;
-    const leftAt = Date.now();
-    emit({ type: 'presence.leave', roomId, peerId: localPeerId, leftAt });
-    void api.publishMetaverseRoomEvent(activeTopic, roomId, localPeerId, leftAt, {
-      type: 'presence_leave',
-      room_id: roomId,
-      peer_id: localPeerId,
-      left_at: leftAt,
-    }).catch((leaveError) => {
-      setError(leaveError instanceof Error ? leaveError.message : 'Failed to publish room leave');
-    });
-    setJoinedRoomIds((current) => {
-      const next = new Set(current);
-      next.delete(roomId);
-      return next;
-    });
-    setSelectedRoomId(null);
-    resetRoomRuntimeState();
-  }
-
-  function handleLocalTransform(transform: AvatarTransform) {
-    lastSentTransformRef.current = transform;
-    setLastSentSeq(transform.seq);
-    emit({ type: 'avatar.transform', transform });
-    const event: MetaverseRoomEventV1 = {
-      type: 'avatar_transform',
-      transform: {
-        room_id: transform.roomId,
-        peer_id: transform.peerId,
-        seq: transform.seq,
-        position: transform.position,
-        rotation: transform.rotation,
-        animation: transform.animation,
-        sent_at: transform.sentAt,
-      },
-    };
-    void api.publishMetaverseRoomEvent(activeTopic, transform.roomId, localPeerId, transform.seq, event).catch(() => {
-      // Browser-only fallback is handled by BroadcastChannel.
-    });
-  }
-
-  function handleSendMessage(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!selectedRoom || !messageDraft.trim()) {
-      return;
-    }
-    const message: RoomChatMessage = {
-      roomId: selectedRoom.room_id,
-      messageId: `${localPeerId}-${Date.now()}`,
-      authorPeerId: localPeerId,
-      displayName: localDisplayName,
-      body: messageDraft.trim(),
-      createdAt: Date.now(),
-    };
-    setMessages((current) => mergeRoomChatMessages(current, [message]));
-    setLatestChatByPeer((current) => ({
-      ...current,
-      [message.authorPeerId]: latestChatBubbleFromMessage(message),
-    }));
-    setMessageDraft('');
-    emit({ type: 'chat.message', message });
-    void api.publishMetaverseRoomEvent(
-      activeTopic,
-      selectedRoom.room_id,
-      localPeerId,
-      Date.now(),
-      {
-        type: 'chat_message',
-        message: {
-          room_id: message.roomId,
-          message_id: message.messageId,
-          author_peer_id: message.authorPeerId,
-          display_name: message.displayName,
-          body: message.body,
-          created_at: message.createdAt,
-        },
-      }
-    ).catch(() => {
-      // Browser-only fallback is handled by BroadcastChannel.
-    });
-  }
-
-  function persistSharedObject(nextObject: SharedRoomObjectV1, room: GameRoomView) {
-    emit({ type: 'object.update', roomId: room.room_id, object: nextObject });
-    void api.publishMetaverseRoomEvent(
-      activeTopic,
-      room.room_id,
-      localPeerId,
-      Date.now(),
-      {
-        type: 'object_update',
-        object: nextObject,
-      }
-    ).catch(() => {
-      // Browser-only fallback is handled by BroadcastChannel.
-    });
-    void api.updateMetaverseRoom(
-      activeTopic,
-      room.room_id,
-      room.status,
-      nextObject.position,
-      nextObject.rotation,
-      nextObject.scale
-    )
-      .then(() => onRefresh())
-      .catch((updateError) => {
-        setError(updateError instanceof Error ? updateError.message : 'Failed to persist shared object');
-      });
-  }
-
-  function moveSharedObject(delta: MetaverseVec3) {
-    if (!selectedRoom) {
-      return;
-    }
-    const room = selectedRoom;
-    const current = sharedObjectRef.current;
-    const nextObject: SharedRoomObjectV1 = {
-      ...current,
-      position: [
-        current.position[0] + delta[0],
-        current.position[1] + delta[1],
-        current.position[2] + delta[2],
-      ],
-      updated_by: localPeerId,
-      updated_at: Date.now(),
-    };
-    sharedObjectRef.current = nextObject;
-    setSharedObject(nextObject);
-    persistSharedObject(nextObject, room);
-  }
-
   return (
     <div className='metaverse-panel'>
       <MetaverseRoomDiscovery
         rooms={rooms}
-        selectedRoomId={selectedRoomId}
-        joinedRoomIds={joinedRoomIds}
+        selectedRoomId={session.selectedRoomId}
+        joinedRoomIds={session.joinedRoomIds}
         pending={pending}
         error={error}
         locale={locale}
@@ -735,39 +139,39 @@ export function MetaverseRoomPanel({
         knownAuthorsByPubkey={knownAuthorsByPubkey}
         mediaObjectUrls={mediaObjectUrls}
         onCreateRoom={handleCreateRoom}
-        onJoinRoom={handleJoinRoom}
+        onJoinRoom={session.joinRoom}
       />
 
       <MetaverseRoomView
-        room={selectedRoom}
+        room={session.selectedRoom}
         activeTopic={activeTopic}
-        localPeerId={localPeerId}
-        remoteTransforms={remoteTransforms}
-        peerPresence={peerPresence}
-        sharedObject={sharedObject}
+        localPeerId={session.localPeerId}
+        remoteTransforms={session.remoteTransforms}
+        peerPresence={session.peerPresence}
+        sharedObject={session.sharedObject}
         avatarAssetUrl={localAvatarAssetUrl}
-        latestChatByPeer={latestChatByPeer}
-        connectionState={roomConnectionState}
-        now={clockNow}
-        knownPeerCount={knownPeerCount}
-        lastSentSeq={lastSentSeq}
-        lastReceivedAt={lastReceivedAt}
-        remoteAnimationSummary={remoteAnimationSummary}
+        latestChatByPeer={session.latestChatByPeer}
+        connectionState={session.roomConnectionState}
+        now={session.clockNow}
+        knownPeerCount={session.knownPeerCount}
+        lastSentSeq={session.lastSentSeq}
+        lastReceivedAt={session.lastReceivedAt}
+        remoteAnimationSummary={session.remoteAnimationSummary}
         avatarAssetStatus={avatarAssetStatus}
         localAvatarAssetRef={localAvatarAssetRef}
         communityAssistAvailable={syncStatus.discovery.bootstrap_seed_peer_ids.length > 0}
         locale={locale}
         pending={pending}
-        messages={messages}
-        messageDraft={messageDraft}
-        onLocalTransform={handleLocalTransform}
+        messages={session.messages}
+        messageDraft={session.messageDraft}
+        onLocalTransform={session.handleLocalTransform}
         onAvatarAssetStatus={setAvatarAssetStatus}
-        onLeaveRoom={handleLeaveRoom}
+        onLeaveRoom={session.leaveRoom}
         onImportAvatar={(file) => void importAvatarBlob(file, file.name)}
         onImportDefaultAvatar={() => void handleSampleAvatarImport()}
-        onMoveSharedObject={(delta) => void moveSharedObject(delta)}
-        onMessageDraftChange={setMessageDraft}
-        onSendMessage={handleSendMessage}
+        onMoveSharedObject={session.moveSharedObject}
+        onMessageDraftChange={session.setMessageDraft}
+        onSendMessage={session.handleSendMessage}
       />
     </div>
   );

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
@@ -1,0 +1,236 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { DesktopApi, GameRoomView, SyncStatus } from '@/lib/api';
+import { createDesktopMockApi } from '@/mocks/desktopApiMock';
+import {
+  DEFAULT_SHARED_OBJECT,
+  METAVERSE_ROOM_RECOVERY_MS,
+  type MetaverseRoomEvent,
+} from '../MetaverseSceneModel';
+import { useMetaverseRoomSession } from './useMetaverseRoomSession';
+
+const room: GameRoomView = {
+  room_id: 'metaverse-room-1',
+  host_pubkey: 'f'.repeat(64),
+  title: 'Atrium',
+  description: 'Small social space',
+  status: 'Waiting',
+  phase_label: 'metaverse-mvp',
+  scores: [],
+  room_kind: 'metaverse_room',
+  metaverse: {
+    world_version: 1,
+    max_peers: 8,
+    scene: {
+      ground: 'default',
+      shared_object: DEFAULT_SHARED_OBJECT,
+    },
+    default_spawn: {
+      position: [0, 0, 260],
+      rotation: [0, 180, 0],
+    },
+    asset_refs: [],
+    chat_history: [],
+  },
+  manifest_blob_hash: 'manifest-1',
+  updated_at: 1,
+  channel_id: null,
+  audience_label: 'Public',
+};
+
+function syncStatus(connected = true): SyncStatus {
+  return {
+    connected,
+    delivery_state: connected ? 'Live' : 'Offline',
+    peer_count: connected ? 1 : 0,
+    pending_events: 0,
+    status_detail: connected ? 'connected' : 'offline',
+    configured_peers: [],
+    subscribed_topics: ['kukuri:topic:demo'],
+    active_path: 'direct_p2p',
+    fallback_peer_ids: [],
+    topic_diagnostics: [],
+    local_author_pubkey: 'f'.repeat(64),
+    discovery: {
+      mode: 'seeded_dht',
+      connect_mode: 'direct_only',
+      active_path: 'direct_p2p',
+      fallback_peer_ids: [],
+      env_locked: false,
+      configured_seed_peer_ids: [],
+      bootstrap_seed_peer_ids: [],
+      manual_ticket_peer_ids: [],
+      connected_peer_ids: [],
+      docs_assist_peer_ids: [],
+      blob_assist_peer_ids: [],
+      local_endpoint_id: 'local-endpoint-a',
+    },
+    gossip_disabled_topics: [],
+    gossip_disabled_channels: [],
+  };
+}
+
+class MockBroadcastChannel {
+  static instances: MockBroadcastChannel[] = [];
+
+  onmessage: ((event: MessageEvent<MetaverseRoomEvent>) => void) | null = null;
+  readonly postMessage = vi.fn();
+  readonly close = vi.fn();
+
+  constructor(readonly name: string) {
+    MockBroadcastChannel.instances.push(this);
+  }
+}
+
+type SessionProps = {
+  rooms: GameRoomView[];
+  sync: SyncStatus;
+};
+
+function renderSession({
+  api = createDesktopMockApi(),
+  rooms = [room],
+  sync = syncStatus(),
+  onRefresh = vi.fn().mockResolvedValue(undefined),
+}: {
+  api?: DesktopApi;
+  rooms?: GameRoomView[];
+  sync?: SyncStatus;
+  onRefresh?: () => Promise<void>;
+} = {}) {
+  const onError = vi.fn();
+  const rendered = renderHook(
+    ({ rooms: currentRooms, sync: currentSync }: SessionProps) =>
+      useMetaverseRoomSession({
+        api,
+        activeTopic: 'kukuri:topic:demo',
+        rooms: currentRooms,
+        syncStatus: currentSync,
+        localDisplayName: 'Local Author',
+        localAvatarAssetRef: null,
+        localAvatarAssetUrl: null,
+        onRefresh,
+        onError,
+      }),
+    { initialProps: { rooms, sync } }
+  );
+  return { ...rendered, api, onRefresh, onError };
+}
+
+beforeEach(() => {
+  MockBroadcastChannel.instances = [];
+  vi.stubGlobal(
+    'BroadcastChannel',
+    MockBroadcastChannel as unknown as typeof BroadcastChannel
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useMetaverseRoomSession', () => {
+  test('clears a missing selected room but preserves a pending created-room selection', async () => {
+    const session = renderSession();
+    act(() => session.result.current.joinRoom(room.room_id));
+    expect(session.result.current.selectedRoom?.room_id).toBe(room.room_id);
+
+    session.rerender({ rooms: [], sync: syncStatus() });
+    await waitFor(() => expect(session.result.current.selectedRoomId).toBeNull());
+
+    act(() => session.result.current.selectCreatedRoom('created-room'));
+    expect(session.result.current.selectedRoomId).toBe('created-room');
+    session.rerender({ rooms: [], sync: syncStatus() });
+    expect(session.result.current.selectedRoomId).toBe('created-room');
+
+    const createdRoom = { ...room, room_id: 'created-room', title: 'Created Room' };
+    session.rerender({ rooms: [createdRoom], sync: syncStatus() });
+    expect(session.result.current.selectedRoom?.room_id).toBe('created-room');
+    session.rerender({ rooms: [], sync: syncStatus() });
+    await waitFor(() => expect(session.result.current.selectedRoomId).toBeNull());
+  });
+
+  test('merges newer BroadcastChannel object updates, rejects stale updates, and closes on cleanup', async () => {
+    const session = renderSession();
+    act(() => session.result.current.joinRoom(room.room_id));
+    await waitFor(() => expect(MockBroadcastChannel.instances).toHaveLength(1));
+    const channel = MockBroadcastChannel.instances[0];
+    const newerObject = {
+      ...DEFAULT_SHARED_OBJECT,
+      position: [100, 0, 0] as [number, number, number],
+      updated_by: 'remote-peer',
+      updated_at: 10,
+    };
+    const staleObject = {
+      ...DEFAULT_SHARED_OBJECT,
+      position: [-100, 0, 0] as [number, number, number],
+      updated_by: 'remote-peer',
+      updated_at: 5,
+    };
+
+    act(() => {
+      channel.onmessage?.({
+        data: { type: 'object.update', roomId: room.room_id, object: newerObject },
+      } as MessageEvent<MetaverseRoomEvent>);
+      channel.onmessage?.({
+        data: { type: 'object.update', roomId: room.room_id, object: staleObject },
+      } as MessageEvent<MetaverseRoomEvent>);
+    });
+
+    expect(session.result.current.sharedObject).toEqual(newerObject);
+    session.unmount();
+    expect(channel.close).toHaveBeenCalledTimes(1);
+  });
+
+  test('marks the room offline after three consecutive backend poll failures', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(100_000);
+    const api: DesktopApi = {
+      ...createDesktopMockApi(),
+      listMetaverseRoomEvents: vi.fn().mockRejectedValue(new Error('poll failed')),
+    };
+    const session = renderSession({ api });
+    act(() => session.result.current.joinRoom(room.room_id));
+
+    await act(async () => {
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(api.listMetaverseRoomEvents).toHaveBeenCalledTimes(3);
+    expect(session.result.current.roomConnectionState).toBe('offline');
+  });
+
+  test('enforces recovery cooldown and clears heartbeat/poll timers on cleanup', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(100_000);
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const clearInterval = vi.spyOn(window, 'clearInterval');
+    const clearTimeout = vi.spyOn(window, 'clearTimeout');
+    const session = renderSession({ onRefresh });
+    act(() => session.result.current.joinRoom(room.room_id));
+    await act(async () => Promise.resolve());
+
+    session.rerender({ rooms: [room], sync: syncStatus(false) });
+    await act(async () => Promise.resolve());
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    session.rerender({ rooms: [room], sync: syncStatus(true) });
+    session.rerender({ rooms: [room], sync: syncStatus(false) });
+    await act(async () => Promise.resolve());
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(100_000 + METAVERSE_ROOM_RECOVERY_MS + 1);
+    session.rerender({ rooms: [room], sync: syncStatus(true) });
+    session.rerender({ rooms: [room], sync: syncStatus(false) });
+    await act(async () => Promise.resolve());
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+
+    session.unmount();
+    expect(clearInterval).toHaveBeenCalled();
+    expect(clearTimeout).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
@@ -1,0 +1,674 @@
+import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
+
+import type {
+  DesktopApi,
+  GameRoomView,
+  MetaverseAssetRef,
+  MetaverseRoomEventView,
+  MetaverseRoomEventV1,
+  SharedRoomObjectV1,
+  SyncStatus,
+} from '@/lib/api';
+import {
+  DEFAULT_SHARED_OBJECT,
+  METAVERSE_CHAT_BUBBLE_TTL_MS,
+  METAVERSE_ROOM_HEARTBEAT_MS,
+  METAVERSE_ROOM_RECOVERY_MS,
+  METAVERSE_ROOM_STALE_MS,
+  isNewerSharedObject,
+  mergeRoomChatMessages,
+  normalizeAvatarAnimationState,
+  type AvatarTransform,
+  type LatestChatBubble,
+  type MetaverseRoomConnectionState,
+  type MetaverseRoomEvent,
+  type MetaverseVec3,
+  type PeerPresence,
+  type RoomChatMessage,
+} from '../MetaverseSceneModel';
+
+type UseMetaverseRoomSessionArgs = {
+  api: DesktopApi;
+  activeTopic: string;
+  rooms: GameRoomView[];
+  syncStatus: SyncStatus;
+  localDisplayName: string | null;
+  localAvatarAssetRef: MetaverseAssetRef | null;
+  localAvatarAssetUrl: string | null;
+  onRefresh: () => Promise<void>;
+  onError: (message: string | null) => void;
+};
+
+const EMPTY_ROOM_CHAT_HISTORY: NonNullable<
+  NonNullable<GameRoomView['metaverse']>['chat_history']
+> = [];
+
+function chatMessageFromApi(message: {
+  room_id: string;
+  message_id: string;
+  author_peer_id: string;
+  display_name?: string | null;
+  body: string;
+  created_at: number;
+}): RoomChatMessage {
+  return {
+    roomId: message.room_id,
+    messageId: message.message_id,
+    authorPeerId: message.author_peer_id,
+    displayName: message.display_name ?? null,
+    body: message.body,
+    createdAt: message.created_at,
+  };
+}
+
+function topicDiagnosticFor(syncStatus: SyncStatus, topic: string) {
+  return syncStatus.topic_diagnostics.find(
+    (diagnostic) => diagnostic.topic === topic || diagnostic.topic === `hint/${topic}`
+  );
+}
+
+function latestChatBubbleFromMessage(message: RoomChatMessage, now = Date.now()): LatestChatBubble {
+  return {
+    peerId: message.authorPeerId,
+    displayName: message.displayName ?? null,
+    body: message.body,
+    createdAt: message.createdAt,
+    expiresAt: now + METAVERSE_CHAT_BUBBLE_TTL_MS,
+  };
+}
+
+export function useMetaverseRoomSession({
+  api,
+  activeTopic,
+  rooms,
+  syncStatus,
+  localDisplayName,
+  localAvatarAssetRef,
+  localAvatarAssetUrl,
+  onRefresh,
+  onError,
+}: UseMetaverseRoomSessionArgs) {
+  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
+  const [joinedRoomIds, setJoinedRoomIds] = useState<Set<string>>(() => new Set());
+  const [remoteTransforms, setRemoteTransforms] = useState<Record<string, AvatarTransform>>({});
+  const [peerPresence, setPeerPresence] = useState<Record<string, PeerPresence>>({});
+  const [messages, setMessages] = useState<RoomChatMessage[]>([]);
+  const [latestChatByPeer, setLatestChatByPeer] = useState<Record<string, LatestChatBubble>>({});
+  const [messageDraft, setMessageDraft] = useState('');
+  const [sharedObject, setSharedObject] = useState<SharedRoomObjectV1>(DEFAULT_SHARED_OBJECT);
+  const [lastSentSeq, setLastSentSeq] = useState(0);
+  const [pollErrorCount, setPollErrorCount] = useState(0);
+  const [lastRoomActivityAt, setLastRoomActivityAt] = useState(() => Date.now());
+  const [recoveringUntil, setRecoveringUntil] = useState(0);
+  const [clockNow, setClockNow] = useState(() => Date.now());
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const lastBackendEventEnvelopeIdRef = useRef<string | null>(null);
+  const lastRecoveryAtRef = useRef(0);
+  const pendingCreatedRoomIdRef = useRef<string | null>(null);
+  const sharedObjectRef = useRef<SharedRoomObjectV1>(DEFAULT_SHARED_OBJECT);
+  const localPeerSeed = useId().replaceAll(':', '');
+  const localPeerId = `${syncStatus.discovery.local_endpoint_id || syncStatus.local_author_pubkey || 'local'}:${localPeerSeed}`;
+  const lastSentTransformRef = useRef<AvatarTransform | null>(null);
+  const lastReceivedAt = useMemo(() => {
+    const values = Object.values(remoteTransforms).map((transform) => transform.sentAt);
+    return values.length ? Math.max(...values) : null;
+  }, [remoteTransforms]);
+  const remoteAnimationSummary = useMemo(
+    () =>
+      Object.values(remoteTransforms)
+        .map((transform) => `${transform.peerId.slice(0, 8)}:${transform.animation}`)
+        .join(', '),
+    [remoteTransforms]
+  );
+
+  const selectedRoom = selectedRoomId
+    ? rooms.find((room) => room.room_id === selectedRoomId) ?? null
+    : null;
+  const selectedRoomRoomId = selectedRoom?.room_id ?? null;
+  const selectedRoomSharedObject = selectedRoom?.metaverse?.scene.shared_object ?? null;
+  const selectedRoomChatHistory = selectedRoom?.metaverse?.chat_history ?? EMPTY_ROOM_CHAT_HISTORY;
+  const activeTopicDiagnostic = useMemo(
+    () => topicDiagnosticFor(syncStatus, activeTopic),
+    [activeTopic, syncStatus]
+  );
+  const roomConnectionState: MetaverseRoomConnectionState = useMemo(() => {
+    if (!selectedRoom) {
+      return 'offline';
+    }
+    if (recoveringUntil > clockNow) {
+      return 'recovering';
+    }
+    const topicPeerCount = activeTopicDiagnostic?.peer_count ?? syncStatus.peer_count;
+    const topicError = activeTopicDiagnostic?.last_error ?? syncStatus.last_error ?? null;
+    if (
+      !syncStatus.connected ||
+      syncStatus.delivery_state === 'Offline' ||
+      topicPeerCount === 0 ||
+      pollErrorCount >= 3 ||
+      topicError
+    ) {
+      return 'offline';
+    }
+    if (clockNow - lastRoomActivityAt > METAVERSE_ROOM_STALE_MS) {
+      return 'stale';
+    }
+    return 'live';
+  }, [
+    activeTopicDiagnostic,
+    clockNow,
+    lastRoomActivityAt,
+    pollErrorCount,
+    recoveringUntil,
+    selectedRoom,
+    syncStatus,
+  ]);
+  const knownPeerCount = Object.keys(remoteTransforms).length;
+
+  useEffect(() => {
+    sharedObjectRef.current = sharedObject;
+  }, [sharedObject]);
+
+  useEffect(() => {
+    if (!selectedRoomId) {
+      return;
+    }
+    if (rooms.some((room) => room.room_id === selectedRoomId)) {
+      if (pendingCreatedRoomIdRef.current === selectedRoomId) {
+        pendingCreatedRoomIdRef.current = null;
+      }
+      return;
+    }
+    if (pendingCreatedRoomIdRef.current !== selectedRoomId) {
+      setSelectedRoomId(null);
+    }
+  }, [rooms, selectedRoomId]);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      const now = Date.now();
+      setClockNow(now);
+      setLatestChatByPeer((current) => {
+        const next = Object.fromEntries(
+          Object.entries(current).filter(([, bubble]) => bubble.expiresAt > now)
+        );
+        return Object.keys(next).length === Object.keys(current).length ? current : next;
+      });
+    }, 1000);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedRoomRoomId) {
+      return;
+    }
+    sharedObjectRef.current = DEFAULT_SHARED_OBJECT;
+    setSharedObject(DEFAULT_SHARED_OBJECT);
+    setRemoteTransforms({});
+    setPeerPresence({});
+    setMessages([]);
+    setLatestChatByPeer({});
+    setPollErrorCount(0);
+    setLastRoomActivityAt(Date.now());
+    lastBackendEventEnvelopeIdRef.current = null;
+    if (typeof BroadcastChannel === 'undefined') {
+      return;
+    }
+    const channel = new BroadcastChannel(`kukuri-metaverse-room:${selectedRoomRoomId}`);
+    channelRef.current = channel;
+    channel.onmessage = (event: MessageEvent<MetaverseRoomEvent>) => {
+      const data = event.data;
+      if (!data || !('type' in data)) {
+        return;
+      }
+      setLastRoomActivityAt(Date.now());
+      if (data.type === 'presence.join' && data.presence.peerId !== localPeerId) {
+        setPeerPresence((current) => ({
+          ...current,
+          [data.presence.peerId]: data.presence,
+        }));
+      }
+      if (data.type === 'presence.leave' && data.peerId !== localPeerId) {
+        setPeerPresence((current) => {
+          const next = { ...current };
+          delete next[data.peerId];
+          return next;
+        });
+        setRemoteTransforms((current) => {
+          const next = { ...current };
+          delete next[data.peerId];
+          return next;
+        });
+        setLatestChatByPeer((current) => {
+          const next = { ...current };
+          delete next[data.peerId];
+          return next;
+        });
+      }
+      if (data.type === 'avatar.transform' && data.transform.peerId !== localPeerId) {
+        setRemoteTransforms((current) => ({
+          ...current,
+          [data.transform.peerId]: data.transform,
+        }));
+      }
+      if (data.type === 'chat.message') {
+        setMessages((current) => mergeRoomChatMessages(current, [data.message]));
+        setLatestChatByPeer((current) => ({
+          ...current,
+          [data.message.authorPeerId]: latestChatBubbleFromMessage(data.message),
+        }));
+      }
+      if (data.type === 'object.update' && data.object.updated_by !== localPeerId) {
+        setSharedObject((current) => {
+          if (!isNewerSharedObject(current, data.object)) {
+            return current;
+          }
+          sharedObjectRef.current = data.object;
+          return data.object;
+        });
+      }
+    };
+    return () => {
+      channel.close();
+      channelRef.current = null;
+    };
+  }, [localPeerId, selectedRoomRoomId]);
+
+  useEffect(() => {
+    const nextObject = selectedRoomSharedObject ?? DEFAULT_SHARED_OBJECT;
+    setSharedObject((current) => {
+      if (!isNewerSharedObject(current, nextObject)) {
+        return current;
+      }
+      sharedObjectRef.current = nextObject;
+      return nextObject;
+    });
+  }, [selectedRoomSharedObject]);
+
+  useEffect(() => {
+    const durableMessages = selectedRoomChatHistory.map(chatMessageFromApi);
+    setMessages((current) => mergeRoomChatMessages(current, durableMessages));
+  }, [selectedRoomChatHistory, selectedRoomRoomId]);
+
+  function emit(event: MetaverseRoomEvent) {
+    channelRef.current?.postMessage(event);
+  }
+
+  useEffect(() => {
+    if (!selectedRoom) {
+      return;
+    }
+    const joinedAt = Date.now();
+    const publishPresence = () => {
+      const now = Date.now();
+      const presence: PeerPresence = {
+        peerId: localPeerId,
+        displayName: localDisplayName,
+        avatarAssetRef: localAvatarAssetRef,
+        avatarAssetUrl: localAvatarAssetUrl,
+        joinedAt,
+        lastSeenAt: now,
+      };
+      emit({ type: 'presence.join', presence });
+      void api.publishMetaverseRoomEvent(activeTopic, selectedRoom.room_id, localPeerId, now, {
+        type: 'presence_join',
+        presence: {
+          room_id: selectedRoom.room_id,
+          peer_id: localPeerId,
+          display_name: localDisplayName,
+          avatar_asset_ref: localAvatarAssetRef,
+          joined_at: joinedAt,
+          last_seen_at: now,
+        },
+      }).catch(() => {
+        // Browser-only fallback is handled by the local scene.
+      });
+    };
+    publishPresence();
+    const intervalId = window.setInterval(publishPresence, METAVERSE_ROOM_HEARTBEAT_MS);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [
+    activeTopic,
+    api,
+    localAvatarAssetRef,
+    localAvatarAssetUrl,
+    localDisplayName,
+    localPeerId,
+    selectedRoom,
+  ]);
+
+  useEffect(() => {
+    if (!selectedRoom) {
+      return;
+    }
+    let cancelled = false;
+    let timeoutId = 0;
+    const applyBackendEvent = (view: MetaverseRoomEventView) => {
+      const event = view.content.event;
+      setLastRoomActivityAt(Date.now());
+      if (event.type === 'presence_join' && event.presence.peer_id !== localPeerId) {
+        const presence: PeerPresence = {
+          peerId: event.presence.peer_id,
+          displayName: event.presence.display_name ?? null,
+          avatarAssetRef: event.presence.avatar_asset_ref ?? null,
+          joinedAt: event.presence.joined_at,
+          lastSeenAt: event.presence.last_seen_at,
+        };
+        setPeerPresence((current) => ({
+          ...current,
+          [presence.peerId]: {
+            ...current[presence.peerId],
+            ...presence,
+          },
+        }));
+        if (presence.avatarAssetRef) {
+          void api
+            .getBlobPreviewUrl(
+              presence.avatarAssetRef.blob_hash,
+              presence.avatarAssetRef.mime_type ?? 'model/vrm'
+            )
+            .then((avatarAssetUrl) => {
+              if (!cancelled && avatarAssetUrl) {
+                setPeerPresence((current) => ({
+                  ...current,
+                  [presence.peerId]: {
+                    ...current[presence.peerId],
+                    avatarAssetUrl,
+                  },
+                }));
+              }
+            })
+            .catch(() => {
+              // Missing remote avatar blobs fall back to the bundled default VRM.
+            });
+        }
+      }
+      if (event.type === 'presence_leave' && event.peer_id !== localPeerId) {
+        setPeerPresence((current) => {
+          const next = { ...current };
+          delete next[event.peer_id];
+          return next;
+        });
+        setRemoteTransforms((current) => {
+          const next = { ...current };
+          delete next[event.peer_id];
+          return next;
+        });
+        setLatestChatByPeer((current) => {
+          const next = { ...current };
+          delete next[event.peer_id];
+          return next;
+        });
+      }
+      if (event.type === 'avatar_transform' && event.transform.peer_id !== localPeerId) {
+        setRemoteTransforms((current) => ({
+          ...current,
+          [event.transform.peer_id]: {
+            roomId: event.transform.room_id,
+            peerId: event.transform.peer_id,
+            seq: event.transform.seq,
+            position: event.transform.position,
+            rotation: event.transform.rotation,
+            animation: normalizeAvatarAnimationState(event.transform.animation),
+            sentAt: event.transform.sent_at,
+          },
+        }));
+      }
+      if (event.type === 'chat_message') {
+        const message = chatMessageFromApi(event.message);
+        setMessages((current) => mergeRoomChatMessages(current, [message]));
+        setLatestChatByPeer((current) => ({
+          ...current,
+          [message.authorPeerId]: latestChatBubbleFromMessage(message),
+        }));
+      }
+      if (event.type === 'object_update' && event.object.updated_by !== localPeerId) {
+        setSharedObject((current) => {
+          if (!isNewerSharedObject(current, event.object)) {
+            return current;
+          }
+          sharedObjectRef.current = event.object;
+          return event.object;
+        });
+      }
+    };
+    const poll = async () => {
+      try {
+        const events = await api.listMetaverseRoomEvents(
+          activeTopic,
+          selectedRoom.room_id,
+          lastBackendEventEnvelopeIdRef.current,
+          64
+        );
+        if (!cancelled && events.length > 0) {
+          for (const event of events) {
+            applyBackendEvent(event);
+          }
+          lastBackendEventEnvelopeIdRef.current = events[events.length - 1].envelope_id;
+        }
+        if (!cancelled) {
+          setPollErrorCount(0);
+        }
+      } catch {
+        if (!cancelled) {
+          setPollErrorCount((current) => current + 1);
+        }
+        // The browser-only dev shell has no Tauri backend. BroadcastChannel remains the local fallback.
+      } finally {
+        if (!cancelled) {
+          timeoutId = window.setTimeout(() => void poll(), 180);
+        }
+      }
+    };
+    void poll();
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+    };
+  }, [activeTopic, api, localPeerId, selectedRoom]);
+
+  useEffect(() => {
+    if (!selectedRoom || (roomConnectionState !== 'stale' && roomConnectionState !== 'offline')) {
+      return;
+    }
+    const now = Date.now();
+    if (now - lastRecoveryAtRef.current < METAVERSE_ROOM_RECOVERY_MS) {
+      return;
+    }
+    lastRecoveryAtRef.current = now;
+    lastBackendEventEnvelopeIdRef.current = null;
+    if (roomConnectionState === 'stale') {
+      setRecoveringUntil(now + 3_000);
+    }
+    void Promise.resolve(onRefresh()).catch(() => {
+      setPollErrorCount((current) => current + 1);
+    });
+  }, [onRefresh, roomConnectionState, selectedRoom]);
+
+  function resetRoomRuntimeState() {
+    setRemoteTransforms({});
+    setPeerPresence({});
+    setLatestChatByPeer({});
+    setPollErrorCount(0);
+    setLastRoomActivityAt(Date.now());
+    setRecoveringUntil(0);
+    setLastSentSeq(0);
+    lastSentTransformRef.current = null;
+    lastBackendEventEnvelopeIdRef.current = null;
+  }
+
+  function joinRoom(roomId: string) {
+    setJoinedRoomIds((current) => new Set(current).add(roomId));
+    setSelectedRoomId(roomId);
+  }
+
+  function selectCreatedRoom(roomId: string) {
+    pendingCreatedRoomIdRef.current = roomId;
+    joinRoom(roomId);
+  }
+
+  function leaveRoom() {
+    if (!selectedRoom) {
+      return;
+    }
+    const roomId = selectedRoom.room_id;
+    const leftAt = Date.now();
+    emit({ type: 'presence.leave', roomId, peerId: localPeerId, leftAt });
+    void api.publishMetaverseRoomEvent(activeTopic, roomId, localPeerId, leftAt, {
+      type: 'presence_leave',
+      room_id: roomId,
+      peer_id: localPeerId,
+      left_at: leftAt,
+    }).catch((leaveError) => {
+      onError(leaveError instanceof Error ? leaveError.message : 'Failed to publish room leave');
+    });
+    setJoinedRoomIds((current) => {
+      const next = new Set(current);
+      next.delete(roomId);
+      return next;
+    });
+    setSelectedRoomId(null);
+    resetRoomRuntimeState();
+  }
+
+  function handleLocalTransform(transform: AvatarTransform) {
+    lastSentTransformRef.current = transform;
+    setLastSentSeq(transform.seq);
+    emit({ type: 'avatar.transform', transform });
+    const event: MetaverseRoomEventV1 = {
+      type: 'avatar_transform',
+      transform: {
+        room_id: transform.roomId,
+        peer_id: transform.peerId,
+        seq: transform.seq,
+        position: transform.position,
+        rotation: transform.rotation,
+        animation: transform.animation,
+        sent_at: transform.sentAt,
+      },
+    };
+    void api
+      .publishMetaverseRoomEvent(
+        activeTopic,
+        transform.roomId,
+        localPeerId,
+        transform.seq,
+        event
+      )
+      .catch(() => {
+        // Browser-only fallback is handled by BroadcastChannel.
+      });
+  }
+
+  function handleSendMessage(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedRoom || !messageDraft.trim()) {
+      return;
+    }
+    const message: RoomChatMessage = {
+      roomId: selectedRoom.room_id,
+      messageId: `${localPeerId}-${Date.now()}`,
+      authorPeerId: localPeerId,
+      displayName: localDisplayName,
+      body: messageDraft.trim(),
+      createdAt: Date.now(),
+    };
+    setMessages((current) => mergeRoomChatMessages(current, [message]));
+    setLatestChatByPeer((current) => ({
+      ...current,
+      [message.authorPeerId]: latestChatBubbleFromMessage(message),
+    }));
+    setMessageDraft('');
+    emit({ type: 'chat.message', message });
+    void api
+      .publishMetaverseRoomEvent(activeTopic, selectedRoom.room_id, localPeerId, Date.now(), {
+        type: 'chat_message',
+        message: {
+          room_id: message.roomId,
+          message_id: message.messageId,
+          author_peer_id: message.authorPeerId,
+          display_name: message.displayName,
+          body: message.body,
+          created_at: message.createdAt,
+        },
+      })
+      .catch(() => {
+        // Browser-only fallback is handled by BroadcastChannel.
+      });
+  }
+
+  function persistSharedObject(nextObject: SharedRoomObjectV1, room: GameRoomView) {
+    emit({ type: 'object.update', roomId: room.room_id, object: nextObject });
+    void api
+      .publishMetaverseRoomEvent(activeTopic, room.room_id, localPeerId, Date.now(), {
+        type: 'object_update',
+        object: nextObject,
+      })
+      .catch(() => {
+        // Browser-only fallback is handled by BroadcastChannel.
+      });
+    void api
+      .updateMetaverseRoom(
+        activeTopic,
+        room.room_id,
+        room.status,
+        nextObject.position,
+        nextObject.rotation,
+        nextObject.scale
+      )
+      .then(() => onRefresh())
+      .catch((updateError) => {
+        onError(updateError instanceof Error ? updateError.message : 'Failed to persist shared object');
+      });
+  }
+
+  function moveSharedObject(delta: MetaverseVec3) {
+    if (!selectedRoom) {
+      return;
+    }
+    const room = selectedRoom;
+    const current = sharedObjectRef.current;
+    const nextObject: SharedRoomObjectV1 = {
+      ...current,
+      position: [
+        current.position[0] + delta[0],
+        current.position[1] + delta[1],
+        current.position[2] + delta[2],
+      ],
+      updated_by: localPeerId,
+      updated_at: Date.now(),
+    };
+    sharedObjectRef.current = nextObject;
+    setSharedObject(nextObject);
+    persistSharedObject(nextObject, room);
+  }
+
+  return {
+    selectedRoomId,
+    joinedRoomIds,
+    selectedRoom,
+    localPeerId,
+    remoteTransforms,
+    peerPresence,
+    messages,
+    latestChatByPeer,
+    messageDraft,
+    setMessageDraft,
+    sharedObject,
+    lastSentSeq,
+    lastReceivedAt,
+    remoteAnimationSummary,
+    roomConnectionState,
+    knownPeerCount,
+    clockNow,
+    joinRoom,
+    selectCreatedRoom,
+    leaveRoom,
+    handleLocalTransform,
+    handleSendMessage,
+    moveSharedObject,
+  };
+}


### PR DESCRIPTION
## Summary
- extract selected/joined room state, presence, transforms, chat, shared object, connection state, polling, BroadcastChannel, heartbeat, and recovery into `useMetaverseRoomSession`
- reduce `MetaverseRoomPanel` to create/import actions and discovery/view composition
- add hook contracts for pending created rooms, stale object rejection, three-failure offline state, recovery cooldown, and cleanup

## Validation
- focused session + panel tests: 29 passed
- `cargo xtask desktop-ui-check` (70 files / 588 tests, Storybook, browser 10, visual 14)
- `cargo xtask oversized-files`
- panel 178 lines; session hook 674 lines