### PR TITLE
refactor(app-api): type private channel import errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,6 +2922,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/crates/app-api/Cargo.toml
+++ b/crates/app-api/Cargo.toml
@@ -15,6 +15,7 @@ tokio.workspace = true
 tokio-stream.workspace = true
 chrono.workspace = true
 tracing.workspace = true
+thiserror.workspace = true
 kukuri-core = { path = "../core" }
 kukuri-blob-service = { path = "../blob-service" }
 kukuri-docs-sync = { path = "../docs-sync" }

--- a/crates/app-api/src/private_channels.rs
+++ b/crates/app-api/src/private_channels.rs
@@ -125,11 +125,11 @@ impl AppService {
         if let Some(expires_at) = spec.expires_at
             && expires_at < Utc::now().timestamp_millis()
         {
-            anyhow::bail!("{}", spec.expired_message);
+            return Err(PrivateChannelImportError::Expired { kind: spec.kind }.into());
         }
         self.ensure_topic_subscription(spec.topic_id.as_str())
             .await?;
-        if let Some((peer_pubkey, message)) = spec.mutual_with.as_ref() {
+        if let Some(peer_pubkey) = spec.mutual_with.as_ref() {
             self.ensure_author_subscription(peer_pubkey.as_str())
                 .await?;
             self.rebuild_author_relationships().await?;
@@ -142,7 +142,10 @@ impl AppService {
                 )
                 .await?;
             if !relationship.as_ref().is_some_and(|value| value.mutual) {
-                anyhow::bail!("{}", message);
+                return Err(PrivateChannelImportError::MutualRelationshipRequired {
+                    kind: spec.kind,
+                }
+                .into());
             }
         }
         let replica = if spec.use_legacy_aware_replica {
@@ -157,7 +160,7 @@ impl AppService {
             let (metadata, policy, participants) = wait_for_private_channel_epoch_snapshot(
                 self.docs_sync(),
                 &replica,
-                spec.sync_context,
+                PrivateChannelSnapshotWaitContext::Import(spec.kind),
             )
             .await?;
             let participants = if spec.refetch_participants {
@@ -171,15 +174,15 @@ impl AppService {
                 participants
             };
             if policy.audience_kind != spec.audience {
-                anyhow::bail!("{}", spec.audience_message);
+                return Err(PrivateChannelImportError::AudienceMismatch { kind: spec.kind }.into());
             }
             if policy.sharing_state != ChannelSharingState::Open {
-                anyhow::bail!("{}", spec.not_open_message);
+                return Err(PrivateChannelImportError::SharingClosed { kind: spec.kind }.into());
             }
             if policy.epoch_id != spec.epoch_id {
-                anyhow::bail!("{}", spec.epoch_mismatch_message);
+                return Err(PrivateChannelImportError::EpochMismatch { kind: spec.kind }.into());
             }
-            if let Some(owner_message) = spec.owner_check_message
+            if spec.check_owner_active
                 && !participants.iter().any(|participant| {
                     participant.participant_pubkey == policy.owner_pubkey
                         && participant.epoch_id == policy.epoch_id
@@ -187,7 +190,7 @@ impl AppService {
                         && participant.left_at.is_none()
                 })
             {
-                anyhow::bail!("{}", owner_message);
+                return Err(PrivateChannelImportError::OwnerInactive { kind: spec.kind }.into());
             }
             let local_pubkey = Pubkey::from(self.current_author_pubkey());
             let already_participant = participants.iter().any(|participant| {
@@ -258,17 +261,13 @@ impl AppService {
             epoch_id: preview.epoch_id.clone(),
             namespace_secret_hex: preview.namespace_secret_hex.clone(),
             expires_at: preview.expires_at,
-            expired_message: "private channel invite is expired",
+            kind: PrivateChannelImportKind::InviteOnly,
             mutual_with: None,
             // 招待だけは epoch なし時代の channel を legacy replica で読む(互換パス)。
             use_legacy_aware_replica: true,
-            sync_context: "invite-only channel replica sync",
             refetch_participants: false,
             audience: ChannelAudienceKind::InviteOnly,
-            audience_message: "invite-only replica audience must be invite_only",
-            not_open_message: "invite-only access token is no longer open for import",
-            epoch_mismatch_message: "invite-only access token epoch does not match the current policy",
-            owner_check_message: Some("invite-only channel owner is not an active participant"),
+            check_owner_active: true,
             join_mode: PrivateChannelJoinMode::InviteToken,
             sponsor: ImportSponsor::Pubkey(preview.inviter_pubkey.clone()),
             share_token_id: None,
@@ -446,19 +445,12 @@ impl AppService {
             epoch_id: preview.epoch_id.clone(),
             namespace_secret_hex: preview.namespace_secret_hex.clone(),
             expires_at: preview.expires_at,
-            expired_message: "friend-only grant is expired",
-            mutual_with: Some((
-                preview.owner_pubkey.as_str().to_string(),
-                "friend-only grant import requires a mutual relationship with the channel owner",
-            )),
+            kind: PrivateChannelImportKind::FriendOnly,
+            mutual_with: Some(preview.owner_pubkey.as_str().to_string()),
             use_legacy_aware_replica: false,
-            sync_context: "friend-only channel replica sync",
             refetch_participants: false,
             audience: ChannelAudienceKind::FriendOnly,
-            audience_message: "friend-only grant replica audience must be friend_only",
-            not_open_message: "friend-only grant is no longer open for import",
-            epoch_mismatch_message: "friend-only grant epoch does not match the current policy",
-            owner_check_message: Some("friend-only grant owner is not an active participant"),
+            check_owner_active: true,
             join_mode: PrivateChannelJoinMode::FriendOnlyGrant,
             // 参加ドキュメントの sponsor は snapshot 取得後の policy.owner_pubkey(統合前と同じ)。
             sponsor: ImportSponsor::PolicyOwner,
@@ -534,21 +526,14 @@ impl AppService {
             namespace_secret_hex: preview.namespace_secret_hex.clone(),
             // friend-plus 共有トークンは期限チェックを行わない(統合前と同じ)。
             expires_at: None,
-            expired_message: "friend-plus share is expired",
-            mutual_with: Some((
-                preview.sponsor_pubkey.as_str().to_string(),
-                "friend-plus share import requires a mutual relationship with the sponsor",
-            )),
+            kind: PrivateChannelImportKind::FriendPlus,
+            mutual_with: Some(preview.sponsor_pubkey.as_str().to_string()),
             use_legacy_aware_replica: false,
-            sync_context: "friend-plus channel replica sync",
             // friend-plus のみ snapshot 後に participants を取り直す(統合前と同じ)。
             refetch_participants: true,
             audience: ChannelAudienceKind::FriendPlus,
-            audience_message: "friend-plus share replica audience must be friend_plus",
-            not_open_message: "friend-plus share is no longer open for import",
-            epoch_mismatch_message: "friend-plus share epoch does not match the current policy",
             // friend-plus は owner の active 参加検査を行わない(統合前と同じ)。
-            owner_check_message: None,
+            check_owner_active: false,
             join_mode: PrivateChannelJoinMode::FriendPlusShare,
             sponsor: ImportSponsor::Pubkey(preview.sponsor_pubkey.clone()),
             share_token_id: Some(preview.share_token_id.clone()),
@@ -1034,20 +1019,16 @@ struct PrivateChannelImportSpec {
     namespace_secret_hex: String,
     /// トークン期限(None = 期限チェックなし)。
     expires_at: Option<i64>,
-    expired_message: &'static str,
-    /// mutual 関係の前提(相手 pubkey とエラー文言。None = チェックなし)。
-    mutual_with: Option<(String, &'static str)>,
+    kind: PrivateChannelImportKind,
+    /// mutual 関係の前提となる相手 pubkey(None = チェックなし)。
+    mutual_with: Option<String>,
     /// epoch なし時代の channel を legacy replica で読むか(招待のみ true。互換パス)。
     use_legacy_aware_replica: bool,
-    sync_context: &'static str,
     /// snapshot 後に participants を取り直すか(friend-plus のみ true)。
     refetch_participants: bool,
     audience: ChannelAudienceKind,
-    audience_message: &'static str,
-    not_open_message: &'static str,
-    epoch_mismatch_message: &'static str,
-    /// owner が active 参加者であることの検査文言(None = 検査なし)。
-    owner_check_message: Option<&'static str>,
+    /// owner が active 参加者であることを検査するか。
+    check_owner_active: bool,
     join_mode: PrivateChannelJoinMode,
     sponsor: ImportSponsor,
     share_token_id: Option<String>,

--- a/crates/app-api/src/service/errors.rs
+++ b/crates/app-api/src/service/errors.rs
@@ -1,0 +1,138 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrivateChannelImportKind {
+    InviteOnly,
+    FriendOnly,
+    FriendPlus,
+}
+
+impl PrivateChannelImportKind {
+    fn expired_message(self) -> &'static str {
+        match self {
+            Self::InviteOnly => "private channel invite is expired",
+            Self::FriendOnly => "friend-only grant is expired",
+            Self::FriendPlus => "friend-plus share is expired",
+        }
+    }
+
+    fn mutual_relationship_message(self) -> &'static str {
+        match self {
+            Self::FriendOnly => {
+                "friend-only grant import requires a mutual relationship with the channel owner"
+            }
+            Self::FriendPlus => {
+                "friend-plus share import requires a mutual relationship with the sponsor"
+            }
+            Self::InviteOnly => "private channel invite does not require a mutual relationship",
+        }
+    }
+
+    fn audience_mismatch_message(self) -> &'static str {
+        match self {
+            Self::InviteOnly => "invite-only replica audience must be invite_only",
+            Self::FriendOnly => "friend-only grant replica audience must be friend_only",
+            Self::FriendPlus => "friend-plus share replica audience must be friend_plus",
+        }
+    }
+
+    fn sharing_closed_message(self) -> &'static str {
+        match self {
+            Self::InviteOnly => "invite-only access token is no longer open for import",
+            Self::FriendOnly => "friend-only grant is no longer open for import",
+            Self::FriendPlus => "friend-plus share is no longer open for import",
+        }
+    }
+
+    fn epoch_mismatch_message(self) -> &'static str {
+        match self {
+            Self::InviteOnly => "invite-only access token epoch does not match the current policy",
+            Self::FriendOnly => "friend-only grant epoch does not match the current policy",
+            Self::FriendPlus => "friend-plus share epoch does not match the current policy",
+        }
+    }
+
+    fn owner_inactive_message(self) -> &'static str {
+        match self {
+            Self::InviteOnly => "invite-only channel owner is not an active participant",
+            Self::FriendOnly => "friend-only grant owner is not an active participant",
+            Self::FriendPlus => "friend-plus channel owner is not an active participant",
+        }
+    }
+
+    fn snapshot_timeout_message(self) -> &'static str {
+        match self {
+            Self::InviteOnly => "timed out waiting for invite-only channel replica sync",
+            Self::FriendOnly => "timed out waiting for friend-only channel replica sync",
+            Self::FriendPlus => "timed out waiting for friend-plus channel replica sync",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum PrivateChannelImportError {
+    #[error("{}", .kind.expired_message())]
+    Expired { kind: PrivateChannelImportKind },
+    #[error("{}", .kind.mutual_relationship_message())]
+    MutualRelationshipRequired { kind: PrivateChannelImportKind },
+    #[error("{}", .kind.audience_mismatch_message())]
+    AudienceMismatch { kind: PrivateChannelImportKind },
+    #[error("{}", .kind.sharing_closed_message())]
+    SharingClosed { kind: PrivateChannelImportKind },
+    #[error("{}", .kind.epoch_mismatch_message())]
+    EpochMismatch { kind: PrivateChannelImportKind },
+    #[error("{}", .kind.owner_inactive_message())]
+    OwnerInactive { kind: PrivateChannelImportKind },
+    #[error("{}", .kind.snapshot_timeout_message())]
+    SnapshotTimeout { kind: PrivateChannelImportKind },
+    #[cfg(test)]
+    #[error("sponsor is not an active participant")]
+    SponsorInactive,
+    #[cfg(test)]
+    #[error("timed out waiting for friend-plus sponsor participant sync")]
+    SponsorSnapshotTimeout,
+}
+
+#[cfg(test)]
+impl PrivateChannelImportError {
+    pub(crate) fn is_retryable_friend_only(&self) -> bool {
+        matches!(
+            self,
+            Self::MutualRelationshipRequired {
+                kind: PrivateChannelImportKind::FriendOnly
+            } | Self::EpochMismatch {
+                kind: PrivateChannelImportKind::FriendOnly
+            } | Self::OwnerInactive {
+                kind: PrivateChannelImportKind::FriendOnly
+            } | Self::SnapshotTimeout {
+                kind: PrivateChannelImportKind::FriendOnly
+            }
+        )
+    }
+
+    pub(crate) fn is_retryable_friend_plus(&self) -> bool {
+        matches!(
+            self,
+            Self::MutualRelationshipRequired {
+                kind: PrivateChannelImportKind::FriendPlus
+            } | Self::SnapshotTimeout {
+                kind: PrivateChannelImportKind::FriendPlus
+            } | Self::SponsorInactive
+                | Self::SponsorSnapshotTimeout
+        )
+    }
+}
+
+pub(crate) enum PrivateChannelSnapshotWaitContext {
+    Import(PrivateChannelImportKind),
+    EpochHandoff,
+}
+
+impl PrivateChannelSnapshotWaitContext {
+    pub(crate) fn timeout_error(&self) -> anyhow::Error {
+        match self {
+            Self::Import(kind) => PrivateChannelImportError::SnapshotTimeout { kind: *kind }.into(),
+            Self::EpochHandoff => {
+                anyhow::anyhow!("timed out waiting for private channel epoch handoff sync")
+            }
+        }
+    }
+}

--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -99,6 +99,7 @@ pub(crate) use crate::views::{
 mod attachment_support;
 mod direct_messages_delivery_support;
 mod direct_messages_subscription_support;
+mod errors;
 mod gossip_subscription_support;
 mod hydration_support;
 mod live_game_support;
@@ -113,6 +114,10 @@ mod social_runtime_support;
 mod subscription_registry;
 mod timeline_subscription_support;
 mod timeline_view_support;
+
+pub(crate) use errors::{
+    PrivateChannelImportError, PrivateChannelImportKind, PrivateChannelSnapshotWaitContext,
+};
 
 pub(crate) use attachment_support::{
     attachment_views, attachment_views_from_refs, blob_status, blob_view_status,

--- a/crates/app-api/src/service/object_persistence_support.rs
+++ b/crates/app-api/src/service/object_persistence_support.rs
@@ -331,7 +331,7 @@ pub(crate) async fn fetch_private_channel_epoch_handoff_grant_from_replica(
 pub(crate) async fn wait_for_private_channel_epoch_snapshot(
     docs_sync: &dyn DocsSync,
     replica: &ReplicaId,
-    timeout_label: &str,
+    context: PrivateChannelSnapshotWaitContext,
 ) -> Result<(
     PrivateChannelMetadataDocV1,
     PrivateChannelPolicyDocV1,
@@ -374,7 +374,7 @@ pub(crate) async fn wait_for_private_channel_epoch_snapshot(
         }
     })
     .await
-    .map_err(|_| anyhow::anyhow!("timed out waiting for {timeout_label}"))?
+    .map_err(|_| context.timeout_error())?
 }
 
 pub(crate) async fn private_channel_rotation_is_pending(

--- a/crates/app-api/src/service/private_channels_support.rs
+++ b/crates/app-api/src/service/private_channels_support.rs
@@ -100,7 +100,7 @@ impl AppService {
             let (metadata, policy, participants) = match wait_for_private_channel_epoch_snapshot(
                 self.docs_sync(),
                 &next_replica,
-                "private channel epoch handoff sync",
+                PrivateChannelSnapshotWaitContext::EpochHandoff,
             )
             .await
             {

--- a/crates/app-api/src/tests/support/waiters.rs
+++ b/crates/app-api/src/tests/support/waiters.rs
@@ -137,11 +137,10 @@ pub(crate) async fn wait_for_mutual_author_view(
     }
 }
 
-pub(crate) fn is_retryable_friend_only_grant_import_error(message: &str) -> bool {
-    message.contains("mutual relationship")
-        || message.contains("friend-only grant epoch does not match the current policy")
-        || message.contains("friend-only grant owner is not an active participant")
-        || message.contains("timed out waiting for friend-only channel replica sync")
+pub(crate) fn is_retryable_friend_only_grant_import_error(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<PrivateChannelImportError>()
+        .is_some_and(PrivateChannelImportError::is_retryable_friend_only)
 }
 
 pub(crate) async fn wait_for_friend_only_grant_import(
@@ -153,9 +152,7 @@ pub(crate) async fn wait_for_friend_only_grant_import(
         loop {
             match app.import_friend_only_grant(token).await {
                 Ok(preview) => return preview,
-                Err(error)
-                    if is_retryable_friend_only_grant_import_error(error.to_string().as_str()) =>
-                {
+                Err(error) if is_retryable_friend_only_grant_import_error(&error) => {
                     sleep(Duration::from_millis(100)).await;
                 }
                 Err(error) => panic!("friend-only grant import failed: {error:#}"),
@@ -195,11 +192,10 @@ pub(crate) async fn wait_for_friend_only_grant_import(
     }
 }
 
-pub(crate) fn is_retryable_friend_plus_share_import_error(message: &str) -> bool {
-    message.contains("mutual relationship")
-        || message.contains("sponsor is not an active participant")
-        || message.contains("timed out waiting for friend-plus sponsor participant sync")
-        || message.contains("timed out waiting for friend-plus channel replica sync")
+pub(crate) fn is_retryable_friend_plus_share_import_error(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<PrivateChannelImportError>()
+        .is_some_and(PrivateChannelImportError::is_retryable_friend_plus)
 }
 
 pub(crate) async fn wait_for_friend_plus_share_import(
@@ -214,9 +210,7 @@ pub(crate) async fn wait_for_friend_plus_share_import(
         loop {
             match app.import_friend_plus_share(token).await {
                 Ok(preview) => return preview,
-                Err(error)
-                    if is_retryable_friend_plus_share_import_error(error.to_string().as_str()) =>
-                {
+                Err(error) if is_retryable_friend_plus_share_import_error(&error) => {
                     *retry_error_slot.lock().await = Some(error.to_string());
                     sleep(Duration::from_millis(100)).await;
                 }
@@ -275,16 +269,19 @@ pub(crate) async fn wait_for_friend_plus_share_rejection(
                 .import_friend_plus_share(token)
                 .await
                 .expect_err("friend-plus share should be rejected");
-            let message = error.to_string();
-            if message.contains("no longer open") {
-                return message;
+            match error.downcast_ref::<PrivateChannelImportError>() {
+                Some(PrivateChannelImportError::SharingClosed {
+                    kind: PrivateChannelImportKind::FriendPlus,
+                }) => return error.to_string(),
+                Some(PrivateChannelImportError::SnapshotTimeout {
+                    kind: PrivateChannelImportKind::FriendPlus,
+                }) => {
+                    *retry_error_slot.lock().await = Some(error.to_string());
+                    sleep(Duration::from_millis(100)).await;
+                    continue;
+                }
+                _ => panic!("unexpected friend-plus share rejection error: {error}"),
             }
-            if message.contains("timed out waiting for friend-plus channel replica sync") {
-                *retry_error_slot.lock().await = Some(message);
-                sleep(Duration::from_millis(100)).await;
-                continue;
-            }
-            panic!("unexpected friend-plus share rejection error: {message}");
         }
     })
     .await
@@ -326,57 +323,91 @@ pub(crate) async fn wait_for_friend_plus_share_rejection(
 
 #[cfg(test)]
 mod error_contract_tests {
+    use crate::service::{PrivateChannelImportError, PrivateChannelImportKind};
+
     use super::{
         is_retryable_friend_only_grant_import_error, is_retryable_friend_plus_share_import_error,
     };
 
     #[test]
     fn friend_only_import_retry_contract_is_exactly_characterized() {
-        for message in [
-            "friend-only grant import requires a mutual relationship with the channel owner",
-            "friend-only grant epoch does not match the current policy",
-            "friend-only grant owner is not an active participant",
-            "timed out waiting for friend-only channel replica sync",
+        for error in [
+            PrivateChannelImportError::MutualRelationshipRequired {
+                kind: PrivateChannelImportKind::FriendOnly,
+            },
+            PrivateChannelImportError::EpochMismatch {
+                kind: PrivateChannelImportKind::FriendOnly,
+            },
+            PrivateChannelImportError::OwnerInactive {
+                kind: PrivateChannelImportKind::FriendOnly,
+            },
+            PrivateChannelImportError::SnapshotTimeout {
+                kind: PrivateChannelImportKind::FriendOnly,
+            },
         ] {
+            let message = error.to_string();
             assert!(
-                is_retryable_friend_only_grant_import_error(message),
+                is_retryable_friend_only_grant_import_error(&error.into()),
                 "expected retryable: {message}"
             );
         }
-        for message in [
-            "friend-only grant is expired",
-            "friend-only grant replica audience must be friend_only",
-            "friend-only grant is no longer open for import",
-            "unrecognized private channel access token",
+        for error in [
+            PrivateChannelImportError::Expired {
+                kind: PrivateChannelImportKind::FriendOnly,
+            },
+            PrivateChannelImportError::AudienceMismatch {
+                kind: PrivateChannelImportKind::FriendOnly,
+            },
+            PrivateChannelImportError::SharingClosed {
+                kind: PrivateChannelImportKind::FriendOnly,
+            },
         ] {
+            let message = error.to_string();
             assert!(
-                !is_retryable_friend_only_grant_import_error(message),
+                !is_retryable_friend_only_grant_import_error(&error.into()),
                 "expected terminal: {message}"
             );
         }
+        assert!(!is_retryable_friend_only_grant_import_error(
+            &anyhow::anyhow!("unrecognized private channel access token")
+        ));
     }
 
     #[test]
     fn friend_plus_import_retry_contract_is_exactly_characterized() {
-        for message in [
-            "friend-plus share import requires a mutual relationship with the sponsor",
-            "sponsor is not an active participant",
-            "timed out waiting for friend-plus sponsor participant sync",
-            "timed out waiting for friend-plus channel replica sync",
+        for error in [
+            PrivateChannelImportError::MutualRelationshipRequired {
+                kind: PrivateChannelImportKind::FriendPlus,
+            },
+            PrivateChannelImportError::SponsorInactive,
+            PrivateChannelImportError::SponsorSnapshotTimeout,
+            PrivateChannelImportError::SnapshotTimeout {
+                kind: PrivateChannelImportKind::FriendPlus,
+            },
         ] {
+            let message = error.to_string();
             assert!(
-                is_retryable_friend_plus_share_import_error(message),
+                is_retryable_friend_plus_share_import_error(&error.into()),
                 "expected retryable: {message}"
             );
         }
-        for message in [
-            "friend-plus share is expired",
-            "friend-plus share replica audience must be friend_plus",
-            "friend-plus share is no longer open for import",
-            "friend-plus share epoch does not match the current policy",
+        for error in [
+            PrivateChannelImportError::Expired {
+                kind: PrivateChannelImportKind::FriendPlus,
+            },
+            PrivateChannelImportError::AudienceMismatch {
+                kind: PrivateChannelImportKind::FriendPlus,
+            },
+            PrivateChannelImportError::SharingClosed {
+                kind: PrivateChannelImportKind::FriendPlus,
+            },
+            PrivateChannelImportError::EpochMismatch {
+                kind: PrivateChannelImportKind::FriendPlus,
+            },
         ] {
+            let message = error.to_string();
             assert!(
-                !is_retryable_friend_plus_share_import_error(message),
+                !is_retryable_friend_plus_share_import_error(&error.into()),
                 "expected terminal: {message}"
             );
         }


### PR DESCRIPTION
## Summary
- represent private-channel import failures with semantic typed errors while preserving public messages
- replace test waiter string matching with typed downcasts
- preserve generic epoch-handoff timeout behavior

## Validation
- cargo test -p kukuri-app-api --no-fail-fast (165 passed)
- cargo xtask rust-check
- cargo xtask oversized-files (existing 3 warnings; both touched oversized files shrank)
- git diff --check