### PR TITLE
refactor: route app-api helpers through ServiceHandles

### DIFF
--- a/crates/app-api/src/direct_messages.rs
+++ b/crates/app-api/src/direct_messages.rs
@@ -19,7 +19,7 @@ impl AppService {
             peers.insert(row.peer_pubkey);
         }
         peers.extend(
-            current_mutual_direct_message_peers_with_services(
+            current_mutual_direct_message_peers(
                 self.services.store.as_ref(),
                 self.current_author_pubkey().as_str(),
             )

--- a/crates/app-api/src/service/direct_messages_delivery_support.rs
+++ b/crates/app-api/src/service/direct_messages_delivery_support.rs
@@ -1,29 +1,24 @@
 use super::*;
 
 pub(crate) struct DirectMessageHintServices<'a> {
-    pub(crate) projection_store: &'a dyn ProjectionStore,
-    pub(crate) blob_service: &'a dyn BlobService,
-    pub(crate) hint_transport: &'a dyn HintTransport,
-    pub(crate) keys: &'a KukuriKeys,
+    pub(crate) services: &'a ServiceHandles,
     pub(crate) local_author_pubkey: &'a str,
     pub(crate) peer_pubkey: &'a str,
     pub(crate) topic: &'a TopicId,
 }
 
 impl AppService {
-    pub(crate) async fn handle_direct_message_hint_with_services(
+    pub(crate) async fn handle_direct_message_hint(
         services: DirectMessageHintServices<'_>,
         hint: &GossipHint,
     ) -> Result<bool> {
         let DirectMessageHintServices {
-            projection_store,
-            blob_service,
-            hint_transport,
-            keys,
+            services,
             local_author_pubkey,
             peer_pubkey,
             topic,
         } = services;
+        let projection_store = services.projection_store.as_ref();
         match hint {
             GossipHint::DirectMessageFrame {
                 dm_id,
@@ -31,11 +26,8 @@ impl AppService {
                 frame_hash,
                 ..
             } => {
-                AppService::ingest_direct_message_frame_with_services(
-                    projection_store,
-                    blob_service,
-                    hint_transport,
-                    keys,
+                AppService::ingest_direct_message_frame(
+                    services,
                     local_author_pubkey,
                     peer_pubkey,
                     topic,
@@ -157,11 +149,8 @@ impl AppService {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn ingest_direct_message_frame_with_services(
-        projection_store: &dyn ProjectionStore,
-        blob_service: &dyn BlobService,
-        hint_transport: &dyn HintTransport,
-        keys: &KukuriKeys,
+    pub(crate) async fn ingest_direct_message_frame(
+        services: &ServiceHandles,
         local_author_pubkey: &str,
         peer_pubkey: &str,
         topic: &TopicId,
@@ -169,6 +158,10 @@ impl AppService {
         message_id: &str,
         frame_hash: &kukuri_core::BlobHash,
     ) -> Result<bool> {
+        let projection_store = services.projection_store.as_ref();
+        let blob_service = services.blob_service.as_ref();
+        let hint_transport = services.hint_transport.as_ref();
+        let keys = services.keys.as_ref();
         let expected_dm_id = direct_message_id_for_participants(
             &Pubkey::from(local_author_pubkey),
             &Pubkey::from(peer_pubkey),
@@ -291,14 +284,15 @@ impl AppService {
         Ok(true)
     }
 
-    pub(crate) async fn flush_direct_message_outbox_for_peer_with_services(
-        projection_store: &dyn ProjectionStore,
-        hint_transport: &dyn HintTransport,
-        transport: &dyn Transport,
+    pub(crate) async fn flush_direct_message_outbox_for_peer(
+        services: &ServiceHandles,
         local_author_pubkey: &str,
-        keys: &KukuriKeys,
         peer_pubkey: &str,
     ) -> Result<usize> {
+        let projection_store = services.projection_store.as_ref();
+        let hint_transport = services.hint_transport.as_ref();
+        let transport = services.transport.as_ref();
+        let keys = services.keys.as_ref();
         let relationship = projection_store
             .get_author_relationship(local_author_pubkey, peer_pubkey)
             .await?;
@@ -434,12 +428,9 @@ impl AppService {
             .await?;
         self.refresh_direct_message_conversation(peer_pubkey)
             .await?;
-        let _ = Self::flush_direct_message_outbox_for_peer_with_services(
-            self.services.projection_store.as_ref(),
-            self.services.hint_transport.as_ref(),
-            self.services.transport.as_ref(),
+        let _ = Self::flush_direct_message_outbox_for_peer(
+            &self.services,
             self.current_author_pubkey().as_str(),
-            self.services.keys.as_ref(),
             peer_pubkey,
         )
         .await?;

--- a/crates/app-api/src/service/direct_messages_subscription_support.rs
+++ b/crates/app-api/src/service/direct_messages_subscription_support.rs
@@ -13,13 +13,8 @@ impl AppService {
     }
 
     pub(crate) async fn reconcile_direct_message_subscriptions(&self) -> Result<()> {
-        reconcile_direct_message_subscriptions_with_services(
-            self.services.store.as_ref(),
-            Arc::clone(&self.services.projection_store),
-            Arc::clone(&self.services.blob_service),
-            Arc::clone(&self.services.hint_transport),
-            Arc::clone(&self.services.transport),
-            Arc::clone(&self.services.keys),
+        reconcile_direct_message_subscriptions(
+            self.services.clone(),
             Arc::clone(&self.last_sync_ts),
             Arc::clone(&self.subscription_registry.direct_message_subscriptions),
             Arc::clone(&self.notification_inserted_notify),
@@ -284,13 +279,9 @@ impl AppService {
             }
             return Ok(());
         }
-        Self::spawn_direct_message_subscription_with_services(
+        Self::spawn_direct_message_subscription(
             Arc::clone(&self.subscription_registry.direct_message_subscriptions),
-            Arc::clone(&self.services.projection_store),
-            Arc::clone(&self.services.blob_service),
-            Arc::clone(&self.services.hint_transport),
-            Arc::clone(&self.services.transport),
-            Arc::clone(&self.services.keys),
+            self.services.clone(),
             Arc::clone(&self.last_sync_ts),
             Arc::clone(&self.notification_inserted_notify),
             self.current_author_pubkey().as_str(),
@@ -304,22 +295,17 @@ impl AppService {
         peer_pubkey: &str,
     ) -> Result<()> {
         let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
-        stop_direct_message_subscription_with_services(
+        stop_direct_message_subscription(
             self.subscription_registry
                 .direct_message_subscriptions
                 .as_ref(),
-            self.services.hint_transport.as_ref(),
-            self.services.keys.as_ref(),
+            &self.services,
             peer_pubkey.as_str(),
         )
         .await?;
-        Self::spawn_direct_message_subscription_with_services(
+        Self::spawn_direct_message_subscription(
             Arc::clone(&self.subscription_registry.direct_message_subscriptions),
-            Arc::clone(&self.services.projection_store),
-            Arc::clone(&self.services.blob_service),
-            Arc::clone(&self.services.hint_transport),
-            Arc::clone(&self.services.transport),
-            Arc::clone(&self.services.keys),
+            self.services.clone(),
             Arc::clone(&self.last_sync_ts),
             Arc::clone(&self.notification_inserted_notify),
             self.current_author_pubkey().as_str(),
@@ -390,13 +376,9 @@ impl AppService {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn spawn_direct_message_subscription_with_services(
+    pub(crate) async fn spawn_direct_message_subscription(
         direct_message_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
-        projection_store: Arc<dyn ProjectionStore>,
-        blob_service: Arc<dyn BlobService>,
-        hint_transport: Arc<dyn HintTransport>,
-        transport: Arc<dyn Transport>,
-        keys: Arc<KukuriKeys>,
+        services: ServiceHandles,
         last_sync: Arc<Mutex<Option<i64>>>,
         notification_inserted: Arc<tokio::sync::Notify>,
         local_author_pubkey: &str,
@@ -413,35 +395,31 @@ impl AppService {
             }
             subscriptions.remove(peer_pubkey.as_str());
         }
-        let topic =
-            derive_direct_message_topic(keys.as_ref(), &Pubkey::from(peer_pubkey.as_str()))?;
-        let mut hint_stream = hint_transport.subscribe_hints(&topic).await?;
+        let topic = derive_direct_message_topic(
+            services.keys.as_ref(),
+            &Pubkey::from(peer_pubkey.as_str()),
+        )?;
+        let mut hint_stream = services.hint_transport.subscribe_hints(&topic).await?;
         let topic_for_task = topic.clone();
         let peer_for_task = peer_pubkey.clone();
         let local_author_pubkey = local_author_pubkey.to_string();
-        let task_hint_transport = Arc::clone(&hint_transport);
+        let cleanup_hint_transport = Arc::clone(&services.hint_transport);
         let handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_millis(
                 DIRECT_MESSAGE_RETRY_INTERVAL_MS,
             ));
-            let _ = AppService::flush_direct_message_outbox_for_peer_with_services(
-                projection_store.as_ref(),
-                task_hint_transport.as_ref(),
-                transport.as_ref(),
+            let _ = AppService::flush_direct_message_outbox_for_peer(
+                &services,
                 local_author_pubkey.as_str(),
-                keys.as_ref(),
                 peer_for_task.as_str(),
             )
             .await;
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        let _ = AppService::flush_direct_message_outbox_for_peer_with_services(
-                            projection_store.as_ref(),
-                            task_hint_transport.as_ref(),
-                            transport.as_ref(),
+                        let _ = AppService::flush_direct_message_outbox_for_peer(
+                            &services,
                             local_author_pubkey.as_str(),
-                            keys.as_ref(),
                             peer_for_task.as_str(),
                         ).await;
                     }
@@ -453,7 +431,7 @@ impl AppService {
                         ) {
                             continue;
                         }
-                        if let Err(error) = blob_service.learn_peer(event.source_peer.as_str()).await {
+                        if let Err(error) = services.blob_service.learn_peer(event.source_peer.as_str()).await {
                             warn!(
                                 peer_pubkey = %peer_for_task,
                                 source_peer = %event.source_peer,
@@ -461,12 +439,9 @@ impl AppService {
                                 "failed to learn direct message blob peer"
                             );
                         }
-                        match AppService::handle_direct_message_hint_with_services(
+                        match AppService::handle_direct_message_hint(
                             DirectMessageHintServices {
-                                projection_store: projection_store.as_ref(),
-                                blob_service: blob_service.as_ref(),
-                                hint_transport: task_hint_transport.as_ref(),
-                                keys: keys.as_ref(),
+                                services: &services,
                                 local_author_pubkey: local_author_pubkey.as_str(),
                                 peer_pubkey: peer_for_task.as_str(),
                                 topic: &topic_for_task,
@@ -488,7 +463,7 @@ impl AppService {
                         }
                     }
                     else => {
-                        let _ = task_hint_transport.unsubscribe_hints(&topic_for_task).await;
+                        let _ = services.hint_transport.unsubscribe_hints(&topic_for_task).await;
                         break;
                     }
                 }
@@ -516,7 +491,7 @@ impl AppService {
             pending_handle
                 .expect("direct message subscription handle must remain pending")
                 .abort();
-            hint_transport.unsubscribe_hints(&topic).await?;
+            cleanup_hint_transport.unsubscribe_hints(&topic).await?;
         }
         Ok(())
     }

--- a/crates/app-api/src/service/hydration_support.rs
+++ b/crates/app-api/src/service/hydration_support.rs
@@ -180,32 +180,23 @@ pub(crate) async fn hydrate_reaction_cache_for_target(
     Ok(hydrated)
 }
 
-pub(crate) async fn hydrate_topic_state_with_services(
-    docs_sync: &dyn DocsSync,
-    blob_service: &dyn BlobService,
-    projection_store: &dyn ProjectionStore,
+pub(crate) async fn hydrate_topic_state(
+    services: &ServiceHandles,
     topic_id: &str,
     policy: DocFetchPolicy,
 ) -> Result<usize> {
-    hydrate_subscription_state_with_services(
-        docs_sync,
-        blob_service,
-        projection_store,
-        topic_id,
-        &topic_replica_id(topic_id),
-        policy,
-    )
-    .await
+    hydrate_subscription_state(services, topic_id, &topic_replica_id(topic_id), policy).await
 }
 
-pub(crate) async fn hydrate_subscription_state_with_services(
-    docs_sync: &dyn DocsSync,
-    blob_service: &dyn BlobService,
-    projection_store: &dyn ProjectionStore,
+pub(crate) async fn hydrate_subscription_state(
+    services: &ServiceHandles,
     topic_id: &str,
     replica: &ReplicaId,
     policy: DocFetchPolicy,
 ) -> Result<usize> {
+    let docs_sync = services.docs_sync.as_ref();
+    let blob_service = services.blob_service.as_ref();
+    let projection_store = services.projection_store.as_ref();
     let post_count = hydrate_object_projection_from_replica(
         docs_sync,
         blob_service,
@@ -484,14 +475,15 @@ pub(crate) async fn hydrate_game_room_from_key_with_retry(
     Ok(0)
 }
 
-pub(crate) async fn hydrate_subscription_event_with_services(
-    docs_sync: &dyn DocsSync,
-    blob_service: &dyn BlobService,
-    projection_store: &dyn ProjectionStore,
+pub(crate) async fn hydrate_subscription_event(
+    services: &ServiceHandles,
     topic_id: &str,
     replica: &ReplicaId,
     key: &str,
 ) -> Result<usize> {
+    let docs_sync = services.docs_sync.as_ref();
+    let blob_service = services.blob_service.as_ref();
+    let projection_store = services.projection_store.as_ref();
     if key.starts_with("objects/") && key.ends_with("/state") {
         return Ok(hydrate_object_projection_from_key(
             docs_sync,
@@ -533,14 +525,15 @@ pub(crate) async fn hydrate_subscription_event_with_services(
     Ok(0)
 }
 
-pub(crate) async fn hydrate_subscription_hint_with_services(
-    docs_sync: &dyn DocsSync,
-    blob_service: &dyn BlobService,
-    projection_store: &dyn ProjectionStore,
+pub(crate) async fn hydrate_subscription_hint(
+    services: &ServiceHandles,
     topic_id: &str,
     replica: &ReplicaId,
     hint: &GossipHint,
 ) -> Result<usize> {
+    let docs_sync = services.docs_sync.as_ref();
+    let blob_service = services.blob_service.as_ref();
+    let projection_store = services.projection_store.as_ref();
     match hint {
         GossipHint::TopicObjectsChanged { objects, .. } => {
             let mut hydrated = 0usize;

--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -128,9 +128,9 @@ pub(crate) use attachment_support::{
 };
 pub(crate) use gossip_subscription_support::gossip_disabled_channel_key;
 pub(crate) use hydration_support::{
-    hint_targets_topic, hydrate_subscription_event_with_services,
-    hydrate_subscription_hint_with_services, hydrate_subscription_state_with_services,
-    hydrate_topic_state_with_services, profile_timeline_page, projection_page_needs_hydration,
+    hint_targets_topic, hydrate_subscription_event, hydrate_subscription_hint,
+    hydrate_subscription_state, hydrate_topic_state, profile_timeline_page,
+    projection_page_needs_hydration,
 };
 pub(crate) use metaverse_room_event_support::{
     metaverse_room_event_buffer_key, parse_metaverse_room_event_envelope,
@@ -159,7 +159,7 @@ pub(crate) use object_persistence_support::{
     wait_for_private_channel_epoch_snapshot,
 };
 pub(crate) use profile_docs_support::{
-    fetch_author_envelope_by_id, hydrate_author_state_with_services,
+    fetch_author_envelope_by_id, hydrate_author_state,
     load_custom_reaction_assets_from_author_replica, load_profile_posts_from_author_replica,
     load_profile_reposts_from_author_replica, merge_seed_peers, persist_custom_reaction_asset_doc,
     persist_follow_edge_doc, persist_profile_doc, persist_profile_post_doc,
@@ -177,10 +177,9 @@ pub(crate) use projection_support::{
     profile_timeline_item_is_muted,
 };
 pub(crate) use social_helpers::{
-    current_mutual_direct_message_peers_with_services, rebuild_author_relationships_with_services,
-    reconcile_direct_message_subscriptions_with_services,
-    schedule_direct_message_reconcile_with_services,
-    stop_direct_message_subscription_with_services,
+    current_mutual_direct_message_peers, rebuild_author_relationships,
+    reconcile_direct_message_subscriptions, schedule_direct_message_reconcile,
+    stop_direct_message_subscription,
 };
 pub(crate) use subscription_registry::SubscriptionRegistry;
 pub(crate) use timeline_view_support::{
@@ -530,10 +529,8 @@ impl AppService {
         .await?
         .is_none()
         {
-            let _ = hydrate_topic_state_with_services(
-                self.services.docs_sync.as_ref(),
-                self.services.blob_service.as_ref(),
-                self.services.projection_store.as_ref(),
+            let _ = hydrate_topic_state(
+                &self.services,
                 source_topic_id,
                 DocFetchPolicy::LocalThenRemote,
             )

--- a/crates/app-api/src/service/private_channels_support.rs
+++ b/crates/app-api/src/service/private_channels_support.rs
@@ -622,11 +622,7 @@ impl AppService {
         hint_topic: TopicId,
         private_key: Option<String>,
     ) -> Result<()> {
-        let projection_store = Arc::clone(&self.services.projection_store);
-        let docs_sync = Arc::clone(&self.services.docs_sync);
-        let blob_service = Arc::clone(&self.services.blob_service);
-        let hint_transport = Arc::clone(&self.services.hint_transport);
-        let transport = Arc::clone(&self.services.transport);
+        let services = self.services.clone();
         let metaverse_room_events = Arc::clone(&self.metaverse_room_events);
         let last_sync = Arc::clone(&self.last_sync_ts);
         let notification_inserted = Arc::clone(&self.notification_inserted_notify);
@@ -643,12 +639,17 @@ impl AppService {
             self.reset_public_topic_delivery_generation(topic_id, generation)
                 .await;
         }
-        docs_sync.open_replica(&replica).await?;
-        let mut doc_stream = docs_sync.subscribe_replica(&replica).await?;
-        let mut hint_stream = hint_transport.subscribe_hints(&hint_topic).await?;
+        services.docs_sync.open_replica(&replica).await?;
+        let mut doc_stream = services.docs_sync.subscribe_replica(&replica).await?;
+        let mut hint_stream = services.hint_transport.subscribe_hints(&hint_topic).await?;
         let replica_for_task = replica.clone();
         let hint_topic_for_task = hint_topic.clone();
         let handle = tokio::spawn(async move {
+            let projection_store = &services.projection_store;
+            let docs_sync = &services.docs_sync;
+            let blob_service = &services.blob_service;
+            let hint_transport = &services.hint_transport;
+            let transport = &services.transport;
             let notification_baseline = match snapshot_object_notification_baseline(
                 docs_sync.as_ref(),
                 &replica_for_task,
@@ -669,10 +670,8 @@ impl AppService {
             };
             let mut recovery_tick = tokio::time::interval(std::time::Duration::from_secs(1));
             recovery_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            if let Err(error) = hydrate_subscription_state_with_services(
-                docs_sync.as_ref(),
-                blob_service.as_ref(),
-                projection_store.as_ref(),
+            if let Err(error) = hydrate_subscription_state(
+                &services,
                 topic.as_str(),
                 &replica_for_task,
                 DocFetchPolicy::LocalOnly,
@@ -737,10 +736,8 @@ impl AppService {
                                     );
                                 }
                             }
-                            let mut hydrated = match hydrate_subscription_event_with_services(
-                                docs_sync.as_ref(),
-                                blob_service.as_ref(),
-                                projection_store.as_ref(),
+                            let mut hydrated = match hydrate_subscription_event(
+                                &services,
                                 topic.as_str(),
                                 &replica_for_task,
                                 event.key.as_str(),
@@ -757,10 +754,8 @@ impl AppService {
                                 }
                             };
                             if hydrated == 0 && !is_public_topic {
-                                hydrated = match hydrate_subscription_state_with_services(
-                                    docs_sync.as_ref(),
-                                    blob_service.as_ref(),
-                                    projection_store.as_ref(),
+                                hydrated = match hydrate_subscription_state(
+                                    &services,
                                     topic.as_str(),
                                     &replica_for_task,
                                     DocFetchPolicy::LocalThenRemote,
@@ -871,10 +866,8 @@ impl AppService {
                                     *last_sync.lock().await = Some(now);
                                 }
                                 _ => {
-                                    let mut hydrated = match hydrate_subscription_hint_with_services(
-                                        docs_sync.as_ref(),
-                                        blob_service.as_ref(),
-                                        projection_store.as_ref(),
+                                    let mut hydrated = match hydrate_subscription_hint(
+                                        &services,
                                         topic.as_str(),
                                         &replica_for_task,
                                         &event.hint,
@@ -892,10 +885,8 @@ impl AppService {
                                     };
                                     let now = Utc::now().timestamp_millis();
                                     if hydrated == 0 {
-                                        hydrated = match hydrate_subscription_state_with_services(
-                                            docs_sync.as_ref(),
-                                            blob_service.as_ref(),
-                                            projection_store.as_ref(),
+                                        hydrated = match hydrate_subscription_state(
+                                            &services,
                                             topic.as_str(),
                                             &replica_for_task,
                                             DocFetchPolicy::LocalThenRemote,
@@ -990,10 +981,8 @@ impl AppService {
                         if docs_assist_peer_count == 0 && !has_configured_topic_peer {
                             continue;
                         }
-                        let hydrated = match hydrate_subscription_state_with_services(
-                            docs_sync.as_ref(),
-                            blob_service.as_ref(),
-                            projection_store.as_ref(),
+                        let hydrated = match hydrate_subscription_state(
+                            &services,
                             topic.as_str(),
                             &replica_for_task,
                             DocFetchPolicy::LocalThenRemote,

--- a/crates/app-api/src/service/profile_docs_support.rs
+++ b/crates/app-api/src/service/profile_docs_support.rs
@@ -230,14 +230,15 @@ pub(crate) async fn persist_reaction_doc(
         .await
 }
 
-pub(crate) async fn hydrate_author_state_with_services(
-    docs_sync: &dyn DocsSync,
-    store: &dyn Store,
-    projection_store: &dyn ProjectionStore,
+pub(crate) async fn hydrate_author_state(
+    services: &ServiceHandles,
     local_author_pubkey: &str,
     author_pubkey: &str,
     policy: DocFetchPolicy,
 ) -> Result<usize> {
+    let docs_sync = services.docs_sync.as_ref();
+    let store = services.store.as_ref();
+    let projection_store = services.projection_store.as_ref();
     let replica = author_replica_id(author_pubkey);
     let mut count = 0usize;
     if let Some(record) = query_replica_with_fetch_policy(
@@ -320,8 +321,7 @@ pub(crate) async fn hydrate_author_state_with_services(
         }
     }
 
-    rebuild_author_relationships_with_services(store, projection_store, local_author_pubkey)
-        .await?;
+    rebuild_author_relationships(store, projection_store, local_author_pubkey).await?;
     Ok(count)
 }
 

--- a/crates/app-api/src/service/social_helpers.rs
+++ b/crates/app-api/src/service/social_helpers.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) async fn current_mutual_direct_message_peers_with_services(
+pub(crate) async fn current_mutual_direct_message_peers(
     store: &dyn Store,
     local_author_pubkey: &str,
 ) -> Result<BTreeSet<String>> {
@@ -21,10 +21,9 @@ pub(crate) async fn current_mutual_direct_message_peers_with_services(
     Ok(following.intersection(&followed_by).cloned().collect())
 }
 
-pub(crate) async fn stop_direct_message_subscription_with_services(
+pub(crate) async fn stop_direct_message_subscription(
     direct_message_subscriptions: &Mutex<HashMap<String, JoinHandle<()>>>,
-    hint_transport: &dyn HintTransport,
-    keys: &KukuriKeys,
+    services: &ServiceHandles,
     peer_pubkey: &str,
 ) -> Result<()> {
     let peer_pubkey = normalize_author_pubkey(peer_pubkey)?;
@@ -35,19 +34,15 @@ pub(crate) async fn stop_direct_message_subscription_with_services(
     {
         handle.abort();
     }
-    let topic = derive_direct_message_topic(keys, &Pubkey::from(peer_pubkey.as_str()))?;
-    hint_transport.unsubscribe_hints(&topic).await?;
+    let topic =
+        derive_direct_message_topic(services.keys.as_ref(), &Pubkey::from(peer_pubkey.as_str()))?;
+    services.hint_transport.unsubscribe_hints(&topic).await?;
     Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn schedule_direct_message_reconcile_with_services(
-    store: Arc<dyn Store>,
-    projection_store: Arc<dyn ProjectionStore>,
-    blob_service: Arc<dyn BlobService>,
-    hint_transport: Arc<dyn HintTransport>,
-    transport: Arc<dyn Transport>,
-    keys: Arc<KukuriKeys>,
+pub(crate) fn schedule_direct_message_reconcile(
+    services: ServiceHandles,
     last_sync: Arc<Mutex<Option<i64>>>,
     direct_message_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
     notification_inserted: Arc<tokio::sync::Notify>,
@@ -55,13 +50,8 @@ pub(crate) fn schedule_direct_message_reconcile_with_services(
     author_pubkey: String,
 ) {
     tokio::spawn(async move {
-        if let Err(error) = reconcile_direct_message_subscriptions_with_services(
-            store.as_ref(),
-            projection_store,
-            blob_service,
-            hint_transport,
-            transport,
-            keys,
+        if let Err(error) = reconcile_direct_message_subscriptions(
+            services,
             last_sync,
             direct_message_subscriptions,
             notification_inserted,
@@ -79,20 +69,15 @@ pub(crate) fn schedule_direct_message_reconcile_with_services(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn reconcile_direct_message_subscriptions_with_services(
-    store: &dyn Store,
-    projection_store: Arc<dyn ProjectionStore>,
-    blob_service: Arc<dyn BlobService>,
-    hint_transport: Arc<dyn HintTransport>,
-    transport: Arc<dyn Transport>,
-    keys: Arc<KukuriKeys>,
+pub(crate) async fn reconcile_direct_message_subscriptions(
+    services: ServiceHandles,
     last_sync: Arc<Mutex<Option<i64>>>,
     direct_message_subscriptions: Arc<Mutex<HashMap<String, JoinHandle<()>>>>,
     notification_inserted: Arc<tokio::sync::Notify>,
     local_author_pubkey: &str,
 ) -> Result<()> {
     let desired_peers =
-        current_mutual_direct_message_peers_with_services(store, local_author_pubkey).await?;
+        current_mutual_direct_message_peers(services.store.as_ref(), local_author_pubkey).await?;
     let current_entries = {
         let subscriptions = direct_message_subscriptions.lock().await;
         subscriptions
@@ -103,10 +88,9 @@ pub(crate) async fn reconcile_direct_message_subscriptions_with_services(
 
     for (peer_pubkey, finished) in &current_entries {
         if *finished || !desired_peers.contains(peer_pubkey) {
-            stop_direct_message_subscription_with_services(
+            stop_direct_message_subscription(
                 direct_message_subscriptions.as_ref(),
-                hint_transport.as_ref(),
-                keys.as_ref(),
+                &services,
                 peer_pubkey.as_str(),
             )
             .await?;
@@ -114,13 +98,9 @@ pub(crate) async fn reconcile_direct_message_subscriptions_with_services(
     }
 
     for peer_pubkey in desired_peers {
-        AppService::spawn_direct_message_subscription_with_services(
+        AppService::spawn_direct_message_subscription(
             Arc::clone(&direct_message_subscriptions),
-            Arc::clone(&projection_store),
-            Arc::clone(&blob_service),
-            Arc::clone(&hint_transport),
-            Arc::clone(&transport),
-            Arc::clone(&keys),
+            services.clone(),
             Arc::clone(&last_sync),
             Arc::clone(&notification_inserted),
             local_author_pubkey,
@@ -131,7 +111,7 @@ pub(crate) async fn reconcile_direct_message_subscriptions_with_services(
     Ok(())
 }
 
-pub(crate) async fn rebuild_author_relationships_with_services(
+pub(crate) async fn rebuild_author_relationships(
     store: &dyn Store,
     projection_store: &dyn ProjectionStore,
     local_author_pubkey: &str,

--- a/crates/app-api/src/service/social_runtime_support.rs
+++ b/crates/app-api/src/service/social_runtime_support.rs
@@ -26,7 +26,7 @@ impl AppService {
     }
 
     pub(crate) async fn rebuild_author_relationships(&self) -> Result<()> {
-        rebuild_author_relationships_with_services(
+        rebuild_author_relationships(
             self.services.store.as_ref(),
             self.services.projection_store.as_ref(),
             self.current_author_pubkey().as_str(),
@@ -45,12 +45,11 @@ impl AppService {
             .cloned()
             .collect::<Vec<_>>();
         for peer_pubkey in existing_peers {
-            stop_direct_message_subscription_with_services(
+            stop_direct_message_subscription(
                 self.subscription_registry
                     .direct_message_subscriptions
                     .as_ref(),
-                self.services.hint_transport.as_ref(),
-                self.services.keys.as_ref(),
+                &self.services,
                 peer_pubkey.as_str(),
             )
             .await?;
@@ -153,13 +152,7 @@ impl AppService {
     }
 
     pub(crate) async fn spawn_author_subscription(&self, author_pubkey: &str) -> Result<()> {
-        let store = Arc::clone(&self.services.store);
-        let projection_store = Arc::clone(&self.services.projection_store);
-        let docs_sync = Arc::clone(&self.services.docs_sync);
-        let blob_service = Arc::clone(&self.services.blob_service);
-        let hint_transport = Arc::clone(&self.services.hint_transport);
-        let transport = Arc::clone(&self.services.transport);
-        let keys = Arc::clone(&self.services.keys);
+        let services = self.services.clone();
         let last_sync = Arc::clone(&self.last_sync_ts);
         let notification_inserted = Arc::clone(&self.notification_inserted_notify);
         let direct_message_subscriptions =
@@ -167,10 +160,14 @@ impl AppService {
         let author_key = normalize_author_pubkey(author_pubkey)?;
         let local_author_pubkey = self.current_author_pubkey();
         let replica = author_replica_id(author_key.as_str());
-        docs_sync.open_replica(&replica).await?;
-        let mut doc_stream = docs_sync.subscribe_replica(&replica).await?;
+        services.docs_sync.open_replica(&replica).await?;
+        let mut doc_stream = services.docs_sync.subscribe_replica(&replica).await?;
         let author_key_for_task = author_key.clone();
         let handle = tokio::spawn(async move {
+            let store = &services.store;
+            let projection_store = &services.projection_store;
+            let docs_sync = &services.docs_sync;
+            let blob_service = &services.blob_service;
             let notification_baseline = match snapshot_follow_notification_baseline(
                 docs_sync.as_ref(),
                 &replica,
@@ -188,10 +185,8 @@ impl AppService {
                     NotificationDocEventBaseline::default()
                 }
             };
-            match hydrate_author_state_with_services(
-                docs_sync.as_ref(),
-                store.as_ref(),
-                projection_store.as_ref(),
+            match hydrate_author_state(
+                &services,
                 local_author_pubkey.as_str(),
                 author_key_for_task.as_str(),
                 DocFetchPolicy::LocalOnly,
@@ -200,13 +195,8 @@ impl AppService {
             {
                 Ok(initial_count) if initial_count > 0 => {
                     *last_sync.lock().await = Some(Utc::now().timestamp_millis());
-                    schedule_direct_message_reconcile_with_services(
-                        Arc::clone(&store),
-                        Arc::clone(&projection_store),
-                        Arc::clone(&blob_service),
-                        Arc::clone(&hint_transport),
-                        Arc::clone(&transport),
-                        Arc::clone(&keys),
+                    schedule_direct_message_reconcile(
+                        services.clone(),
                         Arc::clone(&last_sync),
                         Arc::clone(&direct_message_subscriptions),
                         Arc::clone(&notification_inserted),
@@ -223,13 +213,7 @@ impl AppService {
                     );
                 }
             }
-            let recovery_store = Arc::clone(&store);
-            let recovery_projection_store = Arc::clone(&projection_store);
-            let recovery_docs_sync = Arc::clone(&docs_sync);
-            let recovery_blob_service = Arc::clone(&blob_service);
-            let recovery_hint_transport = Arc::clone(&hint_transport);
-            let recovery_transport = Arc::clone(&transport);
-            let recovery_keys = Arc::clone(&keys);
+            let recovery_services = services.clone();
             let recovery_last_sync = Arc::clone(&last_sync);
             let recovery_notification_inserted = Arc::clone(&notification_inserted);
             let recovery_direct_message_subscriptions = Arc::clone(&direct_message_subscriptions);
@@ -238,10 +222,8 @@ impl AppService {
             tokio::spawn(async move {
                 match tokio::time::timeout(
                     std::time::Duration::from_secs(5),
-                    hydrate_author_state_with_services(
-                        recovery_docs_sync.as_ref(),
-                        recovery_store.as_ref(),
-                        recovery_projection_store.as_ref(),
+                    hydrate_author_state(
+                        &recovery_services,
                         recovery_local_author_pubkey.as_str(),
                         recovery_author_pubkey.as_str(),
                         DocFetchPolicy::LocalThenRemote,
@@ -251,13 +233,8 @@ impl AppService {
                 {
                     Ok(Ok(initial_count)) if initial_count > 0 => {
                         *recovery_last_sync.lock().await = Some(Utc::now().timestamp_millis());
-                        schedule_direct_message_reconcile_with_services(
-                            Arc::clone(&recovery_store),
-                            Arc::clone(&recovery_projection_store),
-                            Arc::clone(&recovery_blob_service),
-                            Arc::clone(&recovery_hint_transport),
-                            Arc::clone(&recovery_transport),
-                            Arc::clone(&recovery_keys),
+                        schedule_direct_message_reconcile(
+                            recovery_services,
                             Arc::clone(&recovery_last_sync),
                             Arc::clone(&recovery_direct_message_subscriptions),
                             Arc::clone(&recovery_notification_inserted),
@@ -330,10 +307,8 @@ impl AppService {
                                 }
                             }
                         }
-                        if let Ok(count) = hydrate_author_state_with_services(
-                            docs_sync.as_ref(),
-                            store.as_ref(),
-                            projection_store.as_ref(),
+                        if let Ok(count) = hydrate_author_state(
+                            &services,
                             local_author_pubkey.as_str(),
                             author_key_for_task.as_str(),
                             DocFetchPolicy::LocalThenRemote,
@@ -341,13 +316,8 @@ impl AppService {
                         && count > 0
                         {
                             *last_sync.lock().await = Some(Utc::now().timestamp_millis());
-                            schedule_direct_message_reconcile_with_services(
-                                Arc::clone(&store),
-                                Arc::clone(&projection_store),
-                                Arc::clone(&blob_service),
-                                Arc::clone(&hint_transport),
-                                Arc::clone(&transport),
-                                Arc::clone(&keys),
+                            schedule_direct_message_reconcile(
+                                services.clone(),
                                 Arc::clone(&last_sync),
                                 Arc::clone(&direct_message_subscriptions),
                                 Arc::clone(&notification_inserted),

--- a/crates/app-api/src/service/timeline_subscription_support.rs
+++ b/crates/app-api/src/service/timeline_subscription_support.rs
@@ -274,14 +274,8 @@ impl AppService {
         topic_id: &str,
         scope: &TimelineScope,
     ) -> Result<usize> {
-        let mut hydrated = hydrate_topic_state_with_services(
-            self.services.docs_sync.as_ref(),
-            self.services.blob_service.as_ref(),
-            self.services.projection_store.as_ref(),
-            topic_id,
-            DocFetchPolicy::LocalOnly,
-        )
-        .await?;
+        let mut hydrated =
+            hydrate_topic_state(&self.services, topic_id, DocFetchPolicy::LocalOnly).await?;
         match scope {
             TimelineScope::Public => {}
             TimelineScope::AllJoined => {
@@ -296,10 +290,8 @@ impl AppService {
                                 )
                             })
                     {
-                        hydrated += hydrate_subscription_state_with_services(
-                            self.services.docs_sync.as_ref(),
-                            self.services.blob_service.as_ref(),
-                            self.services.projection_store.as_ref(),
+                        hydrated += hydrate_subscription_state(
+                            &self.services,
                             topic_id,
                             &replica,
                             DocFetchPolicy::LocalOnly,
@@ -325,10 +317,8 @@ impl AppService {
                                 )
                             })
                     {
-                        hydrated += hydrate_subscription_state_with_services(
-                            self.services.docs_sync.as_ref(),
-                            self.services.blob_service.as_ref(),
-                            self.services.projection_store.as_ref(),
+                        hydrated += hydrate_subscription_state(
+                            &self.services,
                             topic_id,
                             &replica,
                             DocFetchPolicy::LocalOnly,

--- a/crates/app-api/src/tests/direct_messages/restart.rs
+++ b/crates/app-api/src/tests/direct_messages/restart.rs
@@ -151,12 +151,9 @@ async fn dm_restart_resumes_pending_outbox_and_local_delete_prevents_duplicate_r
             last_error: None,
         }];
     }
-    let _published = AppService::flush_direct_message_outbox_for_peer_with_services(
-        store_a.as_ref(),
-        hint_transport.as_ref(),
-        transport.as_ref(),
+    let _published = AppService::flush_direct_message_outbox_for_peer(
+        &reopened_app_a.services,
         a_pubkey.as_str(),
-        &keys_a,
         b_pubkey.as_str(),
     )
     .await

--- a/crates/app-api/src/tests/notifications.rs
+++ b/crates/app-api/src/tests/notifications.rs
@@ -339,10 +339,8 @@ async fn repost_notification_survives_hydration_before_live_doc_event() {
     )
     .await
     .expect("persist simple repost");
-    hydrate_subscription_state_with_services(
-        docs_sync.as_ref(),
-        blob_service.as_ref(),
-        store.as_ref(),
+    hydrate_subscription_state(
+        &app.services,
         topic.as_str(),
         &replica,
         DocFetchPolicy::LocalThenRemote,
@@ -424,10 +422,8 @@ async fn quote_repost_notification_survives_hydration_before_live_doc_event() {
     )
     .await
     .expect("persist quote repost");
-    hydrate_subscription_state_with_services(
-        docs_sync.as_ref(),
-        blob_service.as_ref(),
-        store.as_ref(),
+    hydrate_subscription_state(
+        &app.services,
         topic.as_str(),
         &replica,
         DocFetchPolicy::LocalThenRemote,
@@ -471,7 +467,7 @@ async fn quote_repost_notification_survives_hydration_before_live_doc_event() {
 
 #[tokio::test]
 async fn incoming_dm_frame_creates_single_direct_message_notification_after_store() {
-    let (app, store, _, blob_service) = local_app_with_memory_services();
+    let (app, _store, _, blob_service) = local_app_with_memory_services();
     let local_keys = app.services.keys.clone();
     let local_author_pubkey = app.current_author_pubkey();
     let remote_keys = generate_keys();
@@ -505,11 +501,8 @@ async fn incoming_dm_frame_creates_single_direct_message_notification_after_stor
         .await
         .expect("store frame blob");
 
-    let created = AppService::ingest_direct_message_frame_with_services(
-        store.as_ref(),
-        blob_service.as_ref(),
-        &NoopHintTransport,
-        local_keys.as_ref(),
+    let created = AppService::ingest_direct_message_frame(
+        &app.services,
         local_author_pubkey.as_str(),
         remote_pubkey.as_str(),
         &topic,
@@ -599,10 +592,8 @@ async fn follow_notification_survives_hydration_before_live_doc_event() {
     persist_follow_edge_doc(docs_sync.as_ref(), &edge, &envelope)
         .await
         .expect("persist follow edge doc");
-    hydrate_author_state_with_services(
-        docs_sync.as_ref(),
-        store.as_ref(),
-        store.as_ref(),
+    hydrate_author_state(
+        &app.services,
         local_author_pubkey.as_str(),
         remote_pubkey.as_str(),
         DocFetchPolicy::LocalThenRemote,
@@ -666,10 +657,8 @@ async fn initial_follow_baseline_prevents_backfill_notification() {
     .await
     .expect("snapshot follow baseline");
 
-    hydrate_author_state_with_services(
-        docs_sync.as_ref(),
-        store.as_ref(),
-        store.as_ref(),
+    hydrate_author_state(
+        &app.services,
         local_author_pubkey.as_str(),
         remote_pubkey.as_str(),
         DocFetchPolicy::LocalThenRemote,
@@ -813,10 +802,8 @@ async fn restart_or_manual_hydration_does_not_backfill_or_duplicate_notification
     )
     .await
     .expect("snapshot object baseline");
-    hydrate_subscription_state_with_services(
-        docs_sync.as_ref(),
-        blob_service.as_ref(),
-        store.as_ref(),
+    hydrate_subscription_state(
+        &app.services,
         topic.as_str(),
         &replica,
         DocFetchPolicy::LocalThenRemote,
@@ -884,10 +871,8 @@ async fn restart_or_manual_hydration_does_not_backfill_or_duplicate_notification
         )
         .await
     );
-    hydrate_subscription_state_with_services(
-        docs_sync.as_ref(),
-        blob_service.as_ref(),
-        store.as_ref(),
+    hydrate_subscription_state(
+        &app.services,
         topic.as_str(),
         &replica,
         DocFetchPolicy::LocalThenRemote,

--- a/crates/app-api/src/tests/sync/hint_rehydration.rs
+++ b/crates/app-api/src/tests/sync/hint_rehydration.rs
@@ -443,6 +443,15 @@ async fn topic_session_hints_retry_until_manifest_blob_is_available() {
         blob_service.clone(),
         generate_keys(),
     );
+    let remote_services = ServiceHandles::new(
+        remote_store.clone(),
+        remote_store.clone(),
+        transport,
+        Arc::new(NoopHintTransport),
+        docs_sync.clone(),
+        blob_service.clone(),
+        generate_keys(),
+    );
     let topic = TopicId::new("kukuri:topic:incremental-live-session-retry");
     let replica = topic_replica_id(topic.as_str());
 
@@ -464,10 +473,8 @@ async fn topic_session_hints_retry_until_manifest_blob_is_available() {
         .delay_hash(&state.current_manifest.hash, 2)
         .await;
 
-    let hydrated = hydrate_subscription_hint_with_services(
-        docs_sync.as_ref(),
-        blob_service.as_ref(),
-        remote_store.as_ref(),
+    let hydrated = hydrate_subscription_hint(
+        &remote_services,
         topic.as_str(),
         &replica,
         &GossipHint::SessionChanged {


### PR DESCRIPTION
## Summary
- move hydration, profile, direct-message, and social helper dependency groups onto ServiceHandles
- keep runtime state such as subscriptions, last-sync, generation, and notifications as explicit arguments/owners
- rename helper surfaces to their single base names and remove all *_with_services call sites
- shrink private_channels_support.rs below its existing oversized baseline

## Validation
- cargo test -p kukuri-app-api (163 passed)
- cargo xtask rust-check
- cargo xtask oversized-files
- cargo xtask check
- cargo xtask e2e-smoke
- cargo xtask test: 316 passed before the two known local Windows docs-sync relay timeouts; concurrent friend-plus timed out in that run and passed when rerun alone
- rg '_with_services\\(' crates/app-api/src --glob '*.rs' (0 matches)
- git diff --check