### PR TITLE
refactor: add independent test support foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2917,6 +2917,7 @@ dependencies = [
  "kukuri-docs-sync",
  "kukuri-iroh-node",
  "kukuri-store",
+ "kukuri-test-support",
  "kukuri-transport",
  "n0-mainline",
  "serde",
@@ -3280,6 +3281,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "ts-rs",
+]
+
+[[package]]
+name = "kukuri-test-support"
+version = "0.1.2"
+dependencies = [
+ "async-trait",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/harness",
     "crates/app-api",
     "crates/desktop-runtime",
+    "crates/test-support",
     "crates/cn-core",
     "crates/cn-user-api",
     "crates/cn-iroh-relay",

--- a/crates/app-api/Cargo.toml
+++ b/crates/app-api/Cargo.toml
@@ -28,6 +28,7 @@ ts-rs = { workspace = true, optional = true }
 ts = ["dep:ts-rs", "kukuri-core/ts", "kukuri-store/ts", "kukuri-transport/ts"]
 
 [dev-dependencies]
+kukuri-test-support = { path = "../test-support" }
 kukuri-iroh-node = { path = "../iroh-node" }
 tempfile.workspace = true
 iroh-mainline-address-lookup.workspace = true

--- a/crates/app-api/src/tests/support/timeouts.rs
+++ b/crates/app-api/src/tests/support/timeouts.rs
@@ -1,27 +1,15 @@
 use super::super::*;
 
 pub(crate) fn social_graph_propagation_timeout() -> Duration {
-    if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
-        Duration::from_secs(300)
-    } else {
-        Duration::from_secs(10)
-    }
+    kukuri_test_support::constrained_timeout(Duration::from_secs(10), Duration::from_secs(300))
 }
 
 pub(crate) fn p2p_replication_timeout() -> Duration {
-    if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
-        Duration::from_secs(60)
-    } else {
-        Duration::from_secs(10)
-    }
+    kukuri_test_support::constrained_timeout(Duration::from_secs(10), Duration::from_secs(60))
 }
 
 pub(crate) fn seeded_dht_publish_resolve_timeout() -> Duration {
-    if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
-        Duration::from_secs(15)
-    } else {
-        Duration::from_secs(5)
-    }
+    kukuri_test_support::constrained_timeout(Duration::from_secs(5), Duration::from_secs(15))
 }
 
 pub(crate) fn iroh_integration_test_lock() -> Arc<TokioMutex<()>> {

--- a/crates/app-api/src/tests/support/waiters.rs
+++ b/crates/app-api/src/tests/support/waiters.rs
@@ -1,37 +1,54 @@
 use super::super::*;
+use async_trait::async_trait;
+use kukuri_test_support::{
+    PollError, PollState, SyncSnapshot, SyncStatusSource, TopicSyncSnapshot, poll_until,
+};
+
+fn snapshot_from_status(status: &SyncStatus) -> SyncSnapshot {
+    SyncSnapshot {
+        connected: status.connected,
+        peer_count: status.peer_count,
+        status_detail: status.status_detail.clone(),
+        last_error: status.last_error.clone(),
+        discovery_connected_peers: status.discovery.connected_peer_ids.clone(),
+        topics: status
+            .topic_diagnostics
+            .iter()
+            .map(|entry| TopicSyncSnapshot {
+                topic: entry.topic.clone(),
+                peer_count: entry.peer_count,
+                connected_peers: entry.connected_peers.clone(),
+                docs_assist_peer_ids: entry.docs_assist_peer_ids.clone(),
+                configured_peer_ids: entry.configured_peer_ids.clone(),
+                missing_peer_ids: Vec::new(),
+                delivery_state: format!("{:?}", entry.delivery_state),
+                status_detail: entry.status_detail.clone(),
+            })
+            .collect(),
+    }
+}
+
+#[async_trait]
+impl SyncStatusSource for AppService {
+    type Error = anyhow::Error;
+
+    async fn sync_snapshot(&self) -> Result<SyncSnapshot, Self::Error> {
+        self.get_sync_status()
+            .await
+            .map(|status| snapshot_from_status(&status))
+    }
+}
 
 pub(crate) fn format_sync_snapshot(status: &SyncStatus, topic: &str) -> String {
-    let topic_status = status
-        .topic_diagnostics
-        .iter()
-            .find(|entry| entry.topic == topic)
-            .map(|entry| {
-                format!(
-                    "topic_peers={}, connected_peers={:?}, docs_assist_peer_ids={:?}, configured_peer_ids={:?}, delivery_state={:?}, status_detail={}",
-                    entry.peer_count,
-                    entry.connected_peers,
-                    entry.docs_assist_peer_ids,
-                    entry.configured_peer_ids,
-                    entry.delivery_state,
-                    entry.status_detail
-                )
-            })
-        .unwrap_or_else(|| "topic_status=missing".to_string());
-    format!(
-        "connected={}, peer_count={}, status_detail={}, last_error={:?}, discovery_connected_peers={:?}, {}",
-        status.connected,
-        status.peer_count,
-        status.status_detail,
-        status.last_error,
-        status.discovery.connected_peer_ids,
-        topic_status
-    )
+    kukuri_test_support::format_sync_snapshot(&snapshot_from_status(status), topic)
 }
 
 pub(crate) async fn wait_for_topic_delivery(app: &AppService, topic: &str, expected: usize) {
-    match timeout(social_graph_propagation_timeout(), async {
-        let mut stable_ready_polls = 0usize;
-        loop {
+    let result = poll_until(
+        social_graph_propagation_timeout(),
+        Duration::from_millis(50),
+        3,
+        || async {
             let status = app.get_sync_status().await.expect("sync status");
             let ready = status.topic_diagnostics.iter().any(|entry| {
                 let live_ready = entry.peer_count >= expected
@@ -44,28 +61,25 @@ pub(crate) async fn wait_for_topic_delivery(app: &AppService, topic: &str, expec
                     );
                 entry.topic == topic && (live_ready || durable_ready)
             });
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return;
-                }
+            Ok::<_, anyhow::Error>(if ready {
+                PollState::Ready(())
             } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(50)).await;
-        }
-    })
-    .await
-    {
+                PollState::Pending
+            })
+        },
+    )
+    .await;
+    match result {
         Ok(()) => {}
-        Err(_) => {
+        Err(PollError::Timeout) => {
             let snapshot = app
-                .get_sync_status()
+                .sync_snapshot()
                 .await
-                .map(|status| format_sync_snapshot(&status, topic))
+                .map(|status| kukuri_test_support::format_sync_snapshot(&status, topic))
                 .unwrap_or_else(|_| "failed to read sync status".to_string());
             panic!("topic delivery timeout for {topic}; {snapshot}");
         }
+        Err(PollError::Operation(error)) => panic!("topic delivery failed: {error:#}"),
     }
 }
 

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kukuri-test-support"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -1,0 +1,178 @@
+use std::fmt::Debug;
+use std::future::Future;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use thiserror::Error;
+use tokio::time::{sleep, timeout};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PollState<T> {
+    Pending,
+    Ready(T),
+}
+
+#[derive(Debug, Error)]
+pub enum PollError<E> {
+    #[error("poll timed out")]
+    Timeout,
+    #[error("poll operation failed: {0}")]
+    Operation(E),
+}
+
+pub async fn poll_until<F, Fut, T, E>(
+    deadline: Duration,
+    interval: Duration,
+    stable_ready_polls: usize,
+    mut operation: F,
+) -> Result<T, PollError<E>>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<PollState<T>, E>>,
+{
+    let required = stable_ready_polls.max(1);
+    timeout(deadline, async {
+        let mut ready_polls = 0usize;
+        loop {
+            match operation().await.map_err(PollError::Operation)? {
+                PollState::Ready(value) => {
+                    ready_polls += 1;
+                    if ready_polls >= required {
+                        return Ok(value);
+                    }
+                }
+                PollState::Pending => ready_polls = 0,
+            }
+            sleep(interval).await;
+        }
+    })
+    .await
+    .map_err(|_| PollError::Timeout)?
+}
+
+pub fn constrained_timeout(local: Duration, constrained: Duration) -> Duration {
+    if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
+        constrained
+    } else {
+        local
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TopicSyncSnapshot {
+    pub topic: String,
+    pub peer_count: usize,
+    pub connected_peers: Vec<String>,
+    pub docs_assist_peer_ids: Vec<String>,
+    pub configured_peer_ids: Vec<String>,
+    pub missing_peer_ids: Vec<String>,
+    pub delivery_state: String,
+    pub status_detail: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SyncSnapshot {
+    pub connected: bool,
+    pub peer_count: usize,
+    pub status_detail: String,
+    pub last_error: Option<String>,
+    pub discovery_connected_peers: Vec<String>,
+    pub topics: Vec<TopicSyncSnapshot>,
+}
+
+#[async_trait]
+pub trait SyncStatusSource {
+    type Error: Debug + Send;
+
+    async fn sync_snapshot(&self) -> Result<SyncSnapshot, Self::Error>;
+}
+
+pub fn format_sync_snapshot(snapshot: &SyncSnapshot, topic: &str) -> String {
+    let topic_status = snapshot
+        .topics
+        .iter()
+        .find(|entry| entry.topic == topic)
+        .map(|entry| {
+            let missing = if entry.missing_peer_ids.is_empty() {
+                String::new()
+            } else {
+                format!(", missing_peer_ids={:?}", entry.missing_peer_ids)
+            };
+            format!(
+                "topic_peers={}, connected_peers={:?}, docs_assist_peer_ids={:?}, configured_peer_ids={:?}{missing}, delivery_state={}, status_detail={}",
+                entry.peer_count,
+                entry.connected_peers,
+                entry.docs_assist_peer_ids,
+                entry.configured_peer_ids,
+                entry.delivery_state,
+                entry.status_detail
+            )
+        })
+        .unwrap_or_else(|| "topic_status=missing".to_string());
+    format!(
+        "connected={}, peer_count={}, status_detail={}, last_error={:?}, discovery_connected_peers={:?}, {}",
+        snapshot.connected,
+        snapshot.peer_count,
+        snapshot.status_detail,
+        snapshot.last_error,
+        snapshot.discovery_connected_peers,
+        topic_status
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn poll_requires_consecutive_ready_results() {
+        let states = [true, true, false, true, true, true];
+        let mut index = 0usize;
+        let value = poll_until(Duration::from_secs(1), Duration::ZERO, 3, || {
+            let ready = states[index];
+            index += 1;
+            async move {
+                Ok::<_, Infallible>(if ready {
+                    PollState::Ready(index)
+                } else {
+                    PollState::Pending
+                })
+            }
+        })
+        .await
+        .expect("poll result");
+        assert_eq!(value, 6);
+    }
+
+    #[tokio::test]
+    async fn poll_reports_timeout() {
+        let result = poll_until(
+            Duration::from_millis(5),
+            Duration::from_millis(1),
+            1,
+            || async { Ok::<_, Infallible>(PollState::<()>::Pending) },
+        )
+        .await;
+        assert!(matches!(result, Err(PollError::Timeout)));
+    }
+
+    #[test]
+    fn snapshot_format_keeps_diagnostics() {
+        let snapshot = SyncSnapshot {
+            connected: true,
+            peer_count: 1,
+            status_detail: "ready".into(),
+            topics: vec![TopicSyncSnapshot {
+                topic: "kukuri:test".into(),
+                peer_count: 1,
+                delivery_state: "Live".into(),
+                status_detail: "joined".into(),
+                ..TopicSyncSnapshot::default()
+            }],
+            ..SyncSnapshot::default()
+        };
+        assert!(format_sync_snapshot(&snapshot, "kukuri:test").contains("delivery_state=Live"));
+    }
+}


### PR DESCRIPTION
## Summary
- add dependency-neutral kukuri-test-support polling, timeout, and sync snapshot primitives
- migrate app-api timeout policy and topic-delivery waiter to the shared foundation
- keep product behavior and diagnostics unchanged without reverse crate dependencies

## Validation
- cargo test -p kukuri-test-support
- cargo test -p kukuri-app-api (165 passed)
- cargo tree -p kukuri-test-support --edges normal
- cargo xtask rust-check
- cargo xtask oversized-files