### PR TITLE
test(cn-user-api): freeze HTTP error contracts

### DIFF
--- a/crates/cn-user-api/src/errors.rs
+++ b/crates/cn-user-api/src/errors.rs
@@ -10,3 +10,78 @@ pub(crate) fn internal_error(error: impl std::fmt::Display) -> ApiError {
         error.to_string(),
     )
 }
+
+#[cfg(test)]
+pub(crate) async fn assert_error_contract(
+    error: ApiError,
+    expected_status: axum::http::StatusCode,
+    expected_code: &str,
+    expected_message: &str,
+) {
+    use axum::response::IntoResponse;
+
+    let response = error.into_response();
+    assert_eq!(response.status(), expected_status);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read API error response body");
+    let body: serde_json::Value =
+        serde_json::from_slice(&body).expect("parse API error response body");
+    assert_eq!(body["code"], expected_code);
+    assert_eq!(body["message"], expected_message);
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use kukuri_cn_core::{ApiError, auth_required_error, consent_required_error};
+
+    use super::{assert_error_contract, internal_error};
+
+    #[tokio::test]
+    async fn common_error_response_contracts_are_stable() {
+        assert_error_contract(
+            internal_error(anyhow::anyhow!("database unavailable")),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "INTERNAL_ERROR",
+            "database unavailable",
+        )
+        .await;
+        assert_error_contract(
+            auth_required_error("bearer token is required"),
+            StatusCode::UNAUTHORIZED,
+            "AUTH_REQUIRED",
+            "bearer token is required",
+        )
+        .await;
+        assert_error_contract(
+            consent_required_error("required policies must be accepted"),
+            StatusCode::FORBIDDEN,
+            "CONSENT_REQUIRED",
+            "required policies must be accepted",
+        )
+        .await;
+        assert_error_contract(
+            ApiError::new(
+                StatusCode::BAD_REQUEST,
+                "INVALID_REQUEST",
+                "request is malformed",
+            ),
+            StatusCode::BAD_REQUEST,
+            "INVALID_REQUEST",
+            "request is malformed",
+        )
+        .await;
+        assert_error_contract(
+            ApiError::new(
+                StatusCode::NOT_FOUND,
+                "NOT_CONFIGURED",
+                "capability is not configured",
+            ),
+            StatusCode::NOT_FOUND,
+            "NOT_CONFIGURED",
+            "capability is not configured",
+        )
+        .await;
+    }
+}

--- a/crates/cn-user-api/src/handlers/auth.rs
+++ b/crates/cn-user-api/src/handlers/auth.rs
@@ -59,3 +59,31 @@ fn map_auth_verify_error(error: anyhow::Error) -> ApiError {
         error.to_string(),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use kukuri_cn_core::AdmissionRejection;
+
+    use crate::errors::assert_error_contract;
+
+    use super::map_auth_verify_error;
+
+    #[tokio::test]
+    async fn auth_verify_error_contracts_are_stable() {
+        assert_error_contract(
+            map_auth_verify_error(AdmissionRejection::InviteExpired.into()),
+            StatusCode::FORBIDDEN,
+            "INVITE_EXPIRED",
+            "the provided invite code has expired",
+        )
+        .await;
+        assert_error_contract(
+            map_auth_verify_error(anyhow::anyhow!("signature verification failed")),
+            StatusCode::UNAUTHORIZED,
+            "AUTH_FAILED",
+            "signature verification failed",
+        )
+        .await;
+    }
+}

--- a/crates/cn-user-api/src/handlers/indexing.rs
+++ b/crates/cn-user-api/src/handlers/indexing.rs
@@ -148,6 +148,34 @@ fn map_channel_secret_error(error: anyhow::Error) -> ApiError {
     )
 }
 
+#[cfg(test)]
+mod error_contract_tests {
+    use axum::http::StatusCode;
+    use kukuri_cn_core::ChannelSecretConflict;
+
+    use crate::errors::assert_error_contract;
+
+    use super::map_channel_secret_error;
+
+    #[tokio::test]
+    async fn channel_secret_error_contracts_are_stable() {
+        assert_error_contract(
+            map_channel_secret_error(ChannelSecretConflict::AlreadyRegistered.into()),
+            StatusCode::CONFLICT,
+            "CHANNEL_SECRET_CONFLICT",
+            "a different channel capability is already registered for this channel",
+        )
+        .await;
+        assert_error_contract(
+            map_channel_secret_error(anyhow::anyhow!("channel secret must be 32 bytes")),
+            StatusCode::BAD_REQUEST,
+            "INVALID_CHANNEL_SECRET",
+            "channel secret must be 32 bytes",
+        )
+        .await;
+    }
+}
+
 /// index query の共通クエリパラメータ(#404)。
 ///
 /// `scope_kind` + `scope_id` の組で topic 内(scope 内)読み、両方無指定で supported set 横断。


### PR DESCRIPTION
## Summary
- characterize stable HTTP status, code, and message contracts for CN errors
- cover admission, auth, consent, channel-secret, validation, missing-capability, and internal fallback responses
- keep production error mapping unchanged

## Validation
- cargo test -p kukuri-cn-user-api --lib --no-fail-fast
- cargo xtask cn-check
- cargo xtask cn-test
- cargo xtask oversized-files
- git diff --check