### PR TITLE
refactor: add ServiceHandles composition root

### DIFF
--- a/crates/app-api/src/direct_messages.rs
+++ b/crates/app-api/src/direct_messages.rs
@@ -3,18 +3,24 @@ use crate::service::*;
 impl AppService {
     pub async fn resume_direct_message_state(&self) -> Result<()> {
         let mut peers = self
+            .services
             .projection_store
             .list_direct_message_conversations()
             .await?
             .into_iter()
             .map(|row| row.peer_pubkey)
             .collect::<BTreeSet<_>>();
-        for row in self.projection_store.list_direct_message_outbox().await? {
+        for row in self
+            .services
+            .projection_store
+            .list_direct_message_outbox()
+            .await?
+        {
             peers.insert(row.peer_pubkey);
         }
         peers.extend(
             current_mutual_direct_message_peers_with_services(
-                self.store.as_ref(),
+                self.services.store.as_ref(),
                 self.current_author_pubkey().as_str(),
             )
             .await?,
@@ -36,6 +42,7 @@ impl AppService {
             .await?;
         self.rebuild_author_relationships().await?;
         let existing = self
+            .services
             .projection_store
             .get_direct_message_conversation_by_peer(peer_pubkey.as_str())
             .await?;
@@ -57,6 +64,7 @@ impl AppService {
 
     pub async fn list_direct_messages(&self) -> Result<Vec<DirectMessageConversationView>> {
         let rows = self
+            .services
             .projection_store
             .list_direct_message_conversations()
             .await?;
@@ -78,6 +86,7 @@ impl AppService {
     ) -> Result<DirectMessageTimelineView> {
         let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
         let existing = self
+            .services
             .projection_store
             .get_direct_message_conversation_by_peer(peer_pubkey.as_str())
             .await?;
@@ -98,6 +107,7 @@ impl AppService {
             &Pubkey::from(peer_pubkey.as_str()),
         );
         let page = self
+            .services
             .projection_store
             .list_direct_message_messages(dm_id.as_str(), cursor, limit)
             .await?;
@@ -153,14 +163,16 @@ impl AppService {
             &Pubkey::from(self.current_author_pubkey()),
             &Pubkey::from(peer_pubkey.as_str()),
         );
-        self.projection_store
+        self.services
+            .projection_store
             .put_direct_message_tombstone(DirectMessageTombstoneRow {
                 dm_id: dm_id.clone(),
                 message_id: message_id.to_string(),
                 deleted_at: Utc::now().timestamp_millis(),
             })
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .delete_direct_message_message_local(dm_id.as_str(), message_id)
             .await?;
         self.refresh_direct_message_conversation(peer_pubkey.as_str())
@@ -178,11 +190,13 @@ impl AppService {
         let mut cursor = None;
         loop {
             let page = self
+                .services
                 .projection_store
                 .list_direct_message_messages(dm_id.as_str(), cursor.clone(), 500)
                 .await?;
             for row in &page.items {
-                self.projection_store
+                self.services
+                    .projection_store
                     .put_direct_message_tombstone(DirectMessageTombstoneRow {
                         dm_id: dm_id.clone(),
                         message_id: row.message_id.clone(),
@@ -195,7 +209,8 @@ impl AppService {
             }
             cursor = page.next_cursor;
         }
-        self.projection_store
+        self.services
+            .projection_store
             .clear_direct_message_local(dm_id.as_str())
             .await?;
         Ok(())

--- a/crates/app-api/src/game.rs
+++ b/crates/app-api/src/game.rs
@@ -18,7 +18,8 @@ impl AppService {
         let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
         let allowed = self.allowed_channel_ids_for_scope(topic_id, &scope).await?;
         let mut rows = filter_channel_rows(
-            self.projection_store
+            self.services
+                .projection_store
                 .list_topic_game_rooms(topic_id)
                 .await?,
             &allowed,
@@ -30,7 +31,8 @@ impl AppService {
         if rows.is_empty() {
             self.hydrate_scope_projection(topic_id, &scope).await?;
             rows = filter_channel_rows(
-                self.projection_store
+                self.services
+                    .projection_store
                     .list_topic_game_rooms(topic_id)
                     .await?,
                 &allowed,
@@ -141,7 +143,7 @@ impl AppService {
             updated_at: now,
         };
         let envelope = build_game_session_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &TopicId::new(topic_id),
             room_id.as_str(),
             &serde_json::json!({
@@ -160,7 +162,8 @@ impl AppService {
                 envelope.id.clone(),
             )
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .upsert_game_room_cache(game_projection_row_from_state(
                 &state,
                 &manifest,
@@ -168,7 +171,8 @@ impl AppService {
                 &source_replica_id,
             ))
             .await?;
-        self.hint_transport
+        self.services
+            .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, channel_id.as_ref()),
                 GossipHint::SessionChanged {
@@ -256,7 +260,7 @@ impl AppService {
             updated_at: now,
         };
         let envelope = build_game_session_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &TopicId::new(topic_id),
             room_id.as_str(),
             &serde_json::json!({
@@ -276,7 +280,8 @@ impl AppService {
                 envelope.id.clone(),
             )
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .upsert_game_room_cache(game_projection_row_from_state(
                 &state,
                 &manifest,
@@ -284,7 +289,8 @@ impl AppService {
                 &source_replica_id,
             ))
             .await?;
-        self.hint_transport
+        self.services
+            .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, channel_id.as_ref()),
                 GossipHint::SessionChanged {
@@ -331,7 +337,7 @@ impl AppService {
             .collect();
         manifest.updated_at = Utc::now().timestamp_millis();
         let envelope = build_game_session_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &TopicId::new(topic_id),
             room_id,
             &serde_json::json!({
@@ -351,7 +357,8 @@ impl AppService {
                 envelope.id.clone(),
             )
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .upsert_game_room_cache(game_projection_row_from_state(
                 &state,
                 &manifest,
@@ -359,7 +366,8 @@ impl AppService {
                 &source_replica_id,
             ))
             .await?;
-        self.hint_transport
+        self.services
+            .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, state.channel_id.as_ref()),
                 GossipHint::SessionChanged {
@@ -405,7 +413,7 @@ impl AppService {
         manifest.status = input.status;
         manifest.updated_at = now;
         let envelope = build_game_session_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &TopicId::new(topic_id),
             room_id,
             &serde_json::json!({
@@ -426,7 +434,8 @@ impl AppService {
                 envelope.id.clone(),
             )
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .upsert_game_room_cache(game_projection_row_from_state(
                 &state,
                 &manifest,
@@ -434,7 +443,8 @@ impl AppService {
                 &source_replica_id,
             ))
             .await?;
-        self.hint_transport
+        self.services
+            .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, state.channel_id.as_ref()),
                 GossipHint::SessionChanged {
@@ -487,7 +497,7 @@ impl AppService {
             event: input.event,
         };
         let envelope = build_metaverse_room_event_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &TopicId::new(topic_id),
             content.room_id.as_str(),
             &content,
@@ -522,7 +532,8 @@ impl AppService {
                         envelope.id.clone(),
                     )
                     .await?;
-                self.projection_store
+                self.services
+                    .projection_store
                     .upsert_game_room_cache(game_projection_row_from_state(
                         &persisted,
                         &manifest,
@@ -532,7 +543,8 @@ impl AppService {
                     .await?;
             }
         }
-        self.hint_transport
+        self.services
+            .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, state.channel_id.as_ref()),
                 GossipHint::MetaverseRoomEvent {
@@ -563,10 +575,12 @@ impl AppService {
             anyhow::bail!("metaverse asset bytes are required");
         }
         let stored = self
+            .services
             .blob_service
             .put_blob(input.bytes, input.mime_type.as_str())
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .mark_blob_status(&stored.hash, BlobCacheStatus::Available)
             .await?;
         Ok(MetaverseAssetRef {

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -12,5 +12,5 @@ mod timeline;
 mod views;
 
 pub use kukuri_store::NotificationKind;
-pub use service::AppService;
+pub use service::{AppService, ServiceHandles};
 pub use views::*;

--- a/crates/app-api/src/live.rs
+++ b/crates/app-api/src/live.rs
@@ -13,12 +13,14 @@ impl AppService {
     ) -> Result<Vec<LiveSessionView>> {
         self.ensure_scope_subscriptions(topic_id, &scope).await?;
         let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
-        self.projection_store
+        self.services
+            .projection_store
             .clear_expired_live_presence(Utc::now().timestamp_millis())
             .await?;
         let allowed = self.allowed_channel_ids_for_scope(topic_id, &scope).await?;
         let mut rows = filter_channel_rows(
-            self.projection_store
+            self.services
+                .projection_store
                 .list_topic_live_sessions(topic_id)
                 .await?,
             &allowed,
@@ -36,11 +38,13 @@ impl AppService {
             self.maybe_restart_scope_replica_sync(topic_id, &scope)
                 .await;
             self.hydrate_scope_projection(topic_id, &scope).await?;
-            self.projection_store
+            self.services
+                .projection_store
                 .clear_expired_live_presence(Utc::now().timestamp_millis())
                 .await?;
             rows = filter_channel_rows(
-                self.projection_store
+                self.services
+                    .projection_store
                     .list_topic_live_sessions(topic_id)
                     .await?,
                 &allowed,
@@ -131,7 +135,7 @@ impl AppService {
             ended_at: None,
         };
         let envelope = build_live_session_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &topic,
             session_id.as_str(),
             &serde_json::json!({
@@ -152,7 +156,8 @@ impl AppService {
                 envelope.id.clone(),
             )
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .upsert_live_session_cache(live_projection_row_from_state(
                 &state,
                 &manifest,
@@ -160,7 +165,8 @@ impl AppService {
                 &source_replica_id,
             ))
             .await?;
-        self.hint_transport
+        self.services
+            .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, channel_id.as_ref()),
                 GossipHint::SessionChanged {
@@ -195,7 +201,7 @@ impl AppService {
         manifest.status = LiveSessionStatus::Ended;
         manifest.ended_at = Some(now);
         let envelope = build_live_session_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &TopicId::new(topic_id),
             session_id,
             &serde_json::json!({
@@ -214,7 +220,8 @@ impl AppService {
                 envelope.id.clone(),
             )
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .upsert_live_session_cache(live_projection_row_from_state(
                 &state,
                 &manifest,
@@ -224,7 +231,8 @@ impl AppService {
             .await?;
         self.stop_live_presence_task(topic_id, channel_key.as_str(), session_id)
             .await;
-        self.hint_transport
+        self.services
+            .hint_transport
             .publish_hint(
                 &hint_topic,
                 GossipHint::SessionChanged {
@@ -262,8 +270,8 @@ impl AppService {
         }
         self.apply_live_presence(topic_id, state.channel_id.as_ref(), session_id, 30_000)
             .await?;
-        let hint_transport = Arc::clone(&self.hint_transport);
-        let projection_store = Arc::clone(&self.projection_store);
+        let hint_transport = Arc::clone(&self.services.hint_transport);
+        let projection_store = Arc::clone(&self.services.projection_store);
         let hint_topic = channel_hint_topic_for(topic_id, state.channel_id.as_ref());
         let topic_key = topic_id.to_string();
         let channel_key_for_task = channel_key.clone();

--- a/crates/app-api/src/media.rs
+++ b/crates/app-api/src/media.rs
@@ -13,6 +13,7 @@ impl AppService {
         }
         info!(hash = %hash, mime = %mime, "blob media payload fetch requested");
         let bytes = match self
+            .services
             .blob_service
             .fetch_blob(&kukuri_core::BlobHash::new(hash.to_string()))
             .await

--- a/crates/app-api/src/notifications.rs
+++ b/crates/app-api/src/notifications.rs
@@ -3,7 +3,7 @@ use crate::service::*;
 impl AppService {
     pub async fn list_notifications(&self) -> Result<Vec<NotificationView>> {
         let mut items = Vec::new();
-        for row in self.projection_store.list_notifications().await? {
+        for row in self.services.projection_store.list_notifications().await? {
             items.push(self.notification_view_from_row(row).await?);
         }
         Ok(items)
@@ -13,14 +13,16 @@ impl AppService {
         &self,
         notification_id: &str,
     ) -> Result<NotificationStatusView> {
-        self.projection_store
+        self.services
+            .projection_store
             .mark_notification_read(notification_id, Utc::now().timestamp_millis())
             .await?;
         self.notification_status_view().await
     }
 
     pub async fn mark_all_notifications_read(&self) -> Result<NotificationStatusView> {
-        self.projection_store
+        self.services
+            .projection_store
             .mark_all_notifications_read(Utc::now().timestamp_millis())
             .await?;
         self.notification_status_view().await

--- a/crates/app-api/src/private_channels.rs
+++ b/crates/app-api/src/private_channels.rs
@@ -44,14 +44,14 @@ impl AppService {
             owner_pubkey: Pubkey::from(owner_pubkey.clone()),
         };
         persist_private_channel_metadata(
-            self.docs_sync.as_ref(),
+            self.docs_sync(),
             &current_private_channel_replica_id(&state),
             &metadata,
         )
         .await?;
         persist_private_channel_policy(
-            self.docs_sync.as_ref(),
-            self.keys.as_ref(),
+            self.docs_sync(),
+            self.keys(),
             &PrivateChannelPolicyDocV1 {
                 channel_id: channel_id.clone(),
                 topic_id: input.topic_id.clone(),
@@ -66,8 +66,8 @@ impl AppService {
         )
         .await?;
         persist_private_channel_participant(
-            self.docs_sync.as_ref(),
-            self.keys.as_ref(),
+            self.docs_sync(),
+            self.keys(),
             &PrivateChannelParticipantDocV1 {
                 channel_id,
                 topic_id: input.topic_id,
@@ -104,7 +104,7 @@ impl AppService {
             );
         }
         build_private_channel_invite_token(
-            self.keys.as_ref(),
+            self.keys(),
             PrivateChannelInviteTokenParams {
                 topic: &TopicId::new(topic_id),
                 channel_id: &state.channel_id,
@@ -134,6 +134,7 @@ impl AppService {
                 .await?;
             self.rebuild_author_relationships().await?;
             let relationship = self
+                .services
                 .projection_store
                 .get_author_relationship(
                     self.current_author_pubkey().as_str(),
@@ -149,19 +150,19 @@ impl AppService {
         } else {
             private_channel_epoch_replica_id(spec.channel_id.as_str(), spec.epoch_id.as_str())
         };
-        self.docs_sync
+        self.docs_sync()
             .register_private_replica_secret(&replica, spec.namespace_secret_hex.as_str())
             .await?;
         let import_result = async {
             let (metadata, policy, participants) = wait_for_private_channel_epoch_snapshot(
-                self.docs_sync.as_ref(),
+                self.docs_sync(),
                 &replica,
                 spec.sync_context,
             )
             .await?;
             let participants = if spec.refetch_participants {
                 fetch_private_channel_participants_from_replica(
-                    self.docs_sync.as_ref(),
+                    self.docs_sync(),
                     &replica,
                     LocalThenRemote,
                 )
@@ -200,8 +201,8 @@ impl AppService {
                     ImportSponsor::PolicyOwner => policy.owner_pubkey.clone(),
                 };
                 persist_private_channel_participant(
-                    self.docs_sync.as_ref(),
-                    self.keys.as_ref(),
+                    self.docs_sync(),
+                    self.keys(),
                     &PrivateChannelParticipantDocV1 {
                         channel_id: metadata.channel_id.clone(),
                         topic_id: metadata.topic_id.clone(),
@@ -236,7 +237,11 @@ impl AppService {
         }
         .await;
         if import_result.is_err() {
-            let _ = self.docs_sync.remove_private_replica_secret(&replica).await;
+            let _ = self
+                .services
+                .docs_sync
+                .remove_private_replica_secret(&replica)
+                .await;
         }
         import_result
     }
@@ -422,7 +427,7 @@ impl AppService {
             anyhow::bail!("friend-only grant export is disabled while sharing is frozen");
         }
         build_friend_only_grant_token(
-            self.keys.as_ref(),
+            self.keys(),
             &TopicId::new(topic_id),
             &state.channel_id,
             state.label.as_str(),
@@ -482,12 +487,9 @@ impl AppService {
             anyhow::bail!("friend-plus share export is only available for friends+ channels");
         }
         let replica = current_private_channel_replica_id(&state);
-        let Some(policy) = fetch_private_channel_policy_from_replica(
-            self.docs_sync.as_ref(),
-            &replica,
-            LocalThenRemote,
-        )
-        .await?
+        let Some(policy) =
+            fetch_private_channel_policy_from_replica(self.docs_sync(), &replica, LocalThenRemote)
+                .await?
         else {
             anyhow::bail!("friend-plus channel policy is missing");
         };
@@ -495,7 +497,7 @@ impl AppService {
             anyhow::bail!("friend-plus share export is disabled while sharing is frozen");
         }
         let participants = fetch_private_channel_participants_from_replica(
-            self.docs_sync.as_ref(),
+            self.docs_sync(),
             &replica,
             LocalThenRemote,
         )
@@ -511,7 +513,7 @@ impl AppService {
         let effective_expires_at =
             expires_at.or_else(|| Some(Utc::now().timestamp_millis() + 24 * 60 * 60 * 1000));
         build_friend_plus_share_token(
-            self.keys.as_ref(),
+            self.keys(),
             &TopicId::new(topic_id),
             &state.channel_id,
             state.label.as_str(),
@@ -575,7 +577,7 @@ impl AppService {
         }
         let current_replica = current_private_channel_replica_id(&state);
         let Some(current_policy) = fetch_private_channel_policy_from_replica(
-            self.docs_sync.as_ref(),
+            self.docs_sync(),
             &current_replica,
             LocalThenRemote,
         )
@@ -584,8 +586,8 @@ impl AppService {
             anyhow::bail!("friend-plus channel policy is missing");
         };
         persist_private_channel_policy(
-            self.docs_sync.as_ref(),
-            self.keys.as_ref(),
+            self.docs_sync(),
+            self.keys(),
             &PrivateChannelPolicyDocV1 {
                 sharing_state: ChannelSharingState::Frozen,
                 rotated_at: current_policy.rotated_at,
@@ -641,7 +643,7 @@ impl AppService {
         }
         let current_replica = current_private_channel_replica_id(&state);
         let current_policy = fetch_private_channel_policy_from_replica(
-            self.docs_sync.as_ref(),
+            self.docs_sync(),
             &current_replica,
             LocalThenRemote,
         )
@@ -657,7 +659,7 @@ impl AppService {
             previous_epoch_id: None,
         });
         let current_participants = fetch_private_channel_participants_from_replica(
-            self.docs_sync.as_ref(),
+            self.docs_sync(),
             &current_replica,
             LocalThenRemote,
         )
@@ -678,7 +680,7 @@ impl AppService {
             let archived_replica =
                 private_channel_epoch_replica_id(channel_id, epoch.epoch_id.as_str());
             let archived_participants = fetch_private_channel_participants_from_replica(
-                self.docs_sync.as_ref(),
+                self.docs_sync(),
                 &archived_replica,
                 LocalThenRemote,
             )
@@ -705,8 +707,8 @@ impl AppService {
     /// 以後の import(sharing_state Open 前提)を止める。
     async fn freeze_rotated_epoch_policy(&self, prep: &PrivateChannelRotationPrep) -> Result<()> {
         persist_private_channel_policy(
-            self.docs_sync.as_ref(),
-            self.keys.as_ref(),
+            self.docs_sync(),
+            self.keys(),
             &PrivateChannelPolicyDocV1 {
                 sharing_state: ChannelSharingState::Frozen,
                 rotated_at: Some(Utc::now().timestamp_millis()),
@@ -727,7 +729,7 @@ impl AppService {
         let secret_hex = generate_keys().export_secret_hex();
         let replica =
             private_channel_epoch_replica_id(state.channel_id.as_str(), epoch_id.as_str());
-        self.docs_sync
+        self.docs_sync()
             .register_private_replica_secret(&replica, secret_hex.as_str())
             .await?;
         let metadata = PrivateChannelMetadataDocV1 {
@@ -739,10 +741,10 @@ impl AppService {
             audience_kind: state.audience_kind.clone(),
             owner_pubkey: Pubkey::from(state.owner_pubkey.clone()),
         };
-        persist_private_channel_metadata(self.docs_sync.as_ref(), &replica, &metadata).await?;
+        persist_private_channel_metadata(self.docs_sync(), &replica, &metadata).await?;
         persist_private_channel_policy(
-            self.docs_sync.as_ref(),
-            self.keys.as_ref(),
+            self.docs_sync(),
+            self.keys(),
             &PrivateChannelPolicyDocV1 {
                 channel_id: state.channel_id.clone(),
                 topic_id: TopicId::new(topic_id),
@@ -757,8 +759,8 @@ impl AppService {
         )
         .await?;
         persist_private_channel_participant(
-            self.docs_sync.as_ref(),
-            self.keys.as_ref(),
+            self.docs_sync(),
+            self.keys(),
             &PrivateChannelParticipantDocV1 {
                 channel_id: state.channel_id.clone(),
                 topic_id: TopicId::new(topic_id),
@@ -794,6 +796,7 @@ impl AppService {
                 self.ensure_author_subscription(participant.participant_pubkey.as_str())
                     .await?;
                 let relationship = self
+                    .services
                     .projection_store
                     .get_author_relationship(
                         self.current_author_pubkey().as_str(),
@@ -805,7 +808,7 @@ impl AppService {
                 }
             }
             let grant_doc = encrypt_private_channel_epoch_handoff_grant(
-                self.keys.as_ref(),
+                self.keys(),
                 &PrivateChannelEpochHandoffGrantPayloadV1 {
                     channel_id: state.channel_id.clone(),
                     topic_id: TopicId::new(topic_id),
@@ -817,8 +820,8 @@ impl AppService {
                 },
             )?;
             persist_private_channel_epoch_handoff_grant(
-                self.docs_sync.as_ref(),
-                self.keys.as_ref(),
+                self.docs_sync(),
+                self.keys(),
                 &grant_doc,
                 &prep.current_replica,
             )
@@ -845,6 +848,7 @@ impl AppService {
         state.current_epoch_secret_hex = next.secret_hex;
         self.register_joined_private_channel(state.clone()).await?;
         if let Err(error) = self
+            .services
             .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, Some(&state.channel_id)),
@@ -886,7 +890,7 @@ impl AppService {
         let local_pubkey = Pubkey::from(local_author.clone());
         let now = Utc::now().timestamp_millis();
         let existing_participant = fetch_private_channel_participants_from_replica(
-            self.docs_sync.as_ref(),
+            self.docs_sync(),
             &replica,
             DocFetchPolicy::LocalOnly,
         )
@@ -897,8 +901,8 @@ impl AppService {
                 && participant.participant_pubkey == local_pubkey
         });
         persist_private_channel_participant(
-            self.docs_sync.as_ref(),
-            self.keys.as_ref(),
+            self.docs_sync(),
+            self.keys(),
             &PrivateChannelParticipantDocV1 {
                 channel_id: state.channel_id.clone(),
                 topic_id: TopicId::new(topic_id),
@@ -927,6 +931,7 @@ impl AppService {
         )
         .await?;
         let has_peers = self
+            .services
             .transport
             .peers()
             .await
@@ -934,7 +939,7 @@ impl AppService {
         if has_peers {
             let publish_result = tokio::time::timeout(
                 std::time::Duration::from_secs(2),
-                self.hint_transport.publish_hint(
+                self.hint_transport().publish_hint(
                     &channel_hint_topic_for(topic_id, Some(&state.channel_id)),
                     GossipHint::TopicObjectsChanged {
                         topic_id: TopicId::new(topic_id),
@@ -968,7 +973,6 @@ impl AppService {
             .await?;
         Ok(())
     }
-
     pub async fn list_joined_private_channels(
         &self,
         topic_id: &str,
@@ -988,7 +992,6 @@ impl AppService {
         }
         Ok(items)
     }
-
     pub async fn get_private_channel_capability(
         &self,
         topic_id: &str,
@@ -1006,7 +1009,6 @@ impl AppService {
             self.private_channel_capability_from_state(&state).await?,
         ))
     }
-
     pub async fn list_private_channel_capabilities(&self) -> Result<Vec<PrivateChannelCapability>> {
         let states = self
             .joined_private_channels
@@ -1022,7 +1024,6 @@ impl AppService {
         Ok(items)
     }
 }
-
 /// import 3 系統の差分(注入点)。詳細は import_private_channel_by_spec を参照。
 struct PrivateChannelImportSpec {
     topic_id: String,
@@ -1054,7 +1055,6 @@ struct PrivateChannelImportSpec {
     skip_persist_if_participant: bool,
     joined_via_pubkey: String,
 }
-
 /// 参加ドキュメントに載せる sponsor の出どころ。
 enum ImportSponsor {
     /// トークン preview から(招待 = inviter、friend-plus = sponsor)。

--- a/crates/app-api/src/reactions.rs
+++ b/crates/app-api/src/reactions.rs
@@ -13,6 +13,7 @@ impl AppService {
             .await?;
         let target_object_id = EnvelopeId::from(target_object_id);
         let target = self
+            .services
             .projection_store
             .get_object_projection(&target_object_id)
             .await?
@@ -40,6 +41,7 @@ impl AppService {
             normalized_reaction_key.as_str(),
         );
         let next_status = match self
+            .services
             .projection_store
             .get_reaction_cache(&target.source_replica_id, &target_object_id, &reaction_id)
             .await?
@@ -48,7 +50,7 @@ impl AppService {
             _ => ObjectStatus::Active,
         };
         let envelope = build_reaction_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &target_topic_id,
             target_channel_id.as_ref(),
             &target_object_id,
@@ -59,20 +61,22 @@ impl AppService {
         let reaction = parse_reaction(&envelope)?
             .ok_or_else(|| anyhow::anyhow!("failed to parse reaction envelope"))?;
         persist_reaction_doc(
-            self.docs_sync.as_ref(),
+            self.services.docs_sync.as_ref(),
             &target.source_replica_id,
             &reaction,
             &envelope,
         )
         .await?;
-        self.store.put_envelope(envelope.clone()).await?;
-        self.projection_store
+        self.services.store.put_envelope(envelope.clone()).await?;
+        self.services
+            .projection_store
             .upsert_reaction_cache(reaction_projection_row_from_doc(
                 &reaction,
                 &target.source_replica_id,
             ))
             .await?;
         if let Err(error) = self
+            .services
             .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(target_topic_id.as_str(), target_channel_id.as_ref()),
@@ -103,11 +107,12 @@ impl AppService {
         input: CreateCustomReactionAssetInput,
     ) -> Result<CustomReactionAssetView> {
         let stored_blob = self
+            .services
             .blob_service
             .put_blob(input.bytes, input.mime.as_str())
             .await?;
         let envelope = build_custom_reaction_asset_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             stored_blob.hash.clone(),
             input.search_key,
             input.mime,
@@ -117,9 +122,11 @@ impl AppService {
         )?;
         let asset = parse_custom_reaction_asset(&envelope)?
             .ok_or_else(|| anyhow::anyhow!("failed to parse custom reaction asset envelope"))?;
-        persist_custom_reaction_asset_doc(self.docs_sync.as_ref(), &asset, &envelope).await?;
-        self.store.put_envelope(envelope).await?;
-        self.projection_store
+        persist_custom_reaction_asset_doc(self.services.docs_sync.as_ref(), &asset, &envelope)
+            .await?;
+        self.services.store.put_envelope(envelope).await?;
+        self.services
+            .projection_store
             .mark_blob_status(&stored_blob.hash, BlobCacheStatus::Available)
             .await?;
         *self.last_sync_ts.lock().await = Some(Utc::now().timestamp_millis());
@@ -129,7 +136,7 @@ impl AppService {
     pub async fn list_my_custom_reaction_assets(&self) -> Result<Vec<CustomReactionAssetView>> {
         let author_pubkey = self.current_author_pubkey();
         let mut items = load_custom_reaction_assets_from_author_replica(
-            self.docs_sync.as_ref(),
+            self.services.docs_sync.as_ref(),
             &author_pubkey,
         )
         .await?;
@@ -154,6 +161,7 @@ impl AppService {
         let mut seen = BTreeSet::new();
         let mut items = Vec::new();
         for row in self
+            .services
             .projection_store
             .list_recent_reaction_cache_by_author(author_pubkey.as_str())
             .await?
@@ -173,6 +181,7 @@ impl AppService {
         &self,
     ) -> Result<Vec<BookmarkedCustomReactionView>> {
         Ok(self
+            .services
             .projection_store
             .list_bookmarked_custom_reactions()
             .await?
@@ -199,14 +208,16 @@ impl AppService {
             height: asset.height,
             bookmarked_at: Utc::now().timestamp_millis(),
         };
-        self.projection_store
+        self.services
+            .projection_store
             .put_bookmarked_custom_reaction(row.clone())
             .await?;
         Ok(bookmarked_custom_reaction_view_from_row(row))
     }
 
     pub async fn remove_bookmarked_custom_reaction(&self, asset_id: &str) -> Result<()> {
-        self.projection_store
+        self.services
+            .projection_store
             .remove_bookmarked_custom_reaction(asset_id)
             .await
     }

--- a/crates/app-api/src/service/direct_messages_delivery_support.rs
+++ b/crates/app-api/src/service/direct_messages_delivery_support.rs
@@ -346,8 +346,9 @@ impl AppService {
     }
 
     pub(crate) async fn direct_message_topic_peer_count(&self, peer_pubkey: &str) -> Result<usize> {
-        let topic = derive_direct_message_topic(self.keys.as_ref(), &Pubkey::from(peer_pubkey))?;
-        direct_message_topic_peer_count(self.transport.as_ref(), &topic).await
+        let topic =
+            derive_direct_message_topic(self.services.keys.as_ref(), &Pubkey::from(peer_pubkey))?;
+        direct_message_topic_peer_count(self.services.transport.as_ref(), &topic).await
     }
 
     pub(crate) async fn send_direct_message_internal(
@@ -372,6 +373,7 @@ impl AppService {
         );
         if let Some(reply_to_message_id) = reply_to_message_id
             && self
+                .services
                 .projection_store
                 .get_direct_message_message(dm_id.as_str(), reply_to_message_id.trim())
                 .await?
@@ -384,7 +386,7 @@ impl AppService {
             .await?;
         let created_at = Utc::now().timestamp_millis();
         let frame = encrypt_direct_message_frame(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &Pubkey::from(peer_pubkey),
             dm_id.as_str(),
             message_id.as_str(),
@@ -398,10 +400,12 @@ impl AppService {
         let frame_bytes =
             serde_json::to_vec(&frame).context("failed to encode direct message frame blob")?;
         let frame_blob = self
+            .services
             .blob_service
             .put_blob(frame_bytes, DIRECT_MESSAGE_FRAME_MIME)
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .put_direct_message_message(DirectMessageMessageRow {
                 dm_id: dm_id.clone(),
                 message_id: message_id.clone(),
@@ -417,7 +421,8 @@ impl AppService {
                 acked_at: None,
             })
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .put_direct_message_outbox(DirectMessageOutboxRow {
                 dm_id: dm_id.clone(),
                 message_id: message_id.clone(),
@@ -430,11 +435,11 @@ impl AppService {
         self.refresh_direct_message_conversation(peer_pubkey)
             .await?;
         let _ = Self::flush_direct_message_outbox_for_peer_with_services(
-            self.projection_store.as_ref(),
-            self.hint_transport.as_ref(),
-            self.transport.as_ref(),
+            self.services.projection_store.as_ref(),
+            self.services.hint_transport.as_ref(),
+            self.services.transport.as_ref(),
             self.current_author_pubkey().as_str(),
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             peer_pubkey,
         )
         .await?;
@@ -470,17 +475,19 @@ impl AppService {
                     );
                 }
                 let local_blob = self
+                    .services
                     .blob_service
                     .put_blob(image.bytes.clone(), image.mime.as_str())
                     .await?;
                 let encrypted = encrypt_direct_message_attachment(
-                    self.keys.as_ref(),
+                    self.services.keys.as_ref(),
                     &Pubkey::from(peer_pubkey),
                     message_id,
                     "original",
                     image.bytes.as_slice(),
                 )?;
                 let encrypted_blob = self
+                    .services
                     .blob_service
                     .put_blob(
                         serde_json::to_vec(&encrypted)
@@ -525,28 +532,31 @@ impl AppService {
                     );
                 }
                 let local_video = self
+                    .services
                     .blob_service
                     .put_blob(video.bytes.clone(), video.mime.as_str())
                     .await?;
                 let local_poster = self
+                    .services
                     .blob_service
                     .put_blob(poster.bytes.clone(), poster.mime.as_str())
                     .await?;
                 let encrypted_video = encrypt_direct_message_attachment(
-                    self.keys.as_ref(),
+                    self.services.keys.as_ref(),
                     &Pubkey::from(peer_pubkey),
                     message_id,
                     "original",
                     video.bytes.as_slice(),
                 )?;
                 let encrypted_poster = encrypt_direct_message_attachment(
-                    self.keys.as_ref(),
+                    self.services.keys.as_ref(),
                     &Pubkey::from(peer_pubkey),
                     message_id,
                     "poster",
                     poster.bytes.as_slice(),
                 )?;
                 let encrypted_video_blob = self
+                    .services
                     .blob_service
                     .put_blob(
                         serde_json::to_vec(&encrypted_video)
@@ -555,6 +565,7 @@ impl AppService {
                     )
                     .await?;
                 let encrypted_poster_blob = self
+                    .services
                     .blob_service
                     .put_blob(
                         serde_json::to_vec(&encrypted_poster)

--- a/crates/app-api/src/service/direct_messages_subscription_support.rs
+++ b/crates/app-api/src/service/direct_messages_subscription_support.rs
@@ -4,6 +4,7 @@ use super::*;
 impl AppService {
     pub(crate) async fn direct_message_send_enabled(&self, peer_pubkey: &str) -> Result<bool> {
         Ok(self
+            .services
             .projection_store
             .get_author_relationship(self.current_author_pubkey().as_str(), peer_pubkey)
             .await?
@@ -13,12 +14,12 @@ impl AppService {
 
     pub(crate) async fn reconcile_direct_message_subscriptions(&self) -> Result<()> {
         reconcile_direct_message_subscriptions_with_services(
-            self.store.as_ref(),
-            Arc::clone(&self.projection_store),
-            Arc::clone(&self.blob_service),
-            Arc::clone(&self.hint_transport),
-            Arc::clone(&self.transport),
-            Arc::clone(&self.keys),
+            self.services.store.as_ref(),
+            Arc::clone(&self.services.projection_store),
+            Arc::clone(&self.services.blob_service),
+            Arc::clone(&self.services.hint_transport),
+            Arc::clone(&self.services.transport),
+            Arc::clone(&self.services.keys),
             Arc::clone(&self.last_sync_ts),
             Arc::clone(&self.subscription_registry.direct_message_subscriptions),
             Arc::clone(&self.notification_inserted_notify),
@@ -42,6 +43,7 @@ impl AppService {
             0
         };
         let pending_outbox_count = self
+            .services
             .projection_store
             .list_direct_message_outbox()
             .await?
@@ -63,6 +65,7 @@ impl AppService {
         peer_pubkey: &str,
     ) -> Result<()> {
         if self
+            .services
             .projection_store
             .get_direct_message_conversation_by_peer(peer_pubkey)
             .await?
@@ -74,7 +77,8 @@ impl AppService {
             &Pubkey::from(self.current_author_pubkey()),
             &Pubkey::from(peer_pubkey),
         );
-        self.projection_store
+        self.services
+            .projection_store
             .upsert_direct_message_conversation(DirectMessageConversationRow {
                 dm_id,
                 peer_pubkey: peer_pubkey.to_string(),
@@ -95,10 +99,12 @@ impl AppService {
             &Pubkey::from(peer_pubkey),
         );
         let existing = self
+            .services
             .projection_store
             .get_direct_message_conversation_by_peer(peer_pubkey)
             .await?;
         let page = self
+            .services
             .projection_store
             .list_direct_message_messages(dm_id.as_str(), None, 1)
             .await?;
@@ -117,7 +123,8 @@ impl AppService {
             } else {
                 return Ok(());
             };
-        self.projection_store
+        self.services
+            .projection_store
             .upsert_direct_message_conversation(DirectMessageConversationRow {
                 dm_id,
                 peer_pubkey: peer_pubkey.to_string(),
@@ -134,11 +141,12 @@ impl AppService {
         peer_pubkey: &str,
     ) -> Result<DirectMessageConversationView> {
         let conversation = self
+            .services
             .projection_store
             .get_direct_message_conversation_by_peer(peer_pubkey)
             .await?
             .ok_or_else(|| anyhow::anyhow!("direct message conversation is not initialized"))?;
-        let profile = self.store.get_profile(peer_pubkey).await?;
+        let profile = self.services.store.get_profile(peer_pubkey).await?;
         let status = self.direct_message_status_view(peer_pubkey).await?;
         Ok(DirectMessageConversationView {
             dm_id: conversation.dm_id,
@@ -174,7 +182,7 @@ impl AppService {
             text: row.text.unwrap_or_default(),
             reply_to_message_id: row.reply_to_message_id,
             attachments: direct_message_attachment_views(
-                self.blob_service.as_ref(),
+                self.services.blob_service.as_ref(),
                 row.attachment_manifest.as_ref(),
             )
             .await?,
@@ -189,7 +197,8 @@ impl AppService {
     ) -> Result<NotificationView> {
         let object_id = row.object_id.clone();
         let thread_root_object_id = if let Some(object_id) = object_id.as_ref() {
-            self.projection_store
+            self.services
+                .projection_store
                 .get_object_projection(object_id)
                 .await?
                 .map(|projection| {
@@ -202,7 +211,11 @@ impl AppService {
         } else {
             None
         };
-        let profile = self.store.get_profile(row.actor_pubkey.as_str()).await?;
+        let profile = self
+            .services
+            .store
+            .get_profile(row.actor_pubkey.as_str())
+            .await?;
         Ok(NotificationView {
             notification_id: row.notification_id,
             kind: row.kind,
@@ -238,7 +251,11 @@ impl AppService {
 
     pub(crate) async fn notification_status_view(&self) -> Result<NotificationStatusView> {
         Ok(NotificationStatusView {
-            unread_count: self.projection_store.count_unread_notifications().await?,
+            unread_count: self
+                .services
+                .projection_store
+                .count_unread_notifications()
+                .await?,
         })
     }
 
@@ -269,11 +286,11 @@ impl AppService {
         }
         Self::spawn_direct_message_subscription_with_services(
             Arc::clone(&self.subscription_registry.direct_message_subscriptions),
-            Arc::clone(&self.projection_store),
-            Arc::clone(&self.blob_service),
-            Arc::clone(&self.hint_transport),
-            Arc::clone(&self.transport),
-            Arc::clone(&self.keys),
+            Arc::clone(&self.services.projection_store),
+            Arc::clone(&self.services.blob_service),
+            Arc::clone(&self.services.hint_transport),
+            Arc::clone(&self.services.transport),
+            Arc::clone(&self.services.keys),
             Arc::clone(&self.last_sync_ts),
             Arc::clone(&self.notification_inserted_notify),
             self.current_author_pubkey().as_str(),
@@ -291,18 +308,18 @@ impl AppService {
             self.subscription_registry
                 .direct_message_subscriptions
                 .as_ref(),
-            self.hint_transport.as_ref(),
-            self.keys.as_ref(),
+            self.services.hint_transport.as_ref(),
+            self.services.keys.as_ref(),
             peer_pubkey.as_str(),
         )
         .await?;
         Self::spawn_direct_message_subscription_with_services(
             Arc::clone(&self.subscription_registry.direct_message_subscriptions),
-            Arc::clone(&self.projection_store),
-            Arc::clone(&self.blob_service),
-            Arc::clone(&self.hint_transport),
-            Arc::clone(&self.transport),
-            Arc::clone(&self.keys),
+            Arc::clone(&self.services.projection_store),
+            Arc::clone(&self.services.blob_service),
+            Arc::clone(&self.services.hint_transport),
+            Arc::clone(&self.services.transport),
+            Arc::clone(&self.services.keys),
             Arc::clone(&self.last_sync_ts),
             Arc::clone(&self.notification_inserted_notify),
             self.current_author_pubkey().as_str(),
@@ -316,10 +333,13 @@ impl AppService {
         peer_pubkey: &str,
     ) -> Result<Option<TopicPeerSnapshot>> {
         let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
-        let topic =
-            derive_direct_message_topic(self.keys.as_ref(), &Pubkey::from(peer_pubkey.as_str()))?;
+        let topic = derive_direct_message_topic(
+            self.services.keys.as_ref(),
+            &Pubkey::from(peer_pubkey.as_str()),
+        )?;
         let hint_topic = kukuri_core::wire::hint_topic_id(&topic).0;
         Ok(self
+            .services
             .transport
             .peers()
             .await?

--- a/crates/app-api/src/service/gossip_subscription_support.rs
+++ b/crates/app-api/src/service/gossip_subscription_support.rs
@@ -93,7 +93,8 @@ impl AppService {
                 handle.abort();
             }
         }
-        self.hint_transport
+        self.services
+            .hint_transport
             .unsubscribe_hints(&private_channel_hint_topic(channel_id))
             .await
     }

--- a/crates/app-api/src/service/live_game_support.rs
+++ b/crates/app-api/src/service/live_game_support.rs
@@ -45,7 +45,8 @@ impl AppService {
     ) -> Result<()> {
         let now = Utc::now().timestamp_millis();
         let author = self.current_author_pubkey();
-        self.projection_store
+        self.services
+            .projection_store
             .upsert_live_presence(
                 topic_id,
                 channel_storage_id(channel_id).as_str(),
@@ -55,10 +56,12 @@ impl AppService {
                 now,
             )
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .clear_expired_live_presence(now)
             .await?;
-        self.hint_transport
+        self.services
+            .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(topic_id, channel_id),
                 GossipHint::LivePresence {
@@ -81,8 +84,12 @@ impl AppService {
         last_envelope_id: EnvelopeId,
     ) -> Result<LiveSessionStateDocV1> {
         let now = Utc::now().timestamp_millis();
-        let stored =
-            store_manifest_blob(self.blob_service.as_ref(), &manifest, LIVE_MANIFEST_MIME).await?;
+        let stored = store_manifest_blob(
+            self.services.blob_service.as_ref(),
+            &manifest,
+            LIVE_MANIFEST_MIME,
+        )
+        .await?;
         let state = LiveSessionStateDocV1 {
             session_id: manifest.session_id.clone(),
             topic_id: TopicId::new(topic_id),
@@ -98,8 +105,9 @@ impl AppService {
             },
             last_envelope_id,
         };
-        persist_live_session_state(self.docs_sync.as_ref(), replica, &state).await?;
-        self.projection_store
+        persist_live_session_state(self.services.docs_sync.as_ref(), replica, &state).await?;
+        self.services
+            .projection_store
             .mark_blob_status(&stored.hash, BlobCacheStatus::Available)
             .await?;
         Ok(state)
@@ -114,8 +122,12 @@ impl AppService {
         last_envelope_id: EnvelopeId,
     ) -> Result<GameRoomStateDocV1> {
         let now = Utc::now().timestamp_millis();
-        let stored =
-            store_manifest_blob(self.blob_service.as_ref(), &manifest, GAME_MANIFEST_MIME).await?;
+        let stored = store_manifest_blob(
+            self.services.blob_service.as_ref(),
+            &manifest,
+            GAME_MANIFEST_MIME,
+        )
+        .await?;
         let state = GameRoomStateDocV1 {
             room_id: manifest.room_id.clone(),
             topic_id: TopicId::new(topic_id),
@@ -131,8 +143,9 @@ impl AppService {
             },
             last_envelope_id,
         };
-        persist_game_room_state(self.docs_sync.as_ref(), replica, &state).await?;
-        self.projection_store
+        persist_game_room_state(self.services.docs_sync.as_ref(), replica, &state).await?;
+        self.services
+            .projection_store
             .mark_blob_status(&stored.hash, BlobCacheStatus::Available)
             .await?;
         Ok(state)
@@ -148,7 +161,7 @@ impl AppService {
             self.joined_private_channel_states_for_topic(topic_id).await,
         ) {
             let Some(state) = fetch_live_session_state_from_replica(
-                self.docs_sync.as_ref(),
+                self.services.docs_sync.as_ref(),
                 &replica,
                 session_id,
             )
@@ -157,7 +170,7 @@ impl AppService {
                 continue;
             };
             let Some(manifest) = fetch_manifest_blob::<LiveSessionManifestBlobV1>(
-                self.blob_service.as_ref(),
+                self.services.blob_service.as_ref(),
                 &state.current_manifest,
             )
             .await?
@@ -178,14 +191,17 @@ impl AppService {
             topic_id,
             self.joined_private_channel_states_for_topic(topic_id).await,
         ) {
-            let Some(state) =
-                fetch_game_room_state_from_replica(self.docs_sync.as_ref(), &replica, room_id)
-                    .await?
+            let Some(state) = fetch_game_room_state_from_replica(
+                self.services.docs_sync.as_ref(),
+                &replica,
+                room_id,
+            )
+            .await?
             else {
                 continue;
             };
             let Some(manifest) = fetch_manifest_blob::<GameRoomManifestBlobV1>(
-                self.blob_service.as_ref(),
+                self.services.blob_service.as_ref(),
                 &state.current_manifest,
             )
             .await?

--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -306,7 +306,8 @@ pub(crate) struct ResolvedRepostSource {
 pub type PrivateChannelCapabilityPersist =
     Arc<dyn Fn(&[crate::PrivateChannelCapability]) -> Result<()> + Send + Sync>;
 
-pub struct AppService {
+#[derive(Clone)]
+pub struct ServiceHandles {
     pub(crate) store: Arc<dyn Store>,
     pub(crate) projection_store: Arc<dyn ProjectionStore>,
     pub(crate) transport: Arc<dyn Transport>,
@@ -314,6 +315,32 @@ pub struct AppService {
     pub(crate) docs_sync: Arc<dyn DocsSync>,
     pub(crate) blob_service: Arc<dyn BlobService>,
     pub(crate) keys: Arc<KukuriKeys>,
+}
+
+impl ServiceHandles {
+    pub fn new(
+        store: Arc<dyn Store>,
+        projection_store: Arc<dyn ProjectionStore>,
+        transport: Arc<dyn Transport>,
+        hint_transport: Arc<dyn HintTransport>,
+        docs_sync: Arc<dyn DocsSync>,
+        blob_service: Arc<dyn BlobService>,
+        keys: KukuriKeys,
+    ) -> Self {
+        Self {
+            store,
+            projection_store,
+            transport,
+            hint_transport,
+            docs_sync,
+            blob_service,
+            keys: Arc::new(keys),
+        }
+    }
+}
+
+pub struct AppService {
+    pub(crate) services: ServiceHandles,
     /// 購読タスクの台帳(task ×5 / 世代 / 復旧 deadline。WP-H5 PR5)。
     pub(crate) subscription_registry: SubscriptionRegistry,
     pub(crate) joined_private_channels: Arc<Mutex<HashMap<String, JoinedPrivateChannelState>>>,
@@ -430,6 +457,18 @@ impl NotificationDocEventBaseline {
 }
 
 impl AppService {
+    pub(crate) fn hint_transport(&self) -> &dyn HintTransport {
+        self.services.hint_transport.as_ref()
+    }
+
+    pub(crate) fn docs_sync(&self) -> &dyn DocsSync {
+        self.services.docs_sync.as_ref()
+    }
+
+    pub(crate) fn keys(&self) -> &KukuriKeys {
+        self.services.keys.as_ref()
+    }
+
     pub fn new<S, T>(store: Arc<S>, transport: Arc<T>) -> Self
     where
         S: Store + ProjectionStore + 'static,
@@ -437,7 +476,7 @@ impl AppService {
     {
         let docs_sync = Arc::new(MemoryDocsSync::default());
         let blob_service = Arc::new(MemoryBlobService::default());
-        Self::new_with_services(
+        Self::from_handles(ServiceHandles::new(
             store.clone() as Arc<dyn Store>,
             store as Arc<dyn ProjectionStore>,
             transport.clone(),
@@ -445,26 +484,12 @@ impl AppService {
             docs_sync,
             blob_service,
             generate_keys(),
-        )
+        ))
     }
 
-    pub fn new_with_services(
-        store: Arc<dyn Store>,
-        projection_store: Arc<dyn ProjectionStore>,
-        transport: Arc<dyn Transport>,
-        hint_transport: Arc<dyn HintTransport>,
-        docs_sync: Arc<dyn DocsSync>,
-        blob_service: Arc<dyn BlobService>,
-        keys: KukuriKeys,
-    ) -> Self {
+    pub fn from_handles(services: ServiceHandles) -> Self {
         Self {
-            store,
-            transport,
-            projection_store,
-            hint_transport,
-            docs_sync,
-            blob_service,
-            keys: Arc::new(keys),
+            services,
             subscription_registry: SubscriptionRegistry::default(),
             joined_private_channels: Arc::new(Mutex::new(HashMap::new())),
             metaverse_room_events: Arc::new(Mutex::new(HashMap::new())),
@@ -499,23 +524,23 @@ impl AppService {
     ) -> Result<ResolvedRepostSource> {
         let source_object_id = EnvelopeId::from(source_object_id);
         if ObjectProjectionStore::get_object_projection(
-            self.projection_store.as_ref(),
+            self.services.projection_store.as_ref(),
             &source_object_id,
         )
         .await?
         .is_none()
         {
             let _ = hydrate_topic_state_with_services(
-                self.docs_sync.as_ref(),
-                self.blob_service.as_ref(),
-                self.projection_store.as_ref(),
+                self.services.docs_sync.as_ref(),
+                self.services.blob_service.as_ref(),
+                self.services.projection_store.as_ref(),
                 source_topic_id,
                 DocFetchPolicy::LocalThenRemote,
             )
             .await?;
         }
         let projection = ObjectProjectionStore::get_object_projection(
-            self.projection_store.as_ref(),
+            self.services.projection_store.as_ref(),
             &source_object_id,
         )
         .await?
@@ -531,7 +556,7 @@ impl AppService {
         }
 
         let header = fetch_post_object_for_projection(
-            self.docs_sync.as_ref(),
+            self.services.docs_sync.as_ref(),
             &projection.source_replica_id,
             projection.source_key.as_str(),
         )
@@ -540,7 +565,7 @@ impl AppService {
         let content = match &projection.payload_ref {
             PayloadRef::InlineText { text } => text.clone(),
             PayloadRef::BlobText { hash, .. } => {
-                fetch_projection_blob_text(self.blob_service.as_ref(), hash)
+                fetch_projection_blob_text(self.services.blob_service.as_ref(), hash)
                     .await
                     .ok_or_else(|| anyhow::anyhow!("repost source content is unavailable"))?
             }
@@ -571,6 +596,7 @@ impl AppService {
         let target_replica = topic_replica_id(target_topic_id);
         let local_author_pubkey = self.current_author_pubkey();
         for record in self
+            .services
             .docs_sync
             .query_replica(&target_replica, DocQuery::Prefix("objects/".into()))
             .await?
@@ -603,11 +629,11 @@ impl AppService {
     }
 
     pub(crate) async fn docs_assisted_peer_ids(&self) -> Result<Vec<String>> {
-        self.docs_sync.assist_peer_ids().await
+        self.services.docs_sync.assist_peer_ids().await
     }
 
     pub(crate) async fn blob_assisted_peer_ids(&self) -> Result<Vec<String>> {
-        self.blob_service.assist_peer_ids().await
+        self.services.blob_service.assist_peer_ids().await
     }
 
     pub(crate) async fn next_subscription_generation(&self, key: &str) -> u64 {
@@ -744,12 +770,14 @@ impl AppService {
         }
         for channel_id in private_channels_to_unsubscribe {
             let _ = self
+                .services
                 .hint_transport
                 .unsubscribe_hints(&private_channel_hint_topic(channel_id.as_str()))
                 .await;
         }
         for topic_id in topics_to_unsubscribe {
             let _ = self
+                .services
                 .hint_transport
                 .unsubscribe_hints(&TopicId::new(topic_id))
                 .await;
@@ -778,10 +806,11 @@ impl AppService {
             let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
         }
         for peer_pubkey in dm_peers_to_unsubscribe {
-            if let Ok(topic) =
-                derive_direct_message_topic(self.keys.as_ref(), &Pubkey::from(peer_pubkey.as_str()))
-            {
-                let _ = self.hint_transport.unsubscribe_hints(&topic).await;
+            if let Ok(topic) = derive_direct_message_topic(
+                self.services.keys.as_ref(),
+                &Pubkey::from(peer_pubkey.as_str()),
+            ) {
+                let _ = self.services.hint_transport.unsubscribe_hints(&topic).await;
             }
         }
         let author_handles = {
@@ -806,7 +835,7 @@ impl AppService {
     }
 
     pub(crate) fn current_author_pubkey(&self) -> String {
-        self.keys.public_key_hex()
+        self.services.keys.public_key_hex()
     }
 
     pub(crate) async fn reaction_state_for_target(
@@ -815,6 +844,7 @@ impl AppService {
         target_object_id: &EnvelopeId,
     ) -> Result<ReactionStateView> {
         let rows = self
+            .services
             .projection_store
             .list_reaction_cache_for_target(source_replica_id, target_object_id)
             .await?;

--- a/crates/app-api/src/service/private_channels_support.rs
+++ b/crates/app-api/src/service/private_channels_support.rs
@@ -16,7 +16,7 @@ impl AppService {
             let local_author = self.current_author_pubkey();
             let replica = current_private_channel_replica_id(&state);
             let grant_doc = fetch_private_channel_epoch_handoff_grant_from_replica(
-                self.docs_sync.as_ref(),
+                self.docs_sync(),
                 &replica,
                 local_author.as_str(),
                 DocFetchPolicy::LocalOnly,
@@ -26,6 +26,7 @@ impl AppService {
                 Some(grant_doc)
             } else {
                 let has_peers = self
+                    .services
                     .transport
                     .peers()
                     .await
@@ -33,7 +34,7 @@ impl AppService {
                 if !has_peers {
                     return Ok(redeemed_any);
                 }
-                if let Err(error) = self.docs_sync.restart_replica_sync(&replica).await {
+                if let Err(error) = self.docs_sync().restart_replica_sync(&replica).await {
                     warn!(
                         topic = %topic_id,
                         channel_id = %channel_id,
@@ -43,7 +44,7 @@ impl AppService {
                     );
                 }
                 fetch_private_channel_epoch_handoff_grant_from_replica(
-                    self.docs_sync.as_ref(),
+                    self.docs_sync(),
                     &replica,
                     local_author.as_str(),
                     DocFetchPolicy::LocalThenRemote,
@@ -53,20 +54,20 @@ impl AppService {
             let Some(grant_doc) = grant_doc else {
                 return Ok(redeemed_any);
             };
-            let payload =
-                match decrypt_private_channel_epoch_handoff_grant(self.keys.as_ref(), &grant_doc) {
-                    Ok(payload) => payload,
-                    Err(error) => {
-                        warn!(
-                            topic = %topic_id,
-                            channel_id = %channel_id,
-                            epoch_id = %state.current_epoch_id,
-                            error = %error,
-                            "failed to decrypt private channel epoch handoff grant"
-                        );
-                        return Ok(redeemed_any);
-                    }
-                };
+            let payload = match decrypt_private_channel_epoch_handoff_grant(self.keys(), &grant_doc)
+            {
+                Ok(payload) => payload,
+                Err(error) => {
+                    warn!(
+                        topic = %topic_id,
+                        channel_id = %channel_id,
+                        epoch_id = %state.current_epoch_id,
+                        error = %error,
+                        "failed to decrypt private channel epoch handoff grant"
+                    );
+                    return Ok(redeemed_any);
+                }
+            };
             if payload.old_epoch_id != state.current_epoch_id
                 || private_channel_epoch_capabilities(&state)
                     .iter()
@@ -76,13 +77,18 @@ impl AppService {
             }
             let next_replica =
                 private_channel_epoch_replica_id(channel_id, payload.new_epoch_id.as_str());
-            self.docs_sync
+            self.docs_sync()
                 .register_private_replica_secret(
                     &next_replica,
                     payload.new_namespace_secret_hex.as_str(),
                 )
                 .await?;
-            if let Err(error) = self.docs_sync.restart_replica_sync(&next_replica).await {
+            if let Err(error) = self
+                .services
+                .docs_sync
+                .restart_replica_sync(&next_replica)
+                .await
+            {
                 warn!(
                     topic = %topic_id,
                     channel_id = %channel_id,
@@ -92,7 +98,7 @@ impl AppService {
                 );
             }
             let (metadata, policy, participants) = match wait_for_private_channel_epoch_snapshot(
-                self.docs_sync.as_ref(),
+                self.docs_sync(),
                 &next_replica,
                 "private channel epoch handoff sync",
             )
@@ -130,8 +136,8 @@ impl AppService {
                     && participant.left_at.is_none()
             }) {
                 persist_private_channel_participant(
-                    self.docs_sync.as_ref(),
-                    self.keys.as_ref(),
+                    self.docs_sync(),
+                    self.keys(),
                     &PrivateChannelParticipantDocV1 {
                         channel_id: metadata.channel_id.clone(),
                         topic_id: metadata.topic_id.clone(),
@@ -170,7 +176,7 @@ impl AppService {
     ) -> Result<PrivateChannelDiagnostics> {
         let replica = current_private_channel_replica_id(state);
         let sharing_state = fetch_private_channel_policy_from_replica(
-            self.docs_sync.as_ref(),
+            self.docs_sync(),
             &replica,
             DocFetchPolicy::LocalOnly,
         )
@@ -178,7 +184,7 @@ impl AppService {
         .map(|policy| policy.sharing_state)
         .unwrap_or(ChannelSharingState::Open);
         let participants = fetch_private_channel_participants_from_replica(
-            self.docs_sync.as_ref(),
+            self.docs_sync(),
             &replica,
             DocFetchPolicy::LocalOnly,
         )
@@ -197,6 +203,7 @@ impl AppService {
                 self.ensure_author_subscription(participant.participant_pubkey.as_str())
                     .await?;
                 let relationship = self
+                    .services
                     .projection_store
                     .get_author_relationship(
                         self.current_author_pubkey().as_str(),
@@ -264,7 +271,6 @@ impl AppService {
             namespace_secret_hex: state.current_epoch_secret_hex.clone(),
         })
     }
-
     pub(crate) async fn audience_label_for_storage(
         &self,
         topic_id: &str,
@@ -280,7 +286,6 @@ impl AppService {
             .map(|channel| channel.label.clone())
             .unwrap_or_else(|| "Private channel".to_string())
     }
-
     pub(crate) async fn joined_private_channel_states_for_topic(
         &self,
         topic_id: &str,
@@ -293,7 +298,6 @@ impl AppService {
             .cloned()
             .collect()
     }
-
     pub(crate) async fn joined_private_channel_state(
         &self,
         topic_id: &str,
@@ -305,7 +309,6 @@ impl AppService {
             .get(joined_private_channel_key(topic_id, channel_id).as_str())
             .cloned()
     }
-
     pub(crate) async fn ensure_private_channel_access(
         &self,
         topic_id: &str,
@@ -320,7 +323,6 @@ impl AppService {
         }
         Ok(())
     }
-
     pub(crate) async fn maybe_auto_rotate_private_channel_for_owner(
         &self,
         topic_id: &str,
@@ -355,7 +357,6 @@ impl AppService {
         }
         Ok(())
     }
-
     pub(crate) async fn private_channel_state_for_owner_action(
         &self,
         topic_id: &str,
@@ -380,9 +381,7 @@ impl AppService {
             .joined_private_channel_state(topic_id, channel_id.as_str())
             .await
             .ok_or_else(|| anyhow::anyhow!("private channel is not joined"))?;
-        if private_channel_rotation_is_pending(self.docs_sync.as_ref(), self.keys.as_ref(), &state)
-            .await?
-        {
+        if private_channel_rotation_is_pending(self.docs_sync(), self.keys(), &state).await? {
             anyhow::bail!(
                 "private channel epoch handoff is pending; wait for automatic redemption or use a fresh access token"
             );
@@ -425,7 +424,7 @@ impl AppService {
         &self,
         state: JoinedPrivateChannelState,
     ) -> Result<()> {
-        register_private_channel_replica_secrets(self.docs_sync.as_ref(), &state).await?;
+        register_private_channel_replica_secrets(self.docs_sync(), &state).await?;
         self.joined_private_channels.lock().await.insert(
             joined_private_channel_key(state.topic_id.as_str(), state.channel_id.as_str()),
             state.clone(),
@@ -476,6 +475,7 @@ impl AppService {
             }
         }
         let has_peers = self
+            .services
             .transport
             .peers()
             .await
@@ -484,7 +484,7 @@ impl AppService {
             let hint_topic = private_channel_hint_topic(channel_id);
             match tokio::time::timeout(
                 std::time::Duration::from_secs(2),
-                self.hint_transport.unsubscribe_hints(&hint_topic),
+                self.hint_transport().unsubscribe_hints(&hint_topic),
             )
             .await
             {
@@ -563,7 +563,7 @@ impl AppService {
                 handle.abort();
             }
         }
-        self.hint_transport
+        self.hint_transport()
             .unsubscribe_hints(&private_channel_hint_topic(channel_id))
             .await?;
         let Some(state) = self
@@ -579,7 +579,7 @@ impl AppService {
         &self,
         state: JoinedPrivateChannelState,
     ) -> Result<()> {
-        let docs_sync = Arc::clone(&self.docs_sync);
+        let docs_sync = Arc::clone(&self.services.docs_sync);
         for epoch in private_channel_epoch_capabilities(&state) {
             let replica = private_channel_replica_for_epoch(
                 state.channel_id.as_str(),
@@ -622,11 +622,11 @@ impl AppService {
         hint_topic: TopicId,
         private_key: Option<String>,
     ) -> Result<()> {
-        let projection_store = Arc::clone(&self.projection_store);
-        let docs_sync = Arc::clone(&self.docs_sync);
-        let blob_service = Arc::clone(&self.blob_service);
-        let hint_transport = Arc::clone(&self.hint_transport);
-        let transport = Arc::clone(&self.transport);
+        let projection_store = Arc::clone(&self.services.projection_store);
+        let docs_sync = Arc::clone(&self.services.docs_sync);
+        let blob_service = Arc::clone(&self.services.blob_service);
+        let hint_transport = Arc::clone(&self.services.hint_transport);
+        let transport = Arc::clone(&self.services.transport);
         let metaverse_room_events = Arc::clone(&self.metaverse_room_events);
         let last_sync = Arc::clone(&self.last_sync_ts);
         let notification_inserted = Arc::clone(&self.notification_inserted_notify);

--- a/crates/app-api/src/service/social_runtime_support.rs
+++ b/crates/app-api/src/service/social_runtime_support.rs
@@ -5,12 +5,14 @@ impl AppService {
         &self,
         author_pubkey: &str,
     ) -> Result<AuthorSocialView> {
-        let profile = self.store.get_profile(author_pubkey).await?;
+        let profile = self.services.store.get_profile(author_pubkey).await?;
         let relationship = self
+            .services
             .projection_store
             .get_author_relationship(self.current_author_pubkey().as_str(), author_pubkey)
             .await?;
         let muted = self
+            .services
             .projection_store
             .get_muted_author(author_pubkey)
             .await?
@@ -25,8 +27,8 @@ impl AppService {
 
     pub(crate) async fn rebuild_author_relationships(&self) -> Result<()> {
         rebuild_author_relationships_with_services(
-            self.store.as_ref(),
-            self.projection_store.as_ref(),
+            self.services.store.as_ref(),
+            self.services.projection_store.as_ref(),
             self.current_author_pubkey().as_str(),
         )
         .await?;
@@ -47,8 +49,8 @@ impl AppService {
                 self.subscription_registry
                     .direct_message_subscriptions
                     .as_ref(),
-                self.hint_transport.as_ref(),
-                self.keys.as_ref(),
+                self.services.hint_transport.as_ref(),
+                self.services.keys.as_ref(),
                 peer_pubkey.as_str(),
             )
             .await?;
@@ -58,6 +60,7 @@ impl AppService {
 
     pub(crate) async fn current_muted_author_pubkeys(&self) -> Result<BTreeSet<String>> {
         Ok(self
+            .services
             .projection_store
             .list_muted_authors()
             .await?
@@ -150,13 +153,13 @@ impl AppService {
     }
 
     pub(crate) async fn spawn_author_subscription(&self, author_pubkey: &str) -> Result<()> {
-        let store = Arc::clone(&self.store);
-        let projection_store = Arc::clone(&self.projection_store);
-        let docs_sync = Arc::clone(&self.docs_sync);
-        let blob_service = Arc::clone(&self.blob_service);
-        let hint_transport = Arc::clone(&self.hint_transport);
-        let transport = Arc::clone(&self.transport);
-        let keys = Arc::clone(&self.keys);
+        let store = Arc::clone(&self.services.store);
+        let projection_store = Arc::clone(&self.services.projection_store);
+        let docs_sync = Arc::clone(&self.services.docs_sync);
+        let blob_service = Arc::clone(&self.services.blob_service);
+        let hint_transport = Arc::clone(&self.services.hint_transport);
+        let transport = Arc::clone(&self.services.transport);
+        let keys = Arc::clone(&self.services.keys);
         let last_sync = Arc::clone(&self.last_sync_ts);
         let notification_inserted = Arc::clone(&self.notification_inserted_notify);
         let direct_message_subscriptions =

--- a/crates/app-api/src/service/timeline_subscription_support.rs
+++ b/crates/app-api/src/service/timeline_subscription_support.rs
@@ -58,7 +58,8 @@ impl AppService {
         {
             handle.abort();
         }
-        self.hint_transport
+        self.services
+            .hint_transport
             .unsubscribe_hints(&TopicId::new(topic_id))
             .await?;
         self.spawn_topic_subscription(topic_id).await
@@ -82,7 +83,7 @@ impl AppService {
         _stored_blob: Option<StoredBlob>,
         attachments: Vec<(AssetRole, StoredBlob)>,
     ) -> Result<()> {
-        self.store.put_envelope(envelope.clone()).await?;
+        self.services.store.put_envelope(envelope.clone()).await?;
         let mut object = envelope
             .to_post_object()?
             .ok_or_else(|| anyhow::anyhow!("expected timeline envelope"))?;
@@ -100,19 +101,20 @@ impl AppService {
         let content = match &object.payload_ref {
             PayloadRef::InlineText { text } => Some(text.clone()),
             PayloadRef::BlobText { hash, .. } => self
+                .services
                 .blob_service
                 .fetch_blob(hash)
                 .await?
                 .map(|bytes| String::from_utf8_lossy(&bytes).to_string()),
         };
         persist_post_object(
-            self.docs_sync.as_ref(),
+            self.services.docs_sync.as_ref(),
             replica,
             object.clone(),
             envelope.clone(),
         )
         .await?;
-        if let Err(error) = self.docs_sync.restart_replica_sync(replica).await {
+        if let Err(error) = self.services.docs_sync.restart_replica_sync(replica).await {
             warn!(
                 replica_id = %replica.as_str(),
                 error = %error,
@@ -120,13 +122,13 @@ impl AppService {
             );
         }
         ObjectProjectionStore::put_object_projection(
-            self.projection_store.as_ref(),
+            self.services.projection_store.as_ref(),
             projection_row_from_header(&object, content, replica),
         )
         .await?;
         if let PayloadRef::BlobText { hash, .. } = &object.payload_ref {
             BlobCacheStore::mark_blob_status(
-                self.projection_store.as_ref(),
+                self.services.projection_store.as_ref(),
                 hash,
                 BlobCacheStatus::Available,
             )
@@ -134,7 +136,7 @@ impl AppService {
         }
         for (_, attachment) in attachments {
             BlobCacheStore::mark_blob_status(
-                self.projection_store.as_ref(),
+                self.services.projection_store.as_ref(),
                 &attachment.hash,
                 BlobCacheStatus::Available,
             )
@@ -148,13 +150,15 @@ impl AppService {
         &self,
         object_id: &EnvelopeId,
     ) -> Result<Option<KukuriEnvelope>> {
-        if let Some(envelope) = self.store.get_envelope(object_id).await? {
+        if let Some(envelope) = self.services.store.get_envelope(object_id).await? {
             return Ok(Some(envelope));
         }
 
-        let Some(projection) =
-            ObjectProjectionStore::get_object_projection(self.projection_store.as_ref(), object_id)
-                .await?
+        let Some(projection) = ObjectProjectionStore::get_object_projection(
+            self.services.projection_store.as_ref(),
+            object_id,
+        )
+        .await?
         else {
             return Ok(None);
         };
@@ -271,9 +275,9 @@ impl AppService {
         scope: &TimelineScope,
     ) -> Result<usize> {
         let mut hydrated = hydrate_topic_state_with_services(
-            self.docs_sync.as_ref(),
-            self.blob_service.as_ref(),
-            self.projection_store.as_ref(),
+            self.services.docs_sync.as_ref(),
+            self.services.blob_service.as_ref(),
+            self.services.projection_store.as_ref(),
             topic_id,
             DocFetchPolicy::LocalOnly,
         )
@@ -293,9 +297,9 @@ impl AppService {
                             })
                     {
                         hydrated += hydrate_subscription_state_with_services(
-                            self.docs_sync.as_ref(),
-                            self.blob_service.as_ref(),
-                            self.projection_store.as_ref(),
+                            self.services.docs_sync.as_ref(),
+                            self.services.blob_service.as_ref(),
+                            self.services.projection_store.as_ref(),
                             topic_id,
                             &replica,
                             DocFetchPolicy::LocalOnly,
@@ -322,9 +326,9 @@ impl AppService {
                             })
                     {
                         hydrated += hydrate_subscription_state_with_services(
-                            self.docs_sync.as_ref(),
-                            self.blob_service.as_ref(),
-                            self.projection_store.as_ref(),
+                            self.services.docs_sync.as_ref(),
+                            self.services.blob_service.as_ref(),
+                            self.services.projection_store.as_ref(),
                             topic_id,
                             &replica,
                             DocFetchPolicy::LocalOnly,
@@ -393,7 +397,7 @@ impl AppService {
 
     pub(crate) async fn maybe_restart_replica_sync(&self, topic_id: &str, replica: &ReplicaId) {
         maybe_restart_replica_sync_with_cooldown(
-            self.docs_sync.as_ref(),
+            self.services.docs_sync.as_ref(),
             &self.subscription_registry.replica_sync_restart_deadlines,
             topic_id,
             replica,

--- a/crates/app-api/src/service/timeline_view_support.rs
+++ b/crates/app-api/src/service/timeline_view_support.rs
@@ -23,14 +23,16 @@ impl AppService {
         }
 
         let author_pubkeys = author_pubkeys.into_iter().collect::<Vec<_>>();
-        let profiles = self.store.get_profiles(&author_pubkeys).await?;
+        let profiles = self.services.store.get_profiles(&author_pubkeys).await?;
         let relationships = self
+            .services
             .projection_store
             .list_author_relationships(local_author.as_str(), &author_pubkeys)
             .await?;
         let mut reactions_by_target = HashMap::<String, Vec<ReactionProjectionRow>>::new();
         for (replica_id, object_ids) in targets_by_replica {
             let grouped = self
+                .services
                 .projection_store
                 .list_reaction_cache_for_targets(&ReplicaId::new(replica_id.clone()), &object_ids)
                 .await?;
@@ -65,7 +67,8 @@ impl AppService {
         let content_status = if row.object_kind == "repost" {
             BlobViewStatus::Available
         } else {
-            blob_view_status_for_payload(self.blob_service.as_ref(), &row.payload_ref).await?
+            blob_view_status_for_payload(self.services.blob_service.as_ref(), &row.payload_ref)
+                .await?
         };
         let attachments = self.attachment_views_for_projection_row(&row).await?;
         let repost_of = match row.repost_of.clone() {
@@ -144,6 +147,7 @@ impl AppService {
         source_replica_id: Option<&ReplicaId>,
     ) -> Result<Option<ObjectProjectionRow>> {
         if let Some(row) = self
+            .services
             .projection_store
             .get_object_projection(object_id)
             .await?
@@ -155,7 +159,7 @@ impl AppService {
         };
         let source_key = stable_key("objects", &format!("{}/state", object_id.as_str()));
         let Some(header) = fetch_post_object_for_projection(
-            self.docs_sync.as_ref(),
+            self.services.docs_sync.as_ref(),
             source_replica_id,
             source_key.as_str(),
         )
@@ -166,11 +170,12 @@ impl AppService {
         let content = match &header.payload_ref {
             PayloadRef::InlineText { text } => Some(text.clone()),
             PayloadRef::BlobText { hash, .. } => {
-                fetch_projection_blob_text(self.blob_service.as_ref(), hash).await
+                fetch_projection_blob_text(self.services.blob_service.as_ref(), hash).await
             }
         };
         let row = projection_row_from_header(&header, content, source_replica_id);
-        self.projection_store
+        self.services
+            .projection_store
             .put_object_projection(row.clone())
             .await?;
         Ok(Some(row))
@@ -194,7 +199,12 @@ impl AppService {
         let attachments = self.attachment_views_for_projection_row(&row).await?;
         let profile = match profiles.get(row.author_pubkey.as_str()) {
             Some(profile) => Some(profile.clone()),
-            None => self.store.get_profile(row.author_pubkey.as_str()).await?,
+            None => {
+                self.services
+                    .store
+                    .get_profile(row.author_pubkey.as_str())
+                    .await?
+            }
         };
         Ok(Some(ReplyPreviewView {
             object_id: row.object_id.0.clone(),
@@ -225,17 +235,21 @@ impl AppService {
             return Ok(Vec::new());
         }
         if !row.attachments.is_empty() || row.projection_version >= 2 {
-            return attachment_views_from_refs(self.blob_service.as_ref(), &row.attachments).await;
+            return attachment_views_from_refs(
+                self.services.blob_service.as_ref(),
+                &row.attachments,
+            )
+            .await;
         }
 
         let post_object = fetch_post_object_for_projection(
-            self.docs_sync.as_ref(),
+            self.services.docs_sync.as_ref(),
             &row.source_replica_id,
             row.source_key.as_str(),
         )
         .await?;
         if let Some(post_object) = post_object {
-            return attachment_views(self.blob_service.as_ref(), &post_object).await;
+            return attachment_views(self.services.blob_service.as_ref(), &post_object).await;
         }
         Ok(Vec::new())
     }
@@ -244,8 +258,13 @@ impl AppService {
         &self,
         row: BookmarkedPostRow,
     ) -> Result<BookmarkedPostView> {
-        let profile = self.store.get_profile(row.author_pubkey.as_str()).await?;
+        let profile = self
+            .services
+            .store
+            .get_profile(row.author_pubkey.as_str())
+            .await?;
         let relationship = self
+            .services
             .projection_store
             .get_author_relationship(
                 self.current_author_pubkey().as_str(),
@@ -255,12 +274,14 @@ impl AppService {
         let content_status = if row.object_kind == "repost" {
             BlobViewStatus::Available
         } else {
-            blob_view_status_for_payload(self.blob_service.as_ref(), &row.payload_ref).await?
+            blob_view_status_for_payload(self.services.blob_service.as_ref(), &row.payload_ref)
+                .await?
         };
         let attachments = if row.object_kind == "repost" {
             Vec::new()
         } else {
-            attachment_views_from_refs(self.blob_service.as_ref(), &row.attachments).await?
+            attachment_views_from_refs(self.services.blob_service.as_ref(), &row.attachments)
+                .await?
         };
         let repost_commentary = normalize_repost_commentary(row.content.clone());
         let repost_of = match row.repost_of.clone() {
@@ -329,10 +350,12 @@ impl AppService {
 
     pub(crate) async fn profile_post_to_view(&self, profile_post: ProfilePost) -> Result<PostView> {
         let profile = self
+            .services
             .store
             .get_profile(profile_post.author_pubkey.as_str())
             .await?;
         let relationship = self
+            .services
             .projection_store
             .get_author_relationship(
                 self.current_author_pubkey().as_str(),
@@ -375,7 +398,7 @@ impl AppService {
             content: profile_post.content,
             content_status: BlobViewStatus::Available,
             attachments: attachment_views_from_refs(
-                self.blob_service.as_ref(),
+                self.services.blob_service.as_ref(),
                 &profile_post.attachments,
             )
             .await?,
@@ -400,10 +423,12 @@ impl AppService {
         profile_repost: ProfileRepost,
     ) -> Result<PostView> {
         let profile = self
+            .services
             .store
             .get_profile(profile_repost.author_pubkey.as_str())
             .await?;
         let relationship = self
+            .services
             .projection_store
             .get_author_relationship(
                 self.current_author_pubkey().as_str(),
@@ -461,6 +486,7 @@ impl AppService {
         snapshot: RepostSourceSnapshotV1,
     ) -> Result<RepostSourceView> {
         let profiles = self
+            .services
             .store
             .get_profiles(&[snapshot.source_author_pubkey.as_str().to_string()])
             .await?;
@@ -486,7 +512,7 @@ impl AppService {
             source_object_kind: snapshot.source_object_kind,
             content: snapshot.content,
             attachments: attachment_views_from_refs(
-                self.blob_service.as_ref(),
+                self.services.blob_service.as_ref(),
                 &snapshot.attachments,
             )
             .await?,

--- a/crates/app-api/src/social.rs
+++ b/crates/app-api/src/social.rs
@@ -7,6 +7,7 @@ impl AppService {
             .await?;
         self.rebuild_author_relationships().await?;
         for edge in self
+            .services
             .store
             .list_follow_edges_by_subject(local_author.as_str())
             .await?
@@ -24,6 +25,7 @@ impl AppService {
         self.ensure_author_subscription(local_author.as_str())
             .await?;
         Ok(self
+            .services
             .store
             .get_profile(local_author.as_str())
             .await?
@@ -61,6 +63,7 @@ impl AppService {
             None
         } else if let Some(upload) = input.picture_upload {
             let stored = self
+                .services
                 .blob_service
                 .put_blob(upload.bytes, upload.mime.as_str())
                 .await?;
@@ -74,7 +77,7 @@ impl AppService {
             current_profile.picture_asset.clone()
         };
         let envelope = build_profile_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &KukuriProfileEnvelopeContentV1 {
                 author_pubkey: author_pubkey.clone(),
                 name,
@@ -86,11 +89,12 @@ impl AppService {
         )?;
         let profile = parse_profile(&envelope)?
             .ok_or_else(|| anyhow::anyhow!("failed to parse profile envelope"))?;
-        self.store.put_envelope(envelope.clone()).await?;
-        self.projection_store
+        self.services.store.put_envelope(envelope.clone()).await?;
+        self.services
+            .projection_store
             .upsert_profile_cache(profile.clone())
             .await?;
-        persist_profile_doc(self.docs_sync.as_ref(), &profile, &envelope).await?;
+        persist_profile_doc(self.services.docs_sync.as_ref(), &profile, &envelope).await?;
         self.rebuild_author_relationships().await?;
         *self.last_sync_ts.lock().await = Some(Utc::now().timestamp_millis());
         Ok(profile)
@@ -99,14 +103,14 @@ impl AppService {
     pub async fn follow_author(&self, pubkey: &str) -> Result<AuthorSocialView> {
         let target_pubkey = Pubkey::from(normalize_author_pubkey(pubkey)?);
         let envelope = build_follow_edge_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &target_pubkey,
             FollowEdgeStatus::Active,
         )?;
         let edge = parse_follow_edge(&envelope)?
             .ok_or_else(|| anyhow::anyhow!("failed to parse follow edge"))?;
-        self.store.put_envelope(envelope.clone()).await?;
-        persist_follow_edge_doc(self.docs_sync.as_ref(), &edge, &envelope).await?;
+        self.services.store.put_envelope(envelope.clone()).await?;
+        persist_follow_edge_doc(self.services.docs_sync.as_ref(), &edge, &envelope).await?;
         self.ensure_author_subscription(target_pubkey.as_str())
             .await?;
         self.rebuild_author_relationships().await?;
@@ -117,14 +121,14 @@ impl AppService {
     pub async fn unfollow_author(&self, pubkey: &str) -> Result<AuthorSocialView> {
         let target_pubkey = Pubkey::from(normalize_author_pubkey(pubkey)?);
         let envelope = build_follow_edge_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &target_pubkey,
             FollowEdgeStatus::Revoked,
         )?;
         let edge = parse_follow_edge(&envelope)?
             .ok_or_else(|| anyhow::anyhow!("failed to parse follow edge"))?;
-        self.store.put_envelope(envelope.clone()).await?;
-        persist_follow_edge_doc(self.docs_sync.as_ref(), &edge, &envelope).await?;
+        self.services.store.put_envelope(envelope.clone()).await?;
+        persist_follow_edge_doc(self.services.docs_sync.as_ref(), &edge, &envelope).await?;
         self.ensure_author_subscription(target_pubkey.as_str())
             .await?;
         self.rebuild_author_relationships().await?;
@@ -146,7 +150,8 @@ impl AppService {
         let author_pubkey = normalize_author_pubkey(pubkey)?;
         self.ensure_author_subscription(author_pubkey.as_str())
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .put_muted_author(MutedAuthorRow {
                 author_pubkey: author_pubkey.clone(),
                 muted_at: Utc::now().timestamp_millis(),
@@ -159,7 +164,8 @@ impl AppService {
         let author_pubkey = normalize_author_pubkey(pubkey)?;
         self.ensure_author_subscription(author_pubkey.as_str())
             .await?;
-        self.projection_store
+        self.services
+            .projection_store
             .remove_muted_author(author_pubkey.as_str())
             .await?;
         self.build_author_social_view(author_pubkey.as_str()).await
@@ -172,6 +178,7 @@ impl AppService {
         let local_author_pubkey = self.current_author_pubkey();
         let pubkeys = match kind {
             SocialConnectionKind::Following => self
+                .services
                 .store
                 .list_follow_edges_by_subject(local_author_pubkey.as_str())
                 .await?
@@ -180,6 +187,7 @@ impl AppService {
                 .map(|edge| edge.target_pubkey.as_str().to_string())
                 .collect::<BTreeSet<_>>(),
             SocialConnectionKind::Followed => self
+                .services
                 .store
                 .list_follow_edges_by_target(local_author_pubkey.as_str())
                 .await?
@@ -188,6 +196,7 @@ impl AppService {
                 .map(|edge| edge.subject_pubkey.as_str().to_string())
                 .collect::<BTreeSet<_>>(),
             SocialConnectionKind::Muted => self
+                .services
                 .projection_store
                 .list_muted_authors()
                 .await?

--- a/crates/app-api/src/sync.rs
+++ b/crates/app-api/src/sync.rs
@@ -14,7 +14,7 @@ impl AppService {
             status_detail,
             last_error,
             topic_diagnostics,
-        } = self.transport.peers().await?;
+        } = self.services.transport.peers().await?;
         let subscribed_topics = normalize_topics(subscribed_topics);
         let topic_diagnostics = normalize_topic_diagnostics(topic_diagnostics);
         let docs_assist_peer_ids = self.docs_assisted_peer_ids().await?;
@@ -113,7 +113,7 @@ impl AppService {
             connected_peer_ids,
             local_endpoint_id,
             last_discovery_error,
-        } = self.transport.discovery().await?;
+        } = self.services.transport.discovery().await?;
         let docs_assist_peer_ids = self.docs_assisted_peer_ids().await?;
         let blob_assist_peer_ids = self.blob_assisted_peer_ids().await?;
         Ok(DiscoveryStatus {
@@ -134,9 +134,12 @@ impl AppService {
     }
 
     pub async fn import_peer_ticket(&self, ticket: &str) -> Result<()> {
-        self.transport.import_ticket(ticket).await?;
-        self.docs_sync.import_peer_ticket(ticket).await?;
-        self.blob_service.import_peer_ticket(ticket).await?;
+        self.services.transport.import_ticket(ticket).await?;
+        self.services.docs_sync.import_peer_ticket(ticket).await?;
+        self.services
+            .blob_service
+            .import_peer_ticket(ticket)
+            .await?;
         self.restart_active_subscriptions().await?;
         Ok(())
     }
@@ -150,7 +153,8 @@ impl AppService {
     ) -> Result<()> {
         let effective_seed_peers =
             merge_seed_peers(configured_seed_peers.clone(), bootstrap_seed_peers.clone());
-        self.transport
+        self.services
+            .transport
             .configure_discovery(
                 mode,
                 env_locked,
@@ -158,10 +162,12 @@ impl AppService {
                 bootstrap_seed_peers,
             )
             .await?;
-        self.docs_sync
+        self.services
+            .docs_sync
             .set_seed_peers(effective_seed_peers.clone())
             .await?;
-        self.blob_service
+        self.services
+            .blob_service
             .set_seed_peers(effective_seed_peers)
             .await?;
         self.restart_active_subscriptions().await?;
@@ -201,7 +207,8 @@ impl AppService {
             let mut parts = key.splitn(3, "::");
             let _ = parts.next();
             if let Some(channel_id) = parts.next() {
-                self.hint_transport
+                self.services
+                    .hint_transport
                     .unsubscribe_hints(&private_channel_hint_topic(channel_id))
                     .await?;
             }
@@ -223,13 +230,14 @@ impl AppService {
             self.stop_live_presence_task(topic_id, channel_id.as_str(), session_id.as_str())
                 .await;
         }
-        self.hint_transport
+        self.services
+            .hint_transport
             .unsubscribe_hints(&TopicId::new(topic_id))
             .await
     }
 
     pub async fn peer_ticket(&self) -> Result<Option<String>> {
-        self.transport.export_ticket().await
+        self.services.transport.export_ticket().await
     }
 
     pub async fn set_topic_gossip_enabled(&self, topic_id: &str, enabled: bool) -> Result<()> {

--- a/crates/app-api/src/tests/direct_messages/access.rs
+++ b/crates/app-api/src/tests/direct_messages/access.rs
@@ -38,7 +38,7 @@ async fn dm_status_stays_enabled_during_concurrent_relationship_rebuilds() {
             .expect("connect writer store"),
     );
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         app_store.clone(),
         app_store.clone(),
         transport,
@@ -54,7 +54,7 @@ async fn dm_status_stays_enabled_during_concurrent_relationship_rebuilds() {
     app_store
         .put_envelope(
             build_follow_edge_envelope(
-                app.keys.as_ref(),
+                app.services.keys.as_ref(),
                 &Pubkey::from(peer_pubkey.as_str()),
                 FollowEdgeStatus::Active,
             )

--- a/crates/app-api/src/tests/direct_messages/delivery.rs
+++ b/crates/app-api/src/tests/direct_messages/delivery.rs
@@ -50,7 +50,7 @@ async fn dm_first_message_appears_in_recipient_conversation_list_without_opening
         .await
         .expect("seed follow edge b->a in store b");
 
-    let app_a = AppService::new_with_services(
+    let app_a = app_service_from_dependencies(
         store_a.clone(),
         store_a,
         transport.clone(),
@@ -59,7 +59,7 @@ async fn dm_first_message_appears_in_recipient_conversation_list_without_opening
         blob_service.clone(),
         keys_a.clone(),
     );
-    let app_b = AppService::new_with_services(
+    let app_b = app_service_from_dependencies(
         store_b.clone(),
         store_b,
         transport.clone(),
@@ -178,7 +178,7 @@ async fn dm_outbox_retry_stops_when_mutual_is_lost_and_resumes_when_it_returns()
         .await
         .expect("seed follow edge peer->local");
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),

--- a/crates/app-api/src/tests/direct_messages/restart.rs
+++ b/crates/app-api/src/tests/direct_messages/restart.rs
@@ -50,7 +50,7 @@ async fn dm_restart_resumes_pending_outbox_and_local_delete_prevents_duplicate_r
         .await
         .expect("seed follow edge b->a in store b");
 
-    let app_a = AppService::new_with_services(
+    let app_a = app_service_from_dependencies(
         store_a.clone(),
         store_a.clone(),
         transport.clone(),
@@ -59,7 +59,7 @@ async fn dm_restart_resumes_pending_outbox_and_local_delete_prevents_duplicate_r
         blob_service.clone(),
         keys_a.clone(),
     );
-    let app_b = AppService::new_with_services(
+    let app_b = app_service_from_dependencies(
         store_b.clone(),
         store_b.clone(),
         transport.clone(),
@@ -106,7 +106,7 @@ async fn dm_restart_resumes_pending_outbox_and_local_delete_prevents_duplicate_r
 
     drop(app_a);
 
-    let reopened_app_a = AppService::new_with_services(
+    let reopened_app_a = app_service_from_dependencies(
         store_a.clone(),
         store_a.clone(),
         transport.clone(),
@@ -283,7 +283,7 @@ async fn dm_restart_surfaces_queued_message_in_conversation_list_without_reopeni
         .await
         .expect("seed follow edge b->a in store b");
 
-    let app_a = AppService::new_with_services(
+    let app_a = app_service_from_dependencies(
         store_a.clone(),
         store_a.clone(),
         transport.clone(),
@@ -292,7 +292,7 @@ async fn dm_restart_surfaces_queued_message_in_conversation_list_without_reopeni
         blob_service.clone(),
         keys_a.clone(),
     );
-    let app_b = AppService::new_with_services(
+    let app_b = app_service_from_dependencies(
         store_b.clone(),
         store_b.clone(),
         transport.clone(),
@@ -327,7 +327,7 @@ async fn dm_restart_surfaces_queued_message_in_conversation_list_without_reopeni
     drop(app_a);
     drop(app_b);
 
-    let reopened_app_b = AppService::new_with_services(
+    let reopened_app_b = app_service_from_dependencies(
         store_b.clone(),
         store_b.clone(),
         transport.clone(),
@@ -341,7 +341,7 @@ async fn dm_restart_surfaces_queued_message_in_conversation_list_without_reopeni
         .await
         .expect("resume recipient direct message state");
 
-    let reopened_app_a = AppService::new_with_services(
+    let reopened_app_a = app_service_from_dependencies(
         store_a.clone(),
         store_a.clone(),
         transport.clone(),

--- a/crates/app-api/src/tests/direct_messages/subscription_status.rs
+++ b/crates/app-api/src/tests/direct_messages/subscription_status.rs
@@ -52,7 +52,7 @@ async fn dm_open_does_not_duplicate_active_subscription_when_mutual_auto_subscri
         .await
         .expect("seed peer->local follow edge");
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -126,7 +126,7 @@ async fn dm_list_does_not_restart_active_subscription_after_open() {
         .await
         .expect("seed peer->local follow edge");
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport,
@@ -190,7 +190,7 @@ async fn dm_import_peer_ticket_restarts_active_mutual_subscription() {
         .await
         .expect("seed peer->local follow edge");
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -205,8 +205,11 @@ async fn dm_import_peer_ticket_restarts_active_mutual_subscription() {
         .expect("open direct message");
     sleep(Duration::from_millis(50)).await;
 
-    let topic = derive_direct_message_topic(app.keys.as_ref(), &Pubkey::from(peer_pubkey.as_str()))
-        .expect("derive dm topic");
+    let topic = derive_direct_message_topic(
+        app.services.keys.as_ref(),
+        &Pubkey::from(peer_pubkey.as_str()),
+    )
+    .expect("derive dm topic");
     assert!(
         app.subscription_registry
             .direct_message_subscriptions
@@ -269,7 +272,7 @@ async fn dm_status_restarts_mutual_subscription_when_handle_is_missing() {
         .await
         .expect("seed peer->local follow edge");
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -365,7 +368,7 @@ async fn dm_status_restarts_stale_active_subscription_when_topic_is_unjoined() {
         .await
         .expect("seed peer->local follow edge");
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),

--- a/crates/app-api/src/tests/game.rs
+++ b/crates/app-api/src/tests/game.rs
@@ -624,7 +624,7 @@ async fn metaverse_room_shared_object_update_allows_non_owner_without_status_cha
     let blob_service = Arc::new(MemoryBlobService::default());
     let owner_store = Arc::new(MemoryStore::default());
     let peer_store = Arc::new(MemoryStore::default());
-    let app_owner = AppService::new_with_services(
+    let app_owner = app_service_from_dependencies(
         owner_store.clone(),
         owner_store,
         transport.clone(),
@@ -633,7 +633,7 @@ async fn metaverse_room_shared_object_update_allows_non_owner_without_status_cha
         blob_service.clone(),
         generate_keys(),
     );
-    let app_peer = AppService::new_with_services(
+    let app_peer = app_service_from_dependencies(
         peer_store.clone(),
         peer_store,
         transport.clone(),
@@ -754,7 +754,7 @@ async fn metaverse_room_manifest_restores_after_restart_from_docs_and_blobs() {
     let docs_sync = Arc::new(MemoryDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
     let keys = generate_keys();
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -809,7 +809,7 @@ async fn metaverse_room_manifest_restores_after_restart_from_docs_and_blobs() {
     .expect("publish restart chat");
 
     let restarted_store = Arc::new(MemoryStore::default());
-    let restarted = AppService::new_with_services(
+    let restarted = app_service_from_dependencies(
         restarted_store.clone(),
         restarted_store,
         transport,

--- a/crates/app-api/src/tests/media.rs
+++ b/crates/app-api/src/tests/media.rs
@@ -145,7 +145,7 @@ async fn list_timeline_rehydrates_placeholder_from_blob_store() {
     )
     .await;
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -191,7 +191,7 @@ async fn on_demand_hydration_updates_last_sync_ts() {
     )
     .await;
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -286,7 +286,7 @@ async fn thread_open_triggers_lazy_blob_fetch() {
     )
     .await;
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -348,7 +348,7 @@ async fn image_post_visible_before_full_blob_download() {
     )
     .await;
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -426,7 +426,7 @@ async fn video_post_visible_before_full_blob_download() {
     )
     .await;
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -502,7 +502,7 @@ async fn blob_media_payload_roundtrip() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(FakeTransport::new("app", FakeNetwork::default()));
     let blob_service = Arc::new(MemoryBlobService::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),

--- a/crates/app-api/src/tests/notifications.rs
+++ b/crates/app-api/src/tests/notifications.rs
@@ -472,7 +472,7 @@ async fn quote_repost_notification_survives_hydration_before_live_doc_event() {
 #[tokio::test]
 async fn incoming_dm_frame_creates_single_direct_message_notification_after_store() {
     let (app, store, _, blob_service) = local_app_with_memory_services();
-    let local_keys = app.keys.clone();
+    let local_keys = app.services.keys.clone();
     let local_author_pubkey = app.current_author_pubkey();
     let remote_keys = generate_keys();
     let remote_pubkey = remote_keys.public_key_hex();

--- a/crates/app-api/src/tests/private_channels/friend_only.rs
+++ b/crates/app-api/src/tests/private_channels/friend_only.rs
@@ -16,7 +16,7 @@ async fn friend_only_grant_requires_mutual_and_rotate_requires_fresh_grant() {
     let keys_b = generate_keys();
     let keys_c = generate_keys();
     let keys_d = generate_keys();
-    let app_a = AppService::new_with_services(
+    let app_a = app_service_from_dependencies(
         store_a.clone(),
         store_a.clone(),
         stack_a.transport.clone(),
@@ -25,7 +25,7 @@ async fn friend_only_grant_requires_mutual_and_rotate_requires_fresh_grant() {
         stack_a.blob_service.clone(),
         keys_a.clone(),
     );
-    let app_b = AppService::new_with_services(
+    let app_b = app_service_from_dependencies(
         store_b.clone(),
         store_b.clone(),
         stack_b.transport.clone(),
@@ -34,7 +34,7 @@ async fn friend_only_grant_requires_mutual_and_rotate_requires_fresh_grant() {
         stack_b.blob_service.clone(),
         keys_b.clone(),
     );
-    let app_c = AppService::new_with_services(
+    let app_c = app_service_from_dependencies(
         store_c.clone(),
         store_c.clone(),
         stack_c.transport.clone(),
@@ -43,7 +43,7 @@ async fn friend_only_grant_requires_mutual_and_rotate_requires_fresh_grant() {
         stack_c.blob_service.clone(),
         keys_c.clone(),
     );
-    let app_d = AppService::new_with_services(
+    let app_d = app_service_from_dependencies(
         store_d.clone(),
         store_d.clone(),
         stack_d.transport.clone(),

--- a/crates/app-api/src/tests/private_channels/friend_plus.rs
+++ b/crates/app-api/src/tests/private_channels/friend_plus.rs
@@ -20,7 +20,7 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
     let keys_b = generate_keys();
     let keys_c = generate_keys();
     let keys_d = generate_keys();
-    let app_a = AppService::new_with_services(
+    let app_a = app_service_from_dependencies(
         store_a.clone(),
         store_a.clone(),
         stack_a.transport.clone(),
@@ -29,7 +29,7 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
         stack_a.blob_service.clone(),
         keys_a.clone(),
     );
-    let app_b = AppService::new_with_services(
+    let app_b = app_service_from_dependencies(
         store_b.clone(),
         store_b.clone(),
         stack_b.transport.clone(),
@@ -38,7 +38,7 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
         stack_b.blob_service.clone(),
         keys_b.clone(),
     );
-    let app_c = AppService::new_with_services(
+    let app_c = app_service_from_dependencies(
         store_c.clone(),
         store_c.clone(),
         stack_c.transport.clone(),
@@ -47,7 +47,7 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
         stack_c.blob_service.clone(),
         keys_c.clone(),
     );
-    let app_d = AppService::new_with_services(
+    let app_d = app_service_from_dependencies(
         store_d.clone(),
         store_d.clone(),
         stack_d.transport.clone(),
@@ -348,7 +348,7 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
     );
     assert!(
         fetch_private_channel_epoch_handoff_grant_from_replica(
-            app_a.docs_sync.as_ref(),
+            app_a.services.docs_sync.as_ref(),
             &rotated_source_replica,
             b_pubkey.as_str(),
             DocFetchPolicy::LocalThenRemote,
@@ -398,7 +398,7 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
                 .find(|entry| entry.channel_id == channel.channel_id)
                 .cloned();
             let grant_visible = fetch_private_channel_epoch_handoff_grant_from_replica(
-                app_b.docs_sync.as_ref(),
+                app_b.services.docs_sync.as_ref(),
                 &rotated_source_replica,
                 b_pubkey.as_str(),
                 DocFetchPolicy::LocalThenRemote,

--- a/crates/app-api/src/tests/reactions.rs
+++ b/crates/app-api/src/tests/reactions.rs
@@ -304,7 +304,7 @@ async fn local_bookmarks_restore_saved_custom_reactions_after_restart() {
     let local_keys = generate_keys();
     let foreign_keys = generate_keys();
     let foreign_pubkey = foreign_keys.public_key_hex();
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -334,7 +334,7 @@ async fn local_bookmarks_restore_saved_custom_reactions_after_restart() {
             .await
             .expect("reopen sqlite store"),
     );
-    let reopened_app = AppService::new_with_services(
+    let reopened_app = app_service_from_dependencies(
         reopened.clone(),
         reopened.clone(),
         transport,

--- a/crates/app-api/src/tests/social.rs
+++ b/crates/app-api/src/tests/social.rs
@@ -15,7 +15,7 @@ async fn mute_author_restores_after_restart() {
     let keys = generate_keys();
     let author_pubkey = generate_keys().public_key_hex();
 
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -38,7 +38,7 @@ async fn mute_author_restores_after_restart() {
             .await
             .expect("reopen sqlite store"),
     );
-    let reopened_app = AppService::new_with_services(
+    let reopened_app = app_service_from_dependencies(
         reopened.clone(),
         reopened.clone(),
         transport,
@@ -374,7 +374,7 @@ async fn social_graph_derives_friend_of_friend_and_clears_after_unfollow() {
     let keys_a = generate_keys();
     let keys_b = generate_keys();
     let keys_c = generate_keys();
-    let app_a = AppService::new_with_services(
+    let app_a = app_service_from_dependencies(
         store_a.clone(),
         store_a.clone(),
         stack_a.transport.clone(),
@@ -383,7 +383,7 @@ async fn social_graph_derives_friend_of_friend_and_clears_after_unfollow() {
         stack_a.blob_service.clone(),
         keys_a.clone(),
     );
-    let app_b = AppService::new_with_services(
+    let app_b = app_service_from_dependencies(
         store_b.clone(),
         store_b.clone(),
         stack_b.transport.clone(),

--- a/crates/app-api/src/tests/support/fixtures.rs
+++ b/crates/app-api/src/tests/support/fixtures.rs
@@ -1,5 +1,25 @@
 use super::super::*;
 
+pub(crate) fn app_service_from_dependencies(
+    store: Arc<dyn Store>,
+    projection_store: Arc<dyn ProjectionStore>,
+    transport: Arc<dyn Transport>,
+    hint_transport: Arc<dyn HintTransport>,
+    docs_sync: Arc<dyn DocsSync>,
+    blob_service: Arc<dyn BlobService>,
+    keys: KukuriKeys,
+) -> AppService {
+    AppService::from_handles(ServiceHandles::new(
+        store,
+        projection_store,
+        transport,
+        hint_transport,
+        docs_sync,
+        blob_service,
+        keys,
+    ))
+}
+
 pub(crate) async fn persist_test_post(
     docs_sync: &dyn DocsSync,
     projection_store: Option<&dyn ProjectionStore>,
@@ -88,7 +108,7 @@ pub(crate) fn local_app_with_memory_services() -> (
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let docs_sync = Arc::new(MemoryDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport,
@@ -115,7 +135,7 @@ pub(crate) fn shared_apps_with_memory_services() -> (
     let blob_service = Arc::new(MemoryBlobService::default());
     let local_keys = generate_keys();
     let remote_keys = generate_keys();
-    let local_app = AppService::new_with_services(
+    let local_app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -124,7 +144,7 @@ pub(crate) fn shared_apps_with_memory_services() -> (
         blob_service.clone(),
         local_keys.clone(),
     );
-    let remote_app = AppService::new_with_services(
+    let remote_app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport,

--- a/crates/app-api/src/tests/support/iroh_stack.rs
+++ b/crates/app-api/src/tests/support/iroh_stack.rs
@@ -117,7 +117,7 @@ pub(crate) async fn configure_seeded_dht(app: &AppService, remote_endpoint_id: S
 }
 
 pub(crate) fn app_with_iroh_services(store: Arc<MemoryStore>, stack: &TestIrohStack) -> AppService {
-    AppService::new_with_services(
+    app_service_from_dependencies(
         store.clone(),
         store,
         stack.transport.clone(),
@@ -133,7 +133,7 @@ pub(crate) async fn assert_docs_sync_recovers_post_without_hints(topic: &str, co
     let stack_b = TestIrohStack::new(&dir.path().join("b")).await;
     let store_a = Arc::new(MemoryStore::default());
     let store_b = Arc::new(MemoryStore::default());
-    let app_a = AppService::new_with_services(
+    let app_a = app_service_from_dependencies(
         store_a.clone(),
         store_a,
         stack_a.transport.clone(),
@@ -142,7 +142,7 @@ pub(crate) async fn assert_docs_sync_recovers_post_without_hints(topic: &str, co
         stack_a.blob_service.clone(),
         generate_keys(),
     );
-    let app_b = AppService::new_with_services(
+    let app_b = app_service_from_dependencies(
         store_b.clone(),
         store_b,
         stack_b.transport.clone(),

--- a/crates/app-api/src/tests/sync.rs
+++ b/crates/app-api/src/tests/sync.rs
@@ -269,7 +269,7 @@ fn app_with_hanging_remote_docs(
     blob_service: Arc<MemoryBlobService>,
     keys: KukuriKeys,
 ) -> AppService {
-    AppService::new_with_services(
+    app_service_from_dependencies(
         store.clone(),
         store,
         Arc::new(StaticTransport::new(PeerSnapshot::default())),

--- a/crates/app-api/src/tests/sync/diagnostics.rs
+++ b/crates/app-api/src/tests/sync/diagnostics.rs
@@ -275,7 +275,7 @@ async fn docs_assisted_peers_do_not_mark_live_sync_connected() {
     }));
     let docs_sync = Arc::new(AssistedDocsSync::new(vec!["peer-a", "peer-b"]));
     let blob_service = Arc::new(AssistedBlobService::new(vec!["peer-b", "peer-c"]));
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -348,7 +348,7 @@ async fn blob_only_assist_peers_do_not_mark_sync_healthy() {
             last_error: None,
         }],
     }));
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),

--- a/crates/app-api/src/tests/sync/gossip_toggle.rs
+++ b/crates/app-api/src/tests/sync/gossip_toggle.rs
@@ -3,7 +3,7 @@ use super::*;
 fn build_app(hint_transport: Arc<TrackingHintTransport>) -> AppService {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
-    AppService::new_with_services(
+    app_service_from_dependencies(
         store.clone(),
         store,
         transport,

--- a/crates/app-api/src/tests/sync/hint_rehydration.rs
+++ b/crates/app-api/src/tests/sync/hint_rehydration.rs
@@ -6,7 +6,7 @@ async fn list_profile_timeline_restarts_author_subscription_with_cooldown_when_p
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let docs_sync = Arc::new(TrackingDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -50,7 +50,7 @@ async fn topic_doc_events_do_not_rehydrate_whole_replica() {
     let docs_sync = Arc::new(CountingDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
     let keys = generate_keys();
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -129,7 +129,7 @@ async fn topic_object_hints_do_not_rehydrate_whole_replica() {
     let docs_sync = Arc::new(CountingDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
     let keys = generate_keys();
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -219,7 +219,7 @@ async fn topic_reaction_hints_rehydrate_only_target_reactions() {
     let docs_sync = Arc::new(CountingDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
     let keys = generate_keys();
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -361,7 +361,7 @@ async fn public_topic_recovery_keeps_docs_probe_when_live_peer_has_not_delivered
         }],
     }));
     let docs_sync = Arc::new(CountingDocsSync::with_assist_peer_ids(vec!["peer-a"]));
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -434,7 +434,7 @@ async fn topic_session_hints_retry_until_manifest_blob_is_available() {
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let owner_store = Arc::new(MemoryStore::default());
     let remote_store = Arc::new(MemoryStore::default());
-    let owner_app = AppService::new_with_services(
+    let owner_app = app_service_from_dependencies(
         owner_store.clone(),
         owner_store,
         transport.clone(),

--- a/crates/app-api/src/tests/sync/subscription_restarts.rs
+++ b/crates/app-api/src/tests/sync/subscription_restarts.rs
@@ -6,7 +6,7 @@ async fn list_timeline_restarts_topic_replica_sync_with_cooldown_when_projection
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let docs_sync = Arc::new(TrackingDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -49,7 +49,7 @@ async fn list_timeline_restarts_topic_subscription_with_cooldown_when_projection
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let hint_transport = Arc::new(TrackingHintTransport::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport,
@@ -86,7 +86,7 @@ async fn ensure_topic_subscription_recreates_finished_handle() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let hint_transport = Arc::new(TrackingHintTransport::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport,
@@ -132,7 +132,7 @@ async fn set_discovery_seeds_restarts_existing_topic_hint_subscription() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let hint_transport = Arc::new(TrackingHintTransport::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -173,7 +173,7 @@ async fn import_peer_ticket_restarts_existing_topic_hint_subscription() {
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let hint_transport = Arc::new(TrackingHintTransport::default());
     let docs_sync = Arc::new(TrackingDocsSync::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport,
@@ -206,7 +206,7 @@ async fn local_public_post_restarts_replica_sync_after_each_write() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let docs_sync = Arc::new(TrackingDocsSync::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -246,7 +246,7 @@ async fn hint_miss_coalesces_replica_sync_restarts() {
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let hint_transport = Arc::new(TrackingHintTransport::default());
     let docs_sync = Arc::new(TrackingDocsSync::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport,
@@ -301,7 +301,7 @@ async fn shutdown_unsubscribes_active_hint_topics() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let hint_transport = Arc::new(TrackingHintTransport::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport,

--- a/crates/app-api/src/tests/timeline/bookmarks.rs
+++ b/crates/app-api/src/tests/timeline/bookmarks.rs
@@ -12,7 +12,7 @@ async fn local_bookmarked_posts_restore_after_restart() {
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let docs_sync = Arc::new(MemoryDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store.clone(),
         transport.clone(),
@@ -41,7 +41,7 @@ async fn local_bookmarked_posts_restore_after_restart() {
             .await
             .expect("reopen sqlite store"),
     );
-    let reopened_app = AppService::new_with_services(
+    let reopened_app = app_service_from_dependencies(
         reopened.clone(),
         reopened.clone(),
         transport,

--- a/crates/app-api/src/tests/timeline/profile.rs
+++ b/crates/app-api/src/tests/timeline/profile.rs
@@ -8,7 +8,7 @@ async fn create_public_post_persists_profile_post_doc_and_lists_profile_timeline
     let blob_service = Arc::new(MemoryBlobService::default());
     let keys = generate_keys();
     let author_pubkey = keys.public_key_hex();
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -61,7 +61,7 @@ async fn public_reply_is_indexed_in_profile_timeline() {
     let blob_service = Arc::new(MemoryBlobService::default());
     let keys = generate_keys();
     let author_pubkey = keys.public_key_hex();
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -120,7 +120,7 @@ async fn private_channel_post_is_not_indexed_in_profile_timeline() {
     let blob_service = Arc::new(MemoryBlobService::default());
     let keys = generate_keys();
     let author_pubkey = keys.public_key_hex();
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -301,7 +301,7 @@ async fn create_same_topic_repost_persists_repost_object_and_profile_repost_doc(
     let blob_service = Arc::new(MemoryBlobService::default());
     let keys = generate_keys();
     let author_pubkey = keys.public_key_hex();
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -432,7 +432,7 @@ async fn list_profile_timeline_ignores_profile_post_with_signer_mismatch() {
     let blob_service = Arc::new(MemoryBlobService::default());
     let keys = generate_keys();
     let author_pubkey = keys.public_key_hex();
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),

--- a/crates/app-api/src/tests/timeline/replies.rs
+++ b/crates/app-api/src/tests/timeline/replies.rs
@@ -75,7 +75,7 @@ async fn quote_repost_opens_own_thread_and_simple_repost_cannot_be_reply_parent(
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let docs_sync = Arc::new(MemoryDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),

--- a/crates/app-api/src/tests/timeline/reposts.rs
+++ b/crates/app-api/src/tests/timeline/reposts.rs
@@ -11,7 +11,7 @@ async fn create_cross_topic_repost_renders_from_target_topic_without_tracking_so
     let blob_service = Arc::new(MemoryBlobService::default());
     let keys_a = generate_keys();
     let author_pubkey = keys_a.public_key_hex();
-    let app_a = AppService::new_with_services(
+    let app_a = app_service_from_dependencies(
         store_a.clone(),
         store_a,
         transport_a,
@@ -20,7 +20,7 @@ async fn create_cross_topic_repost_renders_from_target_topic_without_tracking_so
         blob_service.clone(),
         keys_a,
     );
-    let app_b = AppService::new_with_services(
+    let app_b = app_service_from_dependencies(
         store_b.clone(),
         store_b,
         transport_b,
@@ -93,7 +93,7 @@ async fn simple_repost_is_unique_per_author_target_and_original() {
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let docs_sync = Arc::new(MemoryDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -140,7 +140,7 @@ async fn quote_repost_allows_multiple_distinct_quotes_for_same_original() {
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let docs_sync = Arc::new(MemoryDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),
@@ -197,7 +197,7 @@ async fn private_channel_post_cannot_be_reposted_publicly() {
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));
     let docs_sync = Arc::new(MemoryDocsSync::default());
     let blob_service = Arc::new(MemoryBlobService::default());
-    let app = AppService::new_with_services(
+    let app = app_service_from_dependencies(
         store.clone(),
         store,
         transport.clone(),

--- a/crates/app-api/src/timeline.rs
+++ b/crates/app-api/src/timeline.rs
@@ -13,13 +13,13 @@ impl AppService {
             .await?;
         let load_profile_items = || async {
             let posts = load_profile_posts_from_author_replica(
-                self.docs_sync.as_ref(),
+                self.services.docs_sync.as_ref(),
                 author_pubkey.as_str(),
                 DocFetchPolicy::LocalOnly,
             )
             .await?;
             let reposts = load_profile_reposts_from_author_replica(
-                self.docs_sync.as_ref(),
+                self.services.docs_sync.as_ref(),
                 author_pubkey.as_str(),
                 DocFetchPolicy::LocalOnly,
             )
@@ -112,7 +112,7 @@ impl AppService {
             .await?;
         let topic = TopicId::new(target_topic_id);
         let envelope = build_repost_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &topic,
             source_object.repost_of.clone(),
             normalized_commentary.as_deref(),
@@ -130,7 +130,7 @@ impl AppService {
 
         let local_author_pubkey = self.current_author_pubkey();
         let profile_repost_envelope = build_profile_repost_envelope(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &KukuriProfileRepostEnvelopeContentV1 {
                 author_pubkey: Pubkey::from(local_author_pubkey.as_str()),
                 profile_topic_id: author_profile_topic_id(local_author_pubkey.as_str()),
@@ -144,13 +144,14 @@ impl AppService {
         let profile_repost = parse_profile_repost(&profile_repost_envelope)?
             .ok_or_else(|| anyhow::anyhow!("failed to parse profile repost envelope"))?;
         persist_profile_repost_doc(
-            self.docs_sync.as_ref(),
+            self.services.docs_sync.as_ref(),
             &profile_repost,
             &profile_repost_envelope,
         )
         .await?;
 
-        self.hint_transport
+        self.services
+            .hint_transport
             .publish_hint(
                 &channel_hint_topic_for(target_topic_id, None),
                 GossipHint::TopicObjectsChanged {
@@ -168,6 +169,7 @@ impl AppService {
     pub async fn list_bookmarked_posts(&self) -> Result<Vec<BookmarkedPostView>> {
         let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
         let rows = self
+            .services
             .projection_store
             .list_bookmarked_posts()
             .await?
@@ -189,6 +191,7 @@ impl AppService {
         self.ensure_topic_subscription(topic_id).await?;
         let source_object_id = EnvelopeId::from(source_object_id);
         let projection = self
+            .services
             .projection_store
             .get_object_projection(&source_object_id)
             .await?
@@ -206,7 +209,7 @@ impl AppService {
             Vec::new()
         } else {
             fetch_post_object_for_projection(
-                self.docs_sync.as_ref(),
+                self.services.docs_sync.as_ref(),
                 &projection.source_replica_id,
                 projection.source_key.as_str(),
             )
@@ -234,14 +237,16 @@ impl AppService {
             repost_of: projection.repost_of.clone(),
             bookmarked_at: Utc::now().timestamp_millis(),
         };
-        self.projection_store
+        self.services
+            .projection_store
             .put_bookmarked_post(row.clone())
             .await?;
         self.bookmarked_post_view_from_row(row).await
     }
 
     pub async fn remove_bookmarked_post(&self, source_object_id: &str) -> Result<()> {
-        self.projection_store
+        self.services
+            .projection_store
             .remove_bookmarked_post(&EnvelopeId::from(source_object_id))
             .await
     }
@@ -344,12 +349,14 @@ impl AppService {
             .unwrap_or_else(|| topic_replica_id(topic_id));
         let now = Utc::now().timestamp_millis();
         let stored_blob = self
+            .services
             .blob_service
             .put_blob(content.as_bytes().to_vec(), "text/plain")
             .await?;
         let stored_attachments = futures_util::future::try_join_all(attachments.into_iter().map(
             |attachment| async move {
                 let stored = self
+                    .services
                     .blob_service
                     .put_blob(attachment.bytes, attachment.mime.as_str())
                     .await?;
@@ -386,18 +393,19 @@ impl AppService {
                     })
                     .collect(),
             };
-            let envelope = build_media_manifest_envelope(self.keys.as_ref(), &topic, &manifest)?;
+            let envelope =
+                build_media_manifest_envelope(self.services.keys.as_ref(), &topic, &manifest)?;
             persist_media_manifest(
                 &write_replica,
                 &envelope,
                 &manifest,
-                self.docs_sync.as_ref(),
+                self.services.docs_sync.as_ref(),
             )
             .await?;
             vec![manifest_id]
         };
         let envelope = build_post_envelope_with_payload_in_channel(
-            self.keys.as_ref(),
+            self.services.keys.as_ref(),
             &topic,
             PayloadRef::BlobText {
                 hash: stored_blob.hash.clone(),
@@ -435,7 +443,7 @@ impl AppService {
         if effective_channel_id.is_none() {
             let local_author_pubkey = self.current_author_pubkey();
             let profile_post_envelope = build_profile_post_envelope(
-                self.keys.as_ref(),
+                self.services.keys.as_ref(),
                 &KukuriProfilePostEnvelopeContentV1 {
                     author_pubkey: Pubkey::from(local_author_pubkey.as_str()),
                     profile_topic_id: author_profile_topic_id(local_author_pubkey.as_str()),
@@ -452,7 +460,7 @@ impl AppService {
             let profile_post = parse_profile_post(&profile_post_envelope)?
                 .ok_or_else(|| anyhow::anyhow!("failed to parse profile post envelope"))?;
             persist_profile_post_doc(
-                self.docs_sync.as_ref(),
+                self.services.docs_sync.as_ref(),
                 &profile_post,
                 &profile_post_envelope,
             )
@@ -472,6 +480,7 @@ impl AppService {
                 tokio::time::sleep(std::time::Duration::from_millis(250 * attempt)).await;
             }
             match self
+                .services
                 .hint_transport
                 .publish_hint(&hint_topic, hint.clone())
                 .await
@@ -547,7 +556,7 @@ impl AppService {
         self.ensure_scope_subscriptions(topic_id, &scope).await?;
         let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
         let mut page = filtered_timeline_page(
-            self.projection_store.as_ref(),
+            self.services.projection_store.as_ref(),
             topic_id,
             cursor.clone(),
             limit,
@@ -569,7 +578,7 @@ impl AppService {
         {
             *self.last_sync_ts.lock().await = Some(Utc::now().timestamp_millis());
             page = filtered_timeline_page(
-                self.projection_store.as_ref(),
+                self.services.projection_store.as_ref(),
                 topic_id,
                 cursor.clone(),
                 limit,
@@ -589,7 +598,7 @@ impl AppService {
                 *self.last_sync_ts.lock().await = Some(Utc::now().timestamp_millis());
             }
             page = filtered_timeline_page(
-                self.projection_store.as_ref(),
+                self.services.projection_store.as_ref(),
                 topic_id,
                 cursor,
                 limit,
@@ -626,7 +635,7 @@ impl AppService {
         let muted_author_pubkeys = self.current_muted_author_pubkeys().await?;
         let thread_root = EnvelopeId::from(thread_id);
         let mut page = filtered_thread_page(
-            self.projection_store.as_ref(),
+            self.services.projection_store.as_ref(),
             topic_id,
             &thread_root,
             cursor.clone(),
@@ -649,12 +658,13 @@ impl AppService {
         {
             *self.last_sync_ts.lock().await = Some(Utc::now().timestamp_millis());
             let root_channel = self
+                .services
                 .projection_store
                 .get_object_projection(&thread_root)
                 .await?
                 .map(|row| row.channel_id);
             page = filtered_thread_page(
-                self.projection_store.as_ref(),
+                self.services.projection_store.as_ref(),
                 topic_id,
                 &thread_root,
                 cursor.clone(),
@@ -679,12 +689,13 @@ impl AppService {
                 *self.last_sync_ts.lock().await = Some(Utc::now().timestamp_millis());
             }
             let root_channel = self
+                .services
                 .projection_store
                 .get_object_projection(&thread_root)
                 .await?
                 .map(|row| row.channel_id);
             page = filtered_thread_page(
-                self.projection_store.as_ref(),
+                self.services.projection_store.as_ref(),
                 topic_id,
                 &thread_root,
                 cursor,

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -15,7 +15,8 @@ use kukuri_app_api::{
     ImportMetaverseRoomAssetInput, JoinedPrivateChannelView, LiveSessionView,
     MetaverseAssetRefView, MetaverseRoomEventView, NotificationStatusView, NotificationView,
     PrivateChannelCapability, ProfileInput, PublishMetaverseRoomEventInput, ReactionStateView,
-    RecentReactionView, SyncStatus, TimelineView, UpdateGameRoomInput, UpdateMetaverseRoomInput,
+    RecentReactionView, ServiceHandles, SyncStatus, TimelineView, UpdateGameRoomInput,
+    UpdateMetaverseRoomInput,
 };
 use kukuri_cn_protocol::normalize_http_url;
 use kukuri_core::{
@@ -258,7 +259,7 @@ impl DesktopRuntime {
         .await?;
         let keys = load_or_create_keys(&db_path, identity_mode)?;
         let author_keys = Arc::new(keys.clone());
-        let app_service = AppService::new_with_services(
+        let services = ServiceHandles::new(
             store.clone(),
             store.clone(),
             iroh_stack.transport.clone(),
@@ -267,6 +268,7 @@ impl DesktopRuntime {
             iroh_stack.blob_service.clone(),
             keys,
         );
+        let app_service = AppService::from_handles(services);
         for capability in load_private_channel_capabilities(&db_path, identity_mode)? {
             app_service
                 .restore_private_channel_capability(capability)


### PR DESCRIPTION
## Summary
- introduce public cloneable ServiceHandles for the seven app-api service dependencies
- construct AppService through from_handles while keeping the in-memory new convenience
- migrate desktop-runtime and app-api test composition to the explicit handles boundary
- remove AppService::new_with_services and retain the oversized-file baseline

## Validation
- cargo test -p kukuri-app-api (163 passed)
- cargo xtask rust-check
- cargo xtask oversized-files
- cargo clippy -p kukuri-app-api -p kukuri-desktop-runtime --all-targets -- -D warnings
- git diff --check