### PR TITLE
refactor: move safety composition to runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,6 +3092,7 @@ dependencies = [
 name = "kukuri-cn-safety-runtime"
 version = "0.1.2"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "hex",
@@ -3132,6 +3133,7 @@ dependencies = [
  "kukuri-cn-operator",
  "kukuri-cn-protocol",
  "kukuri-cn-safety",
+ "kukuri-cn-safety-runtime",
  "kukuri-cn-trust",
  "kukuri-core",
  "kukuri-test-support",

--- a/crates/cn-core/src/index_entries.rs
+++ b/crates/cn-core/src/index_entries.rs
@@ -23,7 +23,7 @@ use sqlx::Row;
 use sqlx::postgres::{PgPool, PgRow};
 
 use crate::index_scope::IndexScopeKind;
-use crate::safety_runtime::MemorySafetyArtifactStore;
+use kukuri_cn_safety_runtime::MemorySafetyArtifactStore;
 
 /// 真実源に upsert する index entry（`cn-indexer` の投影 entry と同じ内容 + verdict 参照）。
 ///

--- a/crates/cn-core/src/lib.rs
+++ b/crates/cn-core/src/lib.rs
@@ -94,11 +94,7 @@ pub use safety_events::{
     list_distributable_risk_signals, list_risk_signals_for_target, list_signed_moderation_events,
     persist_risk_signal, persist_signed_moderation_event,
 };
-pub use safety_runtime::{
-    MemorySafetyArtifactStore, PgSafetyArtifactStore, SafetyArtifactStore, SafetyRuntimeConfig,
-    SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig, SafetyScanOutcome, SafetyScanService,
-    SafetyScanServiceBuilder, build_safety_orchestrator, build_safety_scan_service,
-};
+pub use safety_runtime::{PgSafetyArtifactStore, resolve_safety_providers};
 pub use scan_verdicts::{StoredScanVerdict, get_scan_verdict, upsert_scan_verdict};
 pub use trust_inputs::{
     TrustComponentKind, TrustRiskInput, TrustRiskInputs, list_trust_risk_inputs,

--- a/crates/cn-core/src/safety_runtime.rs
+++ b/crates/cn-core/src/safety_runtime.rs
@@ -1,158 +1,23 @@
-//! community node runtime の safety scan 結線（#406）。
+//! Community-node固有のsafety永続化とprovider解決。
 //!
-//! `cn-safety-runtime` の `SafetyOrchestrator`（scan → verdict → 未署名 artifact）と、
-//! `cn-core` の永続化（`safety_events`、#405）を合成する runtime 境界。ここまでの実装では
-//! orchestrator は verdict gate（`cn-indexer`）としてのみ使われ、`SafetyScanReport` の
-//! moderation event / risk signal は破棄されていた。本モジュールが scan と同時に
-//! artifact を署名・永続化し、risk signal を trust / relation reads（`trust_inputs`、#415）が
-//! 消費できる状態にする。
-//!
-//! 構成要素:
-//! - [`SafetyArtifactStore`] — artifact 永続化の抽象。本番は Postgres
-//!   （[`PgSafetyArtifactStore`]）、contract test は in-memory
-//!   （[`MemorySafetyArtifactStore`]）。
-//! - [`SafetyScanService`] — scan → risk signal persist → moderation event 署名 / persist を
-//!   合成する service。verdict の判定（allow / fail-closed / artifact 生成可否）は
-//!   `cn-safety-runtime` の artifacts ガードレールに委ね、ここで再判断しない（単一判定点）。
-//! - [`build_safety_orchestrator`] / [`build_safety_scan_service`] — 設定から
-//!   `SystemScanClock` + `UuidEventIdGenerator` + provider 群で orchestrator / service を
-//!   組み立てる構築境界。
-//!
-//! fail-closed の要:
-//! - 未知の provider 名は `required` の真偽に依らず Err（黙って skip すると「unknown_csam を
-//!   設定したつもりで未検査が素通りする」誤構成を隠すため）。
-//! - signed moderation event の emit が有効（既定）なのに signer が無い構成は build Err
-//!   （実行時 skip にしない）。
-//! - provider が 1 つも無い構成では service を構築しない（unscanned を index しない現状と整合）。
-//!
-//! 設計の真実源:
-//! - `docs/adr/0026-community-node-trust-relation-foundation.md` §2.7（risk signal の反映先契約）
-//! - `docs/adr/0027-deterministic-moderation-critical-safety.md` §2.5 / §2.6（signed event / risk
-//!   signal / visibility）
+//! DB非依存のscan serviceと構築処理は`cn-safety-runtime`が所有する。このmoduleには
+//! Postgres storeと、feature/credentialを伴うprovider実装名の解決だけを置く。
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use sqlx::PgPool;
 
-use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
-use kukuri_cn_safety::{
-    ModerationEventSigner, SafetyPolicy, SafetyProvider, SafetyRiskSignal, SafetyVerdict,
-    SignedModerationEvent, issue_signed_event,
-};
+use kukuri_cn_safety::provider::SubjectKind;
+use kukuri_cn_safety::{SafetyProvider, SafetyRiskSignal, SafetyVerdict, SignedModerationEvent};
 use kukuri_cn_safety_runtime::{
-    SAFETY_SIGNING_KEY_ENV, SafetyOrchestrator, SafetyScanReport, Secp256k1ModerationEventSigner,
-    SystemScanClock, UuidEventIdGenerator,
+    SafetyArtifactStore, SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig,
 };
 
-use crate::safety_events::{persist_risk_signal, persist_signed_moderation_event, to_db_enum};
+use crate::safety_events::{persist_risk_signal, persist_signed_moderation_event};
 use crate::scan_verdicts::upsert_scan_verdict;
 
-/// runtime 側の safety provider slot 設定。
-///
-/// operator config（`cn-operator` の `SafetyProvidersConfig`）と slot が 1:1 対応する。
-/// operator → env 注入 → runtime 消費という既存の流儀（`COMMUNITY_NODE_SAFETY_SIGNING_KEY` と
-/// 同じ経路）に合わせ、cn-operator には依存しない。
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct SafetyRuntimeProvidersConfig {
-    /// 既知 CSAM hash match provider（ADR 0027 §2.7）。
-    pub known_csam: Option<SafetyRuntimeProviderEntry>,
-    /// 一般 moderation provider（nsfw / spam 等）。
-    pub general: Option<SafetyRuntimeProviderEntry>,
-    /// 未知 CSAM / CSE classifier provider（#411）。
-    pub unknown_csam: Option<SafetyRuntimeProviderEntry>,
-}
-
-impl SafetyRuntimeProvidersConfig {
-    /// provider が 1 つも設定されていないか。
-    pub fn is_empty(&self) -> bool {
-        self.known_csam.is_none() && self.general.is_none() && self.unknown_csam.is_none()
-    }
-}
-
-/// provider slot 1 つ分の設定。
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SafetyRuntimeProviderEntry {
-    /// provider 実装名。現状解決できるのは `mock`（`safety-mock-provider` feature）のみで、
-    /// 本番 provider 実装名は #391 / #411 で追加する。未知の名前は fail-closed で Err。
-    pub provider: String,
-    /// operator が readiness 上必須と宣言した provider か。現段階の runtime 構築では挙動を
-    /// 変えない（未知名は required に依らず Err）が、operator config との 1:1 対応のため保持する。
-    pub required: bool,
-}
-
-/// safety scan runtime の構成。
-///
-/// env の読み込みは呼び出し側（`cn-indexer` の config 層）が行い、ここには値を渡す。
-/// `Debug` は手動実装で `signing_key` を秘匿する（誤ってログへ署名鍵を出さない）。
-#[derive(Clone, PartialEq, Eq)]
-pub struct SafetyRuntimeConfig {
-    pub providers: SafetyRuntimeProvidersConfig,
-    /// moderation event 署名鍵の値（`COMMUNITY_NODE_SAFETY_SIGNING_KEY` の中身）。
-    pub signing_key: Option<String>,
-    /// signed moderation event を発行するか（operator config の
-    /// `safety.events.emit_signed_moderation_events` に対応。既定 true）。
-    pub emit_signed_events: bool,
-    /// `emit_signed_events = false` のときに risk signal の issuer として使う node id。
-    /// 署名鍵がある場合は鍵から導出した公開鍵 hex を優先する。
-    pub issuer_node_id: Option<String>,
-}
-
-impl Default for SafetyRuntimeConfig {
-    fn default() -> Self {
-        Self {
-            providers: SafetyRuntimeProvidersConfig::default(),
-            signing_key: None,
-            emit_signed_events: true,
-            issuer_node_id: None,
-        }
-    }
-}
-
-impl std::fmt::Debug for SafetyRuntimeConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SafetyRuntimeConfig")
-            .field("providers", &self.providers)
-            .field(
-                "signing_key",
-                &self.signing_key.as_ref().map(|_| "<redacted>"),
-            )
-            .field("emit_signed_events", &self.emit_signed_events)
-            .field("issuer_node_id", &self.issuer_node_id)
-            .finish()
-    }
-}
-
-/// safety artifact（signed moderation event / risk signal）永続化の抽象。
-///
-/// 本番は Postgres（`cn_safety` schema、#405）、contract test は in-memory 実装を差す。
-#[async_trait]
-pub trait SafetyArtifactStore: Send + Sync {
-    /// 署名済み moderation event を保存する。
-    async fn persist_event(&self, event: &SignedModerationEvent) -> Result<()>;
-
-    /// risk signal を保存し、採番した id を返す。
-    async fn persist_signal(
-        &self,
-        issuer_node_id: &str,
-        signal: &SafetyRiskSignal,
-    ) -> Result<String>;
-
-    /// scan 対象の最新 verdict state を upsert し、verdict record id を返す（#404）。
-    ///
-    /// `allow` を含む全 verdict を対象ごとに 1 行で保持する。id は初回採番のまま据え置かれ、
-    /// index 真実源（`cn_index.index_entries`）の FK 参照先になる。
-    async fn persist_verdict(
-        &self,
-        subject_kind: SubjectKind,
-        subject_id: &str,
-        verdict: &SafetyVerdict,
-    ) -> Result<String>;
-}
-
-/// Postgres 実装。`safety_events`（#405）の persist API に委譲する。
 #[derive(Clone, Debug)]
 pub struct PgSafetyArtifactStore {
     pool: PgPool,
@@ -194,342 +59,29 @@ impl SafetyArtifactStore for PgSafetyArtifactStore {
     }
 }
 
-/// contract test 用の in-memory 実装（`MemoryDocsSync` / `MemoryIndexProjection` と同じ流儀）。
+/// Operator由来のslot設定を具体的なprovider実装へ解決する。
 ///
-/// 署名検証は行わない（Postgres 実装は persist 時に検証する）。テストは保存された event を
-/// 読み出して `verify_signed_event` で検証する。
-#[derive(Debug, Default)]
-pub struct MemorySafetyArtifactStore {
-    events: Mutex<Vec<SignedModerationEvent>>,
-    signals: Mutex<Vec<(String, SafetyRiskSignal)>>,
-    /// (subject_kind の snake_case, subject_id) → (verdict record id, 最新 verdict)。
-    /// Postgres 実装と同じく id は初回採番のまま据え置く。
-    verdicts: Mutex<HashMap<(String, String), (String, SafetyVerdict)>>,
-}
-
-impl MemorySafetyArtifactStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// 保存済み signed moderation event のスナップショット。
-    pub fn events(&self) -> Vec<SignedModerationEvent> {
-        self.events.lock().expect("events mutex poisoned").clone()
-    }
-
-    /// 保存済み risk signal（issuer_node_id, signal）のスナップショット。
-    pub fn signals(&self) -> Vec<(String, SafetyRiskSignal)> {
-        self.signals.lock().expect("signals mutex poisoned").clone()
-    }
-
-    /// 保存済みの対象別最新 verdict（verdict record id, verdict）のスナップショット。
-    pub fn verdict_for(
-        &self,
-        subject_kind: SubjectKind,
-        subject_id: &str,
-    ) -> Option<(String, SafetyVerdict)> {
-        let key = (
-            memory_subject_kind_key(subject_kind),
-            subject_id.to_string(),
-        );
-        self.verdicts
-            .lock()
-            .expect("verdicts mutex poisoned")
-            .get(&key)
-            .cloned()
-    }
-
-    /// verdict record id から最新 verdict を引く（Postgres 実装の verdict_id join に対応）。
-    pub fn verdict_by_id(&self, verdict_id: &str) -> Option<SafetyVerdict> {
-        self.verdicts
-            .lock()
-            .expect("verdicts mutex poisoned")
-            .values()
-            .find(|(id, _)| id == verdict_id)
-            .map(|(_, verdict)| verdict.clone())
-    }
-}
-
-/// `SubjectKind` を in-memory map の鍵（snake_case 文字列）に写す。
-fn memory_subject_kind_key(subject_kind: SubjectKind) -> String {
-    to_db_enum(&subject_kind).expect("SubjectKind serializes to a snake_case string")
-}
-
-#[async_trait]
-impl SafetyArtifactStore for MemorySafetyArtifactStore {
-    async fn persist_event(&self, event: &SignedModerationEvent) -> Result<()> {
-        self.events
-            .lock()
-            .expect("events mutex poisoned")
-            .push(event.clone());
-        Ok(())
-    }
-
-    async fn persist_signal(
-        &self,
-        issuer_node_id: &str,
-        signal: &SafetyRiskSignal,
-    ) -> Result<String> {
-        let mut signals = self.signals.lock().expect("signals mutex poisoned");
-        let id = format!("memory-signal-{}", signals.len() + 1);
-        signals.push((issuer_node_id.to_string(), signal.clone()));
-        Ok(id)
-    }
-
-    async fn persist_verdict(
-        &self,
-        subject_kind: SubjectKind,
-        subject_id: &str,
-        verdict: &SafetyVerdict,
-    ) -> Result<String> {
-        if subject_id.trim().is_empty() {
-            bail!("scan verdict subject_id must not be empty");
-        }
-        let mut verdicts = self.verdicts.lock().expect("verdicts mutex poisoned");
-        let key = (
-            memory_subject_kind_key(subject_kind),
-            subject_id.to_string(),
-        );
-        let next_id = format!("memory-verdict-{}", verdicts.len() + 1);
-        let entry = verdicts.entry(key);
-        let (id, stored) = entry.or_insert_with(|| (next_id, verdict.clone()));
-        *stored = verdict.clone();
-        Ok(id.clone())
-    }
-}
-
-/// [`SafetyScanService::scan_and_record`] の結果。
-///
-/// verdict の判定（`is_indexable()` 等）は `report` を、永続化の結果は残りのフィールドを見る。
-#[derive(Clone, Debug)]
-pub struct SafetyScanOutcome {
-    /// orchestrator の生 scan 結果（verdict / scan_results / 未署名 artifact）。
-    pub report: SafetyScanReport,
-    /// 署名して store に保存した moderation event（signer 未構成の場合は None）。
-    pub signed_event: Option<SignedModerationEvent>,
-    /// store が採番した risk signal id（signal が生成されなかった場合は None）。
-    pub persisted_signal_id: Option<String>,
-    /// store が upsert した対象別最新 verdict の record id（#404）。
-    ///
-    /// request に subject_kind / subject_id が無い場合は None。index 真実源
-    /// （`cn_index.index_entries`）はこの id を FK で参照する。
-    pub verdict_id: Option<String>,
-}
-
-/// scan → verdict → artifact 署名 / 永続化を合成する runtime 境界（#406）。
-pub struct SafetyScanService {
-    orchestrator: Arc<SafetyOrchestrator>,
-    signer: Option<Arc<dyn ModerationEventSigner + Send + Sync>>,
-    store: Arc<dyn SafetyArtifactStore>,
-    issuer_node_id: String,
-}
-
-impl std::fmt::Debug for SafetyScanService {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SafetyScanService")
-            .field("issuer_node_id", &self.issuer_node_id)
-            .field("has_signer", &self.signer.is_some())
-            .finish_non_exhaustive()
-    }
-}
-
-impl SafetyScanService {
-    /// builder を開始する。signed moderation event の emit は既定で有効（signer 必須）。
-    pub fn builder(
-        orchestrator: Arc<SafetyOrchestrator>,
-        store: Arc<dyn SafetyArtifactStore>,
-    ) -> SafetyScanServiceBuilder {
-        SafetyScanServiceBuilder {
-            orchestrator,
-            store,
-            signer: None,
-            unsigned_issuer: None,
-        }
-    }
-
-    /// この service が risk signal / moderation event の issuer として使う node id。
-    pub fn issuer_node_id(&self) -> &str {
-        &self.issuer_node_id
-    }
-
-    /// scan して、生成された artifact を署名・永続化する。
-    ///
-    /// 1. `SafetyOrchestrator::scan_subject`（provider 失敗は fail-closed に写像済み）。
-    /// 2. request に subject があれば、対象別の最新 verdict state を store へ upsert する（#404。
-    ///    `allow` を含む。index 真実源の FK 参照先になる）。
-    /// 3. risk signal があれば store へ保存する（署名対象ではないため signer の有無に依らない）。
-    /// 4. moderation event body があり signer が構成されていれば、署名して store へ保存する。
-    ///
-    /// allow verdict / target 欠落 / operational fail-closed（scan_failed 等）で artifact を
-    /// 作らない判断は `cn-safety-runtime` の artifacts ガードレールに委ねる（ここで再判断しない）。
-    /// 永続化失敗は Err で返し、呼び出し側（ingest 等）の per-entry fail-closed に乗せる。
-    pub async fn scan_and_record(
-        &self,
-        request: &ProviderScanRequest,
-    ) -> Result<SafetyScanOutcome> {
-        let report = self.orchestrator.scan_subject(request).await;
-
-        let verdict_id = match (request.subject_kind, request.subject_id.as_deref()) {
-            (Some(kind), Some(subject_id)) if !subject_id.trim().is_empty() => Some(
-                self.store
-                    .persist_verdict(kind, subject_id, &report.verdict)
-                    .await
-                    .context("failed to persist scan verdict state")?,
-            ),
-            _ => None,
-        };
-
-        let persisted_signal_id = match report.risk_signal.as_ref() {
-            Some(signal) => Some(
-                self.store
-                    .persist_signal(&self.issuer_node_id, signal)
-                    .await
-                    .context("failed to persist safety risk signal")?,
-            ),
-            None => None,
-        };
-
-        let signed_event = match (report.moderation_event.as_ref(), self.signer.as_ref()) {
-            (Some(body), Some(signer)) => {
-                let event = issue_signed_event(body.clone(), signer.as_ref());
-                self.store
-                    .persist_event(&event)
-                    .await
-                    .context("failed to persist signed moderation event")?;
-                Some(event)
-            }
-            _ => None,
-        };
-
-        Ok(SafetyScanOutcome {
-            report,
-            signed_event,
-            persisted_signal_id,
-            verdict_id,
-        })
-    }
-}
-
-/// [`SafetyScanService`] の builder。
-pub struct SafetyScanServiceBuilder {
-    orchestrator: Arc<SafetyOrchestrator>,
-    store: Arc<dyn SafetyArtifactStore>,
-    signer: Option<Arc<dyn ModerationEventSigner + Send + Sync>>,
-    unsigned_issuer: Option<String>,
-}
-
-impl SafetyScanServiceBuilder {
-    /// moderation event の signer を設定する。issuer node id は signer から導出する。
-    ///
-    /// 注意: orchestrator の issuer_node_id（`ModerationEventBody.issuer_node_id` になる）と
-    /// signer の公開鍵は一致している必要がある（`verify_signed_event` / persist 時の署名検証が
-    /// 一致を要求する）。[`build_safety_scan_service`] は signer から issuer を導出して
-    /// orchestrator を組むため、構造的に一致する。
-    pub fn signer(mut self, signer: Arc<dyn ModerationEventSigner + Send + Sync>) -> Self {
-        self.signer = Some(signer);
-        self
-    }
-
-    /// signed moderation event の emit を明示的に無効化する（operator config
-    /// `safety.events.emit_signed_moderation_events = false` に対応）。
-    ///
-    /// moderation event は署名・永続化されない（report には未署名 body が残る）。risk signal は
-    /// 署名対象ではないため引き続き永続化され、その issuer として `issuer_node_id` を使う。
-    pub fn without_signed_events(mut self, issuer_node_id: impl Into<String>) -> Self {
-        self.unsigned_issuer = Some(issuer_node_id.into());
-        self
-    }
-
-    /// 構成を検証して [`SafetyScanService`] を構築する。
-    ///
-    /// fail-closed: signed event emit が有効（既定）なのに signer が無い構成は Err にする
-    /// （実行時に黙って署名を skip しない）。
-    pub fn build(self) -> Result<SafetyScanService> {
-        let (signer, issuer_node_id) = match (self.signer, self.unsigned_issuer) {
-            (Some(signer), None) => {
-                let issuer = signer.issuer_node_id().to_string();
-                (Some(signer), issuer)
-            }
-            (None, Some(issuer)) => {
-                let issuer = issuer.trim().to_string();
-                if issuer.is_empty() {
-                    bail!("safety scan service issuer_node_id must not be empty");
-                }
-                (None, issuer)
-            }
-            (None, None) => bail!(
-                "signed moderation events are enabled but no signer is configured \
-                 (set {SAFETY_SIGNING_KEY_ENV}, or disable emission explicitly with \
-                 without_signed_events)"
-            ),
-            (Some(_), Some(_)) => {
-                bail!("safety scan service cannot both sign moderation events and disable emission")
-            }
-        };
-
-        Ok(SafetyScanService {
-            orchestrator: self.orchestrator,
-            signer,
-            store: self.store,
-            issuer_node_id,
-        })
-    }
-}
-
-/// 設定から `SystemScanClock` + `UuidEventIdGenerator` + provider 群で
-/// [`SafetyOrchestrator`] を構築する（#406）。
-///
-/// fail-closed:
-/// - 未知の provider 名は `required` の真偽に依らず Err（黙って skip しない）。
-/// - provider が 1 つも無い構成は Err（orchestrator builder の NoProviders と同じ）。
-///
-/// policy 未指定なら `SafetyPolicy::public_node_default()`（orchestrator builder の既定）。
-pub fn build_safety_orchestrator(
-    issuer_node_id: &str,
+/// 未知名、slot不一致、credential欠落はすべて起動エラーとして返す。空設定はscan serviceを
+/// 無効にする正規状態なので空vectorを返す。
+pub fn resolve_safety_providers(
     providers: &SafetyRuntimeProvidersConfig,
-    policy: Option<SafetyPolicy>,
-) -> Result<SafetyOrchestrator> {
-    if providers.is_empty() {
-        bail!(
-            "no safety providers configured; refusing to build a scan orchestrator (fail-closed)"
-        );
-    }
-
-    let mut builder = SafetyOrchestrator::builder(
-        issuer_node_id,
-        Arc::new(SystemScanClock::new()),
-        Arc::new(UuidEventIdGenerator::new()),
-    );
+) -> Result<Vec<Arc<dyn SafetyProvider>>> {
     let slots: [(&'static str, Option<&SafetyRuntimeProviderEntry>); 3] = [
         ("known_csam", providers.known_csam.as_ref()),
         ("general", providers.general.as_ref()),
         ("unknown_csam", providers.unknown_csam.as_ref()),
     ];
-    for (slot, entry) in slots {
-        let Some(entry) = entry else {
-            continue;
-        };
-        builder = builder.provider(resolve_provider(slot, entry)?);
-    }
-    if let Some(policy) = policy {
-        builder = builder.policy(policy);
-    }
-    builder
-        .build()
-        .context("failed to build safety orchestrator")
+    slots
+        .into_iter()
+        .filter_map(|(slot, entry)| entry.map(|entry| (slot, entry)))
+        .map(|(slot, entry)| resolve_provider(slot, entry))
+        .collect()
 }
 
-/// provider 実装名を実装に解決する。
-///
-/// 解決できるのは `mock`（`safety-mock-provider` feature）と `project-arachnid-shield`
-/// （`safety-arachnid-provider` feature、#391）。未知の名前は `required` に依らず Err
-/// （fail-closed）。
 fn resolve_provider(
     slot: &'static str,
     entry: &SafetyRuntimeProviderEntry,
 ) -> Result<Arc<dyn SafetyProvider>> {
-    // operator-config の underscore 表記（`project_arachnid_shield`）も受理するため、
-    // hyphen へ正規化してから解決する（cn-operator readiness と同じ規則）。
     let normalized = entry.provider.trim().replace('_', "-");
     match normalized.as_str() {
         #[cfg(feature = "safety-mock-provider")]
@@ -543,19 +95,8 @@ fn resolve_provider(
     }
 }
 
-/// Project Arachnid Shield provider（#391）を組み立てる。
-///
-/// - known_csam slot 専用（Shield は known-match provider であり、general / unknown_csam の
-///   役割は果たさない）。他 slot に指定されたら Err（fail-closed）。
-/// - operator-owned credentials は env（既定: `PROJECT_ARACHNID_API_USERNAME` /
-///   `PROJECT_ARACHNID_API_PASSWORD`）から読む。欠落は Err = 起動失敗（fail-closed）。
-///   エラーには env の名前のみ含まれ、値は含まれない。
-/// - media fetcher は未接続（media scan pipeline 側の issue で注入する）。それまで
-///   media_hint 付き scan は provider が `Unavailable` を返し fail-closed に倒れる。
 #[cfg(feature = "safety-arachnid-provider")]
 fn arachnid_shield_provider(slot: &'static str) -> Result<Arc<dyn SafetyProvider>> {
-    use anyhow::Context;
-
     if slot != "known_csam" {
         bail!(
             "safety provider `{}` only supports the `known_csam` slot (got `{slot}`); \
@@ -568,11 +109,9 @@ fn arachnid_shield_provider(slot: &'static str) -> Result<Arc<dyn SafetyProvider
     Ok(Arc::new(provider))
 }
 
-/// slot に対応する capability を持つ mock provider を作る（test / 構成検証用）。
 #[cfg(feature = "safety-mock-provider")]
 fn mock_provider_for_slot(slot: &'static str) -> Arc<dyn SafetyProvider> {
-    use kukuri_cn_safety::MockSafetyProvider;
-    use kukuri_cn_safety::SafetyProviderCapability;
+    use kukuri_cn_safety::{MockSafetyProvider, SafetyProviderCapability};
 
     let name = format!("mock-{slot}");
     let provider = match slot {
@@ -584,7 +123,6 @@ fn mock_provider_for_slot(slot: &'static str) -> Arc<dyn SafetyProvider> {
                 SafetyProviderCapability::SpamAbuseModeration,
             ],
         ),
-        // unknown_csam slot は未知 CSAM / CSE classifier（suspected 判定、#411）。
         _ => MockSafetyProvider::with_capabilities(
             name,
             vec![
@@ -594,60 +132,4 @@ fn mock_provider_for_slot(slot: &'static str) -> Arc<dyn SafetyProvider> {
         ),
     };
     Arc::new(provider)
-}
-
-/// 設定から [`SafetyScanService`] を構築する runtime 構築境界（#406）。
-///
-/// 戻り値:
-/// - `Ok(None)` — safety provider が未構成。scan orchestration は構成されず、呼び出し側は
-///   ingest を起動しない（unscanned を index しない fail-closed と整合）。
-/// - `Ok(Some(service))` — 構成が有効で service を構築した。
-/// - `Err` — provider があるのに構成が不正（未知 provider 名 / emit 有効なのに署名鍵なし等）。
-///   黙って縮退せず起動を失敗させる。
-pub fn build_safety_scan_service(
-    config: &SafetyRuntimeConfig,
-    store: Arc<dyn SafetyArtifactStore>,
-) -> Result<Option<SafetyScanService>> {
-    if config.providers.is_empty() {
-        return Ok(None);
-    }
-
-    // 署名鍵があれば issuer は常に鍵の公開鍵 hex（emit 無効でも issuer 詐称を避ける）。
-    let signer = match config.signing_key.as_deref() {
-        Some(secret) => Some(
-            Secp256k1ModerationEventSigner::from_secret(secret)
-                .context("invalid moderation event signing key")?,
-        ),
-        None => None,
-    };
-
-    if config.emit_signed_events {
-        let Some(signer) = signer else {
-            bail!(
-                "signed moderation events are enabled but no signing key is configured \
-                 (set {SAFETY_SIGNING_KEY_ENV} from Secret Manager, or disable \
-                 safety.events.emit_signed_moderation_events)"
-            );
-        };
-        let issuer = signer.issuer_node_id().to_string();
-        let orchestrator = build_safety_orchestrator(&issuer, &config.providers, None)?;
-        let service = SafetyScanService::builder(Arc::new(orchestrator), store)
-            .signer(Arc::new(signer))
-            .build()?;
-        return Ok(Some(service));
-    }
-
-    let issuer = match (&signer, config.issuer_node_id.as_deref()) {
-        (Some(signer), _) => signer.issuer_node_id().to_string(),
-        (None, Some(issuer)) if !issuer.trim().is_empty() => issuer.trim().to_string(),
-        _ => bail!(
-            "signed moderation events are disabled and no issuer node id is available \
-             (set a signing key or an explicit issuer node id)"
-        ),
-    };
-    let orchestrator = build_safety_orchestrator(&issuer, &config.providers, None)?;
-    let service = SafetyScanService::builder(Arc::new(orchestrator), store)
-        .without_signed_events(issuer)
-        .build()?;
-    Ok(Some(service))
 }

--- a/crates/cn-core/tests/co_participation.rs
+++ b/crates/cn-core/tests/co_participation.rs
@@ -11,12 +11,12 @@ use anyhow::Result;
 
 use kukuri_cn_core::{
     CoParticipationPair, CoParticipationSource, IndexEntryStore, IndexScopeKind,
-    MemoryIndexEntryStore, MemorySafetyArtifactStore, NewIndexEntry, PgCoParticipationSource,
-    SafetyArtifactStore, TestDatabase, connect_postgres, initialize_database, upsert_index_entry,
-    upsert_scan_verdict,
+    MemoryIndexEntryStore, NewIndexEntry, PgCoParticipationSource, TestDatabase, connect_postgres,
+    initialize_database, upsert_index_entry, upsert_scan_verdict,
 };
 use kukuri_cn_safety::provider::SubjectKind;
 use kukuri_cn_safety::{ReasonCode, SafetyAction, SafetyVerdict};
+use kukuri_cn_safety_runtime::{MemorySafetyArtifactStore, SafetyArtifactStore};
 
 const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
 

--- a/crates/cn-core/tests/index_entries.rs
+++ b/crates/cn-core/tests/index_entries.rs
@@ -9,17 +9,17 @@
 
 use anyhow::Result;
 use kukuri_cn_core::{
-    IndexScopeKind, NewIndexEntry, PgSafetyArtifactStore, SafetyScanService, TestDatabase,
-    connect_postgres, filter_surfaceable_objects, get_index_entry, get_scan_verdict,
-    initialize_database, remove_index_entry, remove_index_scope, upsert_index_entry,
-    upsert_scan_verdict,
+    IndexScopeKind, NewIndexEntry, PgSafetyArtifactStore, TestDatabase, connect_postgres,
+    filter_surfaceable_objects, get_index_entry, get_scan_verdict, initialize_database,
+    remove_index_entry, remove_index_scope, upsert_index_entry, upsert_scan_verdict,
 };
 use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
 use kukuri_cn_safety::{
     MockSafetyProvider, ModerationEventSigner, ReasonCode, SafetyAction, SafetyVerdict,
 };
 use kukuri_cn_safety_runtime::{
-    SafetyOrchestrator, Secp256k1ModerationEventSigner, SystemScanClock, UuidEventIdGenerator,
+    SafetyOrchestrator, SafetyScanService, Secp256k1ModerationEventSigner, SystemScanClock,
+    UuidEventIdGenerator,
 };
 use std::sync::Arc;
 

--- a/crates/cn-core/tests/safety_events.rs
+++ b/crates/cn-core/tests/safety_events.rs
@@ -9,11 +9,10 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use kukuri_cn_core::{
-    DistributionAudience, PgSafetyArtifactStore, SafetyScanService, TestDatabase, connect_postgres,
-    get_risk_signal, get_signed_moderation_event, initialize_database,
-    list_distributable_moderation_events, list_distributable_risk_signals,
-    list_risk_signals_for_target, list_trust_risk_inputs, persist_risk_signal,
-    persist_signed_moderation_event,
+    DistributionAudience, PgSafetyArtifactStore, TestDatabase, connect_postgres, get_risk_signal,
+    get_signed_moderation_event, initialize_database, list_distributable_moderation_events,
+    list_distributable_risk_signals, list_risk_signals_for_target, list_trust_risk_inputs,
+    persist_risk_signal, persist_signed_moderation_event,
 };
 use kukuri_cn_safety::event::{ModerationEventBody, SignedModerationEvent, issue_signed_event};
 use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
@@ -21,6 +20,7 @@ use kukuri_cn_safety::{
     AppealStatus, Basis, MockSafetyProvider, ModerationAction, ModerationEventSigner, ReasonCode,
     RiskSignalTarget, SafetyCategory, SafetyLabel, SafetyRiskSignal, Severity, Visibility,
 };
+use kukuri_cn_safety_runtime::SafetyScanService;
 use kukuri_cn_safety_runtime::{
     SafetyOrchestrator, Secp256k1ModerationEventSigner, SystemScanClock, UuidEventIdGenerator,
     verify_signed_event,

--- a/crates/cn-core/tests/safety_runtime.rs
+++ b/crates/cn-core/tests/safety_runtime.rs
@@ -9,18 +9,16 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Result, bail};
 use async_trait::async_trait;
-use kukuri_cn_core::{
-    MemorySafetyArtifactStore, SafetyArtifactStore, SafetyRuntimeConfig,
-    SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig, SafetyScanService,
-    build_safety_orchestrator, build_safety_scan_service,
-};
+use kukuri_cn_core::resolve_safety_providers;
 use kukuri_cn_safety::provider::{ProviderScanRequest, ScanError, SubjectKind};
 use kukuri_cn_safety::{
     MockSafetyProvider, ModerationEventSigner, ReasonCode, RiskSignalTarget, SafetyCategory,
     SafetyProvider, SafetyRiskSignal, SafetyVerdict, SignedModerationEvent,
 };
 use kukuri_cn_safety_runtime::{
-    EventIdGenerator, SafetyOrchestrator, ScanClock, Secp256k1ModerationEventSigner,
+    EventIdGenerator, MemorySafetyArtifactStore, SafetyArtifactStore, SafetyOrchestrator,
+    SafetyRuntimeConfig, SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig,
+    SafetyScanService, ScanClock, Secp256k1ModerationEventSigner, build_safety_scan_service,
     verify_signed_event,
 };
 
@@ -351,7 +349,7 @@ fn mock_slot() -> Option<SafetyRuntimeProviderEntry> {
 }
 
 #[test]
-fn build_orchestrator_rejects_unknown_provider_name() {
+fn provider_resolver_rejects_unknown_provider_name() {
     let providers = SafetyRuntimeProvidersConfig {
         known_csam: Some(SafetyRuntimeProviderEntry {
             provider: "arachnid-shield".to_string(),
@@ -359,7 +357,9 @@ fn build_orchestrator_rejects_unknown_provider_name() {
         }),
         ..Default::default()
     };
-    let error = build_safety_orchestrator("issuer-node", &providers, None).unwrap_err();
+    let error = resolve_safety_providers(&providers)
+        .err()
+        .expect("unknown provider must fail closed");
     assert!(
         error.to_string().contains("unknown safety provider"),
         "{error}"
@@ -367,7 +367,7 @@ fn build_orchestrator_rejects_unknown_provider_name() {
 }
 
 #[test]
-fn build_orchestrator_resolves_arachnid_shield_only_with_credentials() {
+fn provider_resolver_resolves_arachnid_shield_only_with_credentials() {
     // env は process-global なため、この 1 テスト内で「欠落 → Err」と「設定 → Ok」を順に
     // 検証する（他テストはこの env を読まない）。
     let providers = SafetyRuntimeProvidersConfig {
@@ -383,7 +383,9 @@ fn build_orchestrator_resolves_arachnid_shield_only_with_credentials() {
         std::env::remove_var("PROJECT_ARACHNID_API_USERNAME");
         std::env::remove_var("PROJECT_ARACHNID_API_PASSWORD");
     }
-    let error = build_safety_orchestrator("issuer-node", &providers, None).unwrap_err();
+    let error = resolve_safety_providers(&providers)
+        .err()
+        .expect("missing credentials must fail closed");
     let message = format!("{error:#}");
     assert!(message.contains("project-arachnid-shield"), "{message}");
     assert!(
@@ -396,7 +398,7 @@ fn build_orchestrator_resolves_arachnid_shield_only_with_credentials() {
         std::env::set_var("PROJECT_ARACHNID_API_USERNAME", "operator-user");
         std::env::set_var("PROJECT_ARACHNID_API_PASSWORD", "operator-pass");
     }
-    let result = build_safety_orchestrator("issuer-node", &providers, None);
+    let result = resolve_safety_providers(&providers);
     unsafe {
         std::env::remove_var("PROJECT_ARACHNID_API_USERNAME");
         std::env::remove_var("PROJECT_ARACHNID_API_PASSWORD");
@@ -405,7 +407,7 @@ fn build_orchestrator_resolves_arachnid_shield_only_with_credentials() {
 }
 
 #[test]
-fn build_orchestrator_rejects_arachnid_shield_outside_known_csam_slot() {
+fn provider_resolver_rejects_arachnid_shield_outside_known_csam_slot() {
     // Shield は known-match provider。general / unknown_csam slot への指定は fail-closed。
     let providers = SafetyRuntimeProvidersConfig {
         known_csam: mock_slot(),
@@ -415,7 +417,9 @@ fn build_orchestrator_rejects_arachnid_shield_outside_known_csam_slot() {
         }),
         ..Default::default()
     };
-    let error = build_safety_orchestrator("issuer-node", &providers, None).unwrap_err();
+    let error = resolve_safety_providers(&providers)
+        .err()
+        .expect("slot mismatch must fail closed");
     assert!(
         error
             .to_string()
@@ -425,17 +429,11 @@ fn build_orchestrator_rejects_arachnid_shield_outside_known_csam_slot() {
 }
 
 #[test]
-fn build_orchestrator_rejects_empty_provider_set() {
-    let providers = SafetyRuntimeProvidersConfig::default();
-    let error = build_safety_orchestrator("issuer-node", &providers, None).unwrap_err();
-    assert!(error.to_string().contains("no safety providers"), "{error}");
-}
-
-#[test]
 fn build_scan_service_returns_none_without_providers() {
     let config = SafetyRuntimeConfig::default();
     let store = Arc::new(MemorySafetyArtifactStore::new());
-    let service = build_safety_scan_service(&config, store).unwrap();
+    let providers = resolve_safety_providers(&config.providers).unwrap();
+    let service = build_safety_scan_service(&config, providers, store).unwrap();
     assert!(service.is_none());
 }
 
@@ -449,7 +447,8 @@ fn build_scan_service_requires_signing_key_when_emit_enabled() {
         ..Default::default()
     };
     let store = Arc::new(MemorySafetyArtifactStore::new());
-    let error = build_safety_scan_service(&config, store).unwrap_err();
+    let providers = resolve_safety_providers(&config.providers).unwrap();
+    let error = build_safety_scan_service(&config, providers, store).unwrap_err();
     assert!(error.to_string().contains("no signing key"), "{error}");
 }
 
@@ -467,7 +466,8 @@ async fn build_scan_service_constructs_mock_orchestrator_and_scans() {
         ..Default::default()
     };
     let store = Arc::new(MemorySafetyArtifactStore::new());
-    let service = build_safety_scan_service(&config, store.clone())
+    let providers = resolve_safety_providers(&config.providers).unwrap();
+    let service = build_safety_scan_service(&config, providers, store.clone())
         .unwrap()
         .expect("service should be constructed");
     assert_eq!(service.issuer_node_id(), signer().issuer_node_id());

--- a/crates/cn-indexer/src/config.rs
+++ b/crates/cn-indexer/src/config.rs
@@ -11,10 +11,10 @@
 
 use anyhow::{Context, Result, bail};
 
-use kukuri_cn_core::{
-    SafetyRuntimeConfig, SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig,
+use kukuri_cn_safety_runtime::{
+    SAFETY_SIGNING_KEY_ENV, SafetyRuntimeConfig, SafetyRuntimeProviderEntry,
+    SafetyRuntimeProvidersConfig,
 };
-use kukuri_cn_safety_runtime::SAFETY_SIGNING_KEY_ENV;
 
 /// safety provider slot（#406。operator config の `safety.providers.*` と 1:1）の env 名。
 /// 値は provider 実装名（現状 `mock` のみ。#391 / #411 で本番実装名を追加）。
@@ -394,8 +394,15 @@ mod tests {
             let config = IndexerConfig::from_env().unwrap();
             assert!(config.safety.providers.is_empty());
 
-            let store = Arc::new(kukuri_cn_core::MemorySafetyArtifactStore::new());
-            let service = kukuri_cn_core::build_safety_scan_service(&config.safety, store).unwrap();
+            let store = Arc::new(kukuri_cn_safety_runtime::MemorySafetyArtifactStore::new());
+            let providers =
+                kukuri_cn_core::resolve_safety_providers(&config.safety.providers).unwrap();
+            let service = kukuri_cn_safety_runtime::build_safety_scan_service(
+                &config.safety,
+                providers,
+                store,
+            )
+            .unwrap();
             assert!(service.is_none());
         });
     }

--- a/crates/cn-indexer/src/ingest.rs
+++ b/crates/cn-indexer/src/ingest.rs
@@ -24,8 +24,9 @@ use std::sync::Arc;
 use anyhow::{Context, Result, bail};
 use tracing::{debug, warn};
 
-use kukuri_cn_core::{IndexEntryStore, IndexScopeKind, NewIndexEntry, SafetyScanService};
+use kukuri_cn_core::{IndexEntryStore, IndexScopeKind, NewIndexEntry};
 use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
+use kukuri_cn_safety_runtime::SafetyScanService;
 use kukuri_core::{AssetRef, KukuriEnvelope, ObjectStatus, PayloadRef, ReplicaId};
 use kukuri_docs_sync::{DocFetchPolicy, DocQuery, DocRecord, DocsSync, stable_key};
 

--- a/crates/cn-indexer/src/runtime.rs
+++ b/crates/cn-indexer/src/runtime.rs
@@ -58,8 +58,10 @@ async fn run(config: IndexerConfig) -> Result<()> {
     // safety scan runtime の構築境界（#406）。provider が構成されていれば service を構築・検証する
     // （構成不正 = 未知 provider 名 / emit 有効なのに署名鍵なし、は起動失敗）。未構成なら scan
     // service を構成せず、ingest は起動されない（fail-closed）。
-    let safety = kukuri_cn_core::build_safety_scan_service(
+    let safety_providers = kukuri_cn_core::resolve_safety_providers(&config.safety.providers)?;
+    let safety = kukuri_cn_safety_runtime::build_safety_scan_service(
         &config.safety,
+        safety_providers,
         Arc::new(PgSafetyArtifactStore::new(pool.clone())),
     )?;
     match safety.as_ref() {

--- a/crates/cn-indexer/tests/ingestion_contracts.rs
+++ b/crates/cn-indexer/tests/ingestion_contracts.rs
@@ -8,9 +8,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use kukuri_cn_core::{
-    IndexScopeKind, MemoryIndexEntryStore, MemorySafetyArtifactStore, SafetyScanService,
-};
+use kukuri_cn_core::{IndexScopeKind, MemoryIndexEntryStore};
 use kukuri_cn_indexer::config::RelayConfig;
 use kukuri_cn_indexer::ingest::IngestPipeline;
 use kukuri_cn_indexer::participant::ScopeReplica;
@@ -21,6 +19,7 @@ use kukuri_cn_safety::{
 };
 use kukuri_cn_safety_runtime::clock::SystemScanClock;
 use kukuri_cn_safety_runtime::id::UuidEventIdGenerator;
+use kukuri_cn_safety_runtime::{MemorySafetyArtifactStore, SafetyScanService};
 use kukuri_cn_safety_runtime::{
     SafetyOrchestrator, Secp256k1ModerationEventSigner, verify_signed_event,
 };

--- a/crates/cn-indexer/tests/query_contracts.rs
+++ b/crates/cn-indexer/tests/query_contracts.rs
@@ -11,10 +11,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use kukuri_cn_core::{
-    IndexScopeKind, MemoryIndexEntryStore, MemorySafetyArtifactStore, SafetyArtifactStore,
-    SafetyScanService,
-};
+use kukuri_cn_core::{IndexScopeKind, MemoryIndexEntryStore};
 use kukuri_cn_indexer::ingest::IngestPipeline;
 use kukuri_cn_indexer::projection::{IndexProjection, IndexedEntry, MemoryIndexProjection};
 use kukuri_cn_indexer::query::{FailClosedIndexQuery, IndexQuery, MAX_QUERY_LIMIT};
@@ -24,6 +21,7 @@ use kukuri_cn_safety::{
 };
 use kukuri_cn_safety_runtime::clock::SystemScanClock;
 use kukuri_cn_safety_runtime::id::UuidEventIdGenerator;
+use kukuri_cn_safety_runtime::{MemorySafetyArtifactStore, SafetyArtifactStore, SafetyScanService};
 use kukuri_cn_safety_runtime::{SafetyOrchestrator, Secp256k1ModerationEventSigner};
 use kukuri_core::{KukuriKeys, ReplicaId, TopicId, build_post_envelope};
 use kukuri_docs_sync::{DocOp, DocsSync, MemoryDocsSync, stable_key, topic_replica_id};

--- a/crates/cn-indexer/tests/relation_contracts.rs
+++ b/crates/cn-indexer/tests/relation_contracts.rs
@@ -10,13 +10,11 @@ use std::sync::Arc;
 
 use anyhow::Result;
 
-use kukuri_cn_core::{
-    IndexEntryStore, IndexScopeKind, MemoryIndexEntryStore, MemorySafetyArtifactStore,
-    NewIndexEntry, SafetyArtifactStore,
-};
+use kukuri_cn_core::{IndexEntryStore, IndexScopeKind, MemoryIndexEntryStore, NewIndexEntry};
 use kukuri_cn_indexer::{ArcadeDbConfig, ArcadeDbRelationGraph, analyze_relations, topic_cluster};
 use kukuri_cn_safety::provider::SubjectKind;
 use kukuri_cn_safety::{ReasonCode, SafetyAction, SafetyVerdict};
+use kukuri_cn_safety_runtime::{MemorySafetyArtifactStore, SafetyArtifactStore};
 use kukuri_cn_trust::relation_testing::assert_relation_store_contracts;
 use kukuri_cn_trust::{
     FEATURE_CO_PARTICIPATION_EVENTS, FEATURE_SHARED_TOPICS, MemoryRelationStore, RelationStore,

--- a/crates/cn-safety-runtime/Cargo.toml
+++ b/crates/cn-safety-runtime/Cargo.toml
@@ -9,6 +9,8 @@ name = "kukuri_cn_safety_runtime"
 path = "src/lib.rs"
 
 [dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
 chrono.workspace = true
 hex.workspace = true
 kukuri-cn-safety = { path = "../cn-safety" }

--- a/crates/cn-safety-runtime/src/lib.rs
+++ b/crates/cn-safety-runtime/src/lib.rs
@@ -30,6 +30,7 @@ pub mod clock;
 pub mod error;
 pub mod id;
 pub mod orchestrator;
+pub mod service;
 pub mod signer;
 
 pub use clock::{ScanClock, SystemScanClock};
@@ -37,6 +38,11 @@ pub use error::SafetyRuntimeError;
 pub use id::{EventIdGenerator, UuidEventIdGenerator};
 pub use orchestrator::{
     SafetyOrchestrator, SafetyOrchestratorBuilder, SafetyScanReport, map_scan_error,
+};
+pub use service::{
+    MemorySafetyArtifactStore, SafetyArtifactStore, SafetyRuntimeConfig,
+    SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig, SafetyScanOutcome, SafetyScanService,
+    SafetyScanServiceBuilder, build_safety_scan_service,
 };
 pub use signer::{
     SAFETY_SIGNING_KEY_ENV, Secp256k1ModerationEventSigner, SignatureError, SignerKeyError,

--- a/crates/cn-safety-runtime/src/service.rs
+++ b/crates/cn-safety-runtime/src/service.rs
@@ -1,0 +1,375 @@
+//! DB非依存の safety scan service と構築境界。
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+
+use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
+use kukuri_cn_safety::{
+    ModerationEventSigner, SafetyProvider, SafetyRiskSignal, SafetyVerdict, SignedModerationEvent,
+    issue_signed_event,
+};
+
+use crate::{
+    SAFETY_SIGNING_KEY_ENV, SafetyOrchestrator, SafetyScanReport, Secp256k1ModerationEventSigner,
+    SystemScanClock, UuidEventIdGenerator,
+};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SafetyRuntimeProvidersConfig {
+    pub known_csam: Option<SafetyRuntimeProviderEntry>,
+    pub general: Option<SafetyRuntimeProviderEntry>,
+    pub unknown_csam: Option<SafetyRuntimeProviderEntry>,
+}
+
+impl SafetyRuntimeProvidersConfig {
+    pub fn is_empty(&self) -> bool {
+        self.known_csam.is_none() && self.general.is_none() && self.unknown_csam.is_none()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SafetyRuntimeProviderEntry {
+    pub provider: String,
+    pub required: bool,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SafetyRuntimeConfig {
+    pub providers: SafetyRuntimeProvidersConfig,
+    pub signing_key: Option<String>,
+    pub emit_signed_events: bool,
+    pub issuer_node_id: Option<String>,
+}
+
+impl Default for SafetyRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            providers: SafetyRuntimeProvidersConfig::default(),
+            signing_key: None,
+            emit_signed_events: true,
+            issuer_node_id: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for SafetyRuntimeConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SafetyRuntimeConfig")
+            .field("providers", &self.providers)
+            .field(
+                "signing_key",
+                &self.signing_key.as_ref().map(|_| "<redacted>"),
+            )
+            .field("emit_signed_events", &self.emit_signed_events)
+            .field("issuer_node_id", &self.issuer_node_id)
+            .finish()
+    }
+}
+
+#[async_trait]
+pub trait SafetyArtifactStore: Send + Sync {
+    async fn persist_event(&self, event: &SignedModerationEvent) -> Result<()>;
+
+    async fn persist_signal(
+        &self,
+        issuer_node_id: &str,
+        signal: &SafetyRiskSignal,
+    ) -> Result<String>;
+
+    async fn persist_verdict(
+        &self,
+        subject_kind: SubjectKind,
+        subject_id: &str,
+        verdict: &SafetyVerdict,
+    ) -> Result<String>;
+}
+
+#[derive(Debug, Default)]
+pub struct MemorySafetyArtifactStore {
+    events: Mutex<Vec<SignedModerationEvent>>,
+    signals: Mutex<Vec<(String, SafetyRiskSignal)>>,
+    verdicts: Mutex<HashMap<(String, String), (String, SafetyVerdict)>>,
+}
+
+impl MemorySafetyArtifactStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn events(&self) -> Vec<SignedModerationEvent> {
+        self.events.lock().expect("events mutex poisoned").clone()
+    }
+
+    pub fn signals(&self) -> Vec<(String, SafetyRiskSignal)> {
+        self.signals.lock().expect("signals mutex poisoned").clone()
+    }
+
+    pub fn verdict_for(
+        &self,
+        subject_kind: SubjectKind,
+        subject_id: &str,
+    ) -> Option<(String, SafetyVerdict)> {
+        self.verdicts
+            .lock()
+            .expect("verdicts mutex poisoned")
+            .get(&(subject_kind_key(subject_kind), subject_id.to_string()))
+            .cloned()
+    }
+
+    pub fn verdict_by_id(&self, verdict_id: &str) -> Option<SafetyVerdict> {
+        self.verdicts
+            .lock()
+            .expect("verdicts mutex poisoned")
+            .values()
+            .find(|(id, _)| id == verdict_id)
+            .map(|(_, verdict)| verdict.clone())
+    }
+}
+
+fn subject_kind_key(subject_kind: SubjectKind) -> String {
+    match subject_kind {
+        SubjectKind::Post => "post",
+        SubjectKind::Blob => "blob",
+        SubjectKind::User => "user",
+        SubjectKind::Peer => "peer",
+    }
+    .to_string()
+}
+
+#[async_trait]
+impl SafetyArtifactStore for MemorySafetyArtifactStore {
+    async fn persist_event(&self, event: &SignedModerationEvent) -> Result<()> {
+        self.events
+            .lock()
+            .expect("events mutex poisoned")
+            .push(event.clone());
+        Ok(())
+    }
+
+    async fn persist_signal(
+        &self,
+        issuer_node_id: &str,
+        signal: &SafetyRiskSignal,
+    ) -> Result<String> {
+        let mut signals = self.signals.lock().expect("signals mutex poisoned");
+        let id = format!("memory-signal-{}", signals.len() + 1);
+        signals.push((issuer_node_id.to_string(), signal.clone()));
+        Ok(id)
+    }
+
+    async fn persist_verdict(
+        &self,
+        subject_kind: SubjectKind,
+        subject_id: &str,
+        verdict: &SafetyVerdict,
+    ) -> Result<String> {
+        if subject_id.trim().is_empty() {
+            bail!("scan verdict subject_id must not be empty");
+        }
+        let mut verdicts = self.verdicts.lock().expect("verdicts mutex poisoned");
+        let key = (subject_kind_key(subject_kind), subject_id.to_string());
+        let next_id = format!("memory-verdict-{}", verdicts.len() + 1);
+        let (id, stored) = verdicts
+            .entry(key)
+            .or_insert_with(|| (next_id, verdict.clone()));
+        *stored = verdict.clone();
+        Ok(id.clone())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SafetyScanOutcome {
+    pub report: SafetyScanReport,
+    pub signed_event: Option<SignedModerationEvent>,
+    pub persisted_signal_id: Option<String>,
+    pub verdict_id: Option<String>,
+}
+
+pub struct SafetyScanService {
+    orchestrator: Arc<SafetyOrchestrator>,
+    signer: Option<Arc<dyn ModerationEventSigner + Send + Sync>>,
+    store: Arc<dyn SafetyArtifactStore>,
+    issuer_node_id: String,
+}
+
+impl std::fmt::Debug for SafetyScanService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SafetyScanService")
+            .field("issuer_node_id", &self.issuer_node_id)
+            .field("has_signer", &self.signer.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl SafetyScanService {
+    pub fn builder(
+        orchestrator: Arc<SafetyOrchestrator>,
+        store: Arc<dyn SafetyArtifactStore>,
+    ) -> SafetyScanServiceBuilder {
+        SafetyScanServiceBuilder {
+            orchestrator,
+            store,
+            signer: None,
+            unsigned_issuer: None,
+        }
+    }
+
+    pub fn issuer_node_id(&self) -> &str {
+        &self.issuer_node_id
+    }
+
+    pub async fn scan_and_record(
+        &self,
+        request: &ProviderScanRequest,
+    ) -> Result<SafetyScanOutcome> {
+        let report = self.orchestrator.scan_subject(request).await;
+        let verdict_id = match (request.subject_kind, request.subject_id.as_deref()) {
+            (Some(kind), Some(subject_id)) if !subject_id.trim().is_empty() => Some(
+                self.store
+                    .persist_verdict(kind, subject_id, &report.verdict)
+                    .await
+                    .context("failed to persist scan verdict state")?,
+            ),
+            _ => None,
+        };
+        let persisted_signal_id = match report.risk_signal.as_ref() {
+            Some(signal) => Some(
+                self.store
+                    .persist_signal(&self.issuer_node_id, signal)
+                    .await
+                    .context("failed to persist safety risk signal")?,
+            ),
+            None => None,
+        };
+        let signed_event = match (report.moderation_event.as_ref(), self.signer.as_ref()) {
+            (Some(body), Some(signer)) => {
+                let event = issue_signed_event(body.clone(), signer.as_ref());
+                self.store
+                    .persist_event(&event)
+                    .await
+                    .context("failed to persist signed moderation event")?;
+                Some(event)
+            }
+            _ => None,
+        };
+        Ok(SafetyScanOutcome {
+            report,
+            signed_event,
+            persisted_signal_id,
+            verdict_id,
+        })
+    }
+}
+
+pub struct SafetyScanServiceBuilder {
+    orchestrator: Arc<SafetyOrchestrator>,
+    store: Arc<dyn SafetyArtifactStore>,
+    signer: Option<Arc<dyn ModerationEventSigner + Send + Sync>>,
+    unsigned_issuer: Option<String>,
+}
+
+impl SafetyScanServiceBuilder {
+    pub fn signer(mut self, signer: Arc<dyn ModerationEventSigner + Send + Sync>) -> Self {
+        self.signer = Some(signer);
+        self
+    }
+
+    pub fn without_signed_events(mut self, issuer_node_id: impl Into<String>) -> Self {
+        self.unsigned_issuer = Some(issuer_node_id.into());
+        self
+    }
+
+    pub fn build(self) -> Result<SafetyScanService> {
+        let (signer, issuer_node_id) = match (self.signer, self.unsigned_issuer) {
+            (Some(signer), None) => {
+                let issuer = signer.issuer_node_id().to_string();
+                (Some(signer), issuer)
+            }
+            (None, Some(issuer)) => {
+                let issuer = issuer.trim().to_string();
+                if issuer.is_empty() {
+                    bail!("safety scan service issuer_node_id must not be empty");
+                }
+                (None, issuer)
+            }
+            (None, None) => bail!(
+                "signed moderation events are enabled but no signer is configured (set \
+                 {SAFETY_SIGNING_KEY_ENV}, or disable emission explicitly with \
+                 without_signed_events)"
+            ),
+            (Some(_), Some(_)) => {
+                bail!("safety scan service cannot both sign moderation events and disable emission")
+            }
+        };
+        Ok(SafetyScanService {
+            orchestrator: self.orchestrator,
+            signer,
+            store: self.store,
+            issuer_node_id,
+        })
+    }
+}
+
+pub fn build_safety_scan_service(
+    config: &SafetyRuntimeConfig,
+    providers: Vec<Arc<dyn SafetyProvider>>,
+    store: Arc<dyn SafetyArtifactStore>,
+) -> Result<Option<SafetyScanService>> {
+    if config.providers.is_empty() {
+        if !providers.is_empty() {
+            bail!("resolved safety providers do not match an empty runtime configuration");
+        }
+        return Ok(None);
+    }
+    if providers.is_empty() {
+        bail!("no resolved safety providers; refusing to build a scan service (fail-closed)");
+    }
+
+    let signer = match config.signing_key.as_deref() {
+        Some(secret) => Some(
+            Secp256k1ModerationEventSigner::from_secret(secret)
+                .context("invalid moderation event signing key")?,
+        ),
+        None => None,
+    };
+    let issuer = match (
+        &signer,
+        config.emit_signed_events,
+        config.issuer_node_id.as_deref(),
+    ) {
+        (Some(signer), _, _) => signer.issuer_node_id().to_string(),
+        (None, true, _) => bail!(
+            "signed moderation events are enabled but no signing key is configured (set \
+             {SAFETY_SIGNING_KEY_ENV} from Secret Manager, or disable \
+             safety.events.emit_signed_moderation_events)"
+        ),
+        (None, false, Some(issuer)) if !issuer.trim().is_empty() => issuer.trim().to_string(),
+        (None, false, _) => bail!(
+            "signed moderation events are disabled and no issuer node id is available (set a \
+             signing key or an explicit issuer node id)"
+        ),
+    };
+
+    let mut orchestrator = SafetyOrchestrator::builder(
+        &issuer,
+        Arc::new(SystemScanClock::new()),
+        Arc::new(UuidEventIdGenerator::new()),
+    );
+    for provider in providers {
+        orchestrator = orchestrator.provider(provider);
+    }
+    let orchestrator = Arc::new(
+        orchestrator
+            .build()
+            .context("failed to build safety orchestrator")?,
+    );
+    let builder = SafetyScanService::builder(orchestrator, store);
+    let service = match signer {
+        Some(signer) if config.emit_signed_events => builder.signer(Arc::new(signer)).build()?,
+        _ => builder.without_signed_events(issuer).build()?,
+    };
+    Ok(Some(service))
+}

--- a/crates/cn-user-api/Cargo.toml
+++ b/crates/cn-user-api/Cargo.toml
@@ -32,6 +32,7 @@ kukuri-cn-trust = { path = "../cn-trust" }
 [dev-dependencies]
 kukuri-test-support = { path = "../test-support" }
 kukuri-core = { path = "../core" }
+kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 hex.workspace = true
 reqwest.workspace = true
 redis.workspace = true

--- a/crates/cn-user-api/tests/index_query.rs
+++ b/crates/cn-user-api/tests/index_query.rs
@@ -14,13 +14,14 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use kukuri_cn_core::{
-    IndexEntryStore, IndexScopeKind, JwtConfig, MemoryIndexEntryStore, MemorySafetyArtifactStore,
-    NewIndexEntry, SafetyArtifactStore, TestDatabase, build_auth_envelope_json,
+    IndexEntryStore, IndexScopeKind, JwtConfig, MemoryIndexEntryStore, NewIndexEntry, TestDatabase,
+    build_auth_envelope_json,
 };
 use kukuri_cn_indexer::projection::{IndexProjection, IndexedEntry, MemoryIndexProjection};
 use kukuri_cn_indexer::query::FailClosedIndexQuery;
 use kukuri_cn_safety::provider::SubjectKind;
 use kukuri_cn_safety::{ReasonCode, SafetyAction, SafetyVerdict};
+use kukuri_cn_safety_runtime::{MemorySafetyArtifactStore, SafetyArtifactStore};
 use kukuri_cn_user_api::{UserApiConfig, app_router, build_state};
 use kukuri_core::{KukuriKeys, generate_keys};
 use reqwest::{Client, StatusCode};


### PR DESCRIPTION
## Summary
- move DB-independent safety runtime config, artifact-store contract, memory store, scan service, and service composition into `cn-safety-runtime`
- leave only the PostgreSQL artifact store and concrete provider resolution in `cn-core`
- make `cn-indexer` the composition root and update all consumers to import generic runtime types from their owner

## Invariants
- provider/signing/persistence failures remain fail-closed
- PostgreSQL schema, provider credentials, signatures, verdict semantics, and index gates are unchanged
- `cn-safety-runtime` does not depend on `cn-core`

## Validation
- cargo test -p kukuri-cn-safety-runtime
- cargo test -p kukuri-cn-core --features safety-mock-provider,safety-arachnid-provider --test safety_runtime
- cargo test -p kukuri-cn-indexer
- cargo clippy -p kukuri-cn-safety-runtime -p kukuri-cn-core -p kukuri-cn-indexer --all-targets --all-features -- -D warnings
- cargo xtask cn-check
- cargo xtask cn-test
- cargo xtask oversized-files