### PR TITLE
chore: ratchet oversized baseline down to current line counts

### DIFF
--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -2,14 +2,14 @@
   "files": [
     {
       "lines": 1087,
-      "path": "crates/app-api/src/service/private_channels_support.rs"
-    },
-    {
-      "lines": 1087,
       "path": "crates/harness/src/scenarios/community_node.rs"
     },
     {
-      "lines": 1079,
+      "lines": 1076,
+      "path": "crates/app-api/src/service/private_channels_support.rs"
+    },
+    {
+      "lines": 1060,
       "path": "crates/app-api/src/private_channels.rs"
     }
   ]


### PR DESCRIPTION
## Summary
- [chore] `cargo xtask oversized-files --update-baseline`: catch the baseline up with shrinkage from the refactoring window (`private_channels_support.rs` 1087 → 1076, `private_channels.rs` 1079 → 1060; the harness entry is unchanged at 1087)
- closes the 11–19 line regrowth window the stale entries left invisible to the gate, and silences the stale-baseline notes printed on every run

## Validation
- cargo xtask oversized-files — exits 0 with no stale notes after the update

Part of master plan §9.2 B9 (deletion batch, PR 4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)