### PR TITLE
refactor: delete dead frontend exports and CSS selectors

### DIFF
--- a/apps/desktop/src/components/storyFixtures.ts
+++ b/apps/desktop/src/components/storyFixtures.ts
@@ -25,7 +25,6 @@ export function createStoryPrimaryItems(): Array<{
   ];
 }
 
-export const STORY_PRIMARY_ITEMS = createStoryPrimaryItems();
 
 export function createStoryTopicItems(): TopicDiagnosticSummary[] {
   return [
@@ -50,7 +49,6 @@ export function createStoryTopicItems(): TopicDiagnosticSummary[] {
   ];
 }
 
-export const STORY_TOPIC_ITEMS = createStoryTopicItems();
 
 export const STORY_IMAGE_PREVIEW =
   'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360"><rect width="640" height="360" fill="%2300b3a4"/><path d="M0 300l140-130 100 80 110-120 150 170H0z" fill="%230f2231"/></svg>';
@@ -179,7 +177,6 @@ export function createStoryTimelinePosts(): PostCardView[] {
   ];
 }
 
-export const STORY_TIMELINE_POSTS = createStoryTimelinePosts();
 
 export function createStoryThreadPosts(): PostCardView[] {
   const timelinePosts = createStoryTimelinePosts();

--- a/apps/desktop/src/shell/presentation.ts
+++ b/apps/desktop/src/shell/presentation.ts
@@ -1,14 +1,12 @@
 import {
   type AuthorSocialView,
   type ChannelAccessTokenPreview,
-  type ChannelAudienceKind,
   type ChannelRef,
   type CommunityNodeConfig,
   type CommunityNodeConfigInput,
   type CommunityNodeNodeStatus,
   type DirectMessageConversationView,
   type DiscoveryConfig,
-  type GameRoomStatus,
   type GameRoomView,
   type JoinedPrivateChannelView,
   type LiveSessionView,
@@ -479,16 +477,8 @@ export function translateTopicConnectionText(label: string): string {
   return label;
 }
 
-export function translateAudienceKindLabel(kind: ChannelAudienceKind): string {
-  return translate(`channels:audienceOptions.${kind}`);
-}
-
 export function translateLiveStatus(status: LiveSessionView['status']): string {
   return translate(`live:statuses.${status}`);
-}
-
-export function translateGameStatus(status: GameRoomStatus): string {
-  return translate(`game:statuses.${status}`);
 }
 
 export function formatCount(value: number): string {

--- a/apps/desktop/src/shell/store.ts
+++ b/apps/desktop/src/shell/store.ts
@@ -155,25 +155,17 @@ export function useDesktopShellFieldSetter<K extends keyof DesktopShellState>(ke
 // 既存の import 面の互換 re-export(型・定数はスライス側が定義元)。
 export {
   DEFAULT_ASYNC_PANEL_STATE,
-  DEFAULT_TOPIC,
   PUBLIC_CHANNEL_REF,
   PUBLIC_TIMELINE_SCOPE,
-  STARTER_TOPICS,
   activeTimelineStorageKey,
   timelineScopeStorageKey,
   timelineStorageKeyForChannel,
 } from '@/shell/slices/shared';
 export type { AsyncPanelState, DraftMediaItem } from '@/shell/slices/shared';
-export {
-  DEFAULT_COMMUNITY_NODE_CONFIG,
-  DEFAULT_DISCOVERY_CONFIG,
-  DEFAULT_SYNC_STATUS,
-} from '@/shell/slices/connectivity';
+export { DEFAULT_COMMUNITY_NODE_CONFIG } from '@/shell/slices/connectivity';
 export type {
   CommunityNodeDraftNode,
   CommunityNodeManifestEntry,
 } from '@/shell/slices/connectivity';
-export { DEFAULT_SOCIAL_CONNECTIONS } from '@/shell/slices/profileSocial';
-export type { KnownAuthorsByPubkey, SocialConnectionsState } from '@/shell/slices/profileSocial';
-export { DEFAULT_NOTIFICATION_STATUS } from '@/shell/slices/notifications';
+export type { KnownAuthorsByPubkey } from '@/shell/slices/profileSocial';
 export type { GameEditorDraft } from '@/shell/slices/liveGame';

--- a/apps/desktop/src/shell/testSupport/renderShellHook.tsx
+++ b/apps/desktop/src/shell/testSupport/renderShellHook.tsx
@@ -23,7 +23,6 @@ import {
   createDesktopShellStore,
   DesktopShellStoreContext,
   type DesktopShellState,
-  type DesktopShellStateValue,
 } from '@/shell/store';
 
 export type ShellHookHarnessOptions = {
@@ -81,13 +80,3 @@ export function actPatchState(
   });
 }
 
-/** 追加ヘルパ: レンダー済みフックの外から store.setField を呼ぶための act ラッパ。 */
-export function actSetField<K extends keyof DesktopShellState>(
-  store: ShellHookHarness['store'],
-  key: K,
-  value: DesktopShellStateValue<K>
-): void {
-  act(() => {
-    store.getState().setField(key, value);
-  });
-}

--- a/apps/desktop/src/styles/shell-phase1-part1.css
+++ b/apps/desktop/src/styles/shell-phase1-part1.css
@@ -266,13 +266,6 @@
   inset: 0;
 }
 
-.metaverse-viewport {
-  min-height: 34rem;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-xs);
-  overflow: hidden;
-  background: var(--surface-metaverse);
-}
 
 .metaverse-hud-toolbar {
   position: absolute;
@@ -654,8 +647,7 @@
     grid-template-columns: 1fr;
   }
 
-  .metaverse-viewport-shell,
-  .metaverse-viewport {
+  .metaverse-viewport-shell {
     min-height: 24rem;
   }
 

--- a/apps/desktop/src/styles/shell-phase1-part2.css
+++ b/apps/desktop/src/styles/shell-phase1-part2.css
@@ -332,16 +332,6 @@
   grid-template-columns: repeat(var(--reaction-grid-columns, 8), minmax(0, 1fr));
 }
 
-.post-reaction-picker-button-detailed {
-  width: 100%;
-  justify-content: flex-start;
-  min-height: 2.75rem;
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--radius);
-  text-align: left;
-  background: var(--surface-panel-soft);
-}
-
 .post-reaction-picker-button.post-reaction-picker-button-compact {
   width: 100%;
   min-width: 0;
@@ -389,26 +379,14 @@
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
 }
 
-.post-reaction-picker-label,
-.post-reaction-picker-copy {
+.post-reaction-picker-label {
   min-width: 0;
 }
 
-.post-reaction-picker-copy {
-  display: grid;
-  gap: var(--space-2xs);
-}
-
-.post-reaction-picker-copy strong,
-.post-reaction-picker-copy small,
 .post-reaction-picker-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.post-reaction-picker-copy small {
-  color: var(--muted-foreground-soft);
 }
 
 .post-reaction-picker-fallback {
@@ -741,8 +719,7 @@
 }
 
 .shell-main,
-.shell-pane-heading,
-.shell-pane-copy {
+.shell-pane-heading {
   min-width: 0;
 }
 

--- a/apps/desktop/src/styles/shell-phase1-part3.css
+++ b/apps/desktop/src/styles/shell-phase1-part3.css
@@ -24,12 +24,6 @@
   min-width: 0;
 }
 
-.extended-inline-code {
-  display: block;
-  margin-top: var(--space-sm);
-  white-space: pre-wrap;
-  word-break: break-all;
-}
 
 .access-preview-list {
   display: grid;
@@ -69,11 +63,6 @@
 .shell-pane-heading {
   margin: 0;
   font-size: var(--text-h2);
-}
-
-.shell-pane-copy {
-  margin: var(--space-2xs) 0 0;
-  color: var(--muted-foreground);
 }
 
 .shell-nav,

--- a/apps/desktop/src/styles/shell-scoped-overrides.css
+++ b/apps/desktop/src/styles/shell-scoped-overrides.css
@@ -23,25 +23,11 @@
   padding: var(--space-xl) var(--space-lg) var(--space-2xl);
 }
 
-.shell-phase1 .hero {
-  display: grid;
-  gap: var(--space-md);
-  grid-template-columns: 1fr minmax(240px, 320px);
-  align-items: end;
-  margin-bottom: var(--space-lg);
-}
-
 .shell-phase1 .eyebrow {
   margin: 0 0 var(--space-xs);
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--primary-start);
-}
-
-.shell-phase1 .hero h1 {
-  margin: 0;
-  font-size: var(--text-display);
-  line-height: 0.96;
 }
 
 .shell-phase1 .lede {
@@ -144,10 +130,6 @@
 .shell-phase1 .discovery-actions .button {
   flex: 1 1 9.5rem;
   min-width: 0;
-}
-
-.shell-phase1 .diagnostic-error {
-  color: var(--destructive) !important;
 }
 
 .shell-phase1 .post-card {
@@ -374,7 +356,7 @@
 }
 
 @media (max-width: 899px) {
-  .shell-phase1 .hero, .shell-phase1 .grid {
+  .shell-phase1 .grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- [refactor:delete] remove dead frontend code confirmed by the 2026-07-13 completion review (§4.3, adversarially verified) with reference paths re-audited at batch time:
  - store.ts compat re-exports with zero importers outside store/slices: `DEFAULT_TOPIC`, `STARTER_TOPICS`, `DEFAULT_SYNC_STATUS`, `DEFAULT_DISCOVERY_CONFIG`, `DEFAULT_SOCIAL_CONNECTIONS`, `DEFAULT_NOTIFICATION_STATUS`, `SocialConnectionsState` (live re-exports such as `PUBLIC_CHANNEL_REF` / `DraftMediaItem` stay)
  - unused TS exports: `actSetField` (never used since its WP-S5 introduction), `translateAudienceKindLabel` / `translateGameStatus` (unreferenced since #275/#294), and the `STORY_*` fixture constants (their `createStory*` factories stay — stories consume those directly)
  - dead CSS: the H8 sweep leftovers hidden by prefix/suffix token collisions (`.shell-phase1 .hero` set, `.shell-phase1 .diagnostic-error`, `.metaverse-viewport`, `.extended-inline-code` — live classes are `topic-diagnostic-error` / `metaverse-viewport-shell/-canvas`) plus the four classes orphaned when #520 deleted the one-shot review stories (`post-reaction-picker-copy`, `post-reaction-picker-button-detailed`, `shell-pane-copy`)
  - group selectors lose only the dead compound (e.g. `.shell-main, .shell-pane-heading` keeps its live members), same discipline as H8 PR1

## Validation
- pnpm typecheck / pnpm lint
- cargo xtask desktop-ui-check — full gate green, including all 14 visual regression screens (proving effective styles are unchanged after the CSS removals)
- reference grep for every deleted symbol/class → 0 matches outside definitions before deletion

Part of master plan §9.2 B9 (deletion batch, PR 3/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)