### PR TITLE
deps: remove tauri-plugin-notification

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,7 +29,6 @@
     "@react-three/fiber": "^9.6.1",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
-    "@tauri-apps/plugin-notification": "2.3.3",
     "@tauri-apps/plugin-updater": "2.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/desktop/pnpm-lock.yaml
+++ b/apps/desktop/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       '@tauri-apps/plugin-deep-link':
         specifier: ^2.4.9
         version: 2.4.9
-      '@tauri-apps/plugin-notification':
-        specifier: 2.3.3
-        version: 2.3.3
       '@tauri-apps/plugin-updater':
         specifier: 2.10.1
         version: 2.10.1
@@ -1489,9 +1486,6 @@ packages:
 
   '@tauri-apps/plugin-deep-link@2.4.9':
     resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
-
-  '@tauri-apps/plugin-notification@2.3.3':
-    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
   '@tauri-apps/plugin-updater@2.10.1':
     resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
@@ -4191,10 +4185,6 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
   '@tauri-apps/plugin-deep-link@2.4.9':
-    dependencies:
-      '@tauri-apps/api': 2.11.0
-
-  '@tauri-apps/plugin-notification@2.3.3':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3698,7 +3698,6 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
- "tauri-plugin-notification",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-winrt-notification",
@@ -7282,25 +7281,6 @@ dependencies = [
  "url",
  "windows-registry 0.5.3",
  "windows-result 0.3.4",
-]
-
-[[package]]
-name = "tauri-plugin-notification"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
-dependencies = [
- "log",
- "notify-rust",
- "rand 0.9.4",
- "serde",
- "serde_json",
- "serde_repr",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "time",
- "url",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -20,7 +20,6 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tauri = { version = "2.10.3", features = ["tray-icon"] }
 tauri-plugin-deep-link = "2.0.0"
-tauri-plugin-notification = "2.3.3"
 tauri-plugin-single-instance = { version = "2.0.0", features = ["deep-link"] }
 tauri-plugin-updater = "2.10.1"
 tokio = { version = "1", features = ["time"] }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -5,7 +5,6 @@
   "permissions": [
     "core:default",
     "deep-link:default",
-    "updater:default",
-    "notification:default"
+    "updater:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -81,7 +81,6 @@ pub fn run() {
     builder
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_notification::init())
         .on_window_event(|window, event| {
             // Issue #304: closing the window keeps kukuri running in the
             // background (tray) instead of exiting. Only the tray "Quit" entry

--- a/docs/THIRD_PARTY_NOTICES.md
+++ b/docs/THIRD_PARTY_NOTICES.md
@@ -18,7 +18,7 @@ The first preview targets Windows installer distribution through GitHub Releases
 
 ## Rust crates
 
-Total packages: 658
+Total packages: 665
 
 | Package | Version | License | Source |
 | --- | --- | --- | --- |
@@ -42,6 +42,7 @@ Total packages: 658
 | asn1-rs | 0.7.2 | MIT OR Apache-2.0 | https://crates.io/crates/asn1-rs |
 | asn1-rs-derive | 0.6.0 | MIT OR Apache-2.0 | https://crates.io/crates/asn1-rs-derive |
 | asn1-rs-impl | 0.2.0 | MIT/Apache-2.0 | https://crates.io/crates/asn1-rs-impl |
+| assert-json-diff | 2.0.2 | MIT | https://crates.io/crates/assert-json-diff |
 | async-channel | 2.5.0 | Apache-2.0 OR MIT | https://crates.io/crates/async-channel |
 | async-compat | 0.2.5 | Apache-2.0 OR MIT | https://crates.io/crates/async-compat |
 | async-lock | 3.4.2 | Apache-2.0 OR MIT | https://crates.io/crates/async-lock |
@@ -130,6 +131,8 @@ Total packages: 658
 | data-encoding-macro-internal | 0.1.18 | MIT | https://crates.io/crates/data-encoding-macro-internal |
 | dbus | 0.9.11 | Apache-2.0/MIT | https://crates.io/crates/dbus |
 | dbus-secret-service | 4.1.0 | MIT OR Apache-2.0 | https://crates.io/crates/dbus-secret-service |
+| deadpool | 0.12.3 | MIT OR Apache-2.0 | https://crates.io/crates/deadpool |
+| deadpool-runtime | 0.1.4 | MIT OR Apache-2.0 | https://crates.io/crates/deadpool-runtime |
 | der | 0.7.10 | Apache-2.0 OR MIT | https://crates.io/crates/der |
 | der | 0.8.0 | Apache-2.0 OR MIT | https://crates.io/crates/der |
 | der-parser | 10.0.0 | MIT OR Apache-2.0 | https://crates.io/crates/der-parser |
@@ -210,6 +213,7 @@ Total packages: 658
 | hashlink | 0.10.0 | MIT OR Apache-2.0 | https://crates.io/crates/hashlink |
 | heapless | 0.7.17 | MIT OR Apache-2.0 | https://crates.io/crates/heapless |
 | heck | 0.5.0 | MIT OR Apache-2.0 | https://crates.io/crates/heck |
+| hermit-abi | 0.5.2 | MIT OR Apache-2.0 | https://crates.io/crates/hermit-abi |
 | hex | 0.4.3 | MIT OR Apache-2.0 | https://crates.io/crates/hex |
 | hex-conservative | 0.2.2 | CC0-1.0 | https://crates.io/crates/hex-conservative |
 | hickory-net | 0.26.1 | MIT OR Apache-2.0 | https://crates.io/crates/hickory-net |
@@ -333,6 +337,7 @@ Total packages: 658
 | num-integer | 0.1.46 | MIT OR Apache-2.0 | https://crates.io/crates/num-integer |
 | num-iter | 0.1.45 | MIT OR Apache-2.0 | https://crates.io/crates/num-iter |
 | num-traits | 0.2.19 | MIT OR Apache-2.0 | https://crates.io/crates/num-traits |
+| num_cpus | 1.17.0 | MIT OR Apache-2.0 | https://crates.io/crates/num_cpus |
 | num_enum | 0.7.6 | BSD-3-Clause OR MIT OR Apache-2.0 | https://crates.io/crates/num_enum |
 | num_enum_derive | 0.7.6 | BSD-3-Clause OR MIT OR Apache-2.0 | https://crates.io/crates/num_enum_derive |
 | num_threads | 0.1.7 | MIT OR Apache-2.0 | https://crates.io/crates/num_threads |
@@ -417,6 +422,7 @@ Total packages: 658
 | ref-cast | 1.0.25 | MIT OR Apache-2.0 | https://crates.io/crates/ref-cast |
 | ref-cast-impl | 1.0.25 | MIT OR Apache-2.0 | https://crates.io/crates/ref-cast-impl |
 | reflink-copy | 0.1.29 | MIT/Apache-2.0 | https://crates.io/crates/reflink-copy |
+| regex | 1.12.3 | MIT OR Apache-2.0 | https://crates.io/crates/regex |
 | regex-automata | 0.4.14 | MIT OR Apache-2.0 | https://crates.io/crates/regex-automata |
 | regex-syntax | 0.8.10 | MIT OR Apache-2.0 | https://crates.io/crates/regex-syntax |
 | reloadable-core | 0.1.0 | MIT | https://crates.io/crates/reloadable-core |
@@ -651,6 +657,7 @@ Total packages: 658
 | windows_x86_64_msvc | 0.52.6 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
 | windows_x86_64_msvc | 0.53.1 | MIT OR Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
 | winnow | 1.0.3 | MIT | https://crates.io/crates/winnow |
+| wiremock | 0.6.5 | MIT/Apache-2.0 | https://crates.io/crates/wiremock |
 | wit-bindgen | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://crates.io/crates/wit-bindgen |
 | wit-bindgen | 0.57.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://crates.io/crates/wit-bindgen |
 | wit-bindgen-core | 0.51.0 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | https://crates.io/crates/wit-bindgen-core |
@@ -683,7 +690,7 @@ Total packages: 658
 
 ## Desktop npm packages
 
-Total packages: 158
+Total packages: 157
 
 | Package | Version | License | Source |
 | --- | --- | --- | --- |
@@ -760,7 +767,6 @@ Total packages: 158
 | @react-three/fiber | 9.6.1 | MIT | https://github.com/pmndrs/react-three-fiber#readme |
 | @tauri-apps/api | 2.11.0 | Apache-2.0 OR MIT | https://github.com/tauri-apps/tauri#readme |
 | @tauri-apps/plugin-deep-link | 2.4.9 | MIT OR Apache-2.0 | https://github.com/tauri-apps/plugins-workspace#readme |
-| @tauri-apps/plugin-notification | 2.3.3 | MIT OR Apache-2.0 | https://github.com/tauri-apps/plugins-workspace#readme |
 | @tauri-apps/plugin-updater | 2.10.1 | MIT OR Apache-2.0 | https://github.com/tauri-apps/plugins-workspace#readme |
 | @tweenjs/tween.js | 23.1.3 | MIT | https://github.com/tweenjs/tween.js |
 | @types/draco3d | 1.4.10 | MIT | https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/draco3d |


### PR DESCRIPTION
## Summary
- [deps] remove `@tauri-apps/plugin-notification` (npm), `tauri-plugin-notification` (Cargo dependency + `.plugin(...)` registration in lib.rs), and the `notification:default` capability
- regenerate `docs/THIRD_PARTY_NOTICES.md` via `scripts/release/generate-third-party-notices.ps1`
- completes the staged deletion tracked as master plan §9.2 B2 (deferred from WP-Q1 Decision 3; precondition #575 merged as `2bacbba8`)

## Reference-path audit
- toast display has been plugin-free since #304 (`show_os_notification` with tauri-winrt-notification / notify-rust)
- the last runtime consumers (ReleasePanel's two raw `plugin:notification|*` permission invokes) were replaced by app-owned commands in #575
- after this change, `plugin-notification` / `tauri_plugin_notification` / `plugin:notification` match zero times across package.json, pnpm-lock.yaml, Cargo.toml, Cargo.lock, lib.rs, and capabilities (remaining matches are doc comments in `os_notification.rs` describing the replacement history)

## Note on the NOTICES diff
The Rust crates table grows 658 -> 665: the notices check gate only runs in the release workflow, so crates added during the refactoring window (assert-json-diff, deadpool, hermit-abi, etc.) had not been regenerated into the file yet. This PR's regeneration catches those up alongside removing the npm notification entry (158 -> 157). The file is generator-owned, so no manual edits were made.

## Validation
- cargo xtask tauri-check
- cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --lib (14 passed)
- cargo xtask e2e-smoke
- cargo xtask desktop-ui-check (incl. 14 visual regression screens, all passed)
- cargo xtask oversized-files
- pnpm install completes with the dependency removed; grep audits above

🤖 Generated with [Claude Code](https://claude.com/claude-code)