### PR TITLE
refactor: split cn-cli command modules

### DIFF
--- a/crates/cn-cli/src/commands/admission.rs
+++ b/crates/cn-cli/src/commands/admission.rs
@@ -1,0 +1,157 @@
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+
+use kukuri_cn_cli::{format_timestamp, parse_enforce_at};
+use kukuri_cn_core::{
+    AdmissionMode, add_allowlist, ban_subscriber, initialize_database, issue_invite_code,
+    list_allowlist, list_banned, list_invite_codes, load_admission_config, remove_allowlist,
+    revoke_invite_code, set_admission_mode, unban_subscriber,
+};
+
+use crate::{AdmissionAction, AllowAction, BanAction, InviteAction};
+
+pub(super) async fn run(pool: &PgPool, action: AdmissionAction) -> Result<()> {
+    initialize_database(pool).await?;
+    match action {
+        AdmissionAction::Show => {
+            let config = load_admission_config(pool).await?;
+            println!("admission mode: {}", config.mode.as_str());
+        }
+        AdmissionAction::SetMode { mode } => {
+            let mode = AdmissionMode::from(mode);
+            set_admission_mode(pool, mode).await?;
+            println!("admission mode updated: {}", mode.as_str());
+        }
+        AdmissionAction::Invite { action } => run_invite(pool, action).await?,
+        AdmissionAction::Allow { action } => run_allow(pool, action).await?,
+        AdmissionAction::Ban { action } => run_ban(pool, action).await?,
+    }
+    Ok(())
+}
+
+async fn run_invite(pool: &PgPool, action: InviteAction) -> Result<()> {
+    match action {
+        InviteAction::Issue {
+            label,
+            max_uses,
+            expires_at,
+        } => {
+            let expires_at = expires_at
+                .map(|value| parse_enforce_at(value.as_str()))
+                .transpose()?
+                .map(|timestamp| {
+                    DateTime::<Utc>::from_timestamp(timestamp, 0)
+                        .context("invalid expires_at timestamp")
+                })
+                .transpose()?;
+            let code = issue_invite_code(pool, label.as_deref(), max_uses, expires_at).await?;
+            println!("invite code issued (store it now; it will not be shown again):");
+            println!("{code}");
+        }
+        InviteAction::List => {
+            let codes = list_invite_codes(pool).await?;
+            if codes.is_empty() {
+                println!("no invite codes");
+            } else {
+                println!("{} invite code(s):", codes.len());
+                for code in codes {
+                    let max_uses = code
+                        .max_uses
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "unlimited".to_string());
+                    let expires_at = code
+                        .expires_at
+                        .map(format_timestamp)
+                        .unwrap_or_else(|| "never".to_string());
+                    let revoked_at = code
+                        .revoked_at
+                        .map(format_timestamp)
+                        .unwrap_or_else(|| "-".to_string());
+                    println!(
+                        "{}  uses={}/{}  expires={}  revoked={}  label={}",
+                        code.code_hash,
+                        code.used_count,
+                        max_uses,
+                        expires_at,
+                        revoked_at,
+                        code.label.as_deref().unwrap_or("-"),
+                    );
+                }
+            }
+        }
+        InviteAction::Revoke { code } => {
+            if revoke_invite_code(pool, code.as_str()).await? {
+                println!("invite code revoked");
+            } else {
+                println!("invite code not found or already revoked");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_allow(pool: &PgPool, action: AllowAction) -> Result<()> {
+    match action {
+        AllowAction::Add { pubkey, label } => {
+            add_allowlist(pool, pubkey.as_str(), label.as_deref()).await?;
+            println!("allowlisted {pubkey}");
+        }
+        AllowAction::Remove { pubkey } => {
+            if remove_allowlist(pool, pubkey.as_str()).await? {
+                println!("removed {pubkey} from allowlist");
+            } else {
+                println!("{pubkey} was not on the allowlist");
+            }
+        }
+        AllowAction::List => {
+            let entries = list_allowlist(pool).await?;
+            if entries.is_empty() {
+                println!("allowlist is empty");
+            } else {
+                println!("{} allowlisted pubkey(s):", entries.len());
+                for entry in entries {
+                    println!(
+                        "{}  created={}  label={}",
+                        entry.pubkey,
+                        format_timestamp(entry.created_at),
+                        entry.label.as_deref().unwrap_or("-"),
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_ban(pool: &PgPool, action: BanAction) -> Result<()> {
+    match action {
+        BanAction::Add { pubkey } => {
+            ban_subscriber(pool, pubkey.as_str()).await?;
+            println!("banned {pubkey}");
+        }
+        BanAction::Remove { pubkey } => {
+            if unban_subscriber(pool, pubkey.as_str()).await? {
+                println!("unbanned {pubkey}");
+            } else {
+                println!("{pubkey} was not banned");
+            }
+        }
+        BanAction::List => {
+            let entries = list_banned(pool).await?;
+            if entries.is_empty() {
+                println!("no banned subscribers");
+            } else {
+                println!("{} banned subscriber(s):", entries.len());
+                for entry in entries {
+                    println!(
+                        "{}  created={}",
+                        entry.pubkey,
+                        format_timestamp(entry.created_at)
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cn-cli/src/commands/database.rs
+++ b/crates/cn-cli/src/commands/database.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use sqlx::PgPool;
+
+use kukuri_cn_cli::parse_enforce_at;
+use kukuri_cn_core::{
+    AuthMode, AuthRolloutConfig, initialize_database, migrate_postgres, seed_default_policies,
+    store_auth_rollout,
+};
+
+use crate::AuthModeArg;
+
+pub(super) async fn prepare(pool: &PgPool) -> Result<()> {
+    initialize_database(pool).await?;
+    println!("database prepared");
+    Ok(())
+}
+
+pub(super) async fn migrate(pool: &PgPool) -> Result<()> {
+    migrate_postgres(pool).await?;
+    println!("migrations applied");
+    Ok(())
+}
+
+pub(super) async fn seed_policies(pool: &PgPool) -> Result<()> {
+    initialize_database(pool).await?;
+    seed_default_policies(pool).await?;
+    println!("policies seeded");
+    Ok(())
+}
+
+pub(super) async fn set_auth_rollout(
+    pool: &PgPool,
+    service: String,
+    mode: AuthModeArg,
+    enforce_at: Option<String>,
+    grace_seconds: i64,
+    ws_auth_timeout_seconds: i64,
+) -> Result<()> {
+    migrate_postgres(pool).await?;
+    let rollout = AuthRolloutConfig {
+        mode: match mode {
+            AuthModeArg::Off => AuthMode::Off,
+            AuthModeArg::Required => AuthMode::Required,
+        },
+        enforce_at: enforce_at
+            .map(|value| parse_enforce_at(value.as_str()))
+            .transpose()?,
+        grace_seconds,
+        ws_auth_timeout_seconds,
+    };
+    store_auth_rollout(pool, service.as_str(), &rollout).await?;
+    println!(
+        "auth rollout updated service={} mode={:?} enforce_at={:?} grace_seconds={} ws_auth_timeout_seconds={}",
+        service,
+        rollout.mode,
+        rollout.enforce_at,
+        rollout.grace_seconds,
+        rollout.ws_auth_timeout_seconds
+    );
+    Ok(())
+}

--- a/crates/cn-cli/src/commands/indexing.rs
+++ b/crates/cn-cli/src/commands/indexing.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use sqlx::PgPool;
+
+use kukuri_cn_core::{
+    IndexScopeKind, IndexingRequestStatus, add_supported_topic, approve_indexing_request,
+    initialize_database, list_indexing_requests, list_supported_topics, reject_indexing_request,
+    remove_supported_topic,
+};
+
+use crate::{IndexingRequestAction, SupportedTopicAction};
+
+pub(super) async fn run_supported_topic(pool: &PgPool, action: SupportedTopicAction) -> Result<()> {
+    initialize_database(pool).await?;
+    match action {
+        SupportedTopicAction::Add { kind, id } => {
+            let kind = IndexScopeKind::from(kind);
+            let entry = add_supported_topic(pool, kind, id.as_str()).await?;
+            println!(
+                "supported topic added: {} {}",
+                entry.kind.as_str(),
+                entry.id
+            );
+        }
+        SupportedTopicAction::Remove { kind, id } => {
+            let kind = IndexScopeKind::from(kind);
+            if remove_supported_topic(pool, kind, id.as_str()).await? {
+                println!("supported topic removed: {} {}", kind.as_str(), id);
+            } else {
+                println!("supported topic not found: {} {}", kind.as_str(), id);
+            }
+        }
+        SupportedTopicAction::List => {
+            let entries = list_supported_topics(pool).await?;
+            if entries.is_empty() {
+                println!("no supported topics");
+            } else {
+                println!("{} supported topic(s):", entries.len());
+                for entry in entries {
+                    println!(
+                        "{}  {}  {}",
+                        entry.created_at.to_rfc3339(),
+                        entry.kind.as_str(),
+                        entry.id,
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) async fn run_indexing_request(
+    pool: &PgPool,
+    action: IndexingRequestAction,
+) -> Result<()> {
+    initialize_database(pool).await?;
+    match action {
+        IndexingRequestAction::List {
+            status,
+            limit,
+            offset,
+        } => {
+            let status = status.map(IndexingRequestStatus::from);
+            let requests = list_indexing_requests(pool, status, limit, offset).await?;
+            if requests.is_empty() {
+                println!("no indexing requests");
+            } else {
+                println!("{} indexing request(s):", requests.len());
+                for request in requests {
+                    println!(
+                        "{}  {}  {}/{}  requester={}  status={}",
+                        request.created_at.to_rfc3339(),
+                        request.id,
+                        request.kind.as_str(),
+                        request.target_id,
+                        request.requester_pubkey,
+                        request.status.as_str(),
+                    );
+                }
+            }
+        }
+        IndexingRequestAction::Approve { id } => {
+            match approve_indexing_request(pool, id.as_str()).await? {
+                Some(request) => println!(
+                    "indexing request approved: {} ({} {} now supported)",
+                    request.id,
+                    request.kind.as_str(),
+                    request.target_id,
+                ),
+                None => println!("indexing request not found: {id}"),
+            }
+        }
+        IndexingRequestAction::Reject { id } => {
+            match reject_indexing_request(pool, id.as_str()).await? {
+                Some(request) => println!("indexing request rejected: {}", request.id),
+                None => println!("indexing request not found: {id}"),
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/cn-cli/src/commands/mod.rs
+++ b/crates/cn-cli/src/commands/mod.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use sqlx::PgPool;
+
+use crate::Command;
+
+mod admission;
+mod database;
+mod indexing;
+mod relation;
+mod reports;
+
+pub(crate) async fn dispatch(pool: &PgPool, command: Command) -> Result<()> {
+    match command {
+        Command::Prepare => database::prepare(pool).await,
+        Command::Migrate => database::migrate(pool).await,
+        Command::SeedPolicies => database::seed_policies(pool).await,
+        Command::SetAuthRollout {
+            service,
+            mode,
+            enforce_at,
+            grace_seconds,
+            ws_auth_timeout_seconds,
+        } => {
+            database::set_auth_rollout(
+                pool,
+                service,
+                mode,
+                enforce_at,
+                grace_seconds,
+                ws_auth_timeout_seconds,
+            )
+            .await
+        }
+        Command::Reports { action } => reports::run(pool, action).await,
+        Command::Admission { action } => admission::run(pool, action).await,
+        Command::SupportedTopic { action } => indexing::run_supported_topic(pool, action).await,
+        Command::IndexingRequest { action } => indexing::run_indexing_request(pool, action).await,
+        Command::Relation { action } => relation::run(pool, action).await,
+    }
+}

--- a/crates/cn-cli/src/commands/relation.rs
+++ b/crates/cn-cli/src/commands/relation.rs
@@ -1,0 +1,27 @@
+use anyhow::{Context, Result};
+use sqlx::PgPool;
+
+use kukuri_cn_core::PgCoParticipationSource;
+use kukuri_cn_indexer::{ArcadeDbConfig, ArcadeDbRelationGraph, analyze_relations};
+
+use crate::RelationAction;
+
+pub(super) async fn run(pool: &PgPool, action: RelationAction) -> Result<()> {
+    match action {
+        RelationAction::Analyze { limit } => {
+            let source = PgCoParticipationSource::new(pool.clone());
+            let graph = ArcadeDbRelationGraph::new(ArcadeDbConfig::from_env())
+                .context("failed to build ArcadeDB relation graph client")?;
+            graph
+                .ensure_schema()
+                .await
+                .context("failed to ensure relation graph schema")?;
+            let report = analyze_relations(&source, &graph, limit).await?;
+            println!(
+                "relation analysis done: {} edge(s) upserted, {} cluster(s) assigned",
+                report.edges_upserted, report.clusters_assigned
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/cn-cli/src/commands/reports.rs
+++ b/crates/cn-cli/src/commands/reports.rs
@@ -1,0 +1,57 @@
+use anyhow::Result;
+use sqlx::PgPool;
+
+use kukuri_cn_core::{get_community_node_report, list_community_node_reports};
+
+use crate::ReportsAction;
+
+pub(super) async fn run(pool: &PgPool, action: ReportsAction) -> Result<()> {
+    match action {
+        ReportsAction::List { limit, offset } => {
+            let reports = list_community_node_reports(pool, limit, offset).await?;
+            if reports.is_empty() {
+                println!("no reports");
+            } else {
+                println!(
+                    "{} report(s) (limit={} offset={}):",
+                    reports.len(),
+                    limit,
+                    offset
+                );
+                for report in reports {
+                    println!(
+                        "{}  {}  {}/{}  capability={}  reason={}  status={}",
+                        report.created_at.to_rfc3339(),
+                        report.id,
+                        report.subject_kind,
+                        report.subject_id,
+                        report.capability,
+                        report.reason,
+                        report.status,
+                    );
+                }
+            }
+        }
+        ReportsAction::Show { id } => match get_community_node_report(pool, id.as_str()).await? {
+            Some(report) => {
+                println!("id:               {}", report.id);
+                println!("created_at:       {}", report.created_at.to_rfc3339());
+                println!("status:           {}", report.status);
+                println!("subject_kind:     {}", report.subject_kind);
+                println!("subject_id:       {}", report.subject_id);
+                println!("capability:       {}", report.capability);
+                println!("reason:           {}", report.reason);
+                println!(
+                    "details:          {}",
+                    report.details.as_deref().unwrap_or("-")
+                );
+                println!(
+                    "reporter_contact: {}",
+                    report.reporter_contact.as_deref().unwrap_or("-")
+                );
+            }
+            None => println!("report not found: {id}"),
+        },
+    }
+    Ok(())
+}

--- a/crates/cn-cli/src/main.rs
+++ b/crates/cn-cli/src/main.rs
@@ -1,18 +1,11 @@
-use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
+use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
-use kukuri_cn_cli::{format_timestamp, parse_enforce_at};
 use kukuri_cn_core::{
-    AdmissionMode, AuthMode, AuthRolloutConfig, COMMUNITY_NODE_AUTH_SERVICE_NAME, IndexScopeKind,
-    IndexingRequestStatus, PgCoParticipationSource, add_allowlist, add_supported_topic,
-    approve_indexing_request, ban_subscriber, connect_postgres, get_community_node_report,
-    initialize_database, issue_invite_code, list_allowlist, list_banned,
-    list_community_node_reports, list_indexing_requests, list_invite_codes, list_supported_topics,
-    load_admission_config, migrate_postgres, reject_indexing_request, remove_allowlist,
-    remove_supported_topic, revoke_invite_code, seed_default_policies, set_admission_mode,
-    store_auth_rollout, unban_subscriber,
+    AdmissionMode, COMMUNITY_NODE_AUTH_SERVICE_NAME, IndexScopeKind, IndexingRequestStatus,
+    connect_postgres,
 };
-use kukuri_cn_indexer::{ArcadeDbConfig, ArcadeDbRelationGraph, analyze_relations};
+
+mod commands;
 
 #[derive(Debug, Parser)]
 struct Cli {
@@ -68,12 +61,7 @@ enum Command {
 
 #[derive(Debug, Subcommand)]
 enum RelationAction {
-    /// index 真実源の co-participation 集計から relation graph を batch 解析する（非常駐、冪等）。
-    ///
-    /// 書き込み先は ArcadeDB の relation graph（`COMMUNITY_NODE_ARCADEDB_*` env）のみ。
-    /// social graph canonical / index 真実源は改変しない（ADR 0026 §2.2）。
     Analyze {
-        /// 読み込む集計行の上限（有界化）。
         #[arg(long, default_value_t = kukuri_cn_indexer::DEFAULT_ANALYSIS_LIMIT)]
         limit: usize,
     },
@@ -81,27 +69,23 @@ enum RelationAction {
 
 #[derive(Debug, Subcommand)]
 enum SupportedTopicAction {
-    /// supported set に scope を追加する。
     Add {
         #[arg(long)]
         kind: IndexScopeKindArg,
         #[arg(long)]
         id: String,
     },
-    /// supported set から scope を除去する。
     Remove {
         #[arg(long)]
         kind: IndexScopeKindArg,
         #[arg(long)]
         id: String,
     },
-    /// supported set を新着順で一覧する。
     List,
 }
 
 #[derive(Debug, Subcommand)]
 enum IndexingRequestAction {
-    /// indexing request を一覧する（status で絞り込み可能）。
     List {
         #[arg(long)]
         status: Option<IndexingRequestStatusArg>,
@@ -110,12 +94,10 @@ enum IndexingRequestAction {
         #[arg(long, default_value_t = 0)]
         offset: i64,
     },
-    /// request を承認し、対象 scope を supported set に入れる。
     Approve {
         #[arg(long)]
         id: String,
     },
-    /// request を却下する（supported set は変更しない）。
     Reject {
         #[arg(long)]
         id: String,
@@ -131,8 +113,8 @@ enum IndexScopeKindArg {
 impl From<IndexScopeKindArg> for IndexScopeKind {
     fn from(value: IndexScopeKindArg) -> Self {
         match value {
-            IndexScopeKindArg::PublicTopic => IndexScopeKind::PublicTopic,
-            IndexScopeKindArg::PrivateChannel => IndexScopeKind::PrivateChannel,
+            IndexScopeKindArg::PublicTopic => Self::PublicTopic,
+            IndexScopeKindArg::PrivateChannel => Self::PrivateChannel,
         }
     }
 }
@@ -147,33 +129,28 @@ enum IndexingRequestStatusArg {
 impl From<IndexingRequestStatusArg> for IndexingRequestStatus {
     fn from(value: IndexingRequestStatusArg) -> Self {
         match value {
-            IndexingRequestStatusArg::Pending => IndexingRequestStatus::Pending,
-            IndexingRequestStatusArg::Approved => IndexingRequestStatus::Approved,
-            IndexingRequestStatusArg::Rejected => IndexingRequestStatus::Rejected,
+            IndexingRequestStatusArg::Pending => Self::Pending,
+            IndexingRequestStatusArg::Approved => Self::Approved,
+            IndexingRequestStatusArg::Rejected => Self::Rejected,
         }
     }
 }
 
 #[derive(Debug, Subcommand)]
 enum AdmissionAction {
-    /// 現在の入会モードを表示する。
     Show,
-    /// 入会モードを設定する（open / invite / whitelist）。
     SetMode {
         #[arg(long)]
         mode: AdmissionModeArg,
     },
-    /// 招待コードを操作する。
     Invite {
         #[command(subcommand)]
         action: InviteAction,
     },
-    /// 手動許可リスト（whitelist）を操作する。
     Allow {
         #[command(subcommand)]
         action: AllowAction,
     },
-    /// ブラックリスト（ban）を操作する。
     Ban {
         #[command(subcommand)]
         action: BanAction,
@@ -182,21 +159,15 @@ enum AdmissionAction {
 
 #[derive(Debug, Subcommand)]
 enum InviteAction {
-    /// 招待コードを発行する（平文はこのとき一度だけ表示される）。
     Issue {
-        /// 任意のラベル。
         #[arg(long)]
         label: Option<String>,
-        /// 使用可能回数。未指定なら無制限。
         #[arg(long)]
         max_uses: Option<i32>,
-        /// 失効時刻（RFC3339 または epoch 秒）。未指定なら無期限。
         #[arg(long)]
         expires_at: Option<String>,
     },
-    /// 発行済み招待コードを新着順で一覧する（hash のみ表示）。
     List,
-    /// 招待コード（平文）を取り消す。
     Revoke {
         #[arg(long)]
         code: String,
@@ -205,35 +176,29 @@ enum InviteAction {
 
 #[derive(Debug, Subcommand)]
 enum AllowAction {
-    /// pubkey を許可リストへ追加する。
     Add {
         #[arg(long)]
         pubkey: String,
         #[arg(long)]
         label: Option<String>,
     },
-    /// pubkey を許可リストから削除する。
     Remove {
         #[arg(long)]
         pubkey: String,
     },
-    /// 許可リストを一覧する。
     List,
 }
 
 #[derive(Debug, Subcommand)]
 enum BanAction {
-    /// pubkey を ban する（既存利用者の token も即時失効する）。
     Add {
         #[arg(long)]
         pubkey: String,
     },
-    /// pubkey の ban を解除する。
     Remove {
         #[arg(long)]
         pubkey: String,
     },
-    /// ban 済み pubkey を一覧する。
     List,
 }
 
@@ -247,23 +212,21 @@ enum AdmissionModeArg {
 impl From<AdmissionModeArg> for AdmissionMode {
     fn from(value: AdmissionModeArg) -> Self {
         match value {
-            AdmissionModeArg::Open => AdmissionMode::Open,
-            AdmissionModeArg::Invite => AdmissionMode::Invite,
-            AdmissionModeArg::Whitelist => AdmissionMode::Whitelist,
+            AdmissionModeArg::Open => Self::Open,
+            AdmissionModeArg::Invite => Self::Invite,
+            AdmissionModeArg::Whitelist => Self::Whitelist,
         }
     }
 }
 
 #[derive(Debug, Subcommand)]
 enum ReportsAction {
-    /// 受信した通報を新着順で一覧する。
     List {
         #[arg(long, default_value_t = 50)]
         limit: i64,
         #[arg(long, default_value_t = 0)]
         offset: i64,
     },
-    /// 単一の通報を ID で表示する。
     Show {
         #[arg(long)]
         id: String,
@@ -280,353 +243,5 @@ enum AuthModeArg {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     let pool = connect_postgres(cli.database_url.as_str()).await?;
-
-    match cli.command {
-        Command::Prepare => {
-            initialize_database(&pool).await?;
-            println!("database prepared");
-        }
-        Command::Migrate => {
-            migrate_postgres(&pool).await?;
-            println!("migrations applied");
-        }
-        Command::SeedPolicies => {
-            initialize_database(&pool).await?;
-            seed_default_policies(&pool).await?;
-            println!("policies seeded");
-        }
-        Command::SetAuthRollout {
-            service,
-            mode,
-            enforce_at,
-            grace_seconds,
-            ws_auth_timeout_seconds,
-        } => {
-            migrate_postgres(&pool).await?;
-            let enforce_at = enforce_at
-                .map(|value| parse_enforce_at(value.as_str()))
-                .transpose()?;
-            let rollout = AuthRolloutConfig {
-                mode: match mode {
-                    AuthModeArg::Off => AuthMode::Off,
-                    AuthModeArg::Required => AuthMode::Required,
-                },
-                enforce_at,
-                grace_seconds,
-                ws_auth_timeout_seconds,
-            };
-            store_auth_rollout(&pool, service.as_str(), &rollout).await?;
-            println!(
-                "auth rollout updated service={} mode={:?} enforce_at={:?} grace_seconds={} ws_auth_timeout_seconds={}",
-                service,
-                rollout.mode,
-                rollout.enforce_at,
-                rollout.grace_seconds,
-                rollout.ws_auth_timeout_seconds
-            );
-        }
-        Command::Reports { action } => match action {
-            ReportsAction::List { limit, offset } => {
-                let reports = list_community_node_reports(&pool, limit, offset).await?;
-                if reports.is_empty() {
-                    println!("no reports");
-                } else {
-                    println!(
-                        "{} report(s) (limit={} offset={}):",
-                        reports.len(),
-                        limit,
-                        offset
-                    );
-                    for report in reports {
-                        println!(
-                            "{}  {}  {}/{}  capability={}  reason={}  status={}",
-                            report.created_at.to_rfc3339(),
-                            report.id,
-                            report.subject_kind,
-                            report.subject_id,
-                            report.capability,
-                            report.reason,
-                            report.status,
-                        );
-                    }
-                }
-            }
-            ReportsAction::Show { id } => {
-                match get_community_node_report(&pool, id.as_str()).await? {
-                    Some(report) => {
-                        println!("id:               {}", report.id);
-                        println!("created_at:       {}", report.created_at.to_rfc3339());
-                        println!("status:           {}", report.status);
-                        println!("subject_kind:     {}", report.subject_kind);
-                        println!("subject_id:       {}", report.subject_id);
-                        println!("capability:       {}", report.capability);
-                        println!("reason:           {}", report.reason);
-                        println!(
-                            "details:          {}",
-                            report.details.as_deref().unwrap_or("-")
-                        );
-                        println!(
-                            "reporter_contact: {}",
-                            report.reporter_contact.as_deref().unwrap_or("-")
-                        );
-                    }
-                    None => println!("report not found: {id}"),
-                }
-            }
-        },
-        Command::Admission { action } => {
-            run_admission(&pool, action).await?;
-        }
-        Command::SupportedTopic { action } => {
-            run_supported_topic(&pool, action).await?;
-        }
-        Command::IndexingRequest { action } => {
-            run_indexing_request(&pool, action).await?;
-        }
-        Command::Relation { action } => {
-            run_relation(&pool, action).await?;
-        }
-    }
-
-    Ok(())
-}
-
-async fn run_relation(pool: &sqlx::PgPool, action: RelationAction) -> Result<()> {
-    match action {
-        RelationAction::Analyze { limit } => {
-            let source = PgCoParticipationSource::new(pool.clone());
-            let graph = ArcadeDbRelationGraph::new(ArcadeDbConfig::from_env())
-                .context("failed to build ArcadeDB relation graph client")?;
-            graph
-                .ensure_schema()
-                .await
-                .context("failed to ensure relation graph schema")?;
-            let report = analyze_relations(&source, &graph, limit).await?;
-            println!(
-                "relation analysis done: {} edge(s) upserted, {} cluster(s) assigned",
-                report.edges_upserted, report.clusters_assigned
-            );
-        }
-    }
-    Ok(())
-}
-
-async fn run_supported_topic(pool: &sqlx::PgPool, action: SupportedTopicAction) -> Result<()> {
-    // supported set の state を持つテーブルが揃っていることを保証する。
-    initialize_database(pool).await?;
-    match action {
-        SupportedTopicAction::Add { kind, id } => {
-            let kind = IndexScopeKind::from(kind);
-            let entry = add_supported_topic(pool, kind, id.as_str()).await?;
-            println!(
-                "supported topic added: {} {}",
-                entry.kind.as_str(),
-                entry.id
-            );
-        }
-        SupportedTopicAction::Remove { kind, id } => {
-            let kind = IndexScopeKind::from(kind);
-            if remove_supported_topic(pool, kind, id.as_str()).await? {
-                println!("supported topic removed: {} {}", kind.as_str(), id);
-            } else {
-                println!("supported topic not found: {} {}", kind.as_str(), id);
-            }
-        }
-        SupportedTopicAction::List => {
-            let entries = list_supported_topics(pool).await?;
-            if entries.is_empty() {
-                println!("no supported topics");
-            } else {
-                println!("{} supported topic(s):", entries.len());
-                for entry in entries {
-                    println!(
-                        "{}  {}  {}",
-                        entry.created_at.to_rfc3339(),
-                        entry.kind.as_str(),
-                        entry.id,
-                    );
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn run_indexing_request(pool: &sqlx::PgPool, action: IndexingRequestAction) -> Result<()> {
-    initialize_database(pool).await?;
-    match action {
-        IndexingRequestAction::List {
-            status,
-            limit,
-            offset,
-        } => {
-            let status = status.map(IndexingRequestStatus::from);
-            let requests = list_indexing_requests(pool, status, limit, offset).await?;
-            if requests.is_empty() {
-                println!("no indexing requests");
-            } else {
-                println!("{} indexing request(s):", requests.len());
-                for request in requests {
-                    println!(
-                        "{}  {}  {}/{}  requester={}  status={}",
-                        request.created_at.to_rfc3339(),
-                        request.id,
-                        request.kind.as_str(),
-                        request.target_id,
-                        request.requester_pubkey,
-                        request.status.as_str(),
-                    );
-                }
-            }
-        }
-        IndexingRequestAction::Approve { id } => {
-            match approve_indexing_request(pool, id.as_str()).await? {
-                Some(request) => println!(
-                    "indexing request approved: {} ({} {} now supported)",
-                    request.id,
-                    request.kind.as_str(),
-                    request.target_id,
-                ),
-                None => println!("indexing request not found: {id}"),
-            }
-        }
-        IndexingRequestAction::Reject { id } => {
-            match reject_indexing_request(pool, id.as_str()).await? {
-                Some(request) => println!("indexing request rejected: {}", request.id),
-                None => println!("indexing request not found: {id}"),
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn run_admission(pool: &sqlx::PgPool, action: AdmissionAction) -> Result<()> {
-    // admission state を読み書きするテーブルが揃っていることを保証する。
-    initialize_database(pool).await?;
-    match action {
-        AdmissionAction::Show => {
-            let config = load_admission_config(pool).await?;
-            println!("admission mode: {}", config.mode.as_str());
-        }
-        AdmissionAction::SetMode { mode } => {
-            let mode = AdmissionMode::from(mode);
-            set_admission_mode(pool, mode).await?;
-            println!("admission mode updated: {}", mode.as_str());
-        }
-        AdmissionAction::Invite { action } => match action {
-            InviteAction::Issue {
-                label,
-                max_uses,
-                expires_at,
-            } => {
-                let expires_at = expires_at
-                    .map(|value| parse_enforce_at(value.as_str()))
-                    .transpose()?
-                    .map(|timestamp| {
-                        DateTime::<Utc>::from_timestamp(timestamp, 0)
-                            .context("invalid expires_at timestamp")
-                    })
-                    .transpose()?;
-                let code = issue_invite_code(pool, label.as_deref(), max_uses, expires_at).await?;
-                println!("invite code issued (store it now; it will not be shown again):");
-                println!("{code}");
-            }
-            InviteAction::List => {
-                let codes = list_invite_codes(pool).await?;
-                if codes.is_empty() {
-                    println!("no invite codes");
-                } else {
-                    println!("{} invite code(s):", codes.len());
-                    for code in codes {
-                        let max_uses = code
-                            .max_uses
-                            .map(|value| value.to_string())
-                            .unwrap_or_else(|| "unlimited".to_string());
-                        let expires_at = code
-                            .expires_at
-                            .map(format_timestamp)
-                            .unwrap_or_else(|| "never".to_string());
-                        let revoked_at = code
-                            .revoked_at
-                            .map(format_timestamp)
-                            .unwrap_or_else(|| "-".to_string());
-                        println!(
-                            "{}  uses={}/{}  expires={}  revoked={}  label={}",
-                            code.code_hash,
-                            code.used_count,
-                            max_uses,
-                            expires_at,
-                            revoked_at,
-                            code.label.as_deref().unwrap_or("-"),
-                        );
-                    }
-                }
-            }
-            InviteAction::Revoke { code } => {
-                if revoke_invite_code(pool, code.as_str()).await? {
-                    println!("invite code revoked");
-                } else {
-                    println!("invite code not found or already revoked");
-                }
-            }
-        },
-        AdmissionAction::Allow { action } => match action {
-            AllowAction::Add { pubkey, label } => {
-                add_allowlist(pool, pubkey.as_str(), label.as_deref()).await?;
-                println!("allowlisted {pubkey}");
-            }
-            AllowAction::Remove { pubkey } => {
-                if remove_allowlist(pool, pubkey.as_str()).await? {
-                    println!("removed {pubkey} from allowlist");
-                } else {
-                    println!("{pubkey} was not on the allowlist");
-                }
-            }
-            AllowAction::List => {
-                let entries = list_allowlist(pool).await?;
-                if entries.is_empty() {
-                    println!("allowlist is empty");
-                } else {
-                    println!("{} allowlisted pubkey(s):", entries.len());
-                    for entry in entries {
-                        println!(
-                            "{}  created={}  label={}",
-                            entry.pubkey,
-                            format_timestamp(entry.created_at),
-                            entry.label.as_deref().unwrap_or("-"),
-                        );
-                    }
-                }
-            }
-        },
-        AdmissionAction::Ban { action } => match action {
-            BanAction::Add { pubkey } => {
-                ban_subscriber(pool, pubkey.as_str()).await?;
-                println!("banned {pubkey}");
-            }
-            BanAction::Remove { pubkey } => {
-                if unban_subscriber(pool, pubkey.as_str()).await? {
-                    println!("unbanned {pubkey}");
-                } else {
-                    println!("{pubkey} was not banned");
-                }
-            }
-            BanAction::List => {
-                let entries = list_banned(pool).await?;
-                if entries.is_empty() {
-                    println!("no banned subscribers");
-                } else {
-                    println!("{} banned subscriber(s):", entries.len());
-                    for entry in entries {
-                        println!(
-                            "{}  created={}",
-                            entry.pubkey,
-                            format_timestamp(entry.created_at)
-                        );
-                    }
-                }
-            }
-        },
-    }
-    Ok(())
+    commands::dispatch(&pool, cli.command).await
 }

--- a/crates/cn-cli/tests/help.rs
+++ b/crates/cn-cli/tests/help.rs
@@ -1,0 +1,52 @@
+use std::process::Command;
+
+fn help(args: &[&str]) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_cn-cli"))
+        .args(args)
+        .arg("--help")
+        .output()
+        .expect("cn-cli must start");
+    assert!(output.status.success(), "args={args:?}");
+    String::from_utf8(output.stdout).expect("help output must be UTF-8")
+}
+
+#[test]
+fn root_help_keeps_public_command_surface() {
+    let output = help(&[]);
+    for command in [
+        "prepare",
+        "migrate",
+        "seed-policies",
+        "set-auth-rollout",
+        "reports",
+        "admission",
+        "supported-topic",
+        "indexing-request",
+        "relation",
+    ] {
+        assert!(
+            output.contains(command),
+            "missing `{command}` in:\n{output}"
+        );
+    }
+    assert!(output.contains("--database-url <DATABASE_URL>"));
+}
+
+#[test]
+fn command_and_nested_help_remain_parseable() {
+    for args in [
+        &["set-auth-rollout"][..],
+        &["reports"],
+        &["reports", "list"],
+        &["admission"],
+        &["admission", "invite"],
+        &["admission", "allow"],
+        &["admission", "ban"],
+        &["supported-topic"],
+        &["indexing-request"],
+        &["relation"],
+    ] {
+        let output = help(args);
+        assert!(output.contains("Usage:"), "args={args:?}: {output}");
+    }
+}

--- a/docs/runbooks/community-node-operator-docs.md
+++ b/docs/runbooks/community-node-operator-docs.md
@@ -14,6 +14,12 @@ P2P network の補助層を個人・小規模グループでも説明可能に�
 そもそも P2P 基盤上には network 全体を統治する中央権者が構造的に存在しないため、生成文書も
 node 単位の説明責任に閉じる。
 
+## cn-cli との責務境界
+
+`cn-operator` は `operator-config.yaml` を真実源に、deploy 前の宣言、文書・manifest・Terraform 変数の生成、設定 drift と safety readiness の検証を行う。Postgres へ接続して稼働中 node の状態を変更する command は提供しない。
+
+稼働中 node の migration、auth rollout、通報確認、入会制御、supported set、indexing request、relation 解析には `cn-cli` を使う。運用入口と起動順は [`dev.md`](dev.md#cn-cli-と-cn-operator-の役割) を参照する。
+
 ## Phase A / Phase B（宣言と実行可能の分離）
 
 `cn-operator` は各機能を capability として扱い、`availability` を持たせている。

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -160,6 +160,14 @@ curl -fsS https://iroh-relay.kukuri.app/ping
 - `iroh_relay::server::client: failed to handle send packet frame: failed to forward packet: Full` が 3 client 同時起動などで増える場合、まず client 側の topic warmup throttling / coalescing が入った current build で確認する。
 - noisy client の ingress を運用上絞る必要がある場合だけ、`.env.community-node` に `COMMUNITY_NODE_IROH_RELAY_CLIENT_RX_BYTES_PER_SECOND` と任意の `COMMUNITY_NODE_IROH_RELAY_CLIENT_RX_MAX_BURST_BYTES` を設定する。未指定時は従来どおり unlimited。
 
+## cn-cli と cn-operator の役割
+
+- `cn-cli` は稼働中 community node の Postgres / ArcadeDB へ接続し、migration、auth rollout、通報、入会制御、supported set、indexing request、relation 解析を運用する。node の状態を読み書きするため、対象環境の `COMMUNITY_NODE_DATABASE_URL` が必要になる。
+- `cn-operator` は `operator-config.yaml` を入力に、設定検証、開示文書、manifest、Terraform 変数、safety readiness を生成・検証する。通常の DB 運用 command は持たず、稼働中 node の状態を直接変更しない。
+- 「現在の node 状態を操作する」場合は `cn-cli`、「deploy 前の宣言・生成・readiness を扱う」場合は `cn-operator` を使う。両者は相互代替ではない。
+
+`cn-operator` の詳細は [`community-node-operator-docs.md`](community-node-operator-docs.md) を参照する。
+
 ## community-node deploy 順序
 ```bash
 cargo run -p kukuri-cn-cli -- --database-url "$COMMUNITY_NODE_DATABASE_URL" prepare


### PR DESCRIPTION
## Summary
- reduce cn-cli main to clap definitions, database connection, and dispatch
- split database, reports, admission, indexing, and relation command implementations into focused modules
- add root and nested help contract tests
- document the cn-cli runtime-operation role versus the cn-operator declaration/generation/readiness role

## Validation
- cargo test -p kukuri-cn-cli -p kukuri-cn-operator
- cargo clippy -p kukuri-cn-cli --all-targets -- -D warnings
- cargo test -p kukuri-cn-cli --test help
- cargo xtask oversized-files