### PR TITLE
refactor: add metaverse shell actions

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.stories.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.stories.tsx
@@ -6,6 +6,7 @@ import { MetaverseRoomPanel } from './MetaverseRoomPanel';
 import { DEFAULT_SHARED_OBJECT } from './MetaverseSceneModel';
 import { MetaverseRoomDiscovery } from './metaverse/MetaverseRoomDiscovery';
 import { MetaverseRoomView } from './metaverse/MetaverseRoomView';
+import { createMetaverseRoomActions } from '@/shell/actions/metaverse';
 
 const meta = {
   title: 'Extended/MetaverseRoomPanel',
@@ -89,12 +90,17 @@ function StoryFrame({ children }: { children: React.ReactNode }) {
 }
 
 function panel(rooms: GameRoomView[]) {
+  const api = createDesktopMockApi();
   return (
     <StoryFrame>
       <MetaverseRoomPanel
-        api={createDesktopMockApi()}
+        actions={createMetaverseRoomActions({
+          api,
+          activeTopic: 'kukuri:topic:demo',
+          activeComposeChannel: { kind: 'public' },
+          onRefresh: async () => undefined,
+        })}
         activeTopic='kukuri:topic:demo'
-        activeComposeChannel={{ kind: 'public' }}
         rooms={rooms}
         syncStatus={syncStatus}
         locale='en'
@@ -107,7 +113,6 @@ function panel(rooms: GameRoomView[]) {
           picture_asset: null,
           updated_at: STORY_TIMESTAMP,
         }}
-        onRefresh={async () => undefined}
       />
     </StoryFrame>
   );

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
@@ -12,6 +12,7 @@ import type {
   SyncStatus,
 } from '@/lib/api';
 import { MetaverseRoomPanel } from './MetaverseRoomPanel';
+import { createMetaverseRoomActions } from '@/shell/actions/metaverse';
 
 vi.mock('./MetaverseScene', () => ({
   MetaverseScene: (props: {
@@ -194,11 +195,16 @@ function createSyncStatus(): SyncStatus {
 
 function panelElement(api: DesktopApi, options: RenderPanelOptions = {}) {
   const effectiveSyncStatus = options.syncStatus ?? createSyncStatus();
+  const onRefresh = options.onRefresh ?? vi.fn();
   return (
     <MetaverseRoomPanel
-      api={api}
+      actions={createMetaverseRoomActions({
+        api,
+        activeTopic: 'kukuri:topic:demo',
+        activeComposeChannel: { kind: 'public' },
+        onRefresh,
+      })}
       activeTopic='kukuri:topic:demo'
-      activeComposeChannel={{ kind: 'public' }}
       rooms={options.rooms ?? [room]}
       syncStatus={effectiveSyncStatus}
       locale='en'
@@ -211,7 +217,6 @@ function panelElement(api: DesktopApi, options: RenderPanelOptions = {}) {
         picture_asset: null,
         updated_at: 1,
       }}
-      onRefresh={options.onRefresh ?? vi.fn()}
     />
   );
 }

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -2,8 +2,6 @@ import { useState } from 'react';
 
 import type {
   AuthorSocialView,
-  ChannelRef,
-  DesktopApi,
   GameRoomView,
   MetaverseAssetRef,
   Profile,
@@ -17,6 +15,7 @@ import {
 } from './metaverse/MetaverseRoomDiscovery';
 import { MetaverseRoomView } from './metaverse/MetaverseRoomView';
 import { useMetaverseRoomSession } from './metaverse/useMetaverseRoomSession';
+import type { MetaverseRoomActions } from './metaverse/MetaverseRoomActions';
 import {
   DEFAULT_AVATAR_ASSET_NAME,
   DEFAULT_AVATAR_ASSET_URL,
@@ -24,29 +23,25 @@ import {
 } from './MetaverseSceneModel';
 
 type MetaverseRoomPanelProps = {
-  api: DesktopApi;
+  actions: MetaverseRoomActions;
   activeTopic: string;
-  activeComposeChannel: ChannelRef;
   rooms: GameRoomView[];
   syncStatus: SyncStatus;
   locale: SupportedLocale;
   localProfile?: Profile | null;
   knownAuthorsByPubkey?: Record<string, AuthorSocialView>;
   mediaObjectUrls?: Record<string, string | null>;
-  onRefresh: () => Promise<void>;
 };
 
 export function MetaverseRoomPanel({
-  api,
+  actions,
   activeTopic,
-  activeComposeChannel,
   rooms,
   syncStatus,
   locale,
   localProfile = null,
   knownAuthorsByPubkey = {},
   mediaObjectUrls = {},
-  onRefresh,
 }: MetaverseRoomPanelProps) {
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
@@ -55,30 +50,23 @@ export function MetaverseRoomPanel({
   const [localAvatarAssetUrl, setLocalAvatarAssetUrl] = useState<string | null>(null);
   const localDisplayName = localProfile?.display_name?.trim() || localProfile?.name?.trim() || null;
   const session = useMetaverseRoomSession({
-    api,
+    actions,
     activeTopic,
     rooms,
     syncStatus,
     localDisplayName,
     localAvatarAssetRef,
     localAvatarAssetUrl,
-    onRefresh,
     onError: setError,
   });
 
   async function handleCreateRoom(input: CreateMetaverseRoomInput) {
     setPending(true);
     try {
-      const roomId = await api.createMetaverseRoom(
-        activeTopic,
-        input.title,
-        input.description,
-        input.maxPeers,
-        activeComposeChannel
-      );
+      const roomId = await actions.createRoom(input);
       setError(null);
       session.selectCreatedRoom(roomId);
-      await onRefresh();
+      await actions.refresh();
       return true;
     } catch (createError) {
       setError(createError instanceof Error ? createError.message : 'Failed to create metaverse room');
@@ -96,8 +84,7 @@ export function MetaverseRoomPanel({
     try {
       const mime = blob.type || 'model/vrm';
       const dataBase64 = await blobToBase64(blob);
-      const assetRef = await api.importMetaverseRoomAsset(
-        activeTopic,
+      const assetRef = await actions.importRoomAsset(
         session.selectedRoom.room_id,
         'vrm',
         mime,
@@ -105,7 +92,7 @@ export function MetaverseRoomPanel({
         dataBase64
       );
       const resolvedUrl =
-        (await api.getBlobPreviewUrl(assetRef.blob_hash, assetRef.mime_type ?? mime)) ??
+        (await actions.getBlobPreviewUrl(assetRef.blob_hash, assetRef.mime_type ?? mime)) ??
         `data:${mime};base64,${dataBase64}`;
       setLocalAvatarAssetRef(assetRef);
       setLocalAvatarAssetUrl(resolvedUrl);

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomActions.ts
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomActions.ts
@@ -1,0 +1,44 @@
+import type {
+  GameRoomView,
+  MetaverseAssetRef,
+  MetaverseRoomEventView,
+  MetaverseRoomEventV1,
+} from '@/lib/api';
+import type { MetaverseVec3 } from '../MetaverseSceneModel';
+
+export type CreateMetaverseRoomActionInput = {
+  title: string;
+  description: string;
+  maxPeers: number | null;
+};
+
+export type MetaverseRoomActions = {
+  createRoom: (input: CreateMetaverseRoomActionInput) => Promise<string>;
+  publishRoomEvent: (
+    roomId: string,
+    peerId: string,
+    seq: number,
+    event: MetaverseRoomEventV1
+  ) => Promise<void>;
+  listRoomEvents: (
+    roomId: string,
+    afterEnvelopeId: string | null,
+    limit: number
+  ) => Promise<MetaverseRoomEventView[]>;
+  importRoomAsset: (
+    roomId: string,
+    kind: 'vrm',
+    mime: string,
+    name: string,
+    dataBase64: string
+  ) => Promise<MetaverseAssetRef>;
+  getBlobPreviewUrl: (blobHash: string, mime: string) => Promise<string | null>;
+  updateRoom: (
+    roomId: string,
+    status: GameRoomView['status'],
+    position: MetaverseVec3,
+    rotation: MetaverseVec3,
+    scale: MetaverseVec3
+  ) => Promise<void>;
+  refresh: () => Promise<void>;
+};

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
@@ -9,6 +9,7 @@ import {
   type MetaverseRoomEvent,
 } from '../MetaverseSceneModel';
 import { useMetaverseRoomSession } from './useMetaverseRoomSession';
+import { createMetaverseRoomActions } from '@/shell/actions/metaverse';
 
 const room: GameRoomView = {
   room_id: 'metaverse-room-1',
@@ -100,17 +101,22 @@ function renderSession({
   onRefresh?: () => Promise<void>;
 } = {}) {
   const onError = vi.fn();
+  const actions = createMetaverseRoomActions({
+    api,
+    activeTopic: 'kukuri:topic:demo',
+    activeComposeChannel: { kind: 'public' },
+    onRefresh,
+  });
   const rendered = renderHook(
     ({ rooms: currentRooms, sync: currentSync }: SessionProps) =>
       useMetaverseRoomSession({
-        api,
+        actions,
         activeTopic: 'kukuri:topic:demo',
         rooms: currentRooms,
         syncStatus: currentSync,
         localDisplayName: 'Local Author',
         localAvatarAssetRef: null,
         localAvatarAssetUrl: null,
-        onRefresh,
         onError,
       }),
     { initialProps: { rooms, sync } }

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
@@ -1,7 +1,6 @@
 import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
 
 import type {
-  DesktopApi,
   GameRoomView,
   MetaverseAssetRef,
   MetaverseRoomEventView,
@@ -9,6 +8,7 @@ import type {
   SharedRoomObjectV1,
   SyncStatus,
 } from '@/lib/api';
+import type { MetaverseRoomActions } from './MetaverseRoomActions';
 import {
   DEFAULT_SHARED_OBJECT,
   METAVERSE_CHAT_BUBBLE_TTL_MS,
@@ -28,14 +28,13 @@ import {
 } from '../MetaverseSceneModel';
 
 type UseMetaverseRoomSessionArgs = {
-  api: DesktopApi;
+  actions: MetaverseRoomActions;
   activeTopic: string;
   rooms: GameRoomView[];
   syncStatus: SyncStatus;
   localDisplayName: string | null;
   localAvatarAssetRef: MetaverseAssetRef | null;
   localAvatarAssetUrl: string | null;
-  onRefresh: () => Promise<void>;
   onError: (message: string | null) => void;
 };
 
@@ -78,14 +77,13 @@ function latestChatBubbleFromMessage(message: RoomChatMessage, now = Date.now())
 }
 
 export function useMetaverseRoomSession({
-  api,
+  actions,
   activeTopic,
   rooms,
   syncStatus,
   localDisplayName,
   localAvatarAssetRef,
   localAvatarAssetUrl,
-  onRefresh,
   onError,
 }: UseMetaverseRoomSessionArgs) {
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
@@ -311,7 +309,7 @@ export function useMetaverseRoomSession({
         lastSeenAt: now,
       };
       emit({ type: 'presence.join', presence });
-      void api.publishMetaverseRoomEvent(activeTopic, selectedRoom.room_id, localPeerId, now, {
+      void actions.publishRoomEvent(selectedRoom.room_id, localPeerId, now, {
         type: 'presence_join',
         presence: {
           room_id: selectedRoom.room_id,
@@ -332,7 +330,7 @@ export function useMetaverseRoomSession({
     };
   }, [
     activeTopic,
-    api,
+    actions,
     localAvatarAssetRef,
     localAvatarAssetUrl,
     localDisplayName,
@@ -365,7 +363,7 @@ export function useMetaverseRoomSession({
           },
         }));
         if (presence.avatarAssetRef) {
-          void api
+          void actions
             .getBlobPreviewUrl(
               presence.avatarAssetRef.blob_hash,
               presence.avatarAssetRef.mime_type ?? 'model/vrm'
@@ -437,8 +435,7 @@ export function useMetaverseRoomSession({
     };
     const poll = async () => {
       try {
-        const events = await api.listMetaverseRoomEvents(
-          activeTopic,
+        const events = await actions.listRoomEvents(
           selectedRoom.room_id,
           lastBackendEventEnvelopeIdRef.current,
           64
@@ -468,7 +465,7 @@ export function useMetaverseRoomSession({
       cancelled = true;
       window.clearTimeout(timeoutId);
     };
-  }, [activeTopic, api, localPeerId, selectedRoom]);
+  }, [actions, localPeerId, selectedRoom]);
 
   useEffect(() => {
     if (!selectedRoom || (roomConnectionState !== 'stale' && roomConnectionState !== 'offline')) {
@@ -483,10 +480,10 @@ export function useMetaverseRoomSession({
     if (roomConnectionState === 'stale') {
       setRecoveringUntil(now + 3_000);
     }
-    void Promise.resolve(onRefresh()).catch(() => {
+    void Promise.resolve(actions.refresh()).catch(() => {
       setPollErrorCount((current) => current + 1);
     });
-  }, [onRefresh, roomConnectionState, selectedRoom]);
+  }, [actions, roomConnectionState, selectedRoom]);
 
   function resetRoomRuntimeState() {
     setRemoteTransforms({});
@@ -517,7 +514,7 @@ export function useMetaverseRoomSession({
     const roomId = selectedRoom.room_id;
     const leftAt = Date.now();
     emit({ type: 'presence.leave', roomId, peerId: localPeerId, leftAt });
-    void api.publishMetaverseRoomEvent(activeTopic, roomId, localPeerId, leftAt, {
+    void actions.publishRoomEvent(roomId, localPeerId, leftAt, {
       type: 'presence_leave',
       room_id: roomId,
       peer_id: localPeerId,
@@ -550,9 +547,8 @@ export function useMetaverseRoomSession({
         sent_at: transform.sentAt,
       },
     };
-    void api
-      .publishMetaverseRoomEvent(
-        activeTopic,
+    void actions
+      .publishRoomEvent(
         transform.roomId,
         localPeerId,
         transform.seq,
@@ -583,8 +579,8 @@ export function useMetaverseRoomSession({
     }));
     setMessageDraft('');
     emit({ type: 'chat.message', message });
-    void api
-      .publishMetaverseRoomEvent(activeTopic, selectedRoom.room_id, localPeerId, Date.now(), {
+    void actions
+      .publishRoomEvent(selectedRoom.room_id, localPeerId, Date.now(), {
         type: 'chat_message',
         message: {
           room_id: message.roomId,
@@ -602,24 +598,23 @@ export function useMetaverseRoomSession({
 
   function persistSharedObject(nextObject: SharedRoomObjectV1, room: GameRoomView) {
     emit({ type: 'object.update', roomId: room.room_id, object: nextObject });
-    void api
-      .publishMetaverseRoomEvent(activeTopic, room.room_id, localPeerId, Date.now(), {
+    void actions
+      .publishRoomEvent(room.room_id, localPeerId, Date.now(), {
         type: 'object_update',
         object: nextObject,
       })
       .catch(() => {
         // Browser-only fallback is handled by BroadcastChannel.
       });
-    void api
-      .updateMetaverseRoom(
-        activeTopic,
+    void actions
+      .updateRoom(
         room.room_id,
         room.status,
         nextObject.position,
         nextObject.rotation,
         nextObject.scale
       )
-      .then(() => onRefresh())
+      .then(() => actions.refresh())
       .catch((updateError) => {
         onError(updateError instanceof Error ? updateError.message : 'Failed to persist shared object');
       });

--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -672,6 +672,7 @@ export function DesktopShellPage({
           <DesktopShellPrimaryWorkspace
             t={t}
             api={api}
+            metaverseActions={shellActions.metaverseActions}
             locale={locale}
             routeSection={routeSection}
             profileAvatarInputKey={dialogs.profileAvatarInputKey}
@@ -694,7 +695,6 @@ export function DesktopShellPage({
             }}
             loadReactionCatalogData={loadReactionCatalogData}
             refreshTimelineFeed={refreshTimelineFeed}
-            refreshCurrentTopic={() => loadTopics(trackedTopics, activeTopic, selectedThread)}
             loadMoreTimeline={loadMoreTimeline}
             openAuthorDetail={openAuthorDetail}
             openThread={openThread}

--- a/apps/desktop/src/shell/actions/metaverse.test.ts
+++ b/apps/desktop/src/shell/actions/metaverse.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { createDesktopMockApi } from '@/mocks/desktopApiMock';
+import { createMetaverseRoomActions } from './metaverse';
+
+describe('createMetaverseRoomActions', () => {
+  test('binds topic/channel and preserves every API payload and refresh boundary', async () => {
+    const baseApi = createDesktopMockApi();
+    const api = {
+      ...baseApi,
+      createMetaverseRoom: vi.fn(baseApi.createMetaverseRoom),
+      publishMetaverseRoomEvent: vi.fn(baseApi.publishMetaverseRoomEvent),
+      listMetaverseRoomEvents: vi.fn(baseApi.listMetaverseRoomEvents),
+      importMetaverseRoomAsset: vi.fn(baseApi.importMetaverseRoomAsset),
+      getBlobPreviewUrl: vi.fn(baseApi.getBlobPreviewUrl),
+      updateMetaverseRoom: vi.fn(baseApi.updateMetaverseRoom),
+    };
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const actions = createMetaverseRoomActions({
+      api,
+      activeTopic: 'kukuri:topic:demo',
+      activeComposeChannel: { kind: 'private_channel', channel_id: 'channel-1' },
+      onRefresh,
+    });
+    const event = {
+      type: 'presence_leave' as const,
+      room_id: 'room-1',
+      peer_id: 'peer-1',
+      left_at: 7,
+    };
+
+    await actions.createRoom({
+      title: 'Atrium',
+      description: 'Small social space',
+      maxPeers: 8,
+    });
+    await actions.publishRoomEvent('room-1', 'peer-1', 7, event);
+    await actions.listRoomEvents('room-1', 'event-6', 64);
+    await actions.importRoomAsset('room-1', 'vrm', 'model/vrm', 'avatar.vrm', 'YXZhdGFy');
+    await actions.getBlobPreviewUrl('blob-hash', 'model/vrm');
+    await actions.updateRoom(
+      'room-1',
+      'Waiting',
+      [1, 2, 3],
+      [4, 5, 6],
+      [100, 100, 100]
+    );
+
+    expect(api.createMetaverseRoom).toHaveBeenCalledWith(
+      'kukuri:topic:demo',
+      'Atrium',
+      'Small social space',
+      8,
+      { kind: 'private_channel', channel_id: 'channel-1' }
+    );
+    expect(api.publishMetaverseRoomEvent).toHaveBeenCalledWith(
+      'kukuri:topic:demo',
+      'room-1',
+      'peer-1',
+      7,
+      event
+    );
+    expect(api.listMetaverseRoomEvents).toHaveBeenCalledWith(
+      'kukuri:topic:demo',
+      'room-1',
+      'event-6',
+      64
+    );
+    expect(api.importMetaverseRoomAsset).toHaveBeenCalledWith(
+      'kukuri:topic:demo',
+      'room-1',
+      'vrm',
+      'model/vrm',
+      'avatar.vrm',
+      'YXZhdGFy'
+    );
+    expect(api.getBlobPreviewUrl).toHaveBeenCalledWith('blob-hash', 'model/vrm');
+    expect(api.updateMetaverseRoom).toHaveBeenCalledWith(
+      'kukuri:topic:demo',
+      'room-1',
+      'Waiting',
+      [1, 2, 3],
+      [4, 5, 6],
+      [100, 100, 100]
+    );
+    expect(onRefresh).not.toHaveBeenCalled();
+
+    await actions.refresh();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/shell/actions/metaverse.ts
+++ b/apps/desktop/src/shell/actions/metaverse.ts
@@ -1,0 +1,46 @@
+import type { ChannelRef, DesktopApi } from '@/lib/api';
+import type { MetaverseRoomActions } from '@/components/extended/metaverse/MetaverseRoomActions';
+
+type CreateMetaverseRoomActionsArgs = {
+  api: DesktopApi;
+  activeTopic: string;
+  activeComposeChannel: ChannelRef;
+  onRefresh: () => Promise<void>;
+};
+
+export function createMetaverseRoomActions({
+  api,
+  activeTopic,
+  activeComposeChannel,
+  onRefresh,
+}: CreateMetaverseRoomActionsArgs): MetaverseRoomActions {
+  return {
+    createRoom: (input) =>
+      api.createMetaverseRoom(
+        activeTopic,
+        input.title,
+        input.description,
+        input.maxPeers,
+        activeComposeChannel
+      ),
+    publishRoomEvent: (roomId, peerId, seq, event) =>
+      api
+        .publishMetaverseRoomEvent(activeTopic, roomId, peerId, seq, event)
+        .then(() => undefined),
+    listRoomEvents: (roomId, afterEnvelopeId, limit) =>
+      api.listMetaverseRoomEvents(activeTopic, roomId, afterEnvelopeId, limit),
+    importRoomAsset: (roomId, kind, mime, name, dataBase64) =>
+      api.importMetaverseRoomAsset(
+        activeTopic,
+        roomId,
+        kind,
+        mime,
+        name,
+        dataBase64
+      ),
+    getBlobPreviewUrl: (blobHash, mime) => api.getBlobPreviewUrl(blobHash, mime),
+    updateRoom: (roomId, status, position, rotation, scale) =>
+      api.updateMetaverseRoom(activeTopic, roomId, status, position, rotation, scale),
+    refresh: onRefresh,
+  };
+}

--- a/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
@@ -4,6 +4,7 @@ import { Link2 } from 'lucide-react';
 import { TimelineWorkspaceHeader } from '@/components/core/TimelineWorkspaceHeader';
 import { TimelineFeed } from '@/components/core/TimelineFeed';
 import { MetaverseRoomPanel } from '@/components/extended/MetaverseRoomPanel';
+import type { MetaverseRoomActions } from '@/components/extended/metaverse/MetaverseRoomActions';
 import { ProfileConnectionsPanel } from '@/components/extended/ProfileConnectionsPanel';
 import { ProfileEditorPanel } from '@/components/extended/ProfileEditorPanel';
 import { ProfileOverviewPanel } from '@/components/extended/ProfileOverviewPanel';
@@ -48,6 +49,7 @@ type ViewModels = ReturnType<typeof useDesktopShellViewModels>;
 type DesktopShellPrimaryWorkspaceProps = {
   t: Translate;
   api: DesktopApi;
+  metaverseActions: MetaverseRoomActions;
   locale: SupportedLocale;
   routeSection: PrimarySection;
   profileAvatarInputKey: number;
@@ -56,7 +58,6 @@ type DesktopShellPrimaryWorkspaceProps = {
   viewModels: Pick<
     ViewModels,
     | 'activeComposeAudienceLabel'
-    | 'activeComposeChannel'
     | 'activeGamePanelState'
     | 'activeGameRooms'
     | 'activeLivePanelState'
@@ -81,7 +82,6 @@ type DesktopShellPrimaryWorkspaceProps = {
   openCommunityNodeSettings: () => void;
   loadReactionCatalogData: () => Promise<void>;
   refreshTimelineFeed: (topic: string, currentThread: string | null) => Promise<void>;
-  refreshCurrentTopic: () => Promise<void>;
   loadMoreTimeline: (topic: string) => Promise<void>;
   openAuthorDetail: OpenAuthorDetail;
   openThread: OpenThread;
@@ -118,6 +118,7 @@ type DesktopShellPrimaryWorkspaceProps = {
 export function DesktopShellPrimaryWorkspace({
   t,
   api,
+  metaverseActions,
   locale,
   routeSection,
   profileAvatarInputKey,
@@ -130,7 +131,6 @@ export function DesktopShellPrimaryWorkspace({
   openCommunityNodeSettings,
   loadReactionCatalogData,
   refreshTimelineFeed,
-  refreshCurrentTopic,
   loadMoreTimeline,
   openAuthorDetail,
   openThread,
@@ -519,16 +519,14 @@ export function DesktopShellPrimaryWorkspace({
 
         {shellChromeState.activePrimarySection === 'game' ? (
           <MetaverseRoomPanel
-            api={api}
+            actions={metaverseActions}
             activeTopic={activeTopic}
-            activeComposeChannel={viewModels.activeComposeChannel}
             rooms={metaverseRooms}
             syncStatus={syncStatus}
             locale={locale}
             localProfile={localProfile}
             knownAuthorsByPubkey={knownAuthorsByPubkey}
             mediaObjectUrls={mediaObjectUrls}
-            onRefresh={refreshCurrentTopic}
           />
         ) : null}
 

--- a/apps/desktop/src/shell/useDesktopShellActions.ts
+++ b/apps/desktop/src/shell/useDesktopShellActions.ts
@@ -1,4 +1,4 @@
-import { type Dispatch, type FormEvent, type SetStateAction } from 'react';
+import { useMemo, type Dispatch, type FormEvent, type SetStateAction } from 'react';
 
 import type {
   AttachmentView,
@@ -24,6 +24,7 @@ import { createComposeInteractionsActions } from './actions/composeInteractions'
 import { createDirectMessageActions } from './actions/directMessages';
 import { createLiveGameActions } from './actions/liveGame';
 import { createMessageReactionSocialActions } from './actions/messageReactionSocial';
+import { createMetaverseRoomActions } from './actions/metaverse';
 import { createProfileTopicChannelActions } from './actions/profileTopicChannel';
 import { useShallow } from 'zustand/react/shallow';
 import type {
@@ -86,14 +87,18 @@ export function useDesktopShellActions({
   const nextActiveTopic = state.activeTopic;
   const nextSelectedChannelId = state.selectedChannelIdByTopic[nextActiveTopic] ?? null;
   const nextJoinedChannels = state.joinedChannelsByTopic[nextActiveTopic] ?? [];
-  const activeComposeChannel = state.repostTarget
-    ? PUBLIC_CHANNEL_REF
-    : state.replyTarget?.channel_id
-      ? {
-          kind: 'private_channel' as const,
-          channel_id: state.replyTarget.channel_id,
-        }
-      : state.composeChannelByTopic[nextActiveTopic] ?? PUBLIC_CHANNEL_REF;
+  const activeComposeChannel = useMemo(
+    () =>
+      state.repostTarget
+        ? PUBLIC_CHANNEL_REF
+        : state.replyTarget?.channel_id
+          ? {
+              kind: 'private_channel' as const,
+              channel_id: state.replyTarget.channel_id,
+            }
+          : state.composeChannelByTopic[nextActiveTopic] ?? PUBLIC_CHANNEL_REF,
+    [nextActiveTopic, state.composeChannelByTopic, state.replyTarget, state.repostTarget]
+  );
   const {
     trackedTopics,
     activeTopic,
@@ -126,6 +131,16 @@ export function useDesktopShellActions({
   const bookmarkedPostIds = new Set(state.bookmarkedPosts.map((item) => item.post.object_id));
   const activeGameRooms = state.gameRoomsByTopic[nextActiveTopic] ?? [];
   const localAuthorPubkey = state.syncStatus.local_author_pubkey;
+  const metaverseActions = useMemo(
+    () =>
+      createMetaverseRoomActions({
+        api,
+        activeTopic,
+        activeComposeChannel,
+        onRefresh: () => loadTopics(trackedTopics, activeTopic, selectedThread),
+      }),
+    [api, activeComposeChannel, activeTopic, loadTopics, selectedThread, trackedTopics]
+  );
 
   const setTrackedTopics = useDesktopShellFieldSetter('trackedTopics');
   const setActiveTopic = useDesktopShellFieldSetter('activeTopic');
@@ -853,6 +868,7 @@ export function useDesktopShellActions({
   }
 
   return {
+    metaverseActions,
     handleProfileFieldChange,
     handleProfileAvatarFile,
     handleClearProfileAvatar,


### PR DESCRIPTION
## Summary
- add a neutral `MetaverseRoomActions` port and a shell adapter bound to active topic, compose channel, and refresh
- route create/publish/list/import/preview/update calls through the port
- remove DesktopApi imports/direct calls from production Metaverse panel/session files and wire the memoized port through DesktopShell

## Validation
- adapter/session/panel/shell focused tests: 39 passed
- render isolation + channels: 12 passed
- `cargo xtask desktop-ui-check` (71 files / 589 tests, Storybook, browser 10, visual 14)
- `cargo xtask oversized-files`
- production Metaverse DesktopApi/direct API references: 0