### PR TITLE
refactor: replace notification permission plugin invokes with app commands

### DIFF
--- a/apps/desktop/src-tauri/src/commands/os_notification.rs
+++ b/apps/desktop/src-tauri/src/commands/os_notification.rs
@@ -23,6 +23,33 @@ fn activate_main_window(app: &AppHandle, notification_id: String) {
     );
 }
 
+/// Permission value reported to the settings release panel. Desktop OS toasts
+/// need no runtime permission (visibility is governed by OS-level settings),
+/// and the former `tauri-plugin-notification` desktop backend unconditionally
+/// returned `PermissionState::Granted` as well.
+const OS_NOTIFICATION_PERMISSION_GRANTED: &str = "granted";
+
+/// Report the OS notification permission state for the settings release panel.
+///
+/// Replaces the raw `plugin:notification|is_permission_granted` invocation.
+/// The frontend branches on the lowercase permission string
+/// (granted / prompt / unavailable), so this pins the same contract the
+/// plugin's always-granted desktop backend provided.
+#[tauri::command]
+pub fn get_os_notification_permission() -> &'static str {
+    OS_NOTIFICATION_PERMISSION_GRANTED
+}
+
+/// Request OS notification permission for the settings release panel.
+///
+/// Replaces the raw `plugin:notification|request_permission` invocation; no
+/// desktop platform we ship on has a runtime permission prompt, so this
+/// resolves to `granted` exactly like the plugin did.
+#[tauri::command]
+pub fn request_os_notification_permission() -> &'static str {
+    OS_NOTIFICATION_PERMISSION_GRANTED
+}
+
 /// Show an OS toast for an incoming notification. On platforms that support it,
 /// clicking the toast focuses the window and emits `os-notification://activated`
 /// so the frontend can open the related post.
@@ -126,4 +153,17 @@ pub(crate) fn show_platform_notification(
     }
     notification.show().map_err(|error| error.to_string())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pins the permission contract inherited from tauri-plugin-notification's
+    // always-granted desktop backend; ReleasePanel branches on this string.
+    #[test]
+    fn permission_commands_report_granted() {
+        assert_eq!(get_os_notification_permission(), "granted");
+        assert_eq!(request_os_notification_permission(), "granted");
+    }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -214,6 +214,8 @@ pub fn run() {
             commands::community_node::fetch_community_node_manifest,
             commands::community_node::submit_community_node_report,
             commands::os_notification::show_os_notification,
+            commands::os_notification::get_os_notification_permission,
+            commands::os_notification::request_os_notification_permission,
             commands::background_notifications::set_os_notification_settings
         ])
         .run(tauri::generate_context!())

--- a/apps/desktop/src/components/settings/ReleasePanel.tsx
+++ b/apps/desktop/src/components/settings/ReleasePanel.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { invoke } from '@tauri-apps/api/core';
 import { Download, FileText, Power, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader } from '@/components/ui/card';
 import { Notice } from '@/components/ui/notice';
+import {
+  getOsNotificationPermission,
+  requestOsNotificationPermission as requestOsNotificationPermissionCommand,
+} from '@/lib/api/osNotificationPermission';
 import { copyTextToClipboard } from '@/lib/utils';
 import {
   buildSafeDiagnosticReport,
@@ -59,10 +62,10 @@ export function ReleasePanel() {
     let cancelled = false;
     // Query the Tauri backend directly instead of the WebView Web Notification
     // API, whose permission state is volatile and unreliable on Windows (#313).
-    void invoke<boolean | null>('plugin:notification|is_permission_granted')
-      .then((granted) => {
+    void getOsNotificationPermission()
+      .then((permission) => {
         if (!cancelled) {
-          setOsNotificationPermission(granted ? 'granted' : 'prompt');
+          setOsNotificationPermission(permission.toLowerCase());
         }
       })
       .catch(() => {
@@ -98,7 +101,7 @@ export function ReleasePanel() {
       setOsNotificationPermission('unavailable');
       return;
     }
-    const permission = await invoke<string>('plugin:notification|request_permission');
+    const permission = await requestOsNotificationPermissionCommand();
     const normalized = permission.toLowerCase();
     setOsNotificationPermission(normalized);
     if (normalized === 'granted') {

--- a/apps/desktop/src/lib/api/osNotificationPermission.ts
+++ b/apps/desktop/src/lib/api/osNotificationPermission.ts
@@ -1,0 +1,19 @@
+import { invokeDesktop } from './invoke/desktop';
+import { isDesktopMockActive } from './invoke/dispatch';
+
+// DesktopApi 外のスタンドアロンコマンド(appConsent.ts と同じ方式)。デスクトップの
+// OS トーストに実行時権限は無く、旧 tauri-plugin-notification の desktop 実装も常に
+// granted を返していたため、mock ビルドでも同じ固定値を返す。
+export async function getOsNotificationPermission(): Promise<string> {
+  if (isDesktopMockActive()) {
+    return 'granted';
+  }
+  return invokeDesktop<string>('get_os_notification_permission');
+}
+
+export async function requestOsNotificationPermission(): Promise<string> {
+  if (isDesktopMockActive()) {
+    return 'granted';
+  }
+  return invokeDesktop<string>('request_os_notification_permission');
+}


### PR DESCRIPTION
## Summary
- [refactor:boundary] add `get_os_notification_permission` / `request_os_notification_permission` Tauri commands that pin the permission contract inherited from tauri-plugin-notification's desktop backend (which unconditionally returns `PermissionState::Granted` — verified against the plugin 2.3.3 sources), with a unit test freezing the `"granted"` value
- add `apps/desktop/src/lib/api/osNotificationPermission.ts` following the appConsent.ts standalone-command pattern (`isDesktopMockActive` stub + `invokeDesktop`)
- replace the two raw `plugin:notification|*` invokes in ReleasePanel with the typed helper; the granted / prompt / unavailable branching, catch fallback, and `isTauriRuntime` guard are unchanged
- plugin registration and dependencies are intentionally untouched: their removal is the follow-up deps PR (master plan §9.2 B2, staged deletion deferred from WP-Q1 Decision 3; the Q2 push-infrastructure precondition is met)

## Reference-path audit
- toast display itself was already plugin-free since #304 (`show_os_notification`)
- after this change, `plugin:notification` matches only in doc comments describing the replacement history (`os_notification.rs`), no runtime invocations remain
- npm dependency `@tauri-apps/plugin-notification` has zero imports from `apps/desktop/src` (declaration-only) — removed in the follow-up PR together with the Rust plugin, capability, and NOTICES regeneration

## Validation
- pnpm typecheck
- cargo xtask tauri-check
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib permission_commands (1 passed)
- cargo xtask desktop-ui-check (incl. 14 visual regression screens, all passed)
- npx vitest run --project shell-integration src/shell/DesktopShellPage.shellChrome.test.tsx (12 passed)
- cargo xtask oversized-files (pass; only the pre-existing stale-baseline notes for the two app-api private-channel files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)