### PR TITLE
test: characterize private channel import errors

### DIFF
--- a/crates/app-api/src/tests/private_channels/friend_only.rs
+++ b/crates/app-api/src/tests/private_channels/friend_only.rs
@@ -177,7 +177,10 @@ async fn friend_only_grant_requires_mutual_and_rotate_requires_fresh_grant() {
         .import_friend_only_grant(grant.as_str())
         .await
         .expect_err("c should not join without mutual");
-    assert!(non_mutual_error.to_string().contains("mutual relationship"));
+    assert_eq!(
+        non_mutual_error.to_string(),
+        "friend-only grant import requires a mutual relationship with the channel owner"
+    );
 
     let private_channel_id = ChannelId::new(channel.channel_id.clone());
     let private_scope = TimelineScope::Channel {

--- a/crates/app-api/src/tests/private_channels/friend_plus.rs
+++ b/crates/app-api/src/tests/private_channels/friend_plus.rs
@@ -333,9 +333,9 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
     let freeze_error_message =
         wait_for_friend_plus_share_rejection(&app_d, stale_share_for_d.as_str(), rotation_timeout)
             .await;
-    assert!(
-        freeze_error_message.contains("no longer open"),
-        "unexpected frozen share error: {freeze_error_message}"
+    assert_eq!(
+        freeze_error_message,
+        "friend-plus share is no longer open for import"
     );
 
     let rotated = app_a
@@ -462,9 +462,9 @@ async fn friend_plus_share_freeze_rotate_and_new_epoch_visibility() {
     let old_share_error_message =
         wait_for_friend_plus_share_rejection(&app_d, stale_share_for_d.as_str(), rotation_timeout)
             .await;
-    assert!(
-        old_share_error_message.contains("no longer open"),
-        "unexpected old share error after rotate: {old_share_error_message}"
+    assert_eq!(
+        old_share_error_message,
+        "friend-plus share is no longer open for import"
     );
 
     let new_post_id = app_b

--- a/crates/app-api/src/tests/support/waiters.rs
+++ b/crates/app-api/src/tests/support/waiters.rs
@@ -323,3 +323,62 @@ pub(crate) async fn wait_for_friend_plus_share_rejection(
         }
     }
 }
+
+#[cfg(test)]
+mod error_contract_tests {
+    use super::{
+        is_retryable_friend_only_grant_import_error, is_retryable_friend_plus_share_import_error,
+    };
+
+    #[test]
+    fn friend_only_import_retry_contract_is_exactly_characterized() {
+        for message in [
+            "friend-only grant import requires a mutual relationship with the channel owner",
+            "friend-only grant epoch does not match the current policy",
+            "friend-only grant owner is not an active participant",
+            "timed out waiting for friend-only channel replica sync",
+        ] {
+            assert!(
+                is_retryable_friend_only_grant_import_error(message),
+                "expected retryable: {message}"
+            );
+        }
+        for message in [
+            "friend-only grant is expired",
+            "friend-only grant replica audience must be friend_only",
+            "friend-only grant is no longer open for import",
+            "unrecognized private channel access token",
+        ] {
+            assert!(
+                !is_retryable_friend_only_grant_import_error(message),
+                "expected terminal: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn friend_plus_import_retry_contract_is_exactly_characterized() {
+        for message in [
+            "friend-plus share import requires a mutual relationship with the sponsor",
+            "sponsor is not an active participant",
+            "timed out waiting for friend-plus sponsor participant sync",
+            "timed out waiting for friend-plus channel replica sync",
+        ] {
+            assert!(
+                is_retryable_friend_plus_share_import_error(message),
+                "expected retryable: {message}"
+            );
+        }
+        for message in [
+            "friend-plus share is expired",
+            "friend-plus share replica audience must be friend_plus",
+            "friend-plus share is no longer open for import",
+            "friend-plus share epoch does not match the current policy",
+        ] {
+            assert!(
+                !is_retryable_friend_plus_share_import_error(message),
+                "expected terminal: {message}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- freeze exact friend-only and friend-plus import rejection messages
- characterize retryable versus terminal import errors for both token families
- keep production code unchanged before the typed-error migration

## Validation
- cargo test -p kukuri-app-api (165 passed)
- cargo xtask rust-check
- cargo xtask oversized-files
- git diff --check