### PR TITLE
scenario: wire all orphaned scenarios into nightly CI

### DIFF
--- a/.github/workflows/kukuri-nightly.yml
+++ b/.github/workflows/kukuri-nightly.yml
@@ -35,6 +35,59 @@ jobs:
       - name: App API slow iroh integration tests
         run: cargo xtask app-api-slow-test
 
+  linux-additional-scenarios:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - desktop_smoke_bookmark_workflow
+          - desktop_smoke_game_room_persist
+          - desktop_smoke_live_session_persist
+          - pairwise_dm_offline_text_image_video_delivery_and_local_delete
+          - private_channel_invite_connectivity
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust 1.91
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.91.0
+
+      - name: Install Linux system dependencies
+        run: >
+          sudo apt-get update &&
+          sudo apt-get install -y
+          pkg-config
+          libdbus-1-dev
+          libglib2.0-dev
+          libgtk-3-dev
+          libwebkit2gtk-4.1-dev
+          libayatana-appindicator3-dev
+          librsvg2-dev
+          patchelf
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: kukuri-nightly-${{ runner.os }}-additional-scenarios
+
+      - name: Run scenario
+        run: cargo xtask scenario ${{ matrix.scenario }}
+
+      - name: Upload scenario artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kukuri-nightly-${{ matrix.scenario }}-artifacts
+          path: test-results/kukuri/
+          if-no-files-found: warn
+
   linux-rust-static:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -19,6 +19,11 @@ cargo xtask e2e-smoke
 cargo xtask release-check v0.1.0-preview.1
 cargo xtask scenario community_node_public_connectivity
 cargo xtask scenario community_node_multi_device_connectivity
+cargo xtask scenario desktop_smoke_bookmark_workflow
+cargo xtask scenario desktop_smoke_game_room_persist
+cargo xtask scenario desktop_smoke_live_session_persist
+cargo xtask scenario pairwise_dm_offline_text_image_video_delivery_and_local_delete
+cargo xtask scenario private_channel_invite_connectivity
 cargo xtask rust-check
 cargo xtask rust-test
 cargo xtask app-api-slow-test

--- a/xtask/src/scenario.rs
+++ b/xtask/src/scenario.rs
@@ -49,3 +49,48 @@ pub(crate) fn scenario_requires_cn_postgres(name: &str) -> bool {
         "community_node_public_connectivity" | "community_node_multi_device_connectivity"
     )
 }
+
+#[cfg(test)]
+pub(crate) fn scenario_ci_lane(name: &str) -> Option<&'static str> {
+    match name {
+        "desktop_smoke_post_persist" => Some("fast+release+nightly"),
+        "community_node_public_connectivity" => Some("fast+release+nightly"),
+        "community_node_multi_device_connectivity" => Some("nightly"),
+        "desktop_smoke_bookmark_workflow"
+        | "desktop_smoke_game_room_persist"
+        | "desktop_smoke_live_session_persist"
+        | "pairwise_dm_offline_text_image_video_delivery_and_local_delete"
+        | "private_channel_invite_connectivity" => Some("nightly"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    #[test]
+    fn every_scenario_yaml_has_a_ci_lane() {
+        let scenario_dir = root_dir().join("harness").join("scenarios");
+        let scenario_names = std::fs::read_dir(&scenario_dir)
+            .expect("scenario directory")
+            .map(|entry| {
+                entry
+                    .expect("scenario entry")
+                    .path()
+                    .file_stem()
+                    .expect("scenario file stem")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(scenario_names.len(), 8, "scenario inventory changed");
+        let orphaned = scenario_names
+            .iter()
+            .filter(|name| scenario_ci_lane(name).is_none())
+            .collect::<Vec<_>>();
+        assert!(orphaned.is_empty(), "orphaned scenarios: {orphaned:?}");
+    }
+}


### PR DESCRIPTION
## Summary
- add the five previously unowned harness scenarios to a nightly matrix
- add an ownership contract covering all eight scenario YAML files
- document every direct scenario command and upload per-scenario artifacts

## Validation
- cargo test -p xtask
- cargo test -p kukuri-harness
- all five cargo xtask scenario commands
- cargo xtask rust-check
- cargo xtask oversized-files