### PR TITLE
refactor: publish the private channel import retry contract

### DIFF
--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -28,5 +28,8 @@ mod timeline;
 mod views;
 
 pub use kukuri_store::NotificationKind;
+pub use private_channels::{
+    is_retryable_friend_only_grant_import_error, is_retryable_friend_plus_share_import_error,
+};
 pub use service::{AppService, ServiceHandles};
 pub use views::*;

--- a/crates/app-api/src/private_channels.rs
+++ b/crates/app-api/src/private_channels.rs
@@ -1047,3 +1047,23 @@ struct PrivateChannelNextEpoch {
     epoch_id: String,
     secret_hex: String,
 }
+
+/// friend-only grant import 失敗の再試行可能性(リトライ契約。WP-B11)。
+///
+/// gossip 伝播待ちで解消しうる失敗(mutual 未成立 / epoch 不一致 / owner 未着 /
+/// snapshot timeout)のみ true。判定は `PrivateChannelImportError` への downcast で
+/// 行い、**エラー文言に依存しない**(文言は表示用で、契約はこの関数が正本)。
+/// リトライ対象の分類は crate 内の characterization テスト(tests/support/waiters.rs)
+/// が固定している。
+pub fn is_retryable_friend_only_grant_import_error(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<PrivateChannelImportError>()
+        .is_some_and(PrivateChannelImportError::is_retryable_friend_only)
+}
+
+/// friend-plus share import 失敗の再試行可能性(リトライ契約。WP-B11)。
+pub fn is_retryable_friend_plus_share_import_error(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<PrivateChannelImportError>()
+        .is_some_and(PrivateChannelImportError::is_retryable_friend_plus)
+}

--- a/crates/app-api/src/service/errors.rs
+++ b/crates/app-api/src/service/errors.rs
@@ -91,8 +91,9 @@ pub(crate) enum PrivateChannelImportError {
     SponsorSnapshotTimeout,
 }
 
-#[cfg(test)]
 impl PrivateChannelImportError {
+    /// friend-only grant import の再試行可能性(リトライ契約の正本。WP-B11)。
+    /// gossip 伝播待ちで解消しうる失敗のみ true。文言ではなく型で判定する。
     pub(crate) fn is_retryable_friend_only(&self) -> bool {
         matches!(
             self,
@@ -108,16 +109,21 @@ impl PrivateChannelImportError {
         )
     }
 
+    /// friend-plus share import の再試行可能性(リトライ契約の正本。WP-B11)。
     pub(crate) fn is_retryable_friend_plus(&self) -> bool {
-        matches!(
+        let retryable = matches!(
             self,
             Self::MutualRelationshipRequired {
                 kind: PrivateChannelImportKind::FriendPlus
             } | Self::SnapshotTimeout {
                 kind: PrivateChannelImportKind::FriendPlus
-            } | Self::SponsorInactive
-                | Self::SponsorSnapshotTimeout
-        )
+            }
+        );
+        // Sponsor 系はテスト専用 variant(production に発生経路が無い)。
+        #[cfg(test)]
+        let retryable =
+            retryable || matches!(self, Self::SponsorInactive | Self::SponsorSnapshotTimeout);
+        retryable
     }
 }
 

--- a/crates/app-api/src/tests/support/waiters.rs
+++ b/crates/app-api/src/tests/support/waiters.rs
@@ -151,11 +151,11 @@ pub(crate) async fn wait_for_mutual_author_view(
     }
 }
 
-pub(crate) fn is_retryable_friend_only_grant_import_error(error: &anyhow::Error) -> bool {
-    error
-        .downcast_ref::<PrivateChannelImportError>()
-        .is_some_and(PrivateChannelImportError::is_retryable_friend_only)
-}
+// リトライ判定の正本は crate::is_retryable_friend_only_grant_import_error /
+// crate::is_retryable_friend_plus_share_import_error(WP-B11 で pub 化)。
+pub(crate) use crate::{
+    is_retryable_friend_only_grant_import_error, is_retryable_friend_plus_share_import_error,
+};
 
 pub(crate) async fn wait_for_friend_only_grant_import(
     app: &AppService,
@@ -204,12 +204,6 @@ pub(crate) async fn wait_for_friend_only_grant_import(
             );
         }
     }
-}
-
-pub(crate) fn is_retryable_friend_plus_share_import_error(error: &anyhow::Error) -> bool {
-    error
-        .downcast_ref::<PrivateChannelImportError>()
-        .is_some_and(PrivateChannelImportError::is_retryable_friend_plus)
 }
 
 pub(crate) async fn wait_for_friend_plus_share_import(

--- a/crates/desktop-runtime/src/tests/support/social.rs
+++ b/crates/desktop-runtime/src/tests/support/social.rs
@@ -78,19 +78,12 @@ pub(crate) async fn warm_author_social_view(
     }
 }
 
-pub(crate) fn is_retryable_friend_plus_share_import_error(message: &str) -> bool {
-    message.contains("mutual relationship")
-        || message.contains("sponsor is not an active participant")
-        || message.contains("timed out waiting for friend-plus sponsor participant sync")
-        || message.contains("timed out waiting for friend-plus channel replica sync")
-}
-
-pub(crate) fn is_retryable_friend_only_grant_import_error(message: &str) -> bool {
-    message.contains("mutual relationship")
-        || message.contains("friend-only grant epoch does not match the current policy")
-        || message.contains("friend-only grant owner is not an active participant")
-        || message.contains("timed out waiting for friend-only channel replica sync")
-}
+// リトライ判定は app-api の typed 契約(WP-B11 で pub 化)を使う。DesktopRuntime は
+// app_service の anyhow チェーンを素通しするため downcast がそのまま届く。
+// 旧実装のエラー文言 contains 判定(文言 = 暗黙契約)はここで撤去した。
+use kukuri_app_api::{
+    is_retryable_friend_only_grant_import_error, is_retryable_friend_plus_share_import_error,
+};
 
 pub(crate) async fn wait_for_friend_only_grant_import(
     runtime: &DesktopRuntime,
@@ -110,9 +103,7 @@ pub(crate) async fn wait_for_friend_only_grant_import(
                 .await
             {
                 Ok(preview) => return preview,
-                Err(error)
-                    if is_retryable_friend_only_grant_import_error(error.to_string().as_str()) =>
-                {
+                Err(error) if is_retryable_friend_only_grant_import_error(&error) => {
                     *retry_error_slot.lock().await = Some(error.to_string());
                     sleep(Duration::from_millis(100)).await;
                 }
@@ -175,9 +166,7 @@ pub(crate) async fn wait_for_friend_plus_share_import(
                 .await
             {
                 Ok(preview) => return preview,
-                Err(error)
-                    if is_retryable_friend_plus_share_import_error(error.to_string().as_str()) =>
-                {
+                Err(error) if is_retryable_friend_plus_share_import_error(&error) => {
                     *retry_error_slot.lock().await = Some(error.to_string());
                     sleep(Duration::from_millis(100)).await;
                 }

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -9,7 +9,7 @@
       "path": "crates/app-api/src/service/private_channels_support.rs"
     },
     {
-      "lines": 1049,
+      "lines": 1069,
       "path": "crates/app-api/src/private_channels.rs"
     }
   ]


### PR DESCRIPTION
## Summary
- [refactor] make app-api the single source of truth for private channel import retryability (review finding D5, adversarially verified; master plan §9.2 B11, PR 1/2):
  - promote `PrivateChannelImportError::is_retryable_friend_only/plus` out of their `#[cfg(test)]` gate; the sponsor arms stay test-gated together with the test-only variants (production has no path to them)
  - expose two documented pub predicates (`is_retryable_friend_only_grant_import_error` / `is_retryable_friend_plus_share_import_error`, anyhow downcast) from `private_channels.rs`, re-exported at the crate root — the enum itself stays `pub(crate)`
  - app-api's test waiters consume the pub predicates instead of their local twins
  - desktop-runtime's test support drops its string-contains twin (`tests/support/social.rs`) and calls the typed predicates — `DesktopRuntime` passes the anyhow chain through, so the downcast lands (verified by the live friend-only/friend-plus import tests)

## Why
This was the last spot where private channel import error **wording** acted as an implicit contract: a Display change passed app-api's typed tests but silently broke only desktop-runtime's retry loop, surfacing as a 30s timeout flake (the §3.2 landmine list's "retry contains-match" in its final form). The dead sponsor-wording arms in the contains list (unreachable in production) disappear with it.

## Validation
- cargo test -p kukuri-app-api --lib — 137 passed (includes the unchanged retry-classification characterization tests, which now pin the pub predicates)
- cargo nextest run -p kukuri-desktop-runtime -E 'test(friend_only) or test(friend_plus)' — 2/2 passed (live iroh import flows retry through the typed predicates)
- cargo clippy -p kukuri-app-api -p kukuri-desktop-runtime --all-targets -- -D warnings / cargo fmt --check (exit codes verified explicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Oversized baseline update (justified growth)
The two documented pub predicates add 21 lines to `private_channels.rs` (1049 → 1069 actual), tripping the growth gate that B9's #585 had just ratcheted down. Updated the baseline per the REFACTORING.md procedure: the growth is the retry contract's single source of truth plus its doc, still well under the pre-B9 1087 level.
