### PR TITLE
refactor: make docs fetch policy explicit

### DIFF
--- a/crates/app-api/src/private_channels.rs
+++ b/crates/app-api/src/private_channels.rs
@@ -1,5 +1,5 @@
 use crate::service::*;
-
+use DocFetchPolicy::LocalThenRemote;
 impl AppService {
     pub async fn create_private_channel(
         &self,
@@ -85,7 +85,6 @@ impl AppService {
         .await?;
         self.joined_private_channel_view_for_state(&state).await
     }
-
     pub async fn export_private_channel_invite(
         &self,
         topic_id: &str,
@@ -117,7 +116,6 @@ impl AppService {
             },
         )
     }
-
     /// private channel import 3 系統(招待 / friend-only 許可 / friend-plus 共有)の共通仕様。
     ///
     /// フローは同型(トークン検証 → 前提確認 → replica 秘密登録 → snapshot 検証 →
@@ -162,8 +160,12 @@ impl AppService {
             )
             .await?;
             let participants = if spec.refetch_participants {
-                fetch_private_channel_participants_from_replica(self.docs_sync.as_ref(), &replica)
-                    .await?
+                fetch_private_channel_participants_from_replica(
+                    self.docs_sync.as_ref(),
+                    &replica,
+                    LocalThenRemote,
+                )
+                .await?
             } else {
                 participants
             };
@@ -238,7 +240,6 @@ impl AppService {
         }
         import_result
     }
-
     pub async fn import_private_channel_invite(
         &self,
         token: &str,
@@ -272,7 +273,6 @@ impl AppService {
         .await?;
         Ok(preview)
     }
-
     pub async fn export_channel_access_token(
         &self,
         topic_id: &str,
@@ -304,7 +304,6 @@ impl AppService {
         };
         Ok(ChannelAccessTokenExport { kind, token })
     }
-
     pub async fn import_channel_access_token(
         &self,
         token: &str,
@@ -354,7 +353,6 @@ impl AppService {
         }
         anyhow::bail!("unrecognized private channel access token")
     }
-
     pub async fn preview_channel_access_token(
         &self,
         token: &str,
@@ -400,7 +398,6 @@ impl AppService {
         }
         anyhow::bail!("unrecognized private channel access token")
     }
-
     pub async fn export_friend_only_grant(
         &self,
         topic_id: &str,
@@ -434,7 +431,6 @@ impl AppService {
             expires_at,
         )
     }
-
     pub async fn import_friend_only_grant(&self, token: &str) -> Result<FriendOnlyGrantPreview> {
         let preview = parse_friend_only_grant_token(token)?;
         self.import_private_channel_by_spec(PrivateChannelImportSpec {
@@ -469,7 +465,6 @@ impl AppService {
         .await?;
         Ok(preview)
     }
-
     pub async fn export_friend_plus_share(
         &self,
         topic_id: &str,
@@ -487,17 +482,24 @@ impl AppService {
             anyhow::bail!("friend-plus share export is only available for friends+ channels");
         }
         let replica = current_private_channel_replica_id(&state);
-        let Some(policy) =
-            fetch_private_channel_policy_from_replica(self.docs_sync.as_ref(), &replica).await?
+        let Some(policy) = fetch_private_channel_policy_from_replica(
+            self.docs_sync.as_ref(),
+            &replica,
+            LocalThenRemote,
+        )
+        .await?
         else {
             anyhow::bail!("friend-plus channel policy is missing");
         };
         if policy.sharing_state != ChannelSharingState::Open {
             anyhow::bail!("friend-plus share export is disabled while sharing is frozen");
         }
-        let participants =
-            fetch_private_channel_participants_from_replica(self.docs_sync.as_ref(), &replica)
-                .await?;
+        let participants = fetch_private_channel_participants_from_replica(
+            self.docs_sync.as_ref(),
+            &replica,
+            LocalThenRemote,
+        )
+        .await?;
         let local_author = self.current_author_pubkey();
         if !participants.iter().any(|participant| {
             participant.epoch_id == state.current_epoch_id
@@ -519,7 +521,6 @@ impl AppService {
             effective_expires_at,
         )
     }
-
     pub async fn import_friend_plus_share(&self, token: &str) -> Result<FriendPlusSharePreview> {
         let preview = parse_friend_plus_share_token(token)?;
         self.import_private_channel_by_spec(PrivateChannelImportSpec {
@@ -555,7 +556,6 @@ impl AppService {
         .await?;
         Ok(preview)
     }
-
     pub async fn freeze_private_channel(
         &self,
         topic_id: &str,
@@ -574,9 +574,12 @@ impl AppService {
             anyhow::bail!("only the channel owner can freeze the channel");
         }
         let current_replica = current_private_channel_replica_id(&state);
-        let Some(current_policy) =
-            fetch_private_channel_policy_from_replica(self.docs_sync.as_ref(), &current_replica)
-                .await?
+        let Some(current_policy) = fetch_private_channel_policy_from_replica(
+            self.docs_sync.as_ref(),
+            &current_replica,
+            LocalThenRemote,
+        )
+        .await?
         else {
             anyhow::bail!("friend-plus channel policy is missing");
         };
@@ -593,7 +596,6 @@ impl AppService {
         .await?;
         self.joined_private_channel_view_for_state(&state).await
     }
-
     /// private channel の epoch rotate(所有者のみ)。
     ///
     /// フェーズ分割(WP-H5 PR4)。順序と失敗時挙動は分割前と同一:
@@ -617,7 +619,6 @@ impl AppService {
         self.finalize_rotated_channel_state(topic_id, prep.state, next)
             .await
     }
-
     /// フェーズ 1: 前提検証(参加中・epoch 対応・所有者)と、現行 replica の
     /// policy 取得、handoff grant の受信者収集(現 epoch + 過去 epoch の active
     /// 参加者。owner 除外・pubkey で重複排除)。
@@ -639,22 +640,26 @@ impl AppService {
             anyhow::bail!("only the channel owner can rotate the channel");
         }
         let current_replica = current_private_channel_replica_id(&state);
-        let current_policy =
-            fetch_private_channel_policy_from_replica(self.docs_sync.as_ref(), &current_replica)
-                .await?
-                .unwrap_or(PrivateChannelPolicyDocV1 {
-                    channel_id: state.channel_id.clone(),
-                    topic_id: TopicId::new(topic_id),
-                    audience_kind: state.audience_kind.clone(),
-                    owner_pubkey: Pubkey::from(state.owner_pubkey.clone()),
-                    epoch_id: state.current_epoch_id.clone(),
-                    sharing_state: ChannelSharingState::Open,
-                    rotated_at: None,
-                    previous_epoch_id: None,
-                });
+        let current_policy = fetch_private_channel_policy_from_replica(
+            self.docs_sync.as_ref(),
+            &current_replica,
+            LocalThenRemote,
+        )
+        .await?
+        .unwrap_or(PrivateChannelPolicyDocV1 {
+            channel_id: state.channel_id.clone(),
+            topic_id: TopicId::new(topic_id),
+            audience_kind: state.audience_kind.clone(),
+            owner_pubkey: Pubkey::from(state.owner_pubkey.clone()),
+            epoch_id: state.current_epoch_id.clone(),
+            sharing_state: ChannelSharingState::Open,
+            rotated_at: None,
+            previous_epoch_id: None,
+        });
         let current_participants = fetch_private_channel_participants_from_replica(
             self.docs_sync.as_ref(),
             &current_replica,
+            LocalThenRemote,
         )
         .await?;
         let mut rotation_recipients = BTreeMap::new();
@@ -675,6 +680,7 @@ impl AppService {
             let archived_participants = fetch_private_channel_participants_from_replica(
                 self.docs_sync.as_ref(),
                 &archived_replica,
+                LocalThenRemote,
             )
             .await?;
             for participant in
@@ -695,7 +701,6 @@ impl AppService {
             rotation_recipients,
         })
     }
-
     /// フェーズ 2: 旧 epoch の policy を Frozen + rotated_at で書き込み、
     /// 以後の import(sharing_state Open 前提)を止める。
     async fn freeze_rotated_epoch_policy(&self, prep: &PrivateChannelRotationPrep) -> Result<()> {
@@ -711,7 +716,6 @@ impl AppService {
         )
         .await
     }
-
     /// フェーズ 3: 新 epoch(id / secret / replica)を作成し、metadata・
     /// Open policy・owner 参加ドキュメントを書き込む。
     async fn seed_next_private_channel_epoch(
@@ -775,7 +779,6 @@ impl AppService {
             secret_hex,
         })
     }
-
     /// フェーズ 4: 受信者へ handoff grant を暗号化して旧 replica に書く。
     /// friend-only は配布時点でも mutual を再確認し、外れていれば黙って配らない
     /// (分割前と同じ。受け取れなかった参加者は新 epoch に入れない)。
@@ -823,7 +826,6 @@ impl AppService {
         }
         Ok(())
     }
-
     /// フェーズ 5: 旧 epoch を archive して現 epoch を差し替え、registry へ登録、
     /// rotation hint を publish(失敗は warn のみ)して view を返す。
     async fn finalize_rotated_channel_state(
@@ -863,7 +865,6 @@ impl AppService {
         }
         self.joined_private_channel_view_for_state(&state).await
     }
-
     pub async fn restore_private_channel_capability(
         &self,
         capability: PrivateChannelCapability,
@@ -873,7 +874,6 @@ impl AppService {
             .await?;
         self.register_joined_private_channel(state).await
     }
-
     pub async fn leave_private_channel(&self, topic_id: &str, channel_id: &str) -> Result<()> {
         let Some(state) = self
             .joined_private_channel_state(topic_id, channel_id)
@@ -885,7 +885,7 @@ impl AppService {
         let local_author = self.current_author_pubkey();
         let local_pubkey = Pubkey::from(local_author.clone());
         let now = Utc::now().timestamp_millis();
-        let existing_participant = fetch_private_channel_participants_from_replica_with_policy(
+        let existing_participant = fetch_private_channel_participants_from_replica(
             self.docs_sync.as_ref(),
             &replica,
             DocFetchPolicy::LocalOnly,

--- a/crates/app-api/src/service/hydration_support.rs
+++ b/crates/app-api/src/service/hydration_support.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) async fn hydrate_object_projection_from_replica_with_policy(
+pub(crate) async fn hydrate_object_projection_from_replica(
     docs_sync: &dyn DocsSync,
     blob_service: &dyn BlobService,
     projection_store: &dyn ProjectionStore,
@@ -101,7 +101,7 @@ pub(crate) async fn hydrate_object_projection_from_key(
     hydrate_object_projection_from_record(blob_service, projection_store, replica, record).await
 }
 
-pub(crate) async fn hydrate_reaction_cache_from_replica_with_policy(
+pub(crate) async fn hydrate_reaction_cache_from_replica(
     docs_sync: &dyn DocsSync,
     projection_store: &dyn ProjectionStore,
     replica: &ReplicaId,
@@ -185,25 +185,9 @@ pub(crate) async fn hydrate_topic_state_with_services(
     blob_service: &dyn BlobService,
     projection_store: &dyn ProjectionStore,
     topic_id: &str,
-) -> Result<usize> {
-    hydrate_topic_state_with_services_with_policy(
-        docs_sync,
-        blob_service,
-        projection_store,
-        topic_id,
-        DocFetchPolicy::LocalThenRemote,
-    )
-    .await
-}
-
-pub(crate) async fn hydrate_topic_state_with_services_with_policy(
-    docs_sync: &dyn DocsSync,
-    blob_service: &dyn BlobService,
-    projection_store: &dyn ProjectionStore,
-    topic_id: &str,
     policy: DocFetchPolicy,
 ) -> Result<usize> {
-    hydrate_subscription_state_with_services_with_policy(
+    hydrate_subscription_state_with_services(
         docs_sync,
         blob_service,
         projection_store,
@@ -214,7 +198,7 @@ pub(crate) async fn hydrate_topic_state_with_services_with_policy(
     .await
 }
 
-pub(crate) async fn hydrate_subscription_state_with_services_with_policy(
+pub(crate) async fn hydrate_subscription_state_with_services(
     docs_sync: &dyn DocsSync,
     blob_service: &dyn BlobService,
     projection_store: &dyn ProjectionStore,
@@ -222,7 +206,7 @@ pub(crate) async fn hydrate_subscription_state_with_services_with_policy(
     replica: &ReplicaId,
     policy: DocFetchPolicy,
 ) -> Result<usize> {
-    let post_count = hydrate_object_projection_from_replica_with_policy(
+    let post_count = hydrate_object_projection_from_replica(
         docs_sync,
         blob_service,
         projection_store,
@@ -230,14 +214,9 @@ pub(crate) async fn hydrate_subscription_state_with_services_with_policy(
         policy,
     )
     .await?;
-    let reaction_count = hydrate_reaction_cache_from_replica_with_policy(
-        docs_sync,
-        projection_store,
-        replica,
-        policy,
-    )
-    .await?;
-    let live_count = hydrate_live_sessions_from_replica_with_policy(
+    let reaction_count =
+        hydrate_reaction_cache_from_replica(docs_sync, projection_store, replica, policy).await?;
+    let live_count = hydrate_live_sessions_from_replica(
         docs_sync,
         blob_service,
         projection_store,
@@ -246,7 +225,7 @@ pub(crate) async fn hydrate_subscription_state_with_services_with_policy(
         policy,
     )
     .await?;
-    let game_count = hydrate_game_rooms_from_replica_with_policy(
+    let game_count = hydrate_game_rooms_from_replica(
         docs_sync,
         blob_service,
         projection_store,
@@ -258,25 +237,7 @@ pub(crate) async fn hydrate_subscription_state_with_services_with_policy(
     Ok(post_count + reaction_count + live_count + game_count)
 }
 
-pub(crate) async fn hydrate_subscription_state_with_services(
-    docs_sync: &dyn DocsSync,
-    blob_service: &dyn BlobService,
-    projection_store: &dyn ProjectionStore,
-    topic_id: &str,
-    replica: &ReplicaId,
-) -> Result<usize> {
-    hydrate_subscription_state_with_services_with_policy(
-        docs_sync,
-        blob_service,
-        projection_store,
-        topic_id,
-        replica,
-        DocFetchPolicy::LocalThenRemote,
-    )
-    .await
-}
-
-pub(crate) async fn hydrate_live_sessions_from_replica_with_policy(
+pub(crate) async fn hydrate_live_sessions_from_replica(
     docs_sync: &dyn DocsSync,
     blob_service: &dyn BlobService,
     projection_store: &dyn ProjectionStore,
@@ -400,7 +361,7 @@ pub(crate) async fn hydrate_live_session_from_key_with_retry(
     Ok(0)
 }
 
-pub(crate) async fn hydrate_game_rooms_from_replica_with_policy(
+pub(crate) async fn hydrate_game_rooms_from_replica(
     docs_sync: &dyn DocsSync,
     blob_service: &dyn BlobService,
     projection_store: &dyn ProjectionStore,

--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -130,9 +130,7 @@ pub(crate) use gossip_subscription_support::gossip_disabled_channel_key;
 pub(crate) use hydration_support::{
     hint_targets_topic, hydrate_subscription_event_with_services,
     hydrate_subscription_hint_with_services, hydrate_subscription_state_with_services,
-    hydrate_subscription_state_with_services_with_policy, hydrate_topic_state_with_services,
-    hydrate_topic_state_with_services_with_policy, profile_timeline_page,
-    projection_page_needs_hydration,
+    hydrate_topic_state_with_services, profile_timeline_page, projection_page_needs_hydration,
 };
 pub(crate) use metaverse_room_event_support::{
     metaverse_room_event_buffer_key, parse_metaverse_room_event_envelope,
@@ -149,31 +147,24 @@ pub(crate) use object_persistence_support::{
     bookmarked_custom_reaction_view_from_row, custom_reaction_asset_view_from_doc,
     fetch_game_room_state_from_replica, fetch_live_session_state_from_replica, fetch_manifest_blob,
     fetch_private_channel_epoch_handoff_grant_from_replica,
-    fetch_private_channel_epoch_handoff_grant_from_replica_with_policy,
-    fetch_private_channel_participants_from_replica,
-    fetch_private_channel_participants_from_replica_with_policy,
-    fetch_private_channel_policy_from_replica,
-    fetch_private_channel_policy_from_replica_with_policy, fetch_projection_blob_text,
-    game_projection_row_from_state, live_projection_row_from_state, persist_game_room_state,
-    persist_live_session_state, persist_media_manifest, persist_post_object,
-    persist_private_channel_epoch_handoff_grant, persist_private_channel_metadata,
-    persist_private_channel_participant, persist_private_channel_policy,
-    private_channel_rotation_is_pending, projection_row_from_header, reaction_cache_key,
-    reaction_projection_row_from_doc, reaction_state_view_from_rows,
-    recent_reaction_view_from_projection, search_key_or_asset_id,
+    fetch_private_channel_participants_from_replica, fetch_private_channel_policy_from_replica,
+    fetch_projection_blob_text, game_projection_row_from_state, live_projection_row_from_state,
+    persist_game_room_state, persist_live_session_state, persist_media_manifest,
+    persist_post_object, persist_private_channel_epoch_handoff_grant,
+    persist_private_channel_metadata, persist_private_channel_participant,
+    persist_private_channel_policy, private_channel_rotation_is_pending,
+    projection_row_from_header, reaction_cache_key, reaction_projection_row_from_doc,
+    reaction_state_view_from_rows, recent_reaction_view_from_projection, search_key_or_asset_id,
     session_projection_retry_attempts, session_projection_retry_delay, store_manifest_blob,
     wait_for_private_channel_epoch_snapshot,
 };
 pub(crate) use profile_docs_support::{
     fetch_author_envelope_by_id, hydrate_author_state_with_services,
-    hydrate_author_state_with_services_with_policy,
-    load_custom_reaction_assets_from_author_replica,
-    load_profile_posts_from_author_replica_with_policy,
-    load_profile_reposts_from_author_replica_with_policy, merge_seed_peers,
-    persist_custom_reaction_asset_doc, persist_follow_edge_doc, persist_profile_doc,
-    persist_profile_post_doc, persist_profile_repost_doc, persist_reaction_doc,
-    snapshot_follow_notification_baseline_with_policy,
-    snapshot_object_notification_baseline_with_policy,
+    load_custom_reaction_assets_from_author_replica, load_profile_posts_from_author_replica,
+    load_profile_reposts_from_author_replica, merge_seed_peers, persist_custom_reaction_asset_doc,
+    persist_follow_edge_doc, persist_profile_doc, persist_profile_post_doc,
+    persist_profile_repost_doc, persist_reaction_doc, snapshot_follow_notification_baseline,
+    snapshot_object_notification_baseline,
 };
 pub(crate) use projection_support::{
     active_private_channel_participants, archive_private_channel_epoch,
@@ -519,6 +510,7 @@ impl AppService {
                 self.blob_service.as_ref(),
                 self.projection_store.as_ref(),
                 source_topic_id,
+                DocFetchPolicy::LocalThenRemote,
             )
             .await?;
         }

--- a/crates/app-api/src/service/notifications_support.rs
+++ b/crates/app-api/src/service/notifications_support.rs
@@ -140,8 +140,13 @@ pub(crate) async fn notification_candidate_from_follow_event(
     if doc.subject_pubkey.as_str() != author_pubkey {
         return Ok(None);
     }
-    let Some(envelope) =
-        fetch_author_envelope_by_id(docs_sync, &event.replica_id, &doc.envelope_id).await?
+    let Some(envelope) = fetch_author_envelope_by_id(
+        docs_sync,
+        &event.replica_id,
+        &doc.envelope_id,
+        DocFetchPolicy::LocalThenRemote,
+    )
+    .await?
     else {
         return Ok(None);
     };

--- a/crates/app-api/src/service/object_persistence_support.rs
+++ b/crates/app-api/src/service/object_persistence_support.rs
@@ -235,18 +235,6 @@ pub(crate) async fn persist_private_channel_epoch_handoff_grant(
 pub(crate) async fn fetch_private_channel_metadata_from_replica(
     docs_sync: &dyn DocsSync,
     replica: &ReplicaId,
-) -> Result<Option<PrivateChannelMetadataDocV1>> {
-    fetch_private_channel_metadata_from_replica_with_policy(
-        docs_sync,
-        replica,
-        DocFetchPolicy::LocalThenRemote,
-    )
-    .await
-}
-
-pub(crate) async fn fetch_private_channel_metadata_from_replica_with_policy(
-    docs_sync: &dyn DocsSync,
-    replica: &ReplicaId,
     policy: DocFetchPolicy,
 ) -> Result<Option<PrivateChannelMetadataDocV1>> {
     let Some(record) = query_replica_with_fetch_policy(
@@ -270,18 +258,6 @@ pub(crate) async fn fetch_private_channel_metadata_from_replica_with_policy(
 pub(crate) async fn fetch_private_channel_policy_from_replica(
     docs_sync: &dyn DocsSync,
     replica: &ReplicaId,
-) -> Result<Option<PrivateChannelPolicyDocV1>> {
-    fetch_private_channel_policy_from_replica_with_policy(
-        docs_sync,
-        replica,
-        DocFetchPolicy::LocalThenRemote,
-    )
-    .await
-}
-
-pub(crate) async fn fetch_private_channel_policy_from_replica_with_policy(
-    docs_sync: &dyn DocsSync,
-    replica: &ReplicaId,
     policy: DocFetchPolicy,
 ) -> Result<Option<PrivateChannelPolicyDocV1>> {
     let Some(record) = query_replica_with_fetch_policy(
@@ -301,18 +277,6 @@ pub(crate) async fn fetch_private_channel_policy_from_replica_with_policy(
 }
 
 pub(crate) async fn fetch_private_channel_participants_from_replica(
-    docs_sync: &dyn DocsSync,
-    replica: &ReplicaId,
-) -> Result<Vec<PrivateChannelParticipantDocV1>> {
-    fetch_private_channel_participants_from_replica_with_policy(
-        docs_sync,
-        replica,
-        DocFetchPolicy::LocalThenRemote,
-    )
-    .await
-}
-
-pub(crate) async fn fetch_private_channel_participants_from_replica_with_policy(
     docs_sync: &dyn DocsSync,
     replica: &ReplicaId,
     policy: DocFetchPolicy,
@@ -340,20 +304,6 @@ pub(crate) async fn fetch_private_channel_participants_from_replica_with_policy(
 }
 
 pub(crate) async fn fetch_private_channel_epoch_handoff_grant_from_replica(
-    docs_sync: &dyn DocsSync,
-    replica: &ReplicaId,
-    recipient_pubkey: &str,
-) -> Result<Option<PrivateChannelEpochHandoffGrantDocV1>> {
-    fetch_private_channel_epoch_handoff_grant_from_replica_with_policy(
-        docs_sync,
-        replica,
-        recipient_pubkey,
-        DocFetchPolicy::LocalThenRemote,
-    )
-    .await
-}
-
-pub(crate) async fn fetch_private_channel_epoch_handoff_grant_from_replica_with_policy(
     docs_sync: &dyn DocsSync,
     replica: &ReplicaId,
     recipient_pubkey: &str,
@@ -389,10 +339,24 @@ pub(crate) async fn wait_for_private_channel_epoch_snapshot(
 )> {
     tokio::time::timeout(std::time::Duration::from_secs(10), async {
         loop {
-            let metadata = fetch_private_channel_metadata_from_replica(docs_sync, replica).await?;
-            let policy = fetch_private_channel_policy_from_replica(docs_sync, replica).await?;
-            let participants =
-                fetch_private_channel_participants_from_replica(docs_sync, replica).await?;
+            let metadata = fetch_private_channel_metadata_from_replica(
+                docs_sync,
+                replica,
+                DocFetchPolicy::LocalThenRemote,
+            )
+            .await?;
+            let policy = fetch_private_channel_policy_from_replica(
+                docs_sync,
+                replica,
+                DocFetchPolicy::LocalThenRemote,
+            )
+            .await?;
+            let participants = fetch_private_channel_participants_from_replica(
+                docs_sync,
+                replica,
+                DocFetchPolicy::LocalThenRemote,
+            )
+            .await?;
             let owner_participant_visible = policy.as_ref().is_some_and(|policy| {
                 participants.iter().any(|participant| {
                     participant.participant_pubkey == policy.owner_pubkey
@@ -419,7 +383,13 @@ pub(crate) async fn private_channel_rotation_is_pending(
     state: &JoinedPrivateChannelState,
 ) -> Result<bool> {
     let replica = current_private_channel_replica_id(state);
-    let Some(policy) = fetch_private_channel_policy_from_replica(docs_sync, &replica).await? else {
+    let Some(policy) = fetch_private_channel_policy_from_replica(
+        docs_sync,
+        &replica,
+        DocFetchPolicy::LocalThenRemote,
+    )
+    .await?
+    else {
         return Ok(false);
     };
     if policy.sharing_state != ChannelSharingState::Frozen || policy.rotated_at.is_none() {
@@ -430,6 +400,7 @@ pub(crate) async fn private_channel_rotation_is_pending(
         docs_sync,
         &replica,
         local_author.as_str(),
+        DocFetchPolicy::LocalThenRemote,
     )
     .await?
     else {

--- a/crates/app-api/src/service/private_channels_support.rs
+++ b/crates/app-api/src/service/private_channels_support.rs
@@ -1,5 +1,4 @@
 use super::*;
-
 impl AppService {
     pub(crate) async fn maybe_redeem_epoch_handoff_grants_for_channel(
         &self,
@@ -16,7 +15,7 @@ impl AppService {
             };
             let local_author = self.current_author_pubkey();
             let replica = current_private_channel_replica_id(&state);
-            let grant_doc = fetch_private_channel_epoch_handoff_grant_from_replica_with_policy(
+            let grant_doc = fetch_private_channel_epoch_handoff_grant_from_replica(
                 self.docs_sync.as_ref(),
                 &replica,
                 local_author.as_str(),
@@ -47,6 +46,7 @@ impl AppService {
                     self.docs_sync.as_ref(),
                     &replica,
                     local_author.as_str(),
+                    DocFetchPolicy::LocalThenRemote,
                 )
                 .await?
             };
@@ -164,13 +164,12 @@ impl AppService {
             redeemed_any = true;
         }
     }
-
     pub(crate) async fn private_channel_diagnostics(
         &self,
         state: &JoinedPrivateChannelState,
     ) -> Result<PrivateChannelDiagnostics> {
         let replica = current_private_channel_replica_id(state);
-        let sharing_state = fetch_private_channel_policy_from_replica_with_policy(
+        let sharing_state = fetch_private_channel_policy_from_replica(
             self.docs_sync.as_ref(),
             &replica,
             DocFetchPolicy::LocalOnly,
@@ -178,7 +177,7 @@ impl AppService {
         .await?
         .map(|policy| policy.sharing_state)
         .unwrap_or(ChannelSharingState::Open);
-        let participants = fetch_private_channel_participants_from_replica_with_policy(
+        let participants = fetch_private_channel_participants_from_replica(
             self.docs_sync.as_ref(),
             &replica,
             DocFetchPolicy::LocalOnly,
@@ -217,7 +216,6 @@ impl AppService {
                 && stale_participant_count > 0,
         })
     }
-
     pub(crate) async fn joined_private_channel_view_for_state(
         &self,
         state: &JoinedPrivateChannelState,
@@ -244,7 +242,6 @@ impl AppService {
             stale_participant_count: diagnostics.stale_participant_count,
         })
     }
-
     pub(crate) async fn private_channel_capability_from_state(
         &self,
         state: &JoinedPrivateChannelState,
@@ -652,7 +649,7 @@ impl AppService {
         let replica_for_task = replica.clone();
         let hint_topic_for_task = hint_topic.clone();
         let handle = tokio::spawn(async move {
-            let notification_baseline = match snapshot_object_notification_baseline_with_policy(
+            let notification_baseline = match snapshot_object_notification_baseline(
                 docs_sync.as_ref(),
                 &replica_for_task,
                 DocFetchPolicy::LocalOnly,
@@ -672,7 +669,7 @@ impl AppService {
             };
             let mut recovery_tick = tokio::time::interval(std::time::Duration::from_secs(1));
             recovery_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            if let Err(error) = hydrate_subscription_state_with_services_with_policy(
+            if let Err(error) = hydrate_subscription_state_with_services(
                 docs_sync.as_ref(),
                 blob_service.as_ref(),
                 projection_store.as_ref(),
@@ -766,6 +763,7 @@ impl AppService {
                                     projection_store.as_ref(),
                                     topic.as_str(),
                                     &replica_for_task,
+                                    DocFetchPolicy::LocalThenRemote,
                                 )
                                 .await {
                                     Ok(count) => count,
@@ -900,6 +898,7 @@ impl AppService {
                                             projection_store.as_ref(),
                                             topic.as_str(),
                                             &replica_for_task,
+                                            DocFetchPolicy::LocalThenRemote,
                                         )
                                         .await {
                                             Ok(count) => count,
@@ -997,6 +996,7 @@ impl AppService {
                             projection_store.as_ref(),
                             topic.as_str(),
                             &replica_for_task,
+                            DocFetchPolicy::LocalThenRemote,
                         )
                         .await {
                             Ok(count) => count,

--- a/crates/app-api/src/service/profile_docs_support.rs
+++ b/crates/app-api/src/service/profile_docs_support.rs
@@ -236,24 +236,6 @@ pub(crate) async fn hydrate_author_state_with_services(
     projection_store: &dyn ProjectionStore,
     local_author_pubkey: &str,
     author_pubkey: &str,
-) -> Result<usize> {
-    hydrate_author_state_with_services_with_policy(
-        docs_sync,
-        store,
-        projection_store,
-        local_author_pubkey,
-        author_pubkey,
-        DocFetchPolicy::LocalThenRemote,
-    )
-    .await
-}
-
-pub(crate) async fn hydrate_author_state_with_services_with_policy(
-    docs_sync: &dyn DocsSync,
-    store: &dyn Store,
-    projection_store: &dyn ProjectionStore,
-    local_author_pubkey: &str,
-    author_pubkey: &str,
     policy: DocFetchPolicy,
 ) -> Result<usize> {
     let replica = author_replica_id(author_pubkey);
@@ -270,13 +252,9 @@ pub(crate) async fn hydrate_author_state_with_services_with_policy(
     {
         match serde_json::from_slice::<AuthorProfileDocV1>(record.value.as_slice()) {
             Ok(doc) if doc.author_pubkey.as_str() == author_pubkey => {
-                if let Some(envelope) = fetch_author_envelope_by_id_with_policy(
-                    docs_sync,
-                    &replica,
-                    &doc.envelope_id,
-                    policy,
-                )
-                .await?
+                if let Some(envelope) =
+                    fetch_author_envelope_by_id(docs_sync, &replica, &doc.envelope_id, policy)
+                        .await?
                 {
                     store.put_envelope(envelope.clone()).await?;
                     if let Some(profile) = parse_profile(&envelope)? {
@@ -313,13 +291,9 @@ pub(crate) async fn hydrate_author_state_with_services_with_policy(
     {
         match serde_json::from_slice::<FollowEdgeDocV1>(record.value.as_slice()) {
             Ok(doc) if doc.subject_pubkey.as_str() == author_pubkey => {
-                if let Some(envelope) = fetch_author_envelope_by_id_with_policy(
-                    docs_sync,
-                    &replica,
-                    &doc.envelope_id,
-                    policy,
-                )
-                .await?
+                if let Some(envelope) =
+                    fetch_author_envelope_by_id(docs_sync, &replica, &doc.envelope_id, policy)
+                        .await?
                     && let Some(edge) = parse_follow_edge(&envelope)?
                     && edge.target_pubkey == doc.target_pubkey
                     && edge.status == doc.status
@@ -352,20 +326,6 @@ pub(crate) async fn hydrate_author_state_with_services_with_policy(
 }
 
 pub(crate) async fn fetch_author_envelope_by_id(
-    docs_sync: &dyn DocsSync,
-    replica: &ReplicaId,
-    envelope_id: &EnvelopeId,
-) -> Result<Option<KukuriEnvelope>> {
-    fetch_author_envelope_by_id_with_policy(
-        docs_sync,
-        replica,
-        envelope_id,
-        DocFetchPolicy::LocalThenRemote,
-    )
-    .await
-}
-
-pub(crate) async fn fetch_author_envelope_by_id_with_policy(
     docs_sync: &dyn DocsSync,
     replica: &ReplicaId,
     envelope_id: &EnvelopeId,
@@ -411,7 +371,7 @@ pub(crate) async fn load_custom_reaction_assets_from_author_replica(
     Ok(items)
 }
 
-pub(crate) async fn load_profile_posts_from_author_replica_with_policy(
+pub(crate) async fn load_profile_posts_from_author_replica(
     docs_sync: &dyn DocsSync,
     author_pubkey: &str,
     policy: DocFetchPolicy,
@@ -435,13 +395,9 @@ pub(crate) async fn load_profile_posts_from_author_replica_with_policy(
                 if doc.author_pubkey.as_str() == author_pubkey
                     && doc.profile_topic_id == expected_profile_topic_id =>
             {
-                if let Some(envelope) = fetch_author_envelope_by_id_with_policy(
-                    docs_sync,
-                    &replica,
-                    &doc.envelope_id,
-                    policy,
-                )
-                .await?
+                if let Some(envelope) =
+                    fetch_author_envelope_by_id(docs_sync, &replica, &doc.envelope_id, policy)
+                        .await?
                 {
                     match parse_profile_post(&envelope) {
                         Ok(Some(profile_post))
@@ -494,7 +450,7 @@ pub(crate) async fn load_profile_posts_from_author_replica_with_policy(
     Ok(items)
 }
 
-pub(crate) async fn load_profile_reposts_from_author_replica_with_policy(
+pub(crate) async fn load_profile_reposts_from_author_replica(
     docs_sync: &dyn DocsSync,
     author_pubkey: &str,
     policy: DocFetchPolicy,
@@ -518,13 +474,9 @@ pub(crate) async fn load_profile_reposts_from_author_replica_with_policy(
                 if doc.author_pubkey.as_str() == author_pubkey
                     && doc.profile_topic_id == expected_profile_topic_id =>
             {
-                if let Some(envelope) = fetch_author_envelope_by_id_with_policy(
-                    docs_sync,
-                    &replica,
-                    &doc.envelope_id,
-                    policy,
-                )
-                .await?
+                if let Some(envelope) =
+                    fetch_author_envelope_by_id(docs_sync, &replica, &doc.envelope_id, policy)
+                        .await?
                 {
                     match parse_profile_repost(&envelope) {
                         Ok(Some(profile_repost))
@@ -574,7 +526,7 @@ pub(crate) async fn load_profile_reposts_from_author_replica_with_policy(
     Ok(items)
 }
 
-pub(crate) async fn snapshot_object_notification_baseline_with_policy(
+pub(crate) async fn snapshot_object_notification_baseline(
     docs_sync: &dyn DocsSync,
     replica: &ReplicaId,
     policy: DocFetchPolicy,
@@ -594,7 +546,7 @@ pub(crate) async fn snapshot_object_notification_baseline_with_policy(
     ))
 }
 
-pub(crate) async fn snapshot_follow_notification_baseline_with_policy(
+pub(crate) async fn snapshot_follow_notification_baseline(
     docs_sync: &dyn DocsSync,
     replica: &ReplicaId,
     policy: DocFetchPolicy,

--- a/crates/app-api/src/service/social_runtime_support.rs
+++ b/crates/app-api/src/service/social_runtime_support.rs
@@ -168,7 +168,7 @@ impl AppService {
         let mut doc_stream = docs_sync.subscribe_replica(&replica).await?;
         let author_key_for_task = author_key.clone();
         let handle = tokio::spawn(async move {
-            let notification_baseline = match snapshot_follow_notification_baseline_with_policy(
+            let notification_baseline = match snapshot_follow_notification_baseline(
                 docs_sync.as_ref(),
                 &replica,
                 DocFetchPolicy::LocalOnly,
@@ -185,7 +185,7 @@ impl AppService {
                     NotificationDocEventBaseline::default()
                 }
             };
-            match hydrate_author_state_with_services_with_policy(
+            match hydrate_author_state_with_services(
                 docs_sync.as_ref(),
                 store.as_ref(),
                 projection_store.as_ref(),
@@ -241,6 +241,7 @@ impl AppService {
                         recovery_projection_store.as_ref(),
                         recovery_local_author_pubkey.as_str(),
                         recovery_author_pubkey.as_str(),
+                        DocFetchPolicy::LocalThenRemote,
                     ),
                 )
                 .await
@@ -332,6 +333,7 @@ impl AppService {
                             projection_store.as_ref(),
                             local_author_pubkey.as_str(),
                             author_key_for_task.as_str(),
+                            DocFetchPolicy::LocalThenRemote,
                         ).await
                         && count > 0
                         {

--- a/crates/app-api/src/service/timeline_subscription_support.rs
+++ b/crates/app-api/src/service/timeline_subscription_support.rs
@@ -270,7 +270,7 @@ impl AppService {
         topic_id: &str,
         scope: &TimelineScope,
     ) -> Result<usize> {
-        let mut hydrated = hydrate_topic_state_with_services_with_policy(
+        let mut hydrated = hydrate_topic_state_with_services(
             self.docs_sync.as_ref(),
             self.blob_service.as_ref(),
             self.projection_store.as_ref(),
@@ -292,7 +292,7 @@ impl AppService {
                                 )
                             })
                     {
-                        hydrated += hydrate_subscription_state_with_services_with_policy(
+                        hydrated += hydrate_subscription_state_with_services(
                             self.docs_sync.as_ref(),
                             self.blob_service.as_ref(),
                             self.projection_store.as_ref(),
@@ -321,7 +321,7 @@ impl AppService {
                                 )
                             })
                     {
-                        hydrated += hydrate_subscription_state_with_services_with_policy(
+                        hydrated += hydrate_subscription_state_with_services(
                             self.docs_sync.as_ref(),
                             self.blob_service.as_ref(),
                             self.projection_store.as_ref(),

--- a/crates/app-api/src/tests/notifications.rs
+++ b/crates/app-api/src/tests/notifications.rs
@@ -1,5 +1,4 @@
 use super::*;
-
 #[tokio::test]
 async fn remote_reply_to_local_post_creates_single_unread_reply_notification() {
     let (app, store, docs_sync, blob_service) = local_app_with_memory_services();
@@ -313,7 +312,7 @@ async fn repost_notification_survives_hydration_before_live_doc_event() {
         .create_post(topic.as_str(), "source post", None)
         .await
         .expect("create source post");
-    let baseline = snapshot_object_notification_baseline_with_policy(
+    let baseline = snapshot_object_notification_baseline(
         docs_sync.as_ref(),
         &replica,
         DocFetchPolicy::LocalThenRemote,
@@ -340,13 +339,13 @@ async fn repost_notification_survives_hydration_before_live_doc_event() {
     )
     .await
     .expect("persist simple repost");
-
     hydrate_subscription_state_with_services(
         docs_sync.as_ref(),
         blob_service.as_ref(),
         store.as_ref(),
         topic.as_str(),
         &replica,
+        DocFetchPolicy::LocalThenRemote,
     )
     .await
     .expect("hydrate topic state");
@@ -394,7 +393,7 @@ async fn quote_repost_notification_survives_hydration_before_live_doc_event() {
         .create_post(topic.as_str(), "quoted source", None)
         .await
         .expect("create source post");
-    let baseline = snapshot_object_notification_baseline_with_policy(
+    let baseline = snapshot_object_notification_baseline(
         docs_sync.as_ref(),
         &replica,
         DocFetchPolicy::LocalThenRemote,
@@ -425,13 +424,13 @@ async fn quote_repost_notification_survives_hydration_before_live_doc_event() {
     )
     .await
     .expect("persist quote repost");
-
     hydrate_subscription_state_with_services(
         docs_sync.as_ref(),
         blob_service.as_ref(),
         store.as_ref(),
         topic.as_str(),
         &replica,
+        DocFetchPolicy::LocalThenRemote,
     )
     .await
     .expect("hydrate topic state");
@@ -581,7 +580,7 @@ async fn follow_notification_survives_hydration_before_live_doc_event() {
     let remote_keys = generate_keys();
     let remote_pubkey = remote_keys.public_key_hex();
     let replica = author_replica_id(remote_pubkey.as_str());
-    let baseline = snapshot_follow_notification_baseline_with_policy(
+    let baseline = snapshot_follow_notification_baseline(
         docs_sync.as_ref(),
         &replica,
         DocFetchPolicy::LocalThenRemote,
@@ -600,13 +599,13 @@ async fn follow_notification_survives_hydration_before_live_doc_event() {
     persist_follow_edge_doc(docs_sync.as_ref(), &edge, &envelope)
         .await
         .expect("persist follow edge doc");
-
     hydrate_author_state_with_services(
         docs_sync.as_ref(),
         store.as_ref(),
         store.as_ref(),
         local_author_pubkey.as_str(),
         remote_pubkey.as_str(),
+        DocFetchPolicy::LocalThenRemote,
     )
     .await
     .expect("hydrate author state");
@@ -659,7 +658,7 @@ async fn initial_follow_baseline_prevents_backfill_notification() {
     persist_follow_edge_doc(docs_sync.as_ref(), &edge, &envelope)
         .await
         .expect("persist follow edge doc");
-    let baseline = snapshot_follow_notification_baseline_with_policy(
+    let baseline = snapshot_follow_notification_baseline(
         docs_sync.as_ref(),
         &replica,
         DocFetchPolicy::LocalThenRemote,
@@ -673,6 +672,7 @@ async fn initial_follow_baseline_prevents_backfill_notification() {
         store.as_ref(),
         local_author_pubkey.as_str(),
         remote_pubkey.as_str(),
+        DocFetchPolicy::LocalThenRemote,
     )
     .await
     .expect("hydrate author state");
@@ -806,7 +806,7 @@ async fn restart_or_manual_hydration_does_not_backfill_or_duplicate_notification
         .to_post_object()
         .expect("parse existing reply")
         .expect("existing reply object");
-    let baseline = snapshot_object_notification_baseline_with_policy(
+    let baseline = snapshot_object_notification_baseline(
         docs_sync.as_ref(),
         &replica,
         DocFetchPolicy::LocalThenRemote,
@@ -819,6 +819,7 @@ async fn restart_or_manual_hydration_does_not_backfill_or_duplicate_notification
         store.as_ref(),
         topic.as_str(),
         &replica,
+        DocFetchPolicy::LocalThenRemote,
     )
     .await
     .expect("hydrate topic state");
@@ -889,6 +890,7 @@ async fn restart_or_manual_hydration_does_not_backfill_or_duplicate_notification
         store.as_ref(),
         topic.as_str(),
         &replica,
+        DocFetchPolicy::LocalThenRemote,
     )
     .await
     .expect("rehydrate topic state");

--- a/crates/app-api/src/tests/private_channels/friend_plus.rs
+++ b/crates/app-api/src/tests/private_channels/friend_plus.rs
@@ -351,6 +351,7 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
             app_a.docs_sync.as_ref(),
             &rotated_source_replica,
             b_pubkey.as_str(),
+            DocFetchPolicy::LocalThenRemote,
         )
         .await
         .expect("fetch published handoff grant")
@@ -400,6 +401,7 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
                 app_b.docs_sync.as_ref(),
                 &rotated_source_replica,
                 b_pubkey.as_str(),
+                DocFetchPolicy::LocalThenRemote,
             )
             .await
             .expect("fetch handoff grant on b")

--- a/crates/app-api/src/timeline.rs
+++ b/crates/app-api/src/timeline.rs
@@ -12,13 +12,13 @@ impl AppService {
         self.ensure_author_subscription(author_pubkey.as_str())
             .await?;
         let load_profile_items = || async {
-            let posts = load_profile_posts_from_author_replica_with_policy(
+            let posts = load_profile_posts_from_author_replica(
                 self.docs_sync.as_ref(),
                 author_pubkey.as_str(),
                 DocFetchPolicy::LocalOnly,
             )
             .await?;
-            let reposts = load_profile_reposts_from_author_replica_with_policy(
+            let reposts = load_profile_reposts_from_author_replica(
                 self.docs_sync.as_ref(),
                 author_pubkey.as_str(),
                 DocFetchPolicy::LocalOnly,


### PR DESCRIPTION
## What changed
- collapse 16 app-api helper names ending in `_with_policy` into their base names
- remove eight default wrappers and require `DocFetchPolicy` at every call site
- preserve each former default as explicit `LocalThenRemote`; keep existing `LocalOnly` probes unchanged
- leave `DocsSync::query_replica_with_policy` and its implementations untouched

## Why
The paired surface hid remote-fetch behavior behind wrapper selection. A single policy-taking function makes I/O intent visible at every internal call site.

## Validation
- app-api service helper definitions ending `_with_policy`: 0
- remaining `_with_policy` occurrences are only the DocsSync trait call and test-double implementations
- `cargo test -p kukuri-app-api`: 163 passed
- `cargo xtask rust-check`: green
- `cargo xtask oversized-files`: green; existing 1079/1087 baselines retained without update
- `cargo xtask rust-test`: 371 passed before the same two known Windows-local docs-sync relay timeouts; CI is the merge gate