### PR TITLE
refactor: narrow internal core helpers

### DIFF
--- a/crates/core/src/direct_messages.rs
+++ b/crates/core/src/direct_messages.rs
@@ -144,7 +144,7 @@ pub fn direct_message_id_for_participants(left: &Pubkey, right: &Pubkey) -> Stri
     format!("dm-{}", digest.to_hex())
 }
 
-pub fn derive_direct_message_secret(
+pub(crate) fn derive_direct_message_secret(
     local_keys: &KukuriKeys,
     remote_pubkey: &Pubkey,
 ) -> Result<[u8; 32]> {

--- a/crates/core/src/envelope.rs
+++ b/crates/core/src/envelope.rs
@@ -117,7 +117,7 @@ pub fn sign_envelope_json<T: Serialize>(
     sign_envelope(keys, kind, tags, content)
 }
 
-pub fn sign_envelope(
+pub(crate) fn sign_envelope(
     keys: &crate::KukuriKeys,
     kind: impl Into<String>,
     tags: Vec<Vec<String>>,
@@ -130,7 +130,7 @@ pub fn sign_envelope(
     sign_envelope_at(keys, kind, tags, content, created_at)
 }
 
-pub fn sign_envelope_at(
+pub(crate) fn sign_envelope_at(
     keys: &crate::KukuriKeys,
     kind: impl Into<String>,
     tags: Vec<Vec<String>>,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,13 +22,12 @@ pub use direct_messages::{
     DirectMessageAckV1, DirectMessageAttachmentKind, DirectMessageAttachmentManifestV1,
     DirectMessageEncryptedAttachmentV1, DirectMessageEncryptedBlobRefV1, DirectMessageFrameV1,
     DirectMessagePayloadV1, build_direct_message_ack, decrypt_direct_message_attachment,
-    decrypt_direct_message_frame, derive_direct_message_secret, derive_direct_message_topic,
-    direct_message_id_for_participants, encrypt_direct_message_attachment,
-    encrypt_direct_message_frame,
+    decrypt_direct_message_frame, derive_direct_message_topic, direct_message_id_for_participants,
+    encrypt_direct_message_attachment, encrypt_direct_message_frame,
 };
+pub(crate) use envelope::sign_envelope_at;
 pub use envelope::{
-    GossipHint, HintObjectRef, KukuriAuthEnvelopeContentV1, KukuriEnvelope, sign_envelope,
-    sign_envelope_at, sign_envelope_json,
+    GossipHint, HintObjectRef, KukuriAuthEnvelopeContentV1, KukuriEnvelope, sign_envelope_json,
 };
 pub use game::{
     GameParticipant, GameRoomKind, GameRoomManifestBlobV1, GameRoomStateDocV1, GameRoomStatus,
@@ -84,10 +83,6 @@ pub use reactions::{
     CustomReactionAssetDocV1, CustomReactionAssetSnapshotV1,
     KukuriCustomReactionAssetEnvelopeContentV1, KukuriReactionEnvelopeContentV1, ReactionDocV1,
     ReactionKeyKind, ReactionKeyV1, build_custom_reaction_asset_envelope, build_reaction_envelope,
-    deterministic_reaction_id, normalize_reaction_emoji, parse_custom_reaction_asset,
-    parse_reaction,
+    deterministic_reaction_id, parse_custom_reaction_asset, parse_reaction,
 };
-pub use rendezvous::{
-    private_topic_rendezvous_key, private_topic_rendezvous_key_hex_secret,
-    public_topic_rendezvous_key,
-};
+pub use rendezvous::{private_topic_rendezvous_key_hex_secret, public_topic_rendezvous_key};

--- a/crates/core/src/reactions.rs
+++ b/crates/core/src/reactions.rs
@@ -131,7 +131,7 @@ pub struct CustomReactionAssetDocV1 {
 }
 
 impl KukuriEnvelope {
-    pub fn reaction_content(&self) -> Result<Option<KukuriReactionEnvelopeContentV1>> {
+    pub(crate) fn reaction_content(&self) -> Result<Option<KukuriReactionEnvelopeContentV1>> {
         if self.kind != "reaction" {
             return Ok(None);
         }
@@ -140,7 +140,7 @@ impl KukuriEnvelope {
             .context("failed to parse reaction envelope content")
     }
 
-    pub fn to_reaction_doc(&self) -> Result<Option<ReactionDocV1>> {
+    pub(crate) fn to_reaction_doc(&self) -> Result<Option<ReactionDocV1>> {
         let Some(content) = self.reaction_content()? else {
             return Ok(None);
         };
@@ -162,7 +162,7 @@ impl KukuriEnvelope {
         }))
     }
 
-    pub fn custom_reaction_asset_content(
+    pub(crate) fn custom_reaction_asset_content(
         &self,
     ) -> Result<Option<KukuriCustomReactionAssetEnvelopeContentV1>> {
         if self.kind != "custom-reaction-asset" {
@@ -173,7 +173,7 @@ impl KukuriEnvelope {
             .context("failed to parse custom reaction asset envelope content")
     }
 
-    pub fn to_custom_reaction_asset_doc(&self) -> Result<Option<CustomReactionAssetDocV1>> {
+    pub(crate) fn to_custom_reaction_asset_doc(&self) -> Result<Option<CustomReactionAssetDocV1>> {
         let Some(content) = self.custom_reaction_asset_content()? else {
             return Ok(None);
         };
@@ -193,7 +193,7 @@ impl KukuriEnvelope {
     }
 }
 
-pub fn normalize_reaction_emoji(value: &str) -> Option<String> {
+pub(crate) fn normalize_reaction_emoji(value: &str) -> Option<String> {
     let normalized = value.trim();
     (!normalized.is_empty()).then(|| normalized.to_string())
 }

--- a/crates/core/src/rendezvous.rs
+++ b/crates/core/src/rendezvous.rs
@@ -24,7 +24,10 @@ pub fn private_topic_rendezvous_key_hex_secret(
     private_topic_rendezvous_key(namespace_secret.as_slice(), topic)
 }
 
-pub fn private_topic_rendezvous_key(namespace_secret: &[u8], topic: &TopicId) -> Result<String> {
+pub(crate) fn private_topic_rendezvous_key(
+    namespace_secret: &[u8],
+    topic: &TopicId,
+) -> Result<String> {
     let mut mac = Hmac::<Sha256>::new_from_slice(namespace_secret)
         .context("invalid private rendezvous namespace secret")?;
     mac.update(PRIVATE_TOPIC_RENDEZVOUS_DOMAIN);


### PR DESCRIPTION
## What changed
Reduce nine currently unreferenced public helpers to `pub(crate)` and remove them from the public core facade:

- `derive_direct_message_secret`
- `sign_envelope`, `sign_envelope_at`
- `reaction_content`, `to_reaction_doc`
- `custom_reaction_asset_content`, `to_custom_reaction_asset_doc`
- `normalize_reaction_emoji`
- `private_topic_rendezvous_key`

`sign_envelope_at` remains available through a crate-private facade because core modules and canonical signing tests use `crate::sign_envelope_at`.

## Audit
- CodeGraph callers and workspace-wide Rust references were checked for every candidate
- each of the nine items has zero callers outside `crates/core`
- the master-plan count of 14 was historical and did not retain an itemized ledger: four old rotation-grant wrappers were removed in Q5 T2; the remaining one-item difference cannot be safely reconstructed, so no count-filling downgrade was made

## Validation
- `cargo doc -p kukuri-core --no-deps`: green
- `cargo xtask rust-check`: green
- `cargo xtask oversized-files`: existing 3 warnings only
- `cargo xtask rust-test`: 371 passed before the same two known Windows-local docs-sync relay timeouts; CI is the merge gate