### PR TITLE
refactor: split app API iroh tests into slow lane

### DIFF
--- a/.github/workflows/kukuri-nightly.yml
+++ b/.github/workflows/kukuri-nightly.yml
@@ -12,6 +12,29 @@ env:
   SCCACHE_GHA_VERSION: v1
 
 jobs:
+  linux-app-api-slow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust 1.91
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.91.0
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: kukuri-nightly-${{ runner.os }}-${{ github.job }}
+
+      - name: App API slow iroh integration tests
+        run: cargo xtask app-api-slow-test
+
   linux-rust-static:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/crates/app-api/Cargo.toml
+++ b/crates/app-api/Cargo.toml
@@ -26,6 +26,7 @@ ts-rs = { workspace = true, optional = true }
 [features]
 # IPC 型の TypeScript 生成専用(codegen 時のみ有効。production ビルドは無影響)。
 ts = ["dep:ts-rs", "kukuri-core/ts", "kukuri-store/ts", "kukuri-transport/ts"]
+iroh-integration-tests = []
 
 [dev-dependencies]
 kukuri-test-support = { path = "../test-support" }

--- a/crates/app-api/src/tests/game.rs
+++ b/crates/app-api/src/tests/game.rs
@@ -5,6 +5,7 @@ use kukuri_core::{
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn game_room_score_update_replicates() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");
@@ -99,6 +100,7 @@ async fn game_room_score_update_replicates() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn metaverse_room_events_replicate_between_iroh_peers() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");

--- a/crates/app-api/src/tests/live.rs
+++ b/crates/app-api/src/tests/live.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn late_joiner_backfills_live_session_manifest() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");

--- a/crates/app-api/src/tests/media.rs
+++ b/crates/app-api/src/tests/media.rs
@@ -225,6 +225,7 @@ async fn on_demand_hydration_updates_last_sync_ts() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn missing_gossip_but_docs_sync_recovers_post() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     assert_docs_sync_recovers_post_without_hints("kukuri:topic:missing-gossip", "docs recover")
@@ -232,6 +233,7 @@ async fn missing_gossip_but_docs_sync_recovers_post() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn gossip_loss_does_not_lose_durable_post() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     assert_docs_sync_recovers_post_without_hints(
@@ -533,6 +535,7 @@ async fn blob_media_payload_roundtrip() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn iroh_transport_syncs_image_post_between_apps() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");
@@ -611,6 +614,7 @@ async fn iroh_transport_syncs_image_post_between_apps() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn remote_video_manifest_payload_available_after_sync() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");
@@ -710,6 +714,7 @@ async fn remote_video_manifest_payload_available_after_sync() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn late_joiner_backfills_image_post_from_docs() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");
@@ -794,6 +799,7 @@ async fn late_joiner_backfills_image_post_from_docs() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn late_joiner_backfills_video_media_payload() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");
@@ -873,6 +879,7 @@ async fn late_joiner_backfills_video_media_payload() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn image_reply_thread_syncs() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");

--- a/crates/app-api/src/tests/mod.rs
+++ b/crates/app-api/src/tests/mod.rs
@@ -3,20 +3,27 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use futures_util::StreamExt;
+#[cfg(feature = "iroh-integration-tests")]
 use iroh::address_lookup::{AddrFilter, AddressLookup};
+#[cfg(feature = "iroh-integration-tests")]
 use iroh_mainline_address_lookup::DhtAddressLookup;
+#[cfg(feature = "iroh-integration-tests")]
 use kukuri_blob_service::IrohBlobService;
 use kukuri_core::build_post_envelope_with_payload;
+#[cfg(feature = "iroh-integration-tests")]
 use kukuri_docs_sync::IrohDocsSync;
+#[cfg(feature = "iroh-integration-tests")]
 use kukuri_iroh_node::IrohDocsNode;
 use kukuri_store::{
     BookmarkedCustomReactionRow, DirectMessageStore, LiveGameProjectionStore, MemoryStore,
     ReactionBookmarkStore, SocialProjectionStore, SqliteStore,
 };
+#[cfg(feature = "iroh-integration-tests")]
+use kukuri_transport::{DhtDiscoveryOptions, IrohGossipTransport, TransportRelayConfig};
 use kukuri_transport::{
-    DhtDiscoveryOptions, DiscoveryMode, FakeNetwork, FakeTransport, HintEnvelope, HintStream,
-    IrohGossipTransport, SeedPeer, TransportRelayConfig,
+    DiscoveryMode, FakeNetwork, FakeTransport, HintEnvelope, HintStream, SeedPeer,
 };
+#[cfg(feature = "iroh-integration-tests")]
 use n0_mainline::{DhtBuilder, Testnet};
 use std::sync::OnceLock;
 use tempfile::tempdir;

--- a/crates/app-api/src/tests/private_channels.rs
+++ b/crates/app-api/src/tests/private_channels.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "iroh-integration-tests")]
 mod friend_only;
+#[cfg(feature = "iroh-integration-tests")]
 mod friend_plus;
+#[cfg(feature = "iroh-integration-tests")]
 mod invite;
+#[cfg(feature = "iroh-integration-tests")]
 mod leave;
 mod persist_callback;

--- a/crates/app-api/src/tests/social.rs
+++ b/crates/app-api/src/tests/social.rs
@@ -364,6 +364,7 @@ async fn mute_does_not_change_follow_mutual_or_friend_gating() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn social_graph_derives_friend_of_friend_and_clears_after_unfollow() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");

--- a/crates/app-api/src/tests/support.rs
+++ b/crates/app-api/src/tests/support.rs
@@ -1,10 +1,15 @@
 mod doubles;
 mod fixtures;
+#[cfg(feature = "iroh-integration-tests")]
 mod iroh_stack;
+#[allow(dead_code)]
 mod timeouts;
+#[allow(dead_code)]
 mod waiters;
 pub(crate) use doubles::*;
 pub(crate) use fixtures::*;
+#[cfg(feature = "iroh-integration-tests")]
 pub(crate) use iroh_stack::*;
 pub(crate) use timeouts::*;
+#[allow(unused_imports)]
 pub(crate) use waiters::*;

--- a/crates/app-api/src/tests/sync.rs
+++ b/crates/app-api/src/tests/sync.rs
@@ -190,6 +190,7 @@ impl BlobService for DelayedBlobService {
     }
 }
 
+#[cfg(feature = "iroh-integration-tests")]
 async fn iroh_sync_diagnostics(
     app_a: &AppService,
     app_b: &AppService,
@@ -284,4 +285,5 @@ mod diagnostics;
 mod gossip_toggle;
 mod hint_rehydration;
 mod subscription_restarts;
+#[cfg(feature = "iroh-integration-tests")]
 mod transport_replication;

--- a/crates/app-api/src/tests/sync/subscription_restarts.rs
+++ b/crates/app-api/src/tests/sync/subscription_restarts.rs
@@ -364,6 +364,7 @@ async fn sync_status_normalizes_hint_topic_names() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn invalid_ticket_updates_sync_status_error_reason() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let store = Arc::new(MemoryStore::default());

--- a/crates/app-api/src/tests/timeline/bookmarks.rs
+++ b/crates/app-api/src/tests/timeline/bookmarks.rs
@@ -215,6 +215,7 @@ async fn bookmarked_repost_renders_from_saved_snapshot_without_source_timeline_h
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "iroh-integration-tests")]
 async fn bookmarks_do_not_sync_between_apps() {
     let _guard = iroh_integration_test_lock().lock_owned().await;
     let dir = tempdir().expect("tempdir");

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -21,6 +21,7 @@ cargo xtask scenario community_node_public_connectivity
 cargo xtask scenario community_node_multi_device_connectivity
 cargo xtask rust-check
 cargo xtask rust-test
+cargo xtask app-api-slow-test
 cargo xtask tauri-check
 cargo xtask desktop-lint
 cargo xtask desktop-test

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -31,6 +31,7 @@ fn main() -> Result<()> {
         "test" => test(),
         "rust-check" => rust_check(),
         "rust-test" => rust_test(),
+        "app-api-slow-test" => app_api_slow_test(),
         "tauri-check" => tauri_check(),
         "desktop-lint" => desktop_lint(),
         "desktop-test" => desktop_test(),
@@ -104,6 +105,6 @@ fn doctor() -> Result<()> {
 
 fn print_usage() {
     eprintln!(
-        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-visual-test|desktop-ui-check|cn-check|cn-test|desktop-package|release-check [tag]|oversized-files [--update-baseline]|ipc-types [--check]|e2e-smoke|scenario <name>>"
+        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|app-api-slow-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-visual-test|desktop-ui-check|cn-check|cn-test|desktop-package|release-check [tag]|oversized-files [--update-baseline]|ipc-types [--check]|e2e-smoke|scenario <name>>"
     );
 }

--- a/xtask/src/rust.rs
+++ b/xtask/src/rust.rs
@@ -57,6 +57,21 @@ pub(crate) fn rust_test() -> Result<()> {
     }
 }
 
+pub(crate) fn app_api_slow_test() -> Result<()> {
+    run_with_env(
+        "cargo",
+        [
+            "test",
+            "-p",
+            "kukuri-app-api",
+            "--features",
+            "iroh-integration-tests",
+        ],
+        &root_dir(),
+        &env_refs(&rust_test_stack_envs()),
+    )
+}
+
 pub(crate) fn rust_test_with_nextest() -> Result<()> {
     let stack_env = rust_test_stack_envs();
     let stack_env_refs = env_refs(&stack_env);


### PR DESCRIPTION
## Summary
- move 30 real-Iroh test cases behind the explicit iroh-integration-tests feature
- add cargo xtask app-api-slow-test and a dedicated nightly Linux job
- keep 135 memory/fake tests in the default fast lane

## Impact
- warm-cache default app-api test runtime fell from 66.6s to 4.9s (about 93%)
- the slow command still runs all 165 tests

## Validation
- cargo test -p kukuri-app-api (135 passed)
- cargo xtask app-api-slow-test (165 passed)
- cargo xtask rust-check
- cargo xtask oversized-files