### PR TITLE
refactor: scope desktop runtime test locks by resource

### DIFF
--- a/crates/desktop-runtime/src/tests/community_node/config.rs
+++ b/crates/desktop-runtime/src/tests/community_node/config.rs
@@ -92,7 +92,7 @@ fn community_node_config_preserves_public_kukuri_urls() {
 
 #[tokio::test]
 async fn local_community_node_seed_peer_includes_addr_hint() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::ProcessEnvironment).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-seed-peer-addr-hint.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -115,7 +115,7 @@ async fn local_community_node_seed_peer_includes_addr_hint() {
 
 #[tokio::test]
 async fn local_community_node_seed_peer_keeps_addr_hint_when_relay_urls_exist() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::ProcessEnvironment).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-seed-peer-relay-auto-hint.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -202,7 +202,7 @@ fn default_preview_community_node_config_marks_preloaded_node_auto_approve() {
 
 #[tokio::test]
 async fn runtime_preloads_preview_community_node_when_config_file_is_missing() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::ProcessEnvironment).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-preview-preload.db");
 

--- a/crates/desktop-runtime/src/tests/community_node/connectivity.rs
+++ b/crates/desktop-runtime/src/tests/community_node/connectivity.rs
@@ -2,7 +2,7 @@ use super::super::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn community_node_connectivity_assist_relay_backed_seed_peers_ignore_stale_addr_hints() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let relay = kukuri_cn_iroh_relay::spawn_server(kukuri_cn_iroh_relay::IrohRelayConfig {
         http_bind_addr: "127.0.0.1:0".parse().expect("relay bind addr"),
         tls: None,
@@ -137,7 +137,7 @@ async fn community_node_connectivity_assist_relay_backed_seed_peers_ignore_stale
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn community_node_connectivity_assist_backfills_public_timeline_with_relay_only_seed_peers() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let relay = kukuri_cn_iroh_relay::spawn_server(kukuri_cn_iroh_relay::IrohRelayConfig {
         http_bind_addr: "127.0.0.1:0".parse().expect("relay bind addr"),
         tls: None,
@@ -305,7 +305,7 @@ async fn external_relay_endpoint_only_seed_peers_backfill_desktop_public_timelin
         return;
     };
 
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("external-relay-only-a.db");
     let db_b = dir.path().join("external-relay-only-b.db");
@@ -451,7 +451,7 @@ async fn external_relay_endpoint_only_seed_peers_backfill_desktop_public_timelin
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn community_node_connectivity_assist_backfills_three_client_public_timeline_with_stale_addr_hints()
  {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let relay = kukuri_cn_iroh_relay::spawn_server(kukuri_cn_iroh_relay::IrohRelayConfig {
         http_bind_addr: "127.0.0.1:0".parse().expect("relay bind addr"),
         tls: None,
@@ -674,7 +674,7 @@ async fn community_node_connectivity_assist_backfills_three_client_public_timeli
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_peer() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("community-unreachable-a.db");
     let db_b = dir.path().join("community-unreachable-b.db");
@@ -848,7 +848,7 @@ async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn community_node_connectivity_assist_relay_backed_seed_peers_ignore_stale_addr_hints_with_shared_identity()
  {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let relay = kukuri_cn_iroh_relay::spawn_server(kukuri_cn_iroh_relay::IrohRelayConfig {
         http_bind_addr: "127.0.0.1:0".parse().expect("relay bind addr"),
         tls: None,

--- a/crates/desktop-runtime/src/tests/community_node/metadata.rs
+++ b/crates/desktop-runtime/src/tests/community_node/metadata.rs
@@ -2,7 +2,7 @@ use super::super::*;
 
 #[tokio::test]
 async fn community_node_status_refresh_updates_bootstrap_seed_peers() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-heartbeat-refresh.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -92,7 +92,7 @@ async fn community_node_status_refresh_updates_bootstrap_seed_peers() {
 
 #[tokio::test]
 async fn community_node_session_maintenance_updates_bootstrap_seed_peers() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-sync-status-refresh.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -170,7 +170,7 @@ async fn community_node_session_maintenance_updates_bootstrap_seed_peers() {
 #[tokio::test]
 async fn community_node_metadata_refresh_heartbeats_before_bootstrap_sync_even_when_metadata_is_unchanged()
  {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-metadata-refresh-no-churn.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -290,7 +290,7 @@ async fn community_node_metadata_refresh_heartbeats_before_bootstrap_sync_even_w
 
 #[tokio::test]
 async fn community_node_ready_transition_refreshes_bootstrap_metadata_before_next_heartbeat_due() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-ready-refresh.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -410,7 +410,7 @@ async fn community_node_ready_transition_refreshes_bootstrap_metadata_before_nex
 #[tokio::test]
 async fn community_node_ready_transition_refreshes_bootstrap_metadata_only_once_before_next_heartbeat_due()
  {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-ready-refresh-once.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -492,7 +492,7 @@ async fn community_node_ready_transition_refreshes_bootstrap_metadata_only_once_
 
 #[tokio::test]
 async fn community_node_status_retries_bootstrap_metadata_when_seed_peers_are_empty() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-metadata-retry.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -608,7 +608,7 @@ async fn community_node_status_retries_bootstrap_metadata_when_seed_peers_are_em
 
 #[tokio::test]
 async fn refresh_community_node_metadata_refreshes_registration_before_bootstrap_sync() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-refresh-heartbeat.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -701,7 +701,7 @@ async fn refresh_community_node_metadata_refreshes_registration_before_bootstrap
 #[tokio::test]
 async fn refresh_community_node_metadata_requeues_heartbeat_when_runtime_connectivity_changes_local_seed_peer()
  {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
         .await
         .expect("relay server");
@@ -810,7 +810,7 @@ async fn refresh_community_node_metadata_requeues_heartbeat_when_runtime_connect
 
 #[tokio::test]
 async fn reapply_community_node_connectivity_forces_unchanged_runtime_inputs() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server()
         .await
         .expect("relay server");

--- a/crates/desktop-runtime/src/tests/community_node/scheduler.rs
+++ b/crates/desktop-runtime/src/tests/community_node/scheduler.rs
@@ -24,7 +24,7 @@ async fn wait_for_counter(counter: &AtomicUsize, at_least: usize, label: &str) {
 /// WP-C1 の failing test: スケジューラ導入前は heartbeat_hits が 0 のまま timeout で赤になる。
 #[tokio::test]
 async fn session_scheduler_keeps_bootstrap_registration_alive_without_getter_polling() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-scheduler-keepalive.db");
     let runtime = Arc::new(
@@ -153,7 +153,7 @@ async fn session_scheduler_keeps_bootstrap_registration_alive_without_getter_pol
 /// 固定する contract。駆動はスケジューラ(session maintenance tick)のみが担う(WP-C1 T4)。
 #[tokio::test]
 async fn get_sync_status_is_read_only_for_community_node_session() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-sync-status-read-only.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -220,7 +220,7 @@ async fn get_sync_status_is_read_only_for_community_node_session() {
 /// WP-C1 の failing test: スケジューラ導入前は verify_hits が 0 のまま timeout で赤になる。
 #[tokio::test]
 async fn session_scheduler_reauthenticates_near_expiry_token_without_getter_polling() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-scheduler-reauth.db");
     let runtime = Arc::new(

--- a/crates/desktop-runtime/src/tests/community_node/session.rs
+++ b/crates/desktop-runtime/src/tests/community_node/session.rs
@@ -2,7 +2,7 @@ use super::super::*;
 
 #[tokio::test]
 async fn auto_approve_node_bootstraps_session_on_maintenance_tick() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-auto-approve-session.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -106,7 +106,7 @@ async fn status_getter_is_read_only_and_does_not_bootstrap_session() {
     // WP-Q2: get_community_node_statuses は読み取り専用。セッションの establish/refresh は
     // セッション維持スケジューラ(run_community_node_session_maintenance_once)が担い、
     // getter 単独では refresh 副作用(challenge/verify/heartbeat/bootstrap)を持たない。
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-getter-read-only.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -196,7 +196,7 @@ async fn status_getter_is_read_only_and_does_not_bootstrap_session() {
 
 #[tokio::test]
 async fn near_expiry_token_triggers_proactive_community_node_reauthentication() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-proactive-reauth.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -298,7 +298,7 @@ async fn near_expiry_token_triggers_proactive_community_node_reauthentication() 
 
 #[tokio::test]
 async fn consent_required_node_without_auto_approve_stays_pending() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-consent-pending.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -393,7 +393,7 @@ async fn consent_required_node_without_auto_approve_stays_pending() {
 
 #[tokio::test]
 async fn community_node_status_does_not_require_restart_when_connectivity_is_active() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-status.db");
     let test_timeout = Duration::from_secs(15);
@@ -480,7 +480,7 @@ async fn community_node_status_does_not_require_restart_when_connectivity_is_act
 #[tokio::test]
 async fn auto_approve_node_does_not_silently_reaccept_policy_update() {
     // #384: auto_approve でも、版が上がった「更新」のときは黙って再受諾せず Idle に留める。
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-auto-approve-update.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(

--- a/crates/desktop-runtime/src/tests/identity_restart.rs
+++ b/crates/desktop-runtime/src/tests/identity_restart.rs
@@ -20,7 +20,7 @@ fn resolve_db_path_ignores_legacy_runtime_artifacts() {
 
 #[tokio::test]
 async fn desktop_runtime_persists_posts_and_author_identity_after_restart() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IdentityStorage).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("kukuri.db");
     let runtime = timeout(
@@ -111,7 +111,7 @@ async fn desktop_runtime_persists_posts_and_author_identity_after_restart() {
 
 #[tokio::test]
 async fn desktop_runtime_restores_profile_avatar_blob_after_restart() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IdentityStorage).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("profile-avatar-restart.db");
     let avatar_bytes = b"runtime-profile-avatar".to_vec();

--- a/crates/desktop-runtime/src/tests/media_blob_restore.rs
+++ b/crates/desktop-runtime/src/tests/media_blob_restore.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn late_joiner_backfills_timeline_from_docs() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("late-a.db");
     let db_b = dir.path().join("late-b.db");
@@ -71,7 +71,7 @@ async fn late_joiner_backfills_timeline_from_docs() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn late_joiner_backfills_image_post_from_docs() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("late-image-a.db");
     let db_b = dir.path().join("late-image-b.db");
@@ -152,7 +152,7 @@ async fn late_joiner_backfills_image_post_from_docs() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn late_joiner_backfills_video_media_payload() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("late-video-a.db");
     let db_b = dir.path().join("late-video-b.db");
@@ -259,7 +259,7 @@ async fn late_joiner_backfills_video_media_payload() {
 
 #[tokio::test]
 async fn blob_media_payload_roundtrip() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("blob-media-roundtrip.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -317,7 +317,7 @@ async fn blob_media_payload_roundtrip() {
 
 #[tokio::test]
 async fn blank_blob_media_hash_returns_none_without_panicking() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("blank-blob-media-hash.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -341,7 +341,7 @@ async fn blank_blob_media_hash_returns_none_without_panicking() {
 
 #[tokio::test]
 async fn sqlite_deletion_does_not_lose_shared_state() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("delete-sqlite.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -410,7 +410,7 @@ async fn sqlite_deletion_does_not_lose_shared_state() {
 
 #[tokio::test]
 async fn restart_restores_from_docs_blobs_without_sqlite_seed() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("restart-no-seed.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -462,7 +462,7 @@ async fn restart_restores_from_docs_blobs_without_sqlite_seed() {
 
 #[tokio::test]
 async fn restart_restores_image_post_preview() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("restart-image.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -526,7 +526,7 @@ async fn restart_restores_image_post_preview() {
 
 #[tokio::test]
 async fn restart_restores_video_media_payload() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("restart-video.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -616,7 +616,7 @@ async fn restart_restores_video_media_payload() {
 
 #[tokio::test]
 async fn restart_restores_live_session_manifest() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("restart-live.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -679,7 +679,7 @@ async fn restart_restores_live_session_manifest() {
 
 #[tokio::test]
 async fn restart_restores_game_room_manifest() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("restart-game.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(

--- a/crates/desktop-runtime/src/tests/mod.rs
+++ b/crates/desktop-runtime/src/tests/mod.rs
@@ -31,11 +31,11 @@ use kukuri_transport::{
 use n0_mainline::{DhtBuilder, Testnet};
 use std::fs;
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, OnceLock};
 use tempfile::tempdir;
 use tokio::net::TcpListener;
-use tokio::sync::{Mutex, MutexGuard};
+use tokio::sync::Mutex;
 use tokio::time::{Duration, sleep, timeout};
 
 use crate::attachments::{normalize_custom_reaction_gif, normalize_custom_reaction_static};
@@ -48,6 +48,7 @@ use crate::community_node::{
 use crate::discovery::resolve_discovery_config_from_env;
 use crate::identity::IdentityStorageMode;
 use crate::paths::{community_node_config_path, discovery_config_path};
+pub(crate) use kukuri_test_support::{TestResource, lock_test_resource};
 
 mod support;
 pub(crate) use support::*;

--- a/crates/desktop-runtime/src/tests/private_channels/friend_only.rs
+++ b/crates/desktop-runtime/src/tests/private_channels/friend_only.rs
@@ -2,7 +2,7 @@ use super::super::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn friend_only_channel_restore_keeps_archived_epoch_history() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("friend-only-runtime-a.db");
     let db_b = dir.path().join("friend-only-runtime-b.db");

--- a/crates/desktop-runtime/src/tests/private_channels/friend_plus.rs
+++ b/crates/desktop-runtime/src/tests/private_channels/friend_plus.rs
@@ -2,7 +2,7 @@ use super::super::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn friend_plus_channel_restore_accepts_fresh_share_after_restart() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("friend-plus-runtime-a.db");
     let db_b = dir.path().join("friend-plus-runtime-b.db");

--- a/crates/desktop-runtime/src/tests/private_channels/invite.rs
+++ b/crates/desktop-runtime/src/tests/private_channels/invite.rs
@@ -2,7 +2,7 @@ use super::super::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn preview_channel_access_token_is_non_mutating() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("preview-runtime-a.db");
     let db_b = dir.path().join("preview-runtime-b.db");
@@ -89,7 +89,7 @@ async fn preview_channel_access_token_is_non_mutating() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn private_channel_import_without_local_posts_restores_after_restart() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("private-import-owner.db");
     let db_b = dir.path().join("private-import-joiner.db");
@@ -215,7 +215,7 @@ async fn private_channel_import_without_local_posts_restores_after_restart() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn private_channel_invite_restores_after_restart_without_reimport() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("private-runtime-a.db");
     let db_b = dir.path().join("private-runtime-b.db");

--- a/crates/desktop-runtime/src/tests/private_channels/persistence.rs
+++ b/crates/desktop-runtime/src/tests/private_channels/persistence.rs
@@ -9,7 +9,7 @@ use super::super::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn owner_invite_export_auto_rotate_survives_restart() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db = dir.path().join("private-export-persist-invite.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
@@ -96,7 +96,7 @@ async fn owner_invite_export_auto_rotate_survives_restart() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn owner_access_token_export_auto_rotate_survives_restart() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db = dir.path().join("private-export-persist-access-token.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(

--- a/crates/desktop-runtime/src/tests/runtime_events.rs
+++ b/crates/desktop-runtime/src/tests/runtime_events.rs
@@ -19,7 +19,7 @@ fn sync_status_changed_event_wire_shape_is_stable() {
 
 #[tokio::test]
 async fn sync_status_observer_emits_only_changed_snapshot_parts_and_stops_on_shutdown() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("runtime-events.db");
     let runtime = Arc::new(

--- a/crates/desktop-runtime/src/tests/seeded_dht.rs
+++ b/crates/desktop-runtime/src/tests/seeded_dht.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn set_discovery_seeds_reapplies_runtime_without_restart() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::DhtTestnet).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("seeded-a.db");
     let db_b = dir.path().join("seeded-b.db");
@@ -95,7 +95,7 @@ async fn set_discovery_seeds_reapplies_runtime_without_restart() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn restart_restores_seeded_dht_config_and_endpoint_identity() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::DhtTestnet).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("restart-seeded-a.db");
     let db_b = dir.path().join("restart-seeded-b.db");
@@ -199,7 +199,7 @@ async fn restart_restores_seeded_dht_config_and_endpoint_identity() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn invalid_seed_entry_rejected_without_mutating_runtime() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::DhtTestnet).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("invalid-seed.db");
     let testnet = Testnet::new(5).await.expect("testnet");

--- a/crates/desktop-runtime/src/tests/static_peer.rs
+++ b/crates/desktop-runtime/src/tests/static_peer.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn desktop_runtime_imports_peer_ticket_and_tracks_local_posts() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("a.db");
     let db_b = dir.path().join("b.db");
@@ -100,7 +100,7 @@ async fn desktop_runtime_imports_peer_ticket_and_tracks_local_posts() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn profile_timeline_reads_author_public_posts_across_untracked_topics() {
-    let _serial = acquire_async_test_lock().await;
+    let _resource = lock_test_resource(TestResource::IrohNetwork).await;
     let dir = tempdir().expect("tempdir");
     let db_a = dir.path().join("profile-runtime-a.db");
     let db_b = dir.path().join("profile-runtime-b.db");

--- a/crates/desktop-runtime/src/tests/support/env.rs
+++ b/crates/desktop-runtime/src/tests/support/env.rs
@@ -16,10 +16,6 @@ pub(crate) fn runtime_shutdown_timeout() -> Duration {
     kukuri_test_support::constrained_timeout(Duration::from_secs(15), Duration::from_secs(60))
 }
 
-pub(crate) async fn acquire_async_test_lock() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(())).lock().await
-}
 pub(crate) fn public_connectivity_reapply_interval() -> Duration {
     if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
         Duration::from_secs(20)


### PR DESCRIPTION
## Summary
- replace all 53 desktop-runtime global lock acquisitions with named resource locks
- remove the old global lock definition
- allow independent environment, identity, Iroh, DHT, and community-node tests to overlap

## Impact
- desktop-runtime suite improved from about 196s to 118-120s
- three consecutive 96/96 runs passed

## Validation
- cargo test -p kukuri-desktop-runtime (three runs)
- cargo xtask rust-check
- cargo xtask e2e-smoke
- cargo xtask oversized-files