### PR TITLE
fix: localize metaverse room surfaces

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.stories.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import type { GameRoomView, SyncStatus } from '@/lib/api';
+import i18n from '@/i18n';
 import { createDesktopMockApi } from '@/mocks/desktopApiMock';
 import { MetaverseRoomPanel } from './MetaverseRoomPanel';
 import { DEFAULT_SHARED_OBJECT } from './MetaverseSceneModel';
@@ -184,7 +185,7 @@ export const DiscoveryError: Story = {
         selectedRoomId={null}
         joinedRoomIds={new Set()}
         pending={false}
-        error='Room connectivity is unavailable'
+        error={i18n.t('metaverse:connection.details.offline')}
         locale='en'
         localAuthorPubkey={LOCAL_PUBKEY}
         localProfile={null}

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import type {
   AuthorSocialView,
@@ -43,6 +44,7 @@ export function MetaverseRoomPanel({
   knownAuthorsByPubkey = {},
   mediaObjectUrls = {},
 }: MetaverseRoomPanelProps) {
+  const { t } = useTranslation('metaverse');
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const [avatarAssetStatus, setAvatarAssetStatus] = useState<AvatarAssetStatus>('loading');
@@ -69,7 +71,7 @@ export function MetaverseRoomPanel({
       await actions.refresh();
       return true;
     } catch (createError) {
-      setError(createError instanceof Error ? createError.message : 'Failed to create metaverse room');
+      setError(createError instanceof Error ? createError.message : t('errors.createFailed'));
       return false;
     } finally {
       setPending(false);
@@ -98,7 +100,7 @@ export function MetaverseRoomPanel({
       setLocalAvatarAssetUrl(resolvedUrl);
       setError(null);
     } catch (assetError) {
-      setError(assetError instanceof Error ? assetError.message : 'Failed to import VRM avatar');
+      setError(assetError instanceof Error ? assetError.message : t('errors.importAvatarFailed'));
     } finally {
       setPending(false);
     }
@@ -107,7 +109,7 @@ export function MetaverseRoomPanel({
   async function handleSampleAvatarImport() {
     const response = await fetch(DEFAULT_AVATAR_ASSET_URL);
     if (!response.ok) {
-      throw new Error(`sample VRM fetch failed: ${response.status}`);
+      throw new Error(t('errors.sampleFetchFailed', { status: response.status }));
     }
     await importAvatarBlob(await response.blob(), DEFAULT_AVATAR_ASSET_NAME);
   }

--- a/apps/desktop/src/components/extended/MetaverseScene.tsx
+++ b/apps/desktop/src/components/extended/MetaverseScene.tsx
@@ -10,6 +10,7 @@ import {
   createVRMAnimationClip,
   type VRMAnimation,
 } from '@pixiv/three-vrm-animation';
+import { useTranslation } from 'react-i18next';
 
 import type { GameRoomView, SharedRoomObjectV1 } from '@/lib/api';
 import {
@@ -112,12 +113,13 @@ function AvatarChatBubble({ bubble }: { bubble?: LatestChatBubble }) {
 }
 
 function AvatarStaleIndicator({ stale }: { stale: boolean }) {
+  const { t } = useTranslation('metaverse');
   if (!stale) {
     return null;
   }
   return (
     <Html position={[0.32, 1.9, 0]} center distanceFactor={8} occlude={false}>
-      <div className='metaverse-avatar-stale-icon' aria-label='Remote avatar stale'>
+      <div className='metaverse-avatar-stale-icon' aria-label={t('avatar.remoteStale')}>
         <MonitorPause className='size-3' aria-hidden='true' />
       </div>
     </Html>
@@ -724,8 +726,9 @@ export function MetaverseScene({
   onLocalTransform,
   onAvatarAssetStatus,
 }: SceneProps) {
+  const { t } = useTranslation('metaverse');
   return (
-    <div className='metaverse-viewport-shell' aria-label='Metaverse room viewport'>
+    <div className='metaverse-viewport-shell' aria-label={t('viewport.ariaLabel')}>
       <Canvas
         className='metaverse-viewport-canvas'
         camera={{ position: [0, 3.2, 5.2], fov: 54 }}

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.test.tsx
@@ -1,10 +1,15 @@
 import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
+import i18n from '@/i18n';
 import type { GameRoomView } from '@/lib/api';
 import { MetaverseRoomControls } from './MetaverseRoomControls';
+
+afterEach(async () => {
+  await i18n.changeLanguage('en');
+});
 
 const room: GameRoomView = {
   room_id: 'metaverse-room-1',
@@ -61,6 +66,19 @@ function renderControls(
 }
 
 describe('MetaverseRoomControls', () => {
+  test.each([
+    ['en', 'Live', 'Leave room', 'ROOM Chat'],
+    ['ja', '接続中', 'ルームから退出', 'ルームチャット'],
+    ['zh-CN', '在线', '离开房间', '房间聊天'],
+  ] as const)('renders the main HUD/chat surface in %s', async (locale, state, leave, chat) => {
+    await i18n.changeLanguage(locale);
+    renderControls({ locale });
+
+    expect(screen.getByText(state)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: leave })).toBeInTheDocument();
+    expect(screen.getByLabelText(chat)).toBeInTheDocument();
+  });
+
   test.each([
     ['live', 'Live', 'Room events are flowing'],
     ['recovering', 'Recovering', 'Refreshing room connectivity'],

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.tsx
@@ -14,6 +14,7 @@ import {
   WifiOff,
   X,
 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -60,32 +61,6 @@ type MetaverseRoomControlsProps = {
   onSendMessage: FormEventHandler<HTMLFormElement>;
 };
 
-function connectionStateLabel(state: MetaverseRoomConnectionState) {
-  if (state === 'live') {
-    return 'Live';
-  }
-  if (state === 'recovering') {
-    return 'Recovering';
-  }
-  if (state === 'stale') {
-    return 'Stale';
-  }
-  return 'Offline';
-}
-
-function connectionStateDetail(state: MetaverseRoomConnectionState) {
-  if (state === 'live') {
-    return 'Room events are flowing';
-  }
-  if (state === 'recovering') {
-    return 'Refreshing room connectivity';
-  }
-  if (state === 'stale') {
-    return 'No room activity recently';
-  }
-  return 'Peer connectivity is unavailable';
-}
-
 function ConnectionStateIcon({ state }: { state: MetaverseRoomConnectionState }) {
   if (state === 'live') {
     return <Wifi className='size-4' aria-hidden='true' />;
@@ -130,15 +105,17 @@ export function MetaverseRoomControls({
   onMessageDraftChange,
   onSendMessage,
 }: MetaverseRoomControlsProps) {
+  const { t } = useTranslation('metaverse');
+  const avatarStatusLabel = t(`hud.avatarStatuses.${avatarAssetStatus}`);
   return (
     <>
       <div
         className='metaverse-connection-badge'
         data-state={connectionState}
-        title={connectionStateDetail(connectionState)}
+        title={t(`connection.details.${connectionState}`)}
       >
         <ConnectionStateIcon state={connectionState} />
-        <span>{connectionStateLabel(connectionState)}</span>
+        <span>{t(`connection.states.${connectionState}`)}</span>
       </div>
       <div className='metaverse-hud-toolbar' data-open={hudOpen}>
         <Button
@@ -146,7 +123,7 @@ export function MetaverseRoomControls({
           size='icon'
           className='metaverse-hud-icon-button'
           type='button'
-          aria-label='Leave room'
+          aria-label={t('hud.leave')}
           onClick={onLeaveRoom}
         >
           <LogOut className='size-4' aria-hidden='true' />
@@ -156,7 +133,7 @@ export function MetaverseRoomControls({
           size='icon'
           className='metaverse-hud-icon-button'
           type='button'
-          aria-label={hudOpen ? 'Hide room HUD' : 'Open room HUD'}
+          aria-label={t(hudOpen ? 'hud.hide' : 'hud.open')}
           onClick={onToggleHud}
         >
           {hudOpen ? (
@@ -182,41 +159,41 @@ export function MetaverseRoomControls({
                 aria-expanded={hudDebugOpen}
                 onClick={onToggleHudDebug}
               >
-                <span>Debug details</span>
+                <span>{t('hud.debug')}</span>
                 <ChevronDown className='size-4' aria-hidden='true' />
               </button>
               {hudDebugOpen ? (
                 <div className='metaverse-room-diagnostics'>
-                  <span>Topic: {activeTopic}</span>
-                  <span>Local peer: {localPeerId}</span>
-                  <span>Known peers: {knownPeerCount}</span>
-                  <span>Last sent seq: {lastSentSeq}</span>
+                  <span>{t('hud.topic', { topic: activeTopic })}</span>
+                  <span>{t('hud.localPeer', { peer: localPeerId })}</span>
+                  <span>{t('hud.knownPeers', { count: knownPeerCount })}</span>
+                  <span>{t('hud.lastSentSeq', { seq: lastSentSeq })}</span>
                   <span>
-                    Last received: {lastReceivedAt ? formatLocalizedTime(lastReceivedAt, locale) : 'none'}
+                    {t('hud.lastReceived', {
+                      time: lastReceivedAt ? formatLocalizedTime(lastReceivedAt, locale) : t('hud.none'),
+                    })}
                   </span>
-                  <span>Remote animation: {remoteAnimationSummary || 'none'}</span>
+                  <span>{t('hud.remoteAnimation', { value: remoteAnimationSummary || t('hud.none') })}</span>
+                  <span>{t('hud.avatarAsset', { status: avatarStatusLabel })}</span>
                   <span>
-                    Avatar asset:{' '}
-                    {avatarAssetStatus === 'sample-vrm'
-                      ? 'sample VRM loaded'
-                      : avatarAssetStatus === 'blob-vrm'
-                        ? 'blob VRM loaded'
-                        : avatarAssetStatus}
+                    {t('hud.blobResolve', {
+                      value: localAvatarAssetRef?.blob_hash ?? t('hud.publicFallback'),
+                    })}
                   </span>
+                  <span>{t('hud.persistence', { value: room.manifest_blob_hash ?? t('room.pending') })}</span>
                   <span>
-                    Blob asset resolve:{' '}
-                    {localAvatarAssetRef?.blob_hash ?? 'public sample / fallback-ready'}
+                    {t('hud.communityAssist', {
+                      value: t(communityAssistAvailable ? 'hud.assistAvailable' : 'hud.assistOptional'),
+                    })}
                   </span>
-                  <span>Persistence: manifest blob {room.manifest_blob_hash ?? 'pending'}</span>
-                  <span>Community assist: {communityAssistAvailable ? 'available' : 'optional'}</span>
                 </div>
               ) : null}
             </section>
             <div className='metaverse-object-controls'>
-              <strong>Avatar asset</strong>
+              <strong>{t('avatar.title')}</strong>
               <div className='metaverse-avatar-asset-controls'>
                 <Label>
-                  <span className='sr-only'>VRM file</span>
+                  <span className='sr-only'>{t('avatar.fileLabel')}</span>
                   <Input
                     type='file'
                     accept='.vrm,model/vrm,application/octet-stream'
@@ -237,14 +214,14 @@ export function MetaverseRoomControls({
                   disabled={pending}
                   onClick={onImportDefaultAvatar}
                 >
-                  Default
+                  {t('avatar.default')}
                 </Button>
               </div>
             </div>
             <div className='metaverse-object-controls'>
               <strong>
                 <Box className='size-4' aria-hidden='true' />
-                Shared object
+                {t('object.title')}
               </strong>
               <div className='metaverse-nudge-grid'>
                 <Button
@@ -254,16 +231,16 @@ export function MetaverseRoomControls({
                   onClick={() => onMoveSharedObject([0, 0, -50])}
                 >
                   <Move3D className='size-4' aria-hidden='true' />
-                  Forward
+                  {t('object.forward')}
                 </Button>
                 <Button size='sm' variant='secondary' type='button' onClick={() => onMoveSharedObject([-50, 0, 0])}>
-                  Left
+                  {t('object.left')}
                 </Button>
                 <Button size='sm' variant='secondary' type='button' onClick={() => onMoveSharedObject([50, 0, 0])}>
-                  Right
+                  {t('object.right')}
                 </Button>
                 <Button size='sm' variant='secondary' type='button' onClick={() => onMoveSharedObject([0, 0, 50])}>
-                  Back
+                  {t('object.back')}
                 </Button>
               </div>
             </div>
@@ -274,18 +251,18 @@ export function MetaverseRoomControls({
         </>
       ) : null}
       {chatOpen ? (
-        <section className='metaverse-room-chat-log' aria-label='ROOM Chat'>
+        <section className='metaverse-room-chat-log' aria-label={t('chat.title')}>
           <div className='metaverse-room-chat-log-header'>
             <span>
               <MessageSquare className='size-4' aria-hidden='true' />
-              ROOM Chat
+              {t('chat.title')}
             </span>
             <Button
               variant='ghost'
               size='icon'
               className='metaverse-chat-close-button'
               type='button'
-              aria-label='Hide room chat'
+              aria-label={t('chat.hide')}
               onClick={onCloseChat}
             >
               <X className='size-4' aria-hidden='true' />
@@ -296,7 +273,7 @@ export function MetaverseRoomControls({
               <li key={message.messageId}>
                 <strong>
                   {message.authorPeerId === localPeerId
-                    ? 'You'
+                    ? t('chat.you')
                     : message.displayName || message.authorPeerId.slice(0, 12)}
                   <small>{formatLocalizedTime(message.createdAt, locale)}</small>
                 </strong>
@@ -306,17 +283,17 @@ export function MetaverseRoomControls({
           </ul>
           <form className='metaverse-chat-form' onSubmit={onSendMessage}>
             <Label>
-              <span className='sr-only'>Room chat message</span>
+              <span className='sr-only'>{t('chat.messageLabel')}</span>
               <Input
                 ref={messageInputRef}
                 value={messageDraft}
-                placeholder='Say something in the room'
+                placeholder={t('chat.placeholder')}
                 onChange={(event) => onMessageDraftChange(event.target.value)}
               />
             </Label>
             <Button size='sm' type='submit'>
               <Send className='size-4' aria-hidden='true' />
-              Send
+              {t('chat.send')}
             </Button>
           </form>
         </section>
@@ -326,7 +303,7 @@ export function MetaverseRoomControls({
           size='icon'
           className='metaverse-chat-toggle'
           type='button'
-          aria-label='Open room chat'
+          aria-label={t('chat.open')}
           onClick={onOpenChat}
         >
           <MessageSquare className='size-4' aria-hidden='true' />

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
+import i18n from '@/i18n';
 import type { GameRoomView } from '@/lib/api';
 import { MetaverseRoomDiscovery } from './MetaverseRoomDiscovery';
+
+afterEach(async () => {
+  await i18n.changeLanguage('en');
+});
 
 const room: GameRoomView = {
   room_id: 'metaverse-room-1',
@@ -64,6 +69,24 @@ function renderDiscovery(
 }
 
 describe('MetaverseRoomDiscovery', () => {
+  test.each([
+    ['en', 'Metaverse Rooms', 'Create metaverse room', 'Atrium', 'Join Room'],
+    ['ja', 'メタバースルーム', 'メタバースルームを作成', 'アトリウム', 'ルームに参加'],
+    ['zh-CN', '元宇宙房间', '创建元宇宙房间', '中庭', '加入房间'],
+  ] as const)(
+    'renders the primary discovery surface in %s',
+    async (locale, title, createAction, titlePlaceholder, joinAction) => {
+      await i18n.changeLanguage(locale);
+      const user = userEvent.setup();
+      renderDiscovery({ locale });
+
+      expect(screen.getByRole('heading', { name: title })).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: createAction }));
+      expect(screen.getByPlaceholderText(titlePlaceholder)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: joinAction })).toBeInTheDocument();
+    }
+  );
+
   test('shows the empty state and an action error without an API dependency', () => {
     renderDiscovery({ rooms: [], error: 'Room action failed' });
 

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react';
 import { ChevronDown, Cuboid, Play } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 import { AuthorAvatar } from '@/components/core/AuthorAvatar';
 import { Button } from '@/components/ui/button';
@@ -51,7 +52,8 @@ export function MetaverseRoomDiscovery({
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [maxPeers, setMaxPeers] = useState('8');
-  const [validationError, setValidationError] = useState<string | null>(null);
+  const { t } = useTranslation('metaverse');
+  const [validationError, setValidationError] = useState(false);
 
   function hostAuthor(room: GameRoomView): Profile | AuthorSocialView | null {
     return room.host_pubkey === localAuthorPubkey
@@ -76,10 +78,10 @@ export function MetaverseRoomDiscovery({
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!title.trim()) {
-      setValidationError('Room title is required');
+      setValidationError(true);
       return;
     }
-    setValidationError(null);
+    setValidationError(false);
     const parsedMaxPeers = Number.parseInt(maxPeers, 10);
     const created = await onCreateRoom({
       title: title.trim(),
@@ -92,19 +94,19 @@ export function MetaverseRoomDiscovery({
     setTitle('');
     setDescription('');
     setMaxPeers('8');
-    setValidationError(null);
+    setValidationError(false);
   }
 
   return (
     <Card className='shell-workspace-card metaverse-discovery-card'>
       <div className='panel-header'>
         <div>
-          <h3>Metaverse Rooms</h3>
-          <small>{rooms.length} room{rooms.length === 1 ? '' : 's'} in this topic</small>
+          <h3>{t('title')}</h3>
+          <small>{t('rooms.summary', { count: rooms.length })}</small>
         </div>
       </div>
       {validationError || error ? (
-        <Notice tone='destructive'>{validationError ?? error}</Notice>
+        <Notice tone='destructive'>{validationError ? t('create.titleRequired') : error}</Notice>
       ) : null}
       <section className='shell-nav-accordion metaverse-create-accordion' data-open={createOpen}>
         <button
@@ -114,35 +116,35 @@ export function MetaverseRoomDiscovery({
           onClick={() => setCreateOpen((current) => !current)}
         >
           <Cuboid className='size-4' aria-hidden='true' />
-          <span className='shell-nav-accordion-title'>Create metaverse room</span>
+          <span className='shell-nav-accordion-title'>{t('create.action')}</span>
           <ChevronDown className='shell-nav-accordion-icon size-4' aria-hidden='true' />
         </button>
         {createOpen ? (
           <form className='composer composer-compact metaverse-create-form' onSubmit={handleSubmit}>
             <div className='metaverse-create-form-primary'>
               <Label>
-                <span>Room title</span>
-                <Input value={title} placeholder='Atrium' disabled={pending} onChange={(event) => setTitle(event.target.value)} />
+                <span>{t('create.titleLabel')}</span>
+                <Input value={title} placeholder={t('create.titlePlaceholder')} disabled={pending} onChange={(event) => setTitle(event.target.value)} />
               </Label>
               <Label>
-                <span>Max peers</span>
+                <span>{t('create.maxPeersLabel')}</span>
                 <Input value={maxPeers} disabled={pending} onChange={(event) => setMaxPeers(event.target.value)} />
               </Label>
             </div>
             <Label className='metaverse-create-form-description'>
-              <span>Description</span>
-              <Textarea value={description} placeholder='Small social space' disabled={pending} onChange={(event) => setDescription(event.target.value)} />
+              <span>{t('create.descriptionLabel')}</span>
+              <Textarea value={description} placeholder={t('create.descriptionPlaceholder')} disabled={pending} onChange={(event) => setDescription(event.target.value)} />
             </Label>
             <div className='metaverse-create-form-actions'>
               <Button type='submit' disabled={pending}>
                 <Cuboid className='size-4' aria-hidden='true' />
-                Create metaverse room
+                {t('create.action')}
               </Button>
             </div>
           </form>
         ) : null}
       </section>
-      {rooms.length === 0 ? <p className='empty-state'>No metaverse rooms in this topic.</p> : null}
+      {rooms.length === 0 ? <p className='empty-state'>{t('rooms.empty')}</p> : null}
       <ul className='metaverse-room-grid'>
         {rooms.map((room) => (
           <li key={room.room_id}>
@@ -152,22 +154,22 @@ export function MetaverseRoomDiscovery({
                 <span>{room.status}</span>
                 <span className='reply-chip'>{room.audience_label}</span>
               </div>
-              <p>{room.description || 'No description'}</p>
+              <p>{room.description || t('rooms.noDescription')}</p>
               <div className='metaverse-room-host'>
                 <AuthorAvatar label={hostLabel(room)} picture={hostPicture(room)} size='sm' />
-                <span>Host: {hostLabel(room)}</span>
+                <span>{t('room.host', { host: hostLabel(room) })}</span>
               </div>
               <div className='topic-diagnostic topic-diagnostic-secondary'>
-                <span>Updated: {formatLocalizedTime(room.updated_at, locale)}</span>
-                <span>{joinedRoomIds.has(room.room_id) ? 'Joined' : 'Not joined'}</span>
+                <span>{t('room.updated', { time: formatLocalizedTime(room.updated_at, locale) })}</span>
+                <span>{t(joinedRoomIds.has(room.room_id) ? 'room.joined' : 'room.notJoined')}</span>
               </div>
               <div className='topic-diagnostic topic-diagnostic-secondary'>
-                <span>Manifest: {room.manifest_blob_hash ?? 'pending'}</span>
-                <span>World: {room.metaverse?.world_version ?? 1}</span>
+                <span>{t('room.manifest', { value: room.manifest_blob_hash ?? t('room.pending') })}</span>
+                <span>{t('room.world', { version: room.metaverse?.world_version ?? 1 })}</span>
               </div>
               <Button variant='secondary' type='button' onClick={() => onJoinRoom(room.room_id)}>
                 <Play className='size-4' aria-hidden='true' />
-                Join Room
+                {t('room.join')}
               </Button>
             </article>
           </li>

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
@@ -1,4 +1,5 @@
 import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import type {
   GameRoomView,
@@ -86,6 +87,7 @@ export function useMetaverseRoomSession({
   localAvatarAssetUrl,
   onError,
 }: UseMetaverseRoomSessionArgs) {
+  const { t } = useTranslation('metaverse');
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const [joinedRoomIds, setJoinedRoomIds] = useState<Set<string>>(() => new Set());
   const [remoteTransforms, setRemoteTransforms] = useState<Record<string, AvatarTransform>>({});
@@ -520,7 +522,7 @@ export function useMetaverseRoomSession({
       peer_id: localPeerId,
       left_at: leftAt,
     }).catch((leaveError) => {
-      onError(leaveError instanceof Error ? leaveError.message : 'Failed to publish room leave');
+      onError(leaveError instanceof Error ? leaveError.message : t('errors.publishLeaveFailed'));
     });
     setJoinedRoomIds((current) => {
       const next = new Set(current);
@@ -616,7 +618,7 @@ export function useMetaverseRoomSession({
       )
       .then(() => actions.refresh())
       .catch((updateError) => {
-        onError(updateError instanceof Error ? updateError.message : 'Failed to persist shared object');
+        onError(updateError instanceof Error ? updateError.message : t('errors.persistObjectFailed'));
       });
   }
 

--- a/apps/desktop/src/i18n/index.ts
+++ b/apps/desktop/src/i18n/index.ts
@@ -10,6 +10,7 @@ import channelsEn from './locales/en/channels.json';
 import liveEn from './locales/en/live.json';
 import gameEn from './locales/en/game.json';
 import legalEn from './locales/en/legal.json';
+import metaverseEn from './locales/en/metaverse.json';
 import commonJa from './locales/ja/common.json';
 import shellJa from './locales/ja/shell.json';
 import settingsJa from './locales/ja/settings.json';
@@ -18,6 +19,7 @@ import channelsJa from './locales/ja/channels.json';
 import liveJa from './locales/ja/live.json';
 import gameJa from './locales/ja/game.json';
 import legalJa from './locales/ja/legal.json';
+import metaverseJa from './locales/ja/metaverse.json';
 import commonZhCn from './locales/zh-CN/common.json';
 import shellZhCn from './locales/zh-CN/shell.json';
 import settingsZhCn from './locales/zh-CN/settings.json';
@@ -26,6 +28,7 @@ import channelsZhCn from './locales/zh-CN/channels.json';
 import liveZhCn from './locales/zh-CN/live.json';
 import gameZhCn from './locales/zh-CN/game.json';
 import legalZhCn from './locales/zh-CN/legal.json';
+import metaverseZhCn from './locales/zh-CN/metaverse.json';
 
 export const SUPPORTED_LOCALES = ['ja', 'en', 'zh-CN'] as const;
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
@@ -58,6 +61,7 @@ export const resources = {
     game: gameEn,
     legal: legalEn,
     live: liveEn,
+    metaverse: metaverseEn,
     profile: profileEn,
     settings: settingsEn,
     shell: shellEn,
@@ -68,6 +72,7 @@ export const resources = {
     game: gameJa,
     legal: legalJa,
     live: liveJa,
+    metaverse: metaverseJa,
     profile: profileJa,
     settings: settingsJa,
     shell: shellJa,
@@ -78,6 +83,7 @@ export const resources = {
     game: gameZhCn,
     legal: legalZhCn,
     live: liveZhCn,
+    metaverse: metaverseZhCn,
     profile: profileZhCn,
     settings: settingsZhCn,
     shell: shellZhCn,
@@ -97,7 +103,7 @@ if (!i18n.isInitialized) {
       },
       defaultNS: 'common',
       fallbackNS: 'common',
-      ns: ['common', 'shell', 'settings', 'profile', 'channels', 'live', 'game', 'legal'],
+      ns: ['common', 'shell', 'settings', 'profile', 'channels', 'live', 'game', 'legal', 'metaverse'],
       react: {
         useSuspense: false,
       },

--- a/apps/desktop/src/i18n/locales/en/metaverse.json
+++ b/apps/desktop/src/i18n/locales/en/metaverse.json
@@ -1,0 +1,100 @@
+{
+  "title": "Metaverse Rooms",
+  "rooms": {
+    "summary_one": "{{count}} room in this topic",
+    "summary_other": "{{count}} rooms in this topic",
+    "empty": "No metaverse rooms in this topic.",
+    "noDescription": "No description"
+  },
+  "create": {
+    "action": "Create metaverse room",
+    "titleLabel": "Room title",
+    "titlePlaceholder": "Atrium",
+    "maxPeersLabel": "Max peers",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Small social space",
+    "titleRequired": "Room title is required"
+  },
+  "room": {
+    "host": "Host: {{host}}",
+    "updated": "Updated: {{time}}",
+    "joined": "Joined",
+    "notJoined": "Not joined",
+    "manifest": "Manifest: {{value}}",
+    "world": "World: {{version}}",
+    "join": "Join Room",
+    "pending": "pending"
+  },
+  "connection": {
+    "states": {
+      "live": "Live",
+      "recovering": "Recovering",
+      "stale": "Stale",
+      "offline": "Offline"
+    },
+    "details": {
+      "live": "Room events are flowing",
+      "recovering": "Refreshing room connectivity",
+      "stale": "No room activity recently",
+      "offline": "Peer connectivity is unavailable"
+    }
+  },
+  "hud": {
+    "leave": "Leave room",
+    "hide": "Hide room HUD",
+    "open": "Open room HUD",
+    "debug": "Debug details",
+    "topic": "Topic: {{topic}}",
+    "localPeer": "Local peer: {{peer}}",
+    "knownPeers": "Known peers: {{count}}",
+    "lastSentSeq": "Last sent seq: {{seq}}",
+    "lastReceived": "Last received: {{time}}",
+    "remoteAnimation": "Remote animation: {{value}}",
+    "avatarAsset": "Avatar asset: {{status}}",
+    "blobResolve": "Blob asset resolve: {{value}}",
+    "persistence": "Persistence: manifest blob {{value}}",
+    "communityAssist": "Community assist: {{value}}",
+    "none": "none",
+    "publicFallback": "public sample / fallback-ready",
+    "assistAvailable": "available",
+    "assistOptional": "optional",
+    "avatarStatuses": {
+      "loading": "loading",
+      "sample-vrm": "sample VRM loaded",
+      "blob-vrm": "blob VRM loaded",
+      "fallback-primitive": "fallback-primitive"
+    }
+  },
+  "avatar": {
+    "title": "Avatar asset",
+    "fileLabel": "VRM file",
+    "default": "Default",
+    "remoteStale": "Remote avatar stale"
+  },
+  "object": {
+    "title": "Shared object",
+    "forward": "Forward",
+    "left": "Left",
+    "right": "Right",
+    "back": "Back"
+  },
+  "chat": {
+    "title": "ROOM Chat",
+    "hide": "Hide room chat",
+    "open": "Open room chat",
+    "you": "You",
+    "messageLabel": "Room chat message",
+    "placeholder": "Say something in the room",
+    "send": "Send"
+  },
+  "viewport": {
+    "ariaLabel": "Metaverse room viewport"
+  },
+  "errors": {
+    "createFailed": "Failed to create metaverse room",
+    "importAvatarFailed": "Failed to import VRM avatar",
+    "sampleFetchFailed": "sample VRM fetch failed: {{status}}",
+    "publishLeaveFailed": "Failed to publish room leave",
+    "persistObjectFailed": "Failed to persist shared object"
+  }
+}

--- a/apps/desktop/src/i18n/locales/ja/metaverse.json
+++ b/apps/desktop/src/i18n/locales/ja/metaverse.json
@@ -1,0 +1,100 @@
+{
+  "title": "メタバースルーム",
+  "rooms": {
+    "summary_one": "このトピックに{{count}}件のルーム",
+    "summary_other": "このトピックに{{count}}件のルーム",
+    "empty": "このトピックにメタバースルームはありません。",
+    "noDescription": "説明なし"
+  },
+  "create": {
+    "action": "メタバースルームを作成",
+    "titleLabel": "ルーム名",
+    "titlePlaceholder": "アトリウム",
+    "maxPeersLabel": "最大参加者数",
+    "descriptionLabel": "説明",
+    "descriptionPlaceholder": "小さな交流スペース",
+    "titleRequired": "ルーム名は必須です"
+  },
+  "room": {
+    "host": "ホスト: {{host}}",
+    "updated": "更新: {{time}}",
+    "joined": "参加済み",
+    "notJoined": "未参加",
+    "manifest": "マニフェスト: {{value}}",
+    "world": "ワールド: {{version}}",
+    "join": "ルームに参加",
+    "pending": "処理中"
+  },
+  "connection": {
+    "states": {
+      "live": "接続中",
+      "recovering": "復旧中",
+      "stale": "停滞",
+      "offline": "オフライン"
+    },
+    "details": {
+      "live": "ルームイベントを受信しています",
+      "recovering": "ルーム接続を更新しています",
+      "stale": "最近のルーム活動がありません",
+      "offline": "ピア接続を利用できません"
+    }
+  },
+  "hud": {
+    "leave": "ルームから退出",
+    "hide": "ルームHUDを閉じる",
+    "open": "ルームHUDを開く",
+    "debug": "デバッグ詳細",
+    "topic": "トピック: {{topic}}",
+    "localPeer": "ローカルピア: {{peer}}",
+    "knownPeers": "既知のピア: {{count}}",
+    "lastSentSeq": "最終送信シーケンス: {{seq}}",
+    "lastReceived": "最終受信: {{time}}",
+    "remoteAnimation": "リモートアニメーション: {{value}}",
+    "avatarAsset": "アバターアセット: {{status}}",
+    "blobResolve": "Blobアセット解決: {{value}}",
+    "persistence": "永続化: マニフェストBlob {{value}}",
+    "communityAssist": "コミュニティ支援: {{value}}",
+    "none": "なし",
+    "publicFallback": "公開サンプル / フォールバック準備済み",
+    "assistAvailable": "利用可能",
+    "assistOptional": "任意",
+    "avatarStatuses": {
+      "loading": "読み込み中",
+      "sample-vrm": "サンプルVRM読込済み",
+      "blob-vrm": "Blob VRM読込済み",
+      "fallback-primitive": "代替プリミティブ"
+    }
+  },
+  "avatar": {
+    "title": "アバターアセット",
+    "fileLabel": "VRMファイル",
+    "default": "既定",
+    "remoteStale": "リモートアバターが停滞しています"
+  },
+  "object": {
+    "title": "共有オブジェクト",
+    "forward": "前へ",
+    "left": "左へ",
+    "right": "右へ",
+    "back": "後ろへ"
+  },
+  "chat": {
+    "title": "ルームチャット",
+    "hide": "ルームチャットを閉じる",
+    "open": "ルームチャットを開く",
+    "you": "自分",
+    "messageLabel": "ルームチャットのメッセージ",
+    "placeholder": "ルームでメッセージを送信",
+    "send": "送信"
+  },
+  "viewport": {
+    "ariaLabel": "メタバースルーム表示"
+  },
+  "errors": {
+    "createFailed": "メタバースルームを作成できませんでした",
+    "importAvatarFailed": "VRMアバターを読み込めませんでした",
+    "sampleFetchFailed": "サンプルVRMの取得に失敗しました: {{status}}",
+    "publishLeaveFailed": "ルーム退出を配信できませんでした",
+    "persistObjectFailed": "共有オブジェクトを保存できませんでした"
+  }
+}

--- a/apps/desktop/src/i18n/locales/zh-CN/metaverse.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/metaverse.json
@@ -1,0 +1,100 @@
+{
+  "title": "元宇宙房间",
+  "rooms": {
+    "summary_one": "此话题中有 {{count}} 个房间",
+    "summary_other": "此话题中有 {{count}} 个房间",
+    "empty": "此话题中没有元宇宙房间。",
+    "noDescription": "无描述"
+  },
+  "create": {
+    "action": "创建元宇宙房间",
+    "titleLabel": "房间标题",
+    "titlePlaceholder": "中庭",
+    "maxPeersLabel": "最大人数",
+    "descriptionLabel": "描述",
+    "descriptionPlaceholder": "小型社交空间",
+    "titleRequired": "房间标题为必填项"
+  },
+  "room": {
+    "host": "主持人：{{host}}",
+    "updated": "更新时间：{{time}}",
+    "joined": "已加入",
+    "notJoined": "未加入",
+    "manifest": "清单：{{value}}",
+    "world": "世界：{{version}}",
+    "join": "加入房间",
+    "pending": "处理中"
+  },
+  "connection": {
+    "states": {
+      "live": "在线",
+      "recovering": "恢复中",
+      "stale": "停滞",
+      "offline": "离线"
+    },
+    "details": {
+      "live": "正在接收房间事件",
+      "recovering": "正在刷新房间连接",
+      "stale": "最近没有房间活动",
+      "offline": "对等连接不可用"
+    }
+  },
+  "hud": {
+    "leave": "离开房间",
+    "hide": "隐藏房间 HUD",
+    "open": "打开房间 HUD",
+    "debug": "调试详情",
+    "topic": "话题：{{topic}}",
+    "localPeer": "本地节点：{{peer}}",
+    "knownPeers": "已知节点：{{count}}",
+    "lastSentSeq": "最后发送序号：{{seq}}",
+    "lastReceived": "最后接收：{{time}}",
+    "remoteAnimation": "远程动画：{{value}}",
+    "avatarAsset": "头像资源：{{status}}",
+    "blobResolve": "Blob 资源解析：{{value}}",
+    "persistence": "持久化：清单 Blob {{value}}",
+    "communityAssist": "社区辅助：{{value}}",
+    "none": "无",
+    "publicFallback": "公共示例 / 已准备回退",
+    "assistAvailable": "可用",
+    "assistOptional": "可选",
+    "avatarStatuses": {
+      "loading": "加载中",
+      "sample-vrm": "示例 VRM 已加载",
+      "blob-vrm": "Blob VRM 已加载",
+      "fallback-primitive": "回退基础模型"
+    }
+  },
+  "avatar": {
+    "title": "头像资源",
+    "fileLabel": "VRM 文件",
+    "default": "默认",
+    "remoteStale": "远程头像已停滞"
+  },
+  "object": {
+    "title": "共享对象",
+    "forward": "向前",
+    "left": "向左",
+    "right": "向右",
+    "back": "向后"
+  },
+  "chat": {
+    "title": "房间聊天",
+    "hide": "隐藏房间聊天",
+    "open": "打开房间聊天",
+    "you": "你",
+    "messageLabel": "房间聊天消息",
+    "placeholder": "在房间里说点什么",
+    "send": "发送"
+  },
+  "viewport": {
+    "ariaLabel": "元宇宙房间视图"
+  },
+  "errors": {
+    "createFailed": "无法创建元宇宙房间",
+    "importAvatarFailed": "无法导入 VRM 头像",
+    "sampleFetchFailed": "获取示例 VRM 失败：{{status}}",
+    "publishLeaveFailed": "无法发布离开房间事件",
+    "persistObjectFailed": "无法保存共享对象"
+  }
+}

--- a/apps/desktop/src/i18n/parity.test.ts
+++ b/apps/desktop/src/i18n/parity.test.ts
@@ -96,6 +96,7 @@ test('i18n init namespaces match the bundled resources', () => {
     'live',
     'game',
     'legal',
+    'metaverse',
   ]
     .slice()
     .sort();


### PR DESCRIPTION
## Summary
- add a dedicated `metaverse` locale namespace for English, Japanese, and Simplified Chinese
- replace user-visible metaverse room, HUD, avatar, object, chat, and error strings with translation keys
- cover locale parity and render the discovery/controls surfaces in all three supported languages

## Validation
- `cargo xtask desktop-ui-check` (71 files / 599 tests; browser 10; visual 14)
- `cargo xtask oversized-files` (existing 3-file warning only)
- `cargo xtask check`
- `cargo xtask e2e-smoke`
- `cargo xtask test` reached 369 passing tests, then hit the two pre-existing Windows-local docs-sync relay timeouts at 90s; GitHub CI is the merge gate
