### PR TITLE
fix: bind metaverse translations to shell locale

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -44,7 +44,7 @@ export function MetaverseRoomPanel({
   knownAuthorsByPubkey = {},
   mediaObjectUrls = {},
 }: MetaverseRoomPanelProps) {
-  const { t } = useTranslation('metaverse');
+  const { t } = useTranslation('metaverse', { lng: locale });
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const [avatarAssetStatus, setAvatarAssetStatus] = useState<AvatarAssetStatus>('loading');
@@ -56,6 +56,7 @@ export function MetaverseRoomPanel({
     activeTopic,
     rooms,
     syncStatus,
+    locale,
     localDisplayName,
     localAvatarAssetRef,
     localAvatarAssetUrl,

--- a/apps/desktop/src/components/extended/MetaverseScene.tsx
+++ b/apps/desktop/src/components/extended/MetaverseScene.tsx
@@ -12,6 +12,7 @@ import {
 } from '@pixiv/three-vrm-animation';
 import { useTranslation } from 'react-i18next';
 
+import type { SupportedLocale } from '@/i18n';
 import type { GameRoomView, SharedRoomObjectV1 } from '@/lib/api';
 import {
   AVATAR_GROUND_Y,
@@ -46,6 +47,7 @@ type SceneProps = {
   latestChatByPeer: Record<string, LatestChatBubble>;
   connectionState: MetaverseRoomConnectionState;
   now: number;
+  locale: SupportedLocale;
   hud: ReactNode;
   onLocalTransform: (transform: AvatarTransform) => void;
   onAvatarAssetStatus: (status: AvatarAssetStatus) => void;
@@ -112,8 +114,14 @@ function AvatarChatBubble({ bubble }: { bubble?: LatestChatBubble }) {
   );
 }
 
-function AvatarStaleIndicator({ stale }: { stale: boolean }) {
-  const { t } = useTranslation('metaverse');
+function AvatarStaleIndicator({
+  stale,
+  locale,
+}: {
+  stale: boolean;
+  locale: SupportedLocale;
+}) {
+  const { t } = useTranslation('metaverse', { lng: locale });
   if (!stale) {
     return null;
   }
@@ -582,12 +590,14 @@ function RemoteAvatar({
   chatBubble,
   connectionState,
   now,
+  locale,
 }: {
   transform: AvatarTransform;
   presence: PeerPresence | null;
   chatBubble?: LatestChatBubble;
   connectionState: MetaverseRoomConnectionState;
   now: number;
+  locale: SupportedLocale;
 }) {
   const groupRef = useRef<THREE.Group | null>(null);
   const targetRef = useRef(transform);
@@ -632,7 +642,7 @@ function RemoteAvatar({
         animationRef={animationRef}
       />
       <AvatarChatBubble bubble={chatBubble} />
-      <AvatarStaleIndicator stale={stale} />
+      <AvatarStaleIndicator stale={stale} locale={locale} />
     </group>
   );
 }
@@ -668,6 +678,7 @@ function SceneContents({
   latestChatByPeer,
   connectionState,
   now,
+  locale,
   onLocalTransform,
   onAvatarAssetStatus,
 }: Omit<SceneProps, 'hud'>) {
@@ -705,6 +716,7 @@ function SceneContents({
           chatBubble={latestChatByPeer[peerId]}
           connectionState={connectionState}
           now={now}
+          locale={locale}
         />
       ))}
       <SharedObject object={sharedObject} />
@@ -722,11 +734,12 @@ export function MetaverseScene({
   latestChatByPeer,
   connectionState,
   now,
+  locale,
   hud,
   onLocalTransform,
   onAvatarAssetStatus,
 }: SceneProps) {
-  const { t } = useTranslation('metaverse');
+  const { t } = useTranslation('metaverse', { lng: locale });
   return (
     <div className='metaverse-viewport-shell' aria-label={t('viewport.ariaLabel')}>
       <Canvas
@@ -745,6 +758,7 @@ export function MetaverseScene({
           latestChatByPeer={latestChatByPeer}
           connectionState={connectionState}
           now={now}
+          locale={locale}
           onLocalTransform={onLocalTransform}
           onAvatarAssetStatus={onAvatarAssetStatus}
         />

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.tsx
@@ -105,7 +105,7 @@ export function MetaverseRoomControls({
   onMessageDraftChange,
   onSendMessage,
 }: MetaverseRoomControlsProps) {
-  const { t } = useTranslation('metaverse');
+  const { t } = useTranslation('metaverse', { lng: locale });
   const avatarStatusLabel = t(`hud.avatarStatuses.${avatarAssetStatus}`);
   return (
     <>

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.test.tsx
@@ -87,6 +87,13 @@ describe('MetaverseRoomDiscovery', () => {
     }
   );
 
+  test('uses the shell locale even while the global detector still reports English', async () => {
+    await i18n.changeLanguage('en');
+    renderDiscovery({ locale: 'ja' });
+
+    expect(screen.getByRole('heading', { name: 'メタバースルーム' })).toBeInTheDocument();
+  });
+
   test('shows the empty state and an action error without an API dependency', () => {
     renderDiscovery({ rooms: [], error: 'Room action failed' });
 

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomDiscovery.tsx
@@ -52,7 +52,7 @@ export function MetaverseRoomDiscovery({
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [maxPeers, setMaxPeers] = useState('8');
-  const { t } = useTranslation('metaverse');
+  const { t } = useTranslation('metaverse', { lng: locale });
   const [validationError, setValidationError] = useState(false);
 
   function hostAuthor(room: GameRoomView): Profile | AuthorSocialView | null {

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomView.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomView.tsx
@@ -146,6 +146,7 @@ export function MetaverseRoomView({
           latestChatByPeer={latestChatByPeer}
           connectionState={connectionState}
           now={now}
+          locale={locale}
           onLocalTransform={onLocalTransform}
           onAvatarAssetStatus={onAvatarAssetStatus}
           hud={(

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
@@ -114,6 +114,7 @@ function renderSession({
         activeTopic: 'kukuri:topic:demo',
         rooms: currentRooms,
         syncStatus: currentSync,
+        locale: 'en',
         localDisplayName: 'Local Author',
         localAvatarAssetRef: null,
         localAvatarAssetUrl: null,

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useRef, useState, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { SupportedLocale } from '@/i18n';
 import type {
   GameRoomView,
   MetaverseAssetRef,
@@ -33,6 +34,7 @@ type UseMetaverseRoomSessionArgs = {
   activeTopic: string;
   rooms: GameRoomView[];
   syncStatus: SyncStatus;
+  locale: SupportedLocale;
   localDisplayName: string | null;
   localAvatarAssetRef: MetaverseAssetRef | null;
   localAvatarAssetUrl: string | null;
@@ -82,12 +84,13 @@ export function useMetaverseRoomSession({
   activeTopic,
   rooms,
   syncStatus,
+  locale,
   localDisplayName,
   localAvatarAssetRef,
   localAvatarAssetUrl,
   onError,
 }: UseMetaverseRoomSessionArgs) {
-  const { t } = useTranslation('metaverse');
+  const { t } = useTranslation('metaverse', { lng: locale });
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const [joinedRoomIds, setJoinedRoomIds] = useState<Set<string>>(() => new Set());
   const [remoteTransforms, setRemoteTransforms] = useState<Record<string, AvatarTransform>>({});

--- a/apps/desktop/tests/playwright/shell.smoke.spec.ts
+++ b/apps/desktop/tests/playwright/shell.smoke.spec.ts
@@ -161,6 +161,11 @@ test('browser mock shell persists language changes across reloads', async ({ pag
   await expect(page.locator('html')).toHaveAttribute('lang', 'ja');
   await openComposerDialog(page);
   await expect(page.getByPlaceholder('投稿を書く')).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  await page.getByRole('tab', { name: 'ゲーム' }).click();
+  await expect(page.getByRole('heading', { name: 'メタバースルーム' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'メタバースルームを作成' })).toBeVisible();
 });
 
 test('browser mock settings drawer keeps the close button clear of content and captures wheel scrolling', async ({


### PR DESCRIPTION
## Summary
- bind every metaverse translation hook to the locale resolved by the desktop shell
- cover the startup race where the shell locale and the browser detector's global language briefly diverge
- extend the browser language-persistence smoke to assert the metaverse discovery surface after reload

## Validation
- failing contract before the fix: shell locale `ja` + global detector `en` rendered English metaverse copy
- `cargo xtask desktop-ui-check` (71 files / 600 tests; browser 10; visual 14)
- `cargo xtask oversized-files` (existing 3-file warning only)
- `npx pnpm@10.16.1 tauri:build -- --no-bundle`
- Windows release smoke with isolated `KUKURI_APP_DATA_DIR`: create room, leave/rejoin, HUD/chat toggles, Enter-to-chat focus, and en/ja/zh-CN metaverse copy all passed
