### PR TITLE
fix: log the discarded operation context on internal errors

### DIFF
--- a/crates/cn-user-api/src/errors.rs
+++ b/crates/cn-user-api/src/errors.rs
@@ -69,7 +69,8 @@ pub(crate) fn account_lifecycle_error(error: AccountLifecycleError) -> ApiError 
             ApiError::new(StatusCode::UNAUTHORIZED, "AUTH_FAILED", source.to_string())
         }
         AccountLifecycleError::Infrastructure { operation, source } => {
-            let _ = operation;
+            // HTTP 契約(500 / INTERNAL / 汎用文言)は変えず、原因箇所は tracing にだけ出す。
+            tracing::error!(?operation, error = %source, "account lifecycle infrastructure failure");
             internal_error(source)
         }
     }
@@ -100,7 +101,7 @@ impl SupportEndpointError {
 
 pub(crate) fn support_endpoint_error(error: SupportEndpointError) -> ApiError {
     let SupportEndpointError { operation, source } = error;
-    let _ = operation;
+    tracing::error!(?operation, error = %source, "support endpoint infrastructure failure");
     internal_error(source)
 }
 
@@ -153,7 +154,7 @@ pub(crate) fn indexing_error(error: IndexingError) -> ApiError {
             source.to_string(),
         ),
         IndexingError::Infrastructure { operation, source } => {
-            let _ = operation;
+            tracing::error!(?operation, error = %source, "indexing infrastructure failure");
             internal_error(source)
         }
     }
@@ -212,12 +213,17 @@ impl TrustRelationError {
 }
 
 pub(crate) fn trust_relation_error(error: TrustRelationError) -> ApiError {
-    let (operation, source) = match error {
-        TrustRelationError::TrustRead { operation, source }
-        | TrustRelationError::RelationGraph { operation, source }
-        | TrustRelationError::RelationOptOut { operation, source } => (operation, source),
+    // variant 種別(どの依存面の失敗か)と operation(どの読み書きか)を観測に乗せる。
+    let (kind, operation, source) = match error {
+        TrustRelationError::TrustRead { operation, source } => ("trust_read", operation, source),
+        TrustRelationError::RelationGraph { operation, source } => {
+            ("relation_graph", operation, source)
+        }
+        TrustRelationError::RelationOptOut { operation, source } => {
+            ("relation_opt_out", operation, source)
+        }
     };
-    let _ = operation;
+    tracing::error!(kind, ?operation, error = %source, "trust/relation infrastructure failure");
     internal_error(source)
 }
 


### PR DESCRIPTION
## Summary
- [fix] wire the operation context Q6 introduced (24 variants across 4 enums, built at 25 handler call sites) into tracing instead of discarding it: every `let _ = operation;` in cn-user-api's error mappers becomes a `tracing::error!(?operation, error = %source, ...)` at the internal_error boundary
- the trust/relation mapper additionally records which dependency surface failed (`trust_read` / `relation_graph` / `relation_opt_out`), so the three nominally-distinct variants that previously collapsed into one identical mapping become observable
- HTTP contract unchanged: status / code / message are exactly as before (only a log line is added), so all frozen error-contract tests pass unmodified

## Why
Review finding D6 (adversarially verified): "carry information and throw it away" — a 500 from `/v1/*` gave operators no way to tell which of the 24 operations failed, and the ritual grows with every endpoint. This is option (a) from the audit's proposal (observe, don't remove), matching Q6's original intent.

## Validation
- rg 'let _ = operation' crates/cn-user-api → 0 matches
- cargo xtask cn-check (clippy -D warnings)
- cargo xtask cn-test — full contract suite against real Postgres/Valkey via docker compose, unchanged and green (proving the HTTP error contracts are untouched)
- cargo fmt --check (exit codes verified explicitly)

Recovers master plan §9.2 B11 (PR 2/2); the retry-contract companion is #587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)