### PR TITLE
test: cover cn-cli timestamp helpers

### DIFF
--- a/crates/cn-cli/src/lib.rs
+++ b/crates/cn-cli/src/lib.rs
@@ -1,0 +1,68 @@
+//! `cn-cli`のDB非依存な入力変換・表示helper。
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+
+/// Epoch秒をRFC3339へ整形する。表現不能な値は従来どおり数値文字列へfallbackする。
+pub fn format_timestamp(timestamp: i64) -> String {
+    DateTime::<Utc>::from_timestamp(timestamp, 0)
+        .map(|value| value.to_rfc3339())
+        .unwrap_or_else(|| timestamp.to_string())
+}
+
+/// Epoch秒またはRFC3339を認証rollout/admission用のepoch秒へ変換する。
+pub fn parse_enforce_at(value: &str) -> Result<i64> {
+    if let Ok(timestamp) = value.parse::<i64>() {
+        return Ok(timestamp);
+    }
+    let parsed = DateTime::parse_from_rfc3339(value)
+        .with_context(|| format!("failed to parse RFC3339 timestamp `{value}`"))?;
+    Ok(parsed.with_timezone(&Utc).timestamp())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_enforce_at_accepts_epoch_boundaries() {
+        assert_eq!(parse_enforce_at("0").unwrap(), 0);
+        assert_eq!(parse_enforce_at("-1").unwrap(), -1);
+        assert_eq!(parse_enforce_at(&i64::MAX.to_string()).unwrap(), i64::MAX);
+    }
+
+    #[test]
+    fn parse_enforce_at_normalizes_rfc3339_offsets() {
+        assert_eq!(
+            parse_enforce_at("2026-07-11T23:30:00+09:00").unwrap(),
+            parse_enforce_at("2026-07-11T14:30:00Z").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_enforce_at_rejects_blank_and_invalid_values() {
+        for value in ["", "tomorrow", "2026-07-11"] {
+            let error = parse_enforce_at(value).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("failed to parse RFC3339 timestamp")
+            );
+        }
+    }
+
+    #[test]
+    fn format_timestamp_uses_rfc3339_or_numeric_fallback() {
+        assert_eq!(format_timestamp(0), "1970-01-01T00:00:00+00:00");
+        assert_eq!(format_timestamp(i64::MAX), i64::MAX.to_string());
+    }
+
+    #[test]
+    fn parse_and_format_round_trip_representable_seconds() {
+        let timestamp = parse_enforce_at("2026-07-11T14:30:00Z").unwrap();
+        assert_eq!(
+            parse_enforce_at(&format_timestamp(timestamp)).unwrap(),
+            timestamp
+        );
+    }
+}

--- a/crates/cn-cli/src/main.rs
+++ b/crates/cn-cli/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand, ValueEnum};
+use kukuri_cn_cli::{format_timestamp, parse_enforce_at};
 use kukuri_cn_core::{
     AdmissionMode, AuthMode, AuthRolloutConfig, COMMUNITY_NODE_AUTH_SERVICE_NAME, IndexScopeKind,
     IndexingRequestStatus, PgCoParticipationSource, add_allowlist, add_supported_topic,
@@ -628,19 +629,4 @@ async fn run_admission(pool: &sqlx::PgPool, action: AdmissionAction) -> Result<(
         },
     }
     Ok(())
-}
-
-fn format_timestamp(timestamp: i64) -> String {
-    DateTime::<Utc>::from_timestamp(timestamp, 0)
-        .map(|value| value.to_rfc3339())
-        .unwrap_or_else(|| timestamp.to_string())
-}
-
-fn parse_enforce_at(value: &str) -> Result<i64> {
-    if let Ok(timestamp) = value.parse::<i64>() {
-        return Ok(timestamp);
-    }
-    let parsed = DateTime::parse_from_rfc3339(value)
-        .with_context(|| format!("failed to parse RFC3339 timestamp `{value}`"))?;
-    Ok(parsed.with_timezone(&Utc).timestamp())
 }


### PR DESCRIPTION
## Summary
- move cn-cli timestamp parsing and formatting into a DB-independent library boundary
- cover epoch boundaries, RFC3339 offset normalization, invalid input, fallback formatting, and round trips
- keep command names, arguments, output, and database behavior unchanged

## Validation
- cargo test -p kukuri-cn-cli
- cargo clippy -p kukuri-cn-cli --all-targets -- -D warnings
- cargo run -p kukuri-cn-cli -- --help