### PR TITLE
refactor: delete dead client-side pub APIs and unreachable branch

### DIFF
--- a/crates/app-api/src/private_channels.rs
+++ b/crates/app-api/src/private_channels.rs
@@ -977,7 +977,10 @@ impl AppService {
         }
         Ok(items)
     }
-    pub async fn get_private_channel_capability(
+    /// テスト専用: capability の取得→restore 結合テストのユーティリティ
+    /// (production の呼び出し元は WP-C2 T5 #479 で消滅)。
+    #[cfg(test)]
+    pub(crate) async fn get_private_channel_capability(
         &self,
         topic_id: &str,
         channel_id: &str,
@@ -993,20 +996,6 @@ impl AppService {
         Ok(Some(
             self.private_channel_capability_from_state(&state).await?,
         ))
-    }
-    pub async fn list_private_channel_capabilities(&self) -> Result<Vec<PrivateChannelCapability>> {
-        let states = self
-            .joined_private_channels
-            .lock()
-            .await
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        let mut items = Vec::with_capacity(states.len());
-        for state in states {
-            items.push(self.private_channel_capability_from_state(&state).await?);
-        }
-        Ok(items)
     }
 }
 /// import 3 系統の差分(注入点)。詳細は import_private_channel_by_spec を参照。

--- a/crates/app-api/src/service/private_channels_support.rs
+++ b/crates/app-api/src/service/private_channels_support.rs
@@ -249,6 +249,8 @@ impl AppService {
             stale_participant_count: diagnostics.stale_participant_count,
         })
     }
+    /// テスト専用: 唯一の呼び出し元が cfg(test) の get_private_channel_capability。
+    #[cfg(test)]
     pub(crate) async fn private_channel_capability_from_state(
         &self,
         state: &JoinedPrivateChannelState,

--- a/crates/desktop-runtime/src/stack.rs
+++ b/crates/desktop-runtime/src/stack.rs
@@ -310,14 +310,6 @@ impl SharedIrohStack {
                 .rebuild(discovery_config, bootstrap_seed_peers, relay_config)
                 .await;
         }
-        if current_relay_urls != next_relay_urls {
-            info!(
-                current_relay_url_count = current_relay_urls.len(),
-                next_relay_url_count = next_relay_urls.len(),
-                discovery_mode = ?discovery_config.mode,
-                "runtime relay connectivity change applied in place"
-            );
-        }
         let current = self.current.lock().await;
         let current = current
             .as_ref()

--- a/crates/transport/src/config.rs
+++ b/crates/transport/src/config.rs
@@ -140,13 +140,6 @@ impl DhtDiscoveryOptions {
         }
     }
 
-    pub fn with_dht_builder(dht_builder: DhtBuilder) -> Self {
-        Self {
-            enabled: true,
-            dht_builder: Some(dht_builder),
-        }
-    }
-
     pub(crate) fn resolved_dht_builder(&self) -> Option<DhtBuilder> {
         if !self.enabled {
             return None;

--- a/crates/transport/src/iroh/endpoint.rs
+++ b/crates/transport/src/iroh/endpoint.rs
@@ -91,10 +91,6 @@ impl IrohGossipTransport {
     pub async fn bind_local() -> Result<Self> {
         Self::bind(TransportNetworkConfig::loopback()).await
     }
-
-    pub async fn bind_from_env() -> Result<Self> {
-        Self::bind(TransportNetworkConfig::from_env()?).await
-    }
 }
 
 pub(crate) async fn bind_endpoint_with_options(

--- a/crates/transport/src/tickets.rs
+++ b/crates/transport/src/tickets.rs
@@ -185,10 +185,6 @@ pub fn relay_assisted_endpoint_addr(endpoint_addr: &EndpointAddr) -> EndpointAdd
     endpoint_addr.clone()
 }
 
-pub fn prefer_relay_endpoint_addr(endpoint_addr: &EndpointAddr) -> EndpointAddr {
-    relay_assisted_endpoint_addr(endpoint_addr)
-}
-
 pub(crate) fn resolve_socket_addrs(value: &str) -> Result<Vec<SocketAddr>> {
     let trimmed = value.trim();
     if let Ok(socket_addr) = trimmed.parse::<SocketAddr>() {


### PR DESCRIPTION
## Summary
- [refactor:delete] remove dead client-side code confirmed by the 2026-07-13 completion review (§4.3, adversarially verified) with reference paths re-audited at batch time:
  - `AppService::list_private_channel_capabilities` — its only caller was removed by WP-C2 T5 (#479); zero references across the workspace since
  - `AppService::get_private_channel_capability` and its helper `private_channel_capability_from_state` — only consumer is the in-crate capability export/restore test, so they become `#[cfg(test)] pub(crate)` (same treatment H5 PR1 gave test-only re-exports) instead of carrying lib-build dead code
  - transport: `IrohGossipTransport::bind_from_env`, `DhtDiscoveryOptions::with_dht_builder`, `prefer_relay_endpoint_addr` — zero references, leftovers the #519 vestigial sweep missed (`relay_assisted_endpoint_addr` and `TransportNetworkConfig::from_env` stay: both have live consumers)
  - `stack.rs` "applied in place" log branch — unreachable: `should_rebuild_runtime_connectivity` is exactly `current_relay_urls != next_relay_urls` and returns early on that same condition

## Reference-path audit
- `rg list_private_channel_capabilities` → definition only before this PR
- `rg 'bind_from_env|with_dht_builder|prefer_relay_endpoint_addr'` → definitions only before this PR
- frozen-boundary check: none of these touch §3 items (no serde names, no wire literals, no RelayFallback variant)

## Validation
- cargo clippy -p kukuri-app-api -p kukuri-transport -p kukuri-desktop-runtime --all-targets -- -D warnings
- cargo test -p kukuri-app-api --lib (137 passed)
- cargo nextest run -p kukuri-app-api -E 'test(diagnostics)' (7 passed — the capability test consumer)
- cargo fmt --check

Part of master plan §9.2 B9 (deletion batch, PR 1/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)