### PR TITLE
refactor: make core exports explicit

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,15 +15,79 @@ pub mod wire;
 #[cfg(test)]
 mod tests;
 
-pub use crypto::*;
-pub use direct_messages::*;
-pub use envelope::*;
-pub use game::*;
-pub use ids::*;
-pub use live::*;
-pub use media::*;
-pub use posts::*;
-pub use private_channels::*;
-pub use profile::*;
-pub use reactions::*;
-pub use rendezvous::*;
+pub use crypto::{
+    KukuriKeys, LEGACY_SECRET_HRP, encode_secret_key_bech32, generate_keys, is_placeholder_secret,
+};
+pub use direct_messages::{
+    DirectMessageAckV1, DirectMessageAttachmentKind, DirectMessageAttachmentManifestV1,
+    DirectMessageEncryptedAttachmentV1, DirectMessageEncryptedBlobRefV1, DirectMessageFrameV1,
+    DirectMessagePayloadV1, build_direct_message_ack, decrypt_direct_message_attachment,
+    decrypt_direct_message_frame, derive_direct_message_secret, derive_direct_message_topic,
+    direct_message_id_for_participants, encrypt_direct_message_attachment,
+    encrypt_direct_message_frame,
+};
+pub use envelope::{
+    GossipHint, HintObjectRef, KukuriAuthEnvelopeContentV1, KukuriEnvelope, sign_envelope,
+    sign_envelope_at, sign_envelope_json,
+};
+pub use game::{
+    GameParticipant, GameRoomKind, GameRoomManifestBlobV1, GameRoomStateDocV1, GameRoomStatus,
+    GameScoreEntry, MetaverseAssetKind, MetaverseAssetRef, MetaverseAvatarTransformV1,
+    MetaversePrimitive, MetaverseRoomChatMessageV1, MetaverseRoomEventEnvelopeContentV1,
+    MetaverseRoomEventV1, MetaverseRoomPresenceV1, MetaverseRoomSceneV1, MetaverseRoomSpawnV1,
+    MetaverseRoomStateV1, SharedRoomObjectV1, build_game_session_envelope,
+    build_metaverse_room_event_envelope,
+};
+pub use ids::{
+    BlobHash, ChannelId, EnvelopeId, Pubkey, ReplicaId, TopicId, author_profile_topic_id,
+};
+pub use live::{
+    LiveSessionManifestBlobV1, LiveSessionStateDocV1, LiveSessionStatus, LiveSignalKind,
+    build_live_session_envelope,
+};
+pub use media::{
+    AssetRef, AssetRole, GAME_MANIFEST_MIME, KukuriMediaManifestV1, LIVE_MANIFEST_MIME,
+    ManifestBlobRef, MediaManifestItem, blob_hash, build_media_manifest_envelope,
+};
+pub use posts::{
+    CanonicalPostHeader, ChannelRef, KukuriPostEnvelopeContentV1, KukuriPostObjectV1, ObjectStatus,
+    ObjectVisibility, PayloadRef, RepostSourceSnapshotV1, ThreadRef, TimelineScope,
+    build_post_envelope, build_post_envelope_with_payload,
+    build_post_envelope_with_payload_in_channel, build_repost_envelope, timeline_sort_key,
+};
+pub use private_channels::{
+    ChannelAudienceKind, ChannelSharingState, CreatePrivateChannelInput, FriendOnlyGrantPreview,
+    FriendOnlyGrantTokenV1, FriendPlusSharePreview, FriendPlusShareTokenV1,
+    KukuriFriendOnlyGrantEnvelopeContentV1, KukuriFriendPlusShareEnvelopeContentV1,
+    KukuriPrivateChannelInviteEnvelopeContentV1, PrivateChannelEpochHandoffGrantDocV1,
+    PrivateChannelEpochHandoffGrantPayloadV1, PrivateChannelInvitePreview,
+    PrivateChannelInviteTokenParams, PrivateChannelInviteTokenV1, PrivateChannelJoinMode,
+    PrivateChannelMetadataDocV1, PrivateChannelParticipantDocV1, PrivateChannelPolicyDocV1,
+    build_friend_only_grant_token, build_friend_plus_share_token,
+    build_private_channel_epoch_handoff_grant_envelope, build_private_channel_invite_token,
+    build_private_channel_participant_envelope, build_private_channel_policy_envelope,
+    decrypt_private_channel_epoch_handoff_grant, encrypt_private_channel_epoch_handoff_grant,
+    parse_friend_only_grant_token, parse_friend_plus_share_token,
+    parse_private_channel_epoch_handoff_grant, parse_private_channel_invite_token,
+    parse_private_channel_participant, parse_private_channel_policy,
+};
+pub use profile::{
+    AuthorProfileDocV1, AuthorProfilePostDocV1, AuthorProfileRepostDocV1, FollowEdge,
+    FollowEdgeDocV1, FollowEdgeStatus, KukuriFollowEdgeEnvelopeContentV1,
+    KukuriProfileEnvelopeContentV1, KukuriProfilePostEnvelopeContentV1,
+    KukuriProfileRepostEnvelopeContentV1, Profile, ProfilePost, ProfileRepost,
+    build_follow_edge_envelope, build_profile_envelope, build_profile_post_envelope,
+    build_profile_repost_envelope, parse_follow_edge, parse_profile, parse_profile_post,
+    parse_profile_repost,
+};
+pub use reactions::{
+    CustomReactionAssetDocV1, CustomReactionAssetSnapshotV1,
+    KukuriCustomReactionAssetEnvelopeContentV1, KukuriReactionEnvelopeContentV1, ReactionDocV1,
+    ReactionKeyKind, ReactionKeyV1, build_custom_reaction_asset_envelope, build_reaction_envelope,
+    deterministic_reaction_id, normalize_reaction_emoji, parse_custom_reaction_asset,
+    parse_reaction,
+};
+pub use rendezvous::{
+    private_topic_rendezvous_key, private_topic_rendezvous_key_hex_secret,
+    public_topic_rendezvous_key,
+};


### PR DESCRIPTION
## What changed
- replace all 12 wildcard re-exports in `kukuri-core` with explicit item lists
- preserve the existing public surface without changing module implementations

## Why
The wildcard surface made accidental public API growth invisible. An explicit facade lets later visibility tightening be reviewed item by item.

## Validation
- wildcard `pub use module::*`: 0
- `cargo doc -p kukuri-core --no-deps`: green
- `cargo xtask rust-check`: green across all targets
- `cargo xtask oversized-files`: existing 3 warnings only
- `cargo xtask rust-test`: 371 passed before the same two known Windows-local docs-sync relay timeouts; CI is the merge gate