### PR TITLE
refactor: centralize CN tracing setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,6 +3004,7 @@ dependencies = [
  "futures-util",
  "hex",
  "kukuri-cn-core",
+ "kukuri-cn-runtime-support",
  "kukuri-cn-safety",
  "kukuri-cn-safety-runtime",
  "kukuri-cn-trust",
@@ -3017,7 +3018,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3026,12 +3026,12 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "iroh-relay",
+ "kukuri-cn-runtime-support",
  "rcgen",
  "rustls",
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3059,6 +3059,13 @@ dependencies = [
  "serde_json",
  "ts-rs",
  "url",
+]
+
+[[package]]
+name = "kukuri-cn-runtime-support"
+version = "0.1.2"
+dependencies = [
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3132,6 +3139,7 @@ dependencies = [
  "kukuri-cn-indexer",
  "kukuri-cn-operator",
  "kukuri-cn-protocol",
+ "kukuri-cn-runtime-support",
  "kukuri-cn-safety",
  "kukuri-cn-safety-runtime",
  "kukuri-cn-trust",
@@ -3148,7 +3156,6 @@ dependencies = [
  "tower-http",
  "tower_governor",
  "tracing",
- "tracing-subscriber",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/cn-safety",
     "crates/cn-safety-arachnid",
     "crates/cn-safety-runtime",
+    "crates/cn-runtime-support",
     "crates/cn-trust",
     "crates/cn-indexer",
 ]

--- a/crates/cn-indexer/Cargo.toml
+++ b/crates/cn-indexer/Cargo.toml
@@ -24,7 +24,7 @@ serde_json.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
+kukuri-cn-runtime-support = { path = "../cn-runtime-support" }
 kukuri-core = { path = "../core" }
 kukuri-docs-sync = { path = "../docs-sync" }
 # safety-mock-provider: 本番 provider 未使用構成でも runtime 構築（provider 実装名 `mock`）と

--- a/crates/cn-indexer/src/runtime.rs
+++ b/crates/cn-indexer/src/runtime.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use tracing::info;
-use tracing_subscriber::EnvFilter;
 
 use kukuri_cn_core::PgSafetyArtifactStore;
 
@@ -80,10 +79,5 @@ async fn run(config: IndexerConfig) -> Result<()> {
 }
 
 fn init_tracing() {
-    let env_filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new("info,kukuri_cn_indexer=debug"));
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(env_filter)
-        .with_target(true)
-        .try_init();
+    kukuri_cn_runtime_support::init_tracing("info,kukuri_cn_indexer=debug");
 }

--- a/crates/cn-iroh-relay/Cargo.toml
+++ b/crates/cn-iroh-relay/Cargo.toml
@@ -14,7 +14,7 @@ iroh-relay.workspace = true
 rustls.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
+kukuri-cn-runtime-support = { path = "../cn-runtime-support" }
 
 [dev-dependencies]
 rcgen = "0.14"

--- a/crates/cn-iroh-relay/src/lib.rs
+++ b/crates/cn-iroh-relay/src/lib.rs
@@ -11,7 +11,6 @@ use iroh_relay::server::{
 };
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use tracing_subscriber::EnvFilter;
 
 const DEFAULT_HTTP_BIND_ADDR: &str = "127.0.0.1:3340";
 const DEFAULT_TLS_CERT_PATH: &str = "/certs/default.crt";
@@ -161,12 +160,7 @@ pub async fn spawn_server(config: IrohRelayConfig) -> Result<SpawnedIrohRelay> {
 }
 
 pub fn init_tracing() {
-    let env_filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new("info,kukuri_cn_iroh_relay=debug"));
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(env_filter)
-        .with_target(true)
-        .try_init();
+    kukuri_cn_runtime_support::init_tracing("info,kukuri_cn_iroh_relay=debug");
 }
 
 fn parse_tls_config_from_lookup<F>(lookup: &F) -> Result<Option<IrohRelayTlsConfig>>

--- a/crates/cn-runtime-support/Cargo.toml
+++ b/crates/cn-runtime-support/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kukuri-cn-runtime-support"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+tracing-subscriber.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cn-runtime-support/src/lib.rs
+++ b/crates/cn-runtime-support/src/lib.rs
@@ -1,0 +1,52 @@
+//! Community-node binaryに共通する軽量なruntime初期化helper。
+
+use tracing_subscriber::EnvFilter;
+
+/// `RUST_LOG`を優先し、未設定または不正ならbinary固有の既定filterでtracingを初期化する。
+///
+/// testや同一process内の複数runtimeから呼ばれても、既にsubscriberがある場合は成功扱いにする。
+pub fn init_tracing(default_filter: &str) {
+    let env_filter = select_env_filter(std::env::var("RUST_LOG").ok().as_deref(), default_filter);
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_target(true)
+        .try_init();
+}
+
+fn select_env_filter(rust_log: Option<&str>, default_filter: &str) -> EnvFilter {
+    rust_log
+        .and_then(|value| EnvFilter::try_new(value).ok())
+        .unwrap_or_else(|| EnvFilter::new(default_filter))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_log_overrides_binary_default() {
+        let filter = select_env_filter(Some("warn,my_crate=trace"), "info,binary=debug");
+        assert_eq!(
+            filter.to_string(),
+            EnvFilter::new("warn,my_crate=trace").to_string()
+        );
+    }
+
+    #[test]
+    fn missing_rust_log_uses_binary_default() {
+        let filter = select_env_filter(None, "info,binary=debug");
+        assert_eq!(
+            filter.to_string(),
+            EnvFilter::new("info,binary=debug").to_string()
+        );
+    }
+
+    #[test]
+    fn invalid_rust_log_uses_binary_default() {
+        let filter = select_env_filter(Some("[invalid"), "info,binary=debug");
+        assert_eq!(
+            filter.to_string(),
+            EnvFilter::new("info,binary=debug").to_string()
+        );
+    }
+}

--- a/crates/cn-user-api/Cargo.toml
+++ b/crates/cn-user-api/Cargo.toml
@@ -19,7 +19,6 @@ tokio.workspace = true
 tower-http.workspace = true
 tower_governor.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 thiserror.workspace = true
 url.workspace = true
 kukuri-cn-protocol = { path = "../cn-protocol" }
@@ -28,6 +27,7 @@ kukuri-cn-indexer = { path = "../cn-indexer" }
 kukuri-cn-operator = { path = "../cn-operator" }
 kukuri-cn-safety = { path = "../cn-safety" }
 kukuri-cn-trust = { path = "../cn-trust" }
+kukuri-cn-runtime-support = { path = "../cn-runtime-support" }
 
 [dev-dependencies]
 kukuri-test-support = { path = "../test-support" }

--- a/crates/cn-user-api/src/routes.rs
+++ b/crates/cn-user-api/src/routes.rs
@@ -18,7 +18,6 @@ use kukuri_cn_protocol::{
 };
 use serde_json::{Value, json};
 use tower_http::trace::TraceLayer;
-use tracing_subscriber::EnvFilter;
 
 use crate::config::{RateLimitConfig, UserApiConfig};
 use crate::handlers::auth::{auth_challenge, auth_verify};
@@ -135,12 +134,7 @@ pub async fn run_from_env() -> Result<()> {
 }
 
 pub fn init_tracing() {
-    let env_filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new("info,kukuri_cn_user_api=debug"));
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(env_filter)
-        .with_target(true)
-        .try_init();
+    kukuri_cn_runtime_support::init_tracing("info,kukuri_cn_user_api=debug");
 }
 
 async fn healthz() -> Json<Value> {


### PR DESCRIPTION
## Summary
- add a dependency-light `kukuri-cn-runtime-support` crate for shared tracing initialization
- preserve each binary's existing fallback filter while honoring valid `RUST_LOG`
- remove duplicate subscriber construction from cn-user-api, cn-iroh-relay, and cn-indexer

## Validation
- cargo test -p kukuri-cn-runtime-support
- cargo test -p kukuri-cn-user-api -p kukuri-cn-iroh-relay -p kukuri-cn-indexer
- cargo clippy -p kukuri-cn-runtime-support -p kukuri-cn-user-api -p kukuri-cn-iroh-relay -p kukuri-cn-indexer --all-targets -- -D warnings
- cargo xtask cn-check
- cargo xtask rust-check
- cargo xtask oversized-files