### PR TITLE
refactor(cn-user-api): type trust and relation errors

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3606,6 +3606,7 @@ dependencies = [
  "kukuri-transport",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/crates/cn-user-api/src/errors.rs
+++ b/crates/cn-user-api/src/errors.rs
@@ -159,6 +159,68 @@ pub(crate) fn indexing_error(error: IndexingError) -> ApiError {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrustRelationOperation {
+    LoadTrustInputs,
+    LoadTrustPullInputs,
+    CheckRelationVisibility,
+    ReadPairwiseProximity,
+    ReadNeighbors,
+    FilterVisibleNeighbors,
+    SetOptOut,
+    GetOptOut,
+    ClearOptOut,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TrustRelationError {
+    #[error("{source}")]
+    TrustRead {
+        operation: TrustRelationOperation,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("{source}")]
+    RelationGraph {
+        operation: TrustRelationOperation,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("{source}")]
+    RelationOptOut {
+        operation: TrustRelationOperation,
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+impl TrustRelationError {
+    pub(crate) fn trust_read(operation: TrustRelationOperation, source: anyhow::Error) -> Self {
+        Self::TrustRead { operation, source }
+    }
+
+    pub(crate) fn relation_graph(operation: TrustRelationOperation, source: anyhow::Error) -> Self {
+        Self::RelationGraph { operation, source }
+    }
+
+    pub(crate) fn relation_opt_out(
+        operation: TrustRelationOperation,
+        source: anyhow::Error,
+    ) -> Self {
+        Self::RelationOptOut { operation, source }
+    }
+}
+
+pub(crate) fn trust_relation_error(error: TrustRelationError) -> ApiError {
+    let (operation, source) = match error {
+        TrustRelationError::TrustRead { operation, source }
+        | TrustRelationError::RelationGraph { operation, source }
+        | TrustRelationError::RelationOptOut { operation, source } => (operation, source),
+    };
+    let _ = operation;
+    internal_error(source)
+}
+
 #[cfg(test)]
 pub(crate) async fn assert_error_contract(
     error: ApiError,
@@ -185,8 +247,8 @@ mod tests {
     use kukuri_cn_core::{ApiError, auth_required_error, consent_required_error};
 
     use super::{
-        SupportEndpointError, SupportEndpointOperation, assert_error_contract, internal_error,
-        support_endpoint_error,
+        SupportEndpointError, SupportEndpointOperation, TrustRelationError, TrustRelationOperation,
+        assert_error_contract, internal_error, support_endpoint_error, trust_relation_error,
     };
 
     #[tokio::test]
@@ -253,6 +315,33 @@ mod tests {
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "INTERNAL_ERROR",
                 "backend unavailable",
+            )
+            .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn trust_relation_infrastructure_errors_keep_internal_fallback() {
+        for error in [
+            TrustRelationError::trust_read(
+                TrustRelationOperation::LoadTrustInputs,
+                anyhow::anyhow!("trust store unavailable"),
+            ),
+            TrustRelationError::relation_graph(
+                TrustRelationOperation::ReadPairwiseProximity,
+                anyhow::anyhow!("relation graph unavailable"),
+            ),
+            TrustRelationError::relation_opt_out(
+                TrustRelationOperation::SetOptOut,
+                anyhow::anyhow!("opt-out store unavailable"),
+            ),
+        ] {
+            let message = error.to_string();
+            assert_error_contract(
+                trust_relation_error(error),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                message.as_str(),
             )
             .await;
         }

--- a/crates/cn-user-api/src/handlers/trust_relation.rs
+++ b/crates/cn-user-api/src/handlers/trust_relation.rs
@@ -17,7 +17,7 @@ use kukuri_cn_trust::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::errors::internal_error;
+use crate::errors::{TrustRelationError, TrustRelationOperation, trust_relation_error};
 use crate::state::{TrustReadState, UserApiState};
 
 /// trust / relation read 共通の前処理: 機能ゲート(未構成なら 404)+ 認証 + consent。
@@ -83,7 +83,10 @@ pub(crate) async fn trust_user_read(
         now.to_rfc3339().as_str(),
     )
     .await
-    .map_err(internal_error)?;
+    .map_err(|source| {
+        TrustRelationError::trust_read(TrustRelationOperation::LoadTrustInputs, source)
+    })
+    .map_err(trust_relation_error)?;
     let view = build_trust_read(
         target.as_str(),
         &inputs,
@@ -130,7 +133,10 @@ pub(crate) async fn trust_pull(
         now.to_rfc3339().as_str(),
     )
     .await
-    .map_err(internal_error)?;
+    .map_err(|source| {
+        TrustRelationError::trust_read(TrustRelationOperation::LoadTrustPullInputs, source)
+    })
+    .map_err(trust_relation_error)?;
     Ok(Json(cross_node_trust_disclosure(
         target.as_str(),
         &inputs,
@@ -170,7 +176,13 @@ pub(crate) async fn relation_user_read(
     // 「見えない」opt-out: 他者から見た relation read に出さない(§6.3。可逆・trust 非影響)。
     if is_relation_opted_out(&state.pool, target.as_str())
         .await
-        .map_err(internal_error)?
+        .map_err(|source| {
+            TrustRelationError::relation_opt_out(
+                TrustRelationOperation::CheckRelationVisibility,
+                source,
+            )
+        })
+        .map_err(trust_relation_error)?
     {
         return Err(not_found());
     }
@@ -178,7 +190,13 @@ pub(crate) async fn relation_user_read(
         .relation
         .pairwise_proximity(viewer_pubkey.as_str(), target.as_str())
         .await
-        .map_err(internal_error)?
+        .map_err(|source| {
+            TrustRelationError::relation_graph(
+                TrustRelationOperation::ReadPairwiseProximity,
+                source,
+            )
+        })
+        .map_err(trust_relation_error)?
         .ok_or_else(not_found)?;
     Ok(Json(RelationReadResponse {
         viewer_pubkey,
@@ -213,10 +231,19 @@ pub(crate) async fn relation_neighbors(
         .relation
         .neighbors(viewer_pubkey.as_str(), limit)
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            TrustRelationError::relation_graph(TrustRelationOperation::ReadNeighbors, source)
+        })
+        .map_err(trust_relation_error)?;
     let neighbors = filter_relation_visible(&state.pool, neighbors.as_slice())
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            TrustRelationError::relation_graph(
+                TrustRelationOperation::FilterVisibleNeighbors,
+                source,
+            )
+        })
+        .map_err(trust_relation_error)?;
     Ok(Json(RelationNeighborsResponse {
         viewer_pubkey,
         neighbors,
@@ -242,10 +269,16 @@ pub(crate) async fn relation_optout_set(
     let (_, pubkey) = require_trust_read(&state, &headers).await?;
     set_relation_optout(&state.pool, pubkey.as_str())
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            TrustRelationError::relation_opt_out(TrustRelationOperation::SetOptOut, source)
+        })
+        .map_err(trust_relation_error)?;
     let opted_out_at = get_relation_optout(&state.pool, pubkey.as_str())
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            TrustRelationError::relation_opt_out(TrustRelationOperation::GetOptOut, source)
+        })
+        .map_err(trust_relation_error)?;
     Ok(Json(RelationOptoutResponse {
         pubkey,
         opted_out: true,
@@ -261,7 +294,10 @@ pub(crate) async fn relation_optout_clear(
     let (_, pubkey) = require_trust_read(&state, &headers).await?;
     clear_relation_optout(&state.pool, pubkey.as_str())
         .await
-        .map_err(internal_error)?;
+        .map_err(|source| {
+            TrustRelationError::relation_opt_out(TrustRelationOperation::ClearOptOut, source)
+        })
+        .map_err(trust_relation_error)?;
     Ok(Json(RelationOptoutResponse {
         pubkey,
         opted_out: false,


### PR DESCRIPTION
## Summary
- classify trust reads, relation graph operations, and opt-out persistence with typed errors
- complete the cn-user-api audit: map_err(internal_error) 23 -> 0 (auth/consent 4, bootstrap/report 5, indexing 5, trust/relation 9)
- preserve existing 400/401/403/404 responses and keep infrastructure failures on 500 INTERNAL_ERROR
- refresh the nested Tauri lockfile for the workspace thiserror dependency

## Validation
- cargo test -p kukuri-cn-user-api --lib --no-fail-fast
- cargo xtask cn-check
- cargo xtask cn-test
- cargo xtask rust-check
- cargo xtask check
- cargo xtask oversized-files
- rg 'map_err\\(internal_error\\)' crates/cn-user-api/src => 0

## Windows local note
- cargo xtask test passed 373/515 before two pre-existing docs-sync relay tests timed out; both reproduce individually on this Windows host. All Q6-targeted and CN suites pass, and CI is authoritative.