### PR TITLE
chore: reconcile oversized baseline after B9 merges

### DIFF
--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -5,11 +5,11 @@
       "path": "crates/harness/src/scenarios/community_node.rs"
     },
     {
-      "lines": 1076,
+      "lines": 1078,
       "path": "crates/app-api/src/service/private_channels_support.rs"
     },
     {
-      "lines": 1060,
+      "lines": 1049,
       "path": "crates/app-api/src/private_channels.rs"
     }
   ]


### PR DESCRIPTION
## Summary
- [chore] update the oversized baseline to the merged reality of the B9 batch: `private_channels_support.rs` 1076 → 1078 (the justified +2 structural lines from #581's cfg(test) doc/attribute), `private_channels.rs` 1060 → 1049 (further shrinkage from #581's deletion)

## Why
PR #581 and PR #584 were independently green — #581 against the old baseline (1087/1079), #584 ratcheting the baseline down to the pre-#581 counts (1076/1060) — but their merge left the baseline 2 lines below the actual `private_channels_support.rs`, tripping the growth gate on main (caught by the post-merge main check). This is the semantic coupling between "file contents" and "baseline" that independent-file PRs can still trip over.

## Validation
- cargo xtask oversized-files — exits 0 on the merged tree after the update

🤖 Generated with [Claude Code](https://claude.com/claude-code)