### PR TITLE
refactor(cn-user-api): type bootstrap and report errors

### DIFF
--- a/crates/cn-user-api/src/errors.rs
+++ b/crates/cn-user-api/src/errors.rs
@@ -75,6 +75,35 @@ pub(crate) fn account_lifecycle_error(error: AccountLifecycleError) -> ApiError 
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SupportEndpointOperation {
+    LoadBootstrapNodes,
+    LoadBootstrapSeedPeers,
+    RefreshBootstrapPeer,
+    RecordRendezvousHeartbeat,
+    StoreReport,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{source}")]
+pub(crate) struct SupportEndpointError {
+    operation: SupportEndpointOperation,
+    #[source]
+    source: anyhow::Error,
+}
+
+impl SupportEndpointError {
+    pub(crate) fn new(operation: SupportEndpointOperation, source: anyhow::Error) -> Self {
+        Self { operation, source }
+    }
+}
+
+pub(crate) fn support_endpoint_error(error: SupportEndpointError) -> ApiError {
+    let SupportEndpointError { operation, source } = error;
+    let _ = operation;
+    internal_error(source)
+}
+
 #[cfg(test)]
 pub(crate) async fn assert_error_contract(
     error: ApiError,
@@ -100,7 +129,10 @@ mod tests {
     use axum::http::StatusCode;
     use kukuri_cn_core::{ApiError, auth_required_error, consent_required_error};
 
-    use super::{assert_error_contract, internal_error};
+    use super::{
+        SupportEndpointError, SupportEndpointOperation, assert_error_contract, internal_error,
+        support_endpoint_error,
+    };
 
     #[tokio::test]
     async fn common_error_response_contracts_are_stable() {
@@ -147,5 +179,27 @@ mod tests {
             "capability is not configured",
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn support_endpoint_infrastructure_errors_keep_internal_fallback() {
+        for operation in [
+            SupportEndpointOperation::LoadBootstrapNodes,
+            SupportEndpointOperation::LoadBootstrapSeedPeers,
+            SupportEndpointOperation::RefreshBootstrapPeer,
+            SupportEndpointOperation::RecordRendezvousHeartbeat,
+            SupportEndpointOperation::StoreReport,
+        ] {
+            assert_error_contract(
+                support_endpoint_error(SupportEndpointError::new(
+                    operation,
+                    anyhow::anyhow!("backend unavailable"),
+                )),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                "backend unavailable",
+            )
+            .await;
+        }
     }
 }

--- a/crates/cn-user-api/src/handlers/bootstrap.rs
+++ b/crates/cn-user-api/src/handlers/bootstrap.rs
@@ -12,7 +12,7 @@ use kukuri_cn_core::{
 use kukuri_cn_protocol::BootstrapHeartbeatRequest;
 use serde::Serialize;
 
-use crate::errors::internal_error;
+use crate::errors::{SupportEndpointError, SupportEndpointOperation, support_endpoint_error};
 use crate::state::UserApiState;
 
 #[derive(Debug, Serialize)]
@@ -28,14 +28,20 @@ pub(crate) async fn bootstrap_nodes(
     let _ = require_consents(&state.pool, identity.pubkey.as_str()).await?;
     let mut nodes = load_bootstrap_nodes(&state.pool, Some(state.self_node.clone()))
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            SupportEndpointError::new(SupportEndpointOperation::LoadBootstrapNodes, source)
+        })
+        .map_err(support_endpoint_error)?;
     let seed_peers = load_bootstrap_seed_peers(
         &state.pool,
         Some(identity.pubkey.as_str()),
         identity.endpoint_id.as_deref(),
     )
     .await
-    .map_err(internal_error)?;
+    .map_err(|source| {
+        SupportEndpointError::new(SupportEndpointOperation::LoadBootstrapSeedPeers, source)
+    })
+    .map_err(support_endpoint_error)?;
     for node in &mut nodes {
         if node.base_url == state.self_node.base_url {
             node.resolved_urls.seed_peers = seed_peers.clone();
@@ -62,7 +68,10 @@ pub(crate) async fn bootstrap_heartbeat(
         request.addr_hint.as_deref(),
     )
     .await
-    .map_err(internal_error)?;
+    .map_err(|source| {
+        SupportEndpointError::new(SupportEndpointOperation::RefreshBootstrapPeer, source)
+    })
+    .map_err(support_endpoint_error)?;
     Ok(Json(response))
 }
 
@@ -85,6 +94,9 @@ pub(crate) async fn topic_rendezvous_heartbeat(
             state.self_node.resolved_urls.connectivity_urls.as_slice(),
         )
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            SupportEndpointError::new(SupportEndpointOperation::RecordRendezvousHeartbeat, source)
+        })
+        .map_err(support_endpoint_error)?;
     Ok(Json(response))
 }

--- a/crates/cn-user-api/src/handlers/reports.rs
+++ b/crates/cn-user-api/src/handlers/reports.rs
@@ -6,7 +6,7 @@ use axum::http::StatusCode;
 use kukuri_cn_core::{ApiError, ApiResult, NewCommunityNodeReport, insert_community_node_report};
 use serde::{Deserialize, Serialize};
 
-use crate::errors::internal_error;
+use crate::errors::{SupportEndpointError, SupportEndpointOperation, support_endpoint_error};
 use crate::state::UserApiState;
 
 /// 通報受信リクエスト(#370)。client(#310)が provenance + manifest authority scope で
@@ -82,7 +82,8 @@ pub(crate) async fn submit_report(
     };
     let stored = insert_community_node_report(&state.pool, &report)
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| SupportEndpointError::new(SupportEndpointOperation::StoreReport, source))
+        .map_err(support_endpoint_error)?;
     Ok(Json(SubmitReportResponse {
         reference_id: stored.id,
     }))


### PR DESCRIPTION
## Summary
- classify bootstrap reads/heartbeats and report persistence by operation
- preserve existing auth, consent, validation, and not-configured responses
- keep only backend failures on the 500 INTERNAL_ERROR fallback

## Validation
- cargo test -p kukuri-cn-user-api --lib --no-fail-fast
- cargo xtask cn-check
- cargo xtask cn-test
- cargo xtask oversized-files
- bootstrap/report map_err(internal_error): 0