### PR TITLE
refactor(cn-user-api): type auth and consent errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,6 +3137,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tower-http",
  "tower_governor",

--- a/crates/cn-user-api/Cargo.toml
+++ b/crates/cn-user-api/Cargo.toml
@@ -20,6 +20,7 @@ tower-http.workspace = true
 tower_governor.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+thiserror.workspace = true
 url.workspace = true
 kukuri-cn-protocol = { path = "../cn-protocol" }
 kukuri-cn-core = { path = "../cn-core" }

--- a/crates/cn-user-api/src/errors.rs
+++ b/crates/cn-user-api/src/errors.rs
@@ -1,7 +1,12 @@
-//! ドメイン横断の共通エラー写像。ドメイン固有の写像(auth の admission 拒否、
-//! channel secret の衝突など)は各ハンドラファイルに置く。
+//! HTTP error mapping boundary.
+//!
+//! Domain errors are downcast before mapping. Only failures that remain unknown, or are explicitly
+//! classified as infrastructure failures, fall back to `500 INTERNAL_ERROR`. This keeps expected
+//! client failures from being accidentally promoted to 500 responses while retaining the existing
+//! status/code/message wire contract.
 
-use kukuri_cn_core::ApiError;
+use axum::http::StatusCode;
+use kukuri_cn_core::{AdmissionRejection, ApiError};
 
 pub(crate) fn internal_error(error: impl std::fmt::Display) -> ApiError {
     ApiError::new(
@@ -9,6 +14,65 @@ pub(crate) fn internal_error(error: impl std::fmt::Display) -> ApiError {
         "INTERNAL_ERROR",
         error.to_string(),
     )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AccountLifecycleOperation {
+    CreateAuthChallenge,
+    LoadAdmissionConfig,
+    VerifyAuth,
+    GetConsentStatus,
+    AcceptConsents,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AccountLifecycleError {
+    #[error("{source}")]
+    Infrastructure {
+        operation: AccountLifecycleOperation,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("{0}")]
+    Admission(AdmissionRejection),
+    #[error("{0}")]
+    AuthFailed(anyhow::Error),
+}
+
+impl AccountLifecycleError {
+    pub(crate) fn infrastructure(
+        operation: AccountLifecycleOperation,
+        source: anyhow::Error,
+    ) -> Self {
+        Self::Infrastructure { operation, source }
+    }
+
+    pub(crate) fn auth_verify(source: anyhow::Error) -> Self {
+        let source = match source.downcast::<AdmissionRejection>() {
+            Ok(rejection) => return Self::Admission(rejection),
+            Err(source) => source,
+        };
+        if source.downcast_ref::<sqlx::Error>().is_some() {
+            Self::infrastructure(AccountLifecycleOperation::VerifyAuth, source)
+        } else {
+            Self::AuthFailed(source)
+        }
+    }
+}
+
+pub(crate) fn account_lifecycle_error(error: AccountLifecycleError) -> ApiError {
+    match error {
+        AccountLifecycleError::Admission(rejection) => {
+            ApiError::new(StatusCode::FORBIDDEN, rejection.code(), rejection.message())
+        }
+        AccountLifecycleError::AuthFailed(source) => {
+            ApiError::new(StatusCode::UNAUTHORIZED, "AUTH_FAILED", source.to_string())
+        }
+        AccountLifecycleError::Infrastructure { operation, source } => {
+            let _ = operation;
+            internal_error(source)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/cn-user-api/src/handlers/auth.rs
+++ b/crates/cn-user-api/src/handlers/auth.rs
@@ -3,12 +3,12 @@
 use axum::Json;
 use axum::extract::State;
 use kukuri_cn_core::{
-    AdmissionRejection, ApiError, ApiResult, AuthChallengeResponse, AuthVerifyResponse,
-    create_auth_challenge, load_admission_config, verify_auth_envelope_and_issue_token,
+    ApiResult, AuthChallengeResponse, AuthVerifyResponse, create_auth_challenge,
+    load_admission_config, verify_auth_envelope_and_issue_token,
 };
 use kukuri_cn_protocol::{AuthChallengeRequest, AuthVerifyRequest};
 
-use crate::errors::internal_error;
+use crate::errors::{AccountLifecycleError, AccountLifecycleOperation, account_lifecycle_error};
 use crate::state::UserApiState;
 
 pub(crate) async fn auth_challenge(
@@ -17,7 +17,13 @@ pub(crate) async fn auth_challenge(
 ) -> ApiResult<Json<AuthChallengeResponse>> {
     let response = create_auth_challenge(&state.pool, request.pubkey.as_str())
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            AccountLifecycleError::infrastructure(
+                AccountLifecycleOperation::CreateAuthChallenge,
+                source,
+            )
+        })
+        .map_err(account_lifecycle_error)?;
     Ok(Json(response))
 }
 
@@ -27,7 +33,13 @@ pub(crate) async fn auth_verify(
 ) -> ApiResult<Json<AuthVerifyResponse>> {
     let admission_config = load_admission_config(&state.pool)
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            AccountLifecycleError::infrastructure(
+                AccountLifecycleOperation::LoadAdmissionConfig,
+                source,
+            )
+        })
+        .map_err(account_lifecycle_error)?;
     let response = verify_auth_envelope_and_issue_token(
         &state.pool,
         &state.jwt_config,
@@ -39,50 +51,47 @@ pub(crate) async fn auth_verify(
         request.invite_code.as_deref(),
     )
     .await
-    .map_err(map_auth_verify_error)?;
+    .map_err(AccountLifecycleError::auth_verify)
+    .map_err(account_lifecycle_error)?;
     Ok(Json(response))
 }
 
 /// auth/verify の失敗を HTTP 応答へマップする。admission 拒否(#383)は 403 + 専用コードで
 /// 区別し、それ以外の署名・challenge 検証失敗は従来通り 401 AUTH_FAILED にする。
-fn map_auth_verify_error(error: anyhow::Error) -> ApiError {
-    if let Some(rejection) = error.downcast_ref::<AdmissionRejection>() {
-        return ApiError::new(
-            axum::http::StatusCode::FORBIDDEN,
-            rejection.code(),
-            rejection.message(),
-        );
-    }
-    ApiError::new(
-        axum::http::StatusCode::UNAUTHORIZED,
-        "AUTH_FAILED",
-        error.to_string(),
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use axum::http::StatusCode;
     use kukuri_cn_core::AdmissionRejection;
 
-    use crate::errors::assert_error_contract;
-
-    use super::map_auth_verify_error;
+    use crate::errors::{AccountLifecycleError, account_lifecycle_error, assert_error_contract};
 
     #[tokio::test]
     async fn auth_verify_error_contracts_are_stable() {
         assert_error_contract(
-            map_auth_verify_error(AdmissionRejection::InviteExpired.into()),
+            account_lifecycle_error(AccountLifecycleError::auth_verify(
+                AdmissionRejection::InviteExpired.into(),
+            )),
             StatusCode::FORBIDDEN,
             "INVITE_EXPIRED",
             "the provided invite code has expired",
         )
         .await;
         assert_error_contract(
-            map_auth_verify_error(anyhow::anyhow!("signature verification failed")),
+            account_lifecycle_error(AccountLifecycleError::auth_verify(anyhow::anyhow!(
+                "signature verification failed"
+            ))),
             StatusCode::UNAUTHORIZED,
             "AUTH_FAILED",
             "signature verification failed",
+        )
+        .await;
+        assert_error_contract(
+            account_lifecycle_error(AccountLifecycleError::auth_verify(
+                sqlx::Error::RowNotFound.into(),
+            )),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "INTERNAL_ERROR",
+            "no rows returned by a query that expected to return at least one row",
         )
         .await;
     }

--- a/crates/cn-user-api/src/handlers/consents.rs
+++ b/crates/cn-user-api/src/handlers/consents.rs
@@ -9,7 +9,7 @@ use kukuri_cn_core::{
 };
 use kukuri_cn_protocol::AcceptConsentsRequest;
 
-use crate::errors::internal_error;
+use crate::errors::{AccountLifecycleError, AccountLifecycleOperation, account_lifecycle_error};
 use crate::state::UserApiState;
 
 pub(crate) async fn consent_status(
@@ -19,7 +19,13 @@ pub(crate) async fn consent_status(
     let pubkey = require_bearer_pubkey(&state.pool, &state.jwt_config, &headers).await?;
     let status = get_consent_status(&state.pool, pubkey.as_str())
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            AccountLifecycleError::infrastructure(
+                AccountLifecycleOperation::GetConsentStatus,
+                source,
+            )
+        })
+        .map_err(account_lifecycle_error)?;
     Ok(Json(status))
 }
 
@@ -31,6 +37,9 @@ pub(crate) async fn accept_consents_handler(
     let pubkey = require_bearer_pubkey(&state.pool, &state.jwt_config, &headers).await?;
     let status = accept_consents(&state.pool, pubkey.as_str(), &request.policy_slugs)
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            AccountLifecycleError::infrastructure(AccountLifecycleOperation::AcceptConsents, source)
+        })
+        .map_err(account_lifecycle_error)?;
     Ok(Json(status))
 }


### PR DESCRIPTION
## Summary
- classify account lifecycle failures as admission, auth verification, or infrastructure errors
- move auth and consent handlers to the typed mapper
- preserve existing 403/401/500 status, code, and message contracts

## Validation
- cargo test -p kukuri-cn-user-api --lib --no-fail-fast
- cargo xtask cn-check
- cargo xtask cn-test
- cargo xtask oversized-files
- auth/consent map_err(internal_error): 0