### PR TITLE
docs: write placement conventions for refactored boundaries

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -234,6 +234,24 @@ kukuri にはマーケティング的な First View / ブランドロックア�
 - portal（Radix の Dialog / Tooltip / DropdownMenu / Popover）は `body` 直下に描画され `.shell-phase1` スコープの外にある。同じ semantic クラスを portal と shell で別値にしたい場合のみ、base 値を `shell-phase1-part*` に、shell 上書き値を `shell-scoped-overrides.css` に置く二層構造にする。
 - `var(--token)` は同梱スタイルシート内で定義済みのものだけ参照する（`css-vars.test.ts` が未定義参照を検出する）。
 
+### 4.8 shell 状態層とファイル構成（WP-H6 / Q3 / Q4 / B4 / B5、規約化は WP-B10）
+
+`apps/desktop/src/shell/` の状態・データ取得・表示変換は次の層に分ける。**新規コードはこのルールに従って置き場を選ぶ**（4.7 の CSS 層規約と対になる state 層の規約）。
+
+| 置き場 | 役割 |
+|---|---|
+| `slices/` | store の**状態の形と初期値**（ドメイン別スライス。単一 store の交差型合成。`set()` の原子性維持のため store は分割しない） |
+| `storeSelectors.ts` | **複数の hook が共有する**名前付き購読スライス（`useShallow` 前提）。単一コンポーネント専用の購読は、そのコンポーネント内のインライン `useShallow` でよい（2 流儀はこの使い分けが意図） |
+| `presentation.ts` | store 非依存の**表示変換 helper**（純関数） |
+| `data/` + `data/loaders/` | **取得系 hook**。section 取得ロジックの SSoT は `loaders/`（WP-B5）で、`useDesktopShellDataEffects` の section effect はトリガ判定（+ messages の interval 管理）だけを持つ |
+| `viewModels/` | **section 別の projection hook**（timeline / channels / profile / messages / settings。WP-Q3 / B4）。`useDesktopShellViewModels` はその合成 facade で、section に属さない shell 横断 projection（chrome / topic nav / composer / thread / route コピー）だけを直接持つ |
+| `actions/` | **API 副作用を持つ action creator**（操作フロー別） |
+| `page/` | **画面合成**と page 専用 hook（dialog / focus / share preview） |
+| `routing/` | URL ↔ `RouteState` の**同期 adapter**（純関数は `routes.ts` が正） |
+
+- 層ごとの分類軸は意図的に異なる（slices = 状態ドメイン / actions = 操作フロー / viewModels = 表示 section）。層をまたいで名前を無理に揃えない。
+- selector なしの全ストア購読（`useDesktopShellStore()` 引数なし）を新規に書かない（WP-H6 で全廃済み。型面では書けてしまうため、防波堤はレビュー）。
+
 ---
 
 ## 5. レイアウト原則

--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -1,3 +1,19 @@
+//! デスクトップ向けアプリケーション API(`AppService`)。
+//!
+//! 配置規約(WP-B10):
+//! - トップレベルのドメインファイル(`timeline.rs` / `private_channels.rs` 等)=
+//!   IPC(desktop-runtime / src-tauri)から呼ばれる**公開ドメイン API**。
+//!   新メソッドはまず該当ドメインファイルへ置く。
+//! - `service/` 配下 = pub(crate) の内部ヘルパ(`*_support.rs`)と合成
+//!   (`mod.rs` の `ServiceHandles` / `SubscriptionRegistry`)。複数ドメインから
+//!   使う内部処理だけをここへ下ろす。
+//! - `AppService` へフィールドを足す前に、依存なら `ServiceHandles`、購読タスク
+//!   なら `SubscriptionRegistry` への収容を先に検討する(単一型への集中は既知の
+//!   負債。2026-07-13 完了レビュー D12)。
+//!
+//! ※ `private_channels.rs` ↔ `service/private_channels_support.rs` は公開 / 内部の
+//! 正当な分割であり、同名を理由に統合しない(REFACTORING.md 地雷リスト)。
+
 mod direct_messages;
 mod game;
 mod live;

--- a/crates/cn-core/src/lib.rs
+++ b/crates/cn-core/src/lib.rs
@@ -1,3 +1,16 @@
+//! コミュニティノードのサーバ側 合成・永続化層。
+//!
+//! 収容基準: **Postgres / Redis を伴うサーバ側の合成・永続化だけ**をここに置く。
+//! 次に該当するものは本 crate に足さない:
+//! - wire 型・正規化・認証封筒(serde 表現 = 凍結境界)→ `kukuri-cn-protocol`
+//! - ドメインロジック(safety / trust の純粋規則)→ `kukuri-cn-safety` / `kukuri-cn-trust`
+//!   (DB 非依存の safety 合成は `kukuri-cn-safety-runtime`。WP-Q8)
+//! - 常駐プロセス → `kukuri-cn-indexer` / `kukuri-cn-user-api`、運用 CLI → `kukuri-cn-cli`
+//! - tracing 等の実行時共通部品 → `kukuri-cn-runtime-support`
+//!
+//! 新しいサーバ側機能は、まず上のどれに属するかを判定し、DB との合成・永続化に
+//! 該当する場合だけ本 crate へ足す(「何でも入る受け皿」に戻さない。WP-B10)。
+
 mod admission;
 mod auth;
 mod bootstrap;

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,3 +1,17 @@
+//! クライアント側 P2P transport の部品層。
+//!
+//! ここに置くもの: gossip transport(`IrohGossipTransport`)と gossip hint 転送、
+//! endpoint 構築部品(bind / builder)、独自 ticket(`<endpoint_id>@<host:port>`)、
+//! ピア台帳(`peers` — docs-sync / blob-service が共有する接続候補とリトライ状態)、
+//! テスト用 `FakeTransport`。
+//!
+//! ここに置かないもの: 実運用 iroh ノード全体(endpoint / gossip / router / blobs /
+//! docs)の所有権と composition は `kukuri-iroh-node`(WP-H2)。本 crate はそこへ
+//! 部品を貸す側で、ノードのライフサイクルを持たない。ピア台帳まわりの挙動差分
+//! (bool 返却 / reapply 等)は呼び出し側 crate に残す(`peers.rs` の doc 参照)。
+//! endpoint 構築部品を足すときは本 crate、ノードの起動・停止・再構成に関わるもの
+//! を足すときは `kukuri-iroh-node` が置き場。
+
 mod config;
 mod diagnostics;
 mod discovery;


### PR DESCRIPTION
## Summary
- [docs] add the placement conventions the 2026-07-13 completion review proposed for four boundaries that were split cleanly but had no written rule to stay that way (findings D10–D13, adversarially verified):
  - `crates/transport/src/lib.rs` — crate doc contrasting what belongs here (gossip transport, endpoint building blocks, tickets, shared peers ledger, FakeTransport) with what belongs to `kukuri-iroh-node` (node ownership / composition)
  - `crates/cn-core/src/lib.rs` — admission criteria: Postgres/Redis-backed composition & persistence only, with pointers to cn-protocol (wire), cn-safety / cn-trust (domain), the resident crates, and cn-runtime-support
  - `crates/app-api/src/lib.rs` — top-level domain files = IPC-facing public API, `service/` = pub(crate) helpers & composition; consider ServiceHandles / SubscriptionRegistry before adding AppService fields; restates the private_channels split landmine
  - `DESIGN.md` §4.8 — the state-layer counterpart to §4.7's CSS rules: roles of slices / storeSelectors / presentation / data+loaders / viewModels / actions / page / routing, the intended two-style selector split, and the loaders-as-SSoT rule (B5) / facade boundary (B4)

Doc comments and markdown only — zero code changes.

## Validation
- cargo fmt --check / cargo xtask rust-check / cargo xtask cn-check (exit codes verified explicitly)

Recovers master plan §9.2 B10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)