### PR TITLE
refactor: unify hand-rolled stable polls onto poll_until

### DIFF
--- a/crates/app-api/src/tests/sync/transport_replication.rs
+++ b/crates/app-api/src/tests/sync/transport_replication.rs
@@ -1,4 +1,5 @@
 ﻿use super::*;
+use kukuri_test_support::{PollState, poll_until};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn iroh_transport_syncs_post_between_apps() {
@@ -476,9 +477,11 @@ async fn seeded_dht_updates_existing_topic_subscription_after_seed_update() {
     configure_seeded_dht(&app_a, endpoint_b.clone()).await;
     configure_seeded_dht(&app_b, endpoint_a.clone()).await;
 
-    timeout(Duration::from_secs(20), async {
-        let mut stable_ready_polls = 0usize;
-        loop {
+    poll_until(
+        Duration::from_secs(20),
+        Duration::from_millis(100),
+        3,
+        || async {
             let status_a = app_a.get_sync_status().await.expect("status a");
             let status_b = app_b.get_sync_status().await.expect("status b");
             let ready_a = status_a.topic_diagnostics.iter().any(|topic_status| {
@@ -491,17 +494,13 @@ async fn seeded_dht_updates_existing_topic_subscription_after_seed_update() {
                     && topic_status.joined
                     && !topic_status.connected_peers.is_empty()
             });
-            if ready_a && ready_b {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return;
-                }
+            Ok::<_, std::convert::Infallible>(if ready_a && ready_b {
+                PollState::Ready(())
             } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
+                PollState::Pending
+            })
+        },
+    )
     .await
     .expect("seeded dht topic update timeout");
 

--- a/crates/desktop-runtime/src/tests/support/net.rs
+++ b/crates/desktop-runtime/src/tests/support/net.rs
@@ -1,40 +1,38 @@
+use std::convert::Infallible;
+
 use super::super::*;
+use kukuri_test_support::{PollState, poll_until};
 
 pub(crate) async fn wait_for_seeded_dht_topic_ready(
     runtime_a: &DesktopRuntime,
     runtime_b: &DesktopRuntime,
     topic: &str,
 ) {
-    match timeout(seeded_dht_runtime_ready_timeout(), async {
-        let mut stable_ready_polls = 0usize;
-        loop {
+    let result = poll_until(
+        seeded_dht_runtime_ready_timeout(),
+        Duration::from_millis(100),
+        3,
+        || async {
             let status_a = runtime_a.get_sync_status().await.expect("status a");
             let status_b = runtime_b.get_sync_status().await.expect("status b");
             let ready_a = topic_has_direct_peer(&status_a, topic, 1)
                 || topic_has_durable_delivery(&status_a, topic);
             let ready_b = topic_has_direct_peer(&status_b, topic, 1)
                 || topic_has_durable_delivery(&status_b, topic);
-            if ready_a && ready_b {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return;
-                }
+            Ok::<_, Infallible>(if ready_a && ready_b {
+                PollState::Ready(())
             } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    {
-        Ok(()) => {}
-        Err(_) => {
-            let status_a = runtime_a.get_sync_status().await.expect("status a");
-            let status_b = runtime_b.get_sync_status().await.expect("status b");
-            panic!(
-                "seeded dht topic readiness timeout for `{topic}`: status_a={status_a:?} status_b={status_b:?}"
-            );
-        }
+                PollState::Pending
+            })
+        },
+    )
+    .await;
+    if result.is_err() {
+        let status_a = runtime_a.get_sync_status().await.expect("status a");
+        let status_b = runtime_b.get_sync_status().await.expect("status b");
+        panic!(
+            "seeded dht topic readiness timeout for `{topic}`: status_a={status_a:?} status_b={status_b:?}"
+        );
     }
 }
 pub(crate) async fn wait_for_runtime_endpoint_in_testnet(

--- a/crates/desktop-runtime/src/tests/support/replication.rs
+++ b/crates/desktop-runtime/src/tests/support/replication.rs
@@ -1,4 +1,7 @@
+use std::cell::Cell;
+
 use super::super::*;
+use kukuri_test_support::{PollError, PollState, poll_until};
 
 pub(crate) async fn refresh_public_runtime_for_retry(
     runtime: &DesktopRuntime,
@@ -44,42 +47,37 @@ pub(crate) async fn wait_for_public_runtime_delivery_with_refresh(
 ) -> Result<()> {
     let refresh_interval = Duration::from_secs(5);
     let reapply_interval = public_connectivity_reapply_interval();
-    match timeout(step_timeout, async {
-        let mut next_refresh_at = tokio::time::Instant::now();
-        let mut next_reapply_at = tokio::time::Instant::now() + reapply_interval;
-        let mut stable_ready_polls = 0usize;
-        loop {
-            if tokio::time::Instant::now() >= next_refresh_at {
-                refresh_public_runtime_for_retry(runtime, topic).await?;
-                next_refresh_at = tokio::time::Instant::now() + refresh_interval;
-            }
-            if tokio::time::Instant::now() >= next_reapply_at {
-                force_public_runtime_connectivity_retry(runtime).await?;
-                next_reapply_at = tokio::time::Instant::now() + reapply_interval;
-            }
-
-            let status = runtime
-                .get_sync_status()
-                .await
-                .context("runtime sync status")?;
-            let ready = topic_has_direct_peer(&status, topic, expected)
-                || topic_has_durable_delivery(&status, topic);
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return Ok::<(), anyhow::Error>(());
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-
-            sleep(Duration::from_millis(100)).await;
+    // poll_until のクロージャは FnMut のため、時限アクションの締切は Cell 経由の
+    // 共有参照で持ち回る(値の意味・実行順序は従来の手書きループと同一)。
+    let next_refresh_at = Cell::new(tokio::time::Instant::now());
+    let next_reapply_at = Cell::new(tokio::time::Instant::now() + reapply_interval);
+    match poll_until(step_timeout, Duration::from_millis(100), 3, || async {
+        if tokio::time::Instant::now() >= next_refresh_at.get() {
+            refresh_public_runtime_for_retry(runtime, topic).await?;
+            next_refresh_at.set(tokio::time::Instant::now() + refresh_interval);
         }
+        if tokio::time::Instant::now() >= next_reapply_at.get() {
+            force_public_runtime_connectivity_retry(runtime).await?;
+            next_reapply_at.set(tokio::time::Instant::now() + reapply_interval);
+        }
+
+        let status = runtime
+            .get_sync_status()
+            .await
+            .context("runtime sync status")?;
+        let ready = topic_has_direct_peer(&status, topic, expected)
+            || topic_has_durable_delivery(&status, topic);
+        Ok::<_, anyhow::Error>(if ready {
+            PollState::Ready(())
+        } else {
+            PollState::Pending
+        })
     })
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
+        Ok(()) => Ok(()),
+        Err(PollError::Operation(error)) => Err(error),
+        Err(PollError::Timeout) => {
             let status = runtime
                 .get_sync_status()
                 .await
@@ -100,50 +98,43 @@ pub(crate) async fn wait_for_public_pair_delivery_with_refresh(
 ) -> Result<()> {
     let refresh_interval = Duration::from_secs(5);
     let reapply_interval = public_connectivity_reapply_interval();
-    match timeout(step_timeout, async {
-        let mut next_refresh_at = tokio::time::Instant::now();
-        let mut next_reapply_at = tokio::time::Instant::now() + reapply_interval;
-        let mut stable_ready_polls = 0usize;
-        loop {
-            if tokio::time::Instant::now() >= next_refresh_at {
-                refresh_public_runtime_for_retry(runtime_a, topic).await?;
-                refresh_public_runtime_for_retry(runtime_b, topic).await?;
-                next_refresh_at = tokio::time::Instant::now() + refresh_interval;
-            }
-            if tokio::time::Instant::now() >= next_reapply_at {
-                force_public_runtime_connectivity_retry(runtime_a).await?;
-                force_public_runtime_connectivity_retry(runtime_b).await?;
-                next_reapply_at = tokio::time::Instant::now() + reapply_interval;
-            }
-
-            let status_a = runtime_a
-                .get_sync_status()
-                .await
-                .context("runtime a sync status")?;
-            let status_b = runtime_b
-                .get_sync_status()
-                .await
-                .context("runtime b sync status")?;
-            let ready_a = topic_has_direct_peer(&status_a, topic, expected)
-                || topic_has_durable_delivery(&status_a, topic);
-            let ready_b = topic_has_direct_peer(&status_b, topic, expected)
-                || topic_has_durable_delivery(&status_b, topic);
-            if ready_a && ready_b {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return Ok::<(), anyhow::Error>(());
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-
-            sleep(Duration::from_millis(100)).await;
+    let next_refresh_at = Cell::new(tokio::time::Instant::now());
+    let next_reapply_at = Cell::new(tokio::time::Instant::now() + reapply_interval);
+    match poll_until(step_timeout, Duration::from_millis(100), 3, || async {
+        if tokio::time::Instant::now() >= next_refresh_at.get() {
+            refresh_public_runtime_for_retry(runtime_a, topic).await?;
+            refresh_public_runtime_for_retry(runtime_b, topic).await?;
+            next_refresh_at.set(tokio::time::Instant::now() + refresh_interval);
         }
+        if tokio::time::Instant::now() >= next_reapply_at.get() {
+            force_public_runtime_connectivity_retry(runtime_a).await?;
+            force_public_runtime_connectivity_retry(runtime_b).await?;
+            next_reapply_at.set(tokio::time::Instant::now() + reapply_interval);
+        }
+
+        let status_a = runtime_a
+            .get_sync_status()
+            .await
+            .context("runtime a sync status")?;
+        let status_b = runtime_b
+            .get_sync_status()
+            .await
+            .context("runtime b sync status")?;
+        let ready_a = topic_has_direct_peer(&status_a, topic, expected)
+            || topic_has_durable_delivery(&status_a, topic);
+        let ready_b = topic_has_direct_peer(&status_b, topic, expected)
+            || topic_has_durable_delivery(&status_b, topic);
+        Ok::<_, anyhow::Error>(if ready_a && ready_b {
+            PollState::Ready(())
+        } else {
+            PollState::Pending
+        })
     })
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
+        Ok(()) => Ok(()),
+        Err(PollError::Operation(error)) => Err(error),
+        Err(PollError::Timeout) => {
             let status_a = runtime_a
                 .get_sync_status()
                 .await

--- a/crates/desktop-runtime/src/tests/support/sync_status.rs
+++ b/crates/desktop-runtime/src/tests/support/sync_status.rs
@@ -1,5 +1,7 @@
+use std::convert::Infallible;
+
 use super::super::*;
-use kukuri_test_support::{SyncSnapshot, TopicSyncSnapshot};
+use kukuri_test_support::{PollError, PollState, SyncSnapshot, TopicSyncSnapshot, poll_until};
 
 fn snapshot_from_status(status: &SyncStatus) -> SyncSnapshot {
     SyncSnapshot {
@@ -35,29 +37,23 @@ pub(crate) async fn wait_for_connected_topic_peer_count(
     expected: usize,
     timeout_label: &str,
 ) {
-    match timeout(runtime_replication_timeout(), async {
-        let mut stable_ready_polls = 0usize;
-        loop {
+    let result = poll_until(
+        runtime_replication_timeout(),
+        Duration::from_millis(100),
+        3,
+        || async {
             let status = runtime.get_sync_status().await.expect("sync status");
-            let ready = topic_has_direct_peer(&status, topic, expected);
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return;
-                }
+            Ok::<_, Infallible>(if topic_has_direct_peer(&status, topic, expected) {
+                PollState::Ready(())
             } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    {
-        Ok(()) => {}
-        Err(_) => {
-            let status = runtime.get_sync_status().await.expect("sync status");
-            panic!("{timeout_label}: {}", format_sync_snapshot(&status, topic));
-        }
+                PollState::Pending
+            })
+        },
+    )
+    .await;
+    if result.is_err() {
+        let status = runtime.get_sync_status().await.expect("sync status");
+        panic!("{timeout_label}: {}", format_sync_snapshot(&status, topic));
     }
 }
 
@@ -67,29 +63,23 @@ pub(crate) async fn wait_for_topic_delivery(
     expected: usize,
     timeout_label: &str,
 ) {
-    match timeout(runtime_replication_timeout(), async {
-        let mut stable_ready_polls = 0usize;
-        loop {
+    let result = poll_until(
+        runtime_replication_timeout(),
+        Duration::from_millis(100),
+        3,
+        || async {
             let status = runtime.get_sync_status().await.expect("sync status");
-            let ready = topic_has_delivery(&status, topic, expected);
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return;
-                }
+            Ok::<_, Infallible>(if topic_has_delivery(&status, topic, expected) {
+                PollState::Ready(())
             } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    {
-        Ok(()) => {}
-        Err(_) => {
-            let status = runtime.get_sync_status().await.expect("sync status");
-            panic!("{timeout_label}: {}", format_sync_snapshot(&status, topic));
-        }
+                PollState::Pending
+            })
+        },
+    )
+    .await;
+    if result.is_err() {
+        let status = runtime.get_sync_status().await.expect("sync status");
+        panic!("{timeout_label}: {}", format_sync_snapshot(&status, topic));
     }
 }
 
@@ -99,26 +89,19 @@ pub(crate) async fn wait_for_topic_delivery_result(
     expected: usize,
     step_timeout: Duration,
 ) -> Result<()> {
-    match timeout(step_timeout, async {
-        let mut stable_ready_polls = 0usize;
-        loop {
-            let status = runtime.get_sync_status().await.context("sync status")?;
-            let ready = topic_has_delivery(&status, topic, expected);
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return Ok::<(), anyhow::Error>(());
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
+    match poll_until(step_timeout, Duration::from_millis(100), 3, || async {
+        let status = runtime.get_sync_status().await.context("sync status")?;
+        Ok::<_, anyhow::Error>(if topic_has_delivery(&status, topic, expected) {
+            PollState::Ready(())
+        } else {
+            PollState::Pending
+        })
     })
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
+        Ok(()) => Ok(()),
+        Err(PollError::Operation(error)) => Err(error),
+        Err(PollError::Timeout) => {
             let status = runtime
                 .get_sync_status()
                 .await
@@ -163,26 +146,19 @@ pub(crate) async fn wait_for_direct_topic_peer_count_result(
     expected: usize,
     step_timeout: Duration,
 ) -> Result<()> {
-    match timeout(step_timeout, async {
-        let mut stable_ready_polls = 0usize;
-        loop {
-            let status = runtime.get_sync_status().await.context("sync status")?;
-            let ready = topic_has_direct_peer(&status, topic, expected);
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return Ok::<(), anyhow::Error>(());
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
+    match poll_until(step_timeout, Duration::from_millis(100), 3, || async {
+        let status = runtime.get_sync_status().await.context("sync status")?;
+        Ok::<_, anyhow::Error>(if topic_has_direct_peer(&status, topic, expected) {
+            PollState::Ready(())
+        } else {
+            PollState::Pending
+        })
     })
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
+        Ok(()) => Ok(()),
+        Err(PollError::Operation(error)) => Err(error),
+        Err(PollError::Timeout) => {
             let status = runtime
                 .get_sync_status()
                 .await

--- a/crates/harness/src/waiters/replication.rs
+++ b/crates/harness/src/waiters/replication.rs
@@ -1,5 +1,8 @@
+use std::cell::Cell;
+
 use super::*;
 use crate::*;
+use kukuri_test_support::{PollError, PollState, poll_until};
 
 pub(crate) fn public_replication_retry_schedule(
     step_timeout: Duration,
@@ -243,50 +246,45 @@ pub(crate) async fn refresh_public_pair(
 
     let refresh_interval = Duration::from_secs(5);
     let reapply_interval = public_connectivity_reapply_interval();
-    match timeout(step_timeout, async {
-        let mut next_refresh_at = Instant::now();
-        let mut next_reapply_at = Instant::now() + reapply_interval;
-        let mut stable_ready_polls = 0usize;
-        loop {
-            if Instant::now() >= next_refresh_at {
-                refresh_public_runtime(runtime_a, topic).await;
-                refresh_public_runtime(runtime_b, topic).await;
-                next_refresh_at = Instant::now() + refresh_interval;
-            }
-            if Instant::now() >= next_reapply_at {
-                force_public_runtime_connectivity(runtime_a).await;
-                force_public_runtime_connectivity(runtime_b).await;
-                next_reapply_at = Instant::now() + reapply_interval;
-            }
-
-            let status_a = runtime_a
-                .get_sync_status()
-                .await
-                .context("desktop a public sync status")?;
-            let status_b = runtime_b
-                .get_sync_status()
-                .await
-                .context("desktop b public sync status")?;
-            let ready_a = topic_has_direct_peer(&status_a, topic, 1)
-                || topic_has_durable_delivery(&status_a, topic);
-            let ready_b = topic_has_direct_peer(&status_b, topic, 1)
-                || topic_has_durable_delivery(&status_b, topic);
-            if ready_a && ready_b {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return Ok::<(), anyhow::Error>(());
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-
-            sleep(Duration::from_millis(100)).await;
+    // poll_until のクロージャは FnMut のため、時限アクションの締切は Cell 経由の
+    // 共有参照で持ち回る(値の意味・実行順序は従来の手書きループと同一)。
+    let next_refresh_at = Cell::new(Instant::now());
+    let next_reapply_at = Cell::new(Instant::now() + reapply_interval);
+    match poll_until(step_timeout, Duration::from_millis(100), 3, || async {
+        if Instant::now() >= next_refresh_at.get() {
+            refresh_public_runtime(runtime_a, topic).await;
+            refresh_public_runtime(runtime_b, topic).await;
+            next_refresh_at.set(Instant::now() + refresh_interval);
         }
+        if Instant::now() >= next_reapply_at.get() {
+            force_public_runtime_connectivity(runtime_a).await;
+            force_public_runtime_connectivity(runtime_b).await;
+            next_reapply_at.set(Instant::now() + reapply_interval);
+        }
+
+        let status_a = runtime_a
+            .get_sync_status()
+            .await
+            .context("desktop a public sync status")?;
+        let status_b = runtime_b
+            .get_sync_status()
+            .await
+            .context("desktop b public sync status")?;
+        let ready_a = topic_has_direct_peer(&status_a, topic, 1)
+            || topic_has_durable_delivery(&status_a, topic);
+        let ready_b = topic_has_direct_peer(&status_b, topic, 1)
+            || topic_has_durable_delivery(&status_b, topic);
+        Ok::<_, anyhow::Error>(if ready_a && ready_b {
+            PollState::Ready(())
+        } else {
+            PollState::Pending
+        })
     })
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
+        Ok(()) => Ok(()),
+        Err(PollError::Operation(error)) => Err(error),
+        Err(PollError::Timeout) => {
             let snapshot_a = runtime_a
                 .get_sync_status()
                 .await

--- a/crates/harness/src/waiters/timeline.rs
+++ b/crates/harness/src/waiters/timeline.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::*;
-use kukuri_test_support::{SyncSnapshot, TopicSyncSnapshot};
+use kukuri_test_support::{PollError, PollState, SyncSnapshot, TopicSyncSnapshot, poll_until};
 
 fn snapshot_from_status(status: &SyncStatus) -> SyncSnapshot {
     SyncSnapshot {
@@ -167,31 +167,25 @@ pub(crate) async fn wait_for_topic_peer_count(
     expected: usize,
     step_timeout: Duration,
 ) -> Result<()> {
-    match timeout(step_timeout, async {
-        let mut stable_ready_polls = 0usize;
-        loop {
-            let status = runtime.get_sync_status().await?;
-            let ready = status.topic_diagnostics.iter().any(|entry| {
-                entry.topic == topic
-                    && entry.joined
-                    && entry.peer_count >= expected
-                    && entry.connected_peers.len() >= expected.min(1)
-            });
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return Ok::<(), anyhow::Error>(());
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(50)).await;
-        }
+    match poll_until(step_timeout, Duration::from_millis(50), 3, || async {
+        let status = runtime.get_sync_status().await?;
+        let ready = status.topic_diagnostics.iter().any(|entry| {
+            entry.topic == topic
+                && entry.joined
+                && entry.peer_count >= expected
+                && entry.connected_peers.len() >= expected.min(1)
+        });
+        Ok::<_, anyhow::Error>(if ready {
+            PollState::Ready(())
+        } else {
+            PollState::Pending
+        })
     })
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
+        Ok(()) => Ok(()),
+        Err(PollError::Operation(error)) => Err(error),
+        Err(PollError::Timeout) => {
             let snapshot = runtime
                 .get_sync_status()
                 .await
@@ -209,27 +203,21 @@ pub(crate) async fn wait_for_topic_delivery(
     expected: usize,
     step_timeout: Duration,
 ) -> Result<()> {
-    match timeout(step_timeout, async {
-        let mut stable_ready_polls = 0usize;
-        loop {
-            let status = runtime.get_sync_status().await?;
-            let ready = topic_has_direct_peer(&status, topic, expected)
-                || topic_has_durable_delivery(&status, topic);
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return Ok::<(), anyhow::Error>(());
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(50)).await;
-        }
+    match poll_until(step_timeout, Duration::from_millis(50), 3, || async {
+        let status = runtime.get_sync_status().await?;
+        let ready = topic_has_direct_peer(&status, topic, expected)
+            || topic_has_durable_delivery(&status, topic);
+        Ok::<_, anyhow::Error>(if ready {
+            PollState::Ready(())
+        } else {
+            PollState::Pending
+        })
     })
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
+        Ok(()) => Ok(()),
+        Err(PollError::Operation(error)) => Err(error),
+        Err(PollError::Timeout) => {
             let snapshot = runtime
                 .get_sync_status()
                 .await
@@ -355,26 +343,19 @@ pub(crate) async fn wait_for_direct_topic_peer_count(
     expected: usize,
     step_timeout: Duration,
 ) -> Result<()> {
-    match timeout(step_timeout, async {
-        let mut stable_ready_polls = 0usize;
-        loop {
-            let status = runtime.get_sync_status().await?;
-            let ready = topic_has_direct_peer(&status, topic, expected);
-            if ready {
-                stable_ready_polls += 1;
-                if stable_ready_polls >= 3 {
-                    return Ok::<(), anyhow::Error>(());
-                }
-            } else {
-                stable_ready_polls = 0;
-            }
-            sleep(Duration::from_millis(50)).await;
-        }
+    match poll_until(step_timeout, Duration::from_millis(50), 3, || async {
+        let status = runtime.get_sync_status().await?;
+        Ok::<_, anyhow::Error>(if topic_has_direct_peer(&status, topic, expected) {
+            PollState::Ready(())
+        } else {
+            PollState::Pending
+        })
     })
     .await
     {
-        Ok(result) => result,
-        Err(_) => {
+        Ok(()) => Ok(()),
+        Err(PollError::Operation(error)) => Err(error),
+        Err(PollError::Timeout) => {
             let snapshot = runtime
                 .get_sync_status()
                 .await


### PR DESCRIPTION
## Summary
- [refactor:extract] replace the twelve hand-written stable-poll loops with `kukuri-test-support::poll_until`: desktop-runtime test support ×7 (`sync_status.rs` ×4, `net.rs` ×1, `replication.rs` ×2), harness waiters ×4 (`timeline.rs` ×3, `replication.rs` ×1), app-api inline integration test ×1 (`transport_replication.rs`)
- behavior-preserving by construction: timeouts, poll intervals (100ms / 50ms as before), the 3-consecutive-ready stable count, error propagation (expect-panic vs anyhow Result), and every timeout diagnostic message are unchanged
- the three timed variants (periodic refresh + reapply inside the loop) keep their action ordering; the deadlines move into `Cell<Instant>` state shared with the `FnMut` closure
- test code only, production untouched

## Why
WP-Q7's DoD item 1 claimed "no duplicated stable-poll implementations across the three consumers", but the 2026-07-13 completion review (adversarially verified) found these twelve loops still duplicating `poll_until`'s semantics, with `poll_until` consumed only by one app-api waiter. Tracked as master plan §9.2 B3; the companion lock-classification contract lands as a separate PR.

## Validation
- rg 'stable_ready_polls' across crates/ — 0 matches outside kukuri-test-support's own implementation
- cargo xtask rust-check (clippy -D warnings) — pass
- cargo nextest run -p kukuri-desktop-runtime — 96/96 passed
- cargo test -p kukuri-harness — 18/18 passed
- cargo test -p kukuri-app-api --features iroh-integration-tests seeded_dht_updates_existing_topic_subscription_after_seed_update — passed (the converted slow-lane test, run standalone)
- cargo xtask rust-test — the only failure was the known local-Windows docs-sync relay flake (`tests::relay::public_replica_syncs_over_custom_relay_seed_peers`, 90s timeout; docs-sync is untouched by this PR and the same flake is on record in the Q6–Q8 completion notes)
- cargo xtask oversized-files — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)