### PR TITLE
contract: generate and enforce the IPC request DTO types

### DIFF
--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -127,7 +127,9 @@ PR を作成または説明するときは、タスク種別を明確にする�
    同一バイナリ内契約のため両側同時変更なら改名可能だが、片側変更は silent break。
    固定: 高頻度 8 型グループは共有 fixture(apps/desktop/src/lib/api/__fixtures__/views/)を
    Rust 側 crates/app-api/src/tests/views_wire_snapshot.rs と TS 側 viewsContract.ts(+ .test.ts)が
-   両側から検証する(再生成手順は各ファイル冒頭)。CommunityNode 系・requests.rs 入力方向は未。
+   両側から検証する(再生成手順は各ファイル冒頭)。入力方向(requests.rs ほかの request DTO)は
+   WP-B6 で codegen 対象になり、runtimeApi.ts の request literal が生成型への `satisfies` で
+   拘束される(再生成 diff + tsc の二重検出)。CommunityNode 系 view の fixture 化は未。
 
 ## 地雷リスト(直したくなるが、してはいけない)
 

--- a/apps/desktop/src/lib/api/commands/runtimeApi.ts
+++ b/apps/desktop/src/lib/api/commands/runtimeApi.ts
@@ -32,6 +32,66 @@ import type {
   TimelineView,
 } from '../types';
 
+// request DTO の生成型(WP-B6)。組み立てた literal を satisfies で拘束し、
+// Rust 側 DTO の変更を tsc で検出する。手書き types.ts の同名 shadow を避けるため
+// types.generated から直接 import する。
+import type {
+  AcceptCommunityNodeConsentsRequest,
+  AuthorRequest,
+  BookmarkCustomReactionRequest,
+  BookmarkPostRequest,
+  CommunityNodeTargetRequest,
+  CreateCustomReactionAssetRequest,
+  CreateGameRoomRequest,
+  CreateLiveSessionRequest,
+  CreateMetaverseRoomRequest,
+  CreatePostRequest,
+  CreatePrivateChannelRequest,
+  CreateRepostRequest,
+  DeleteDirectMessageMessageRequest,
+  DirectMessageRequest,
+  ExportChannelAccessTokenRequest,
+  ExportFriendOnlyGrantRequest,
+  ExportFriendPlusShareRequest,
+  ExportPrivateChannelInviteRequest,
+  FreezePrivateChannelRequest,
+  GetBlobMediaRequest,
+  GetBlobPreviewRequest,
+  ImportChannelAccessTokenRequest,
+  ImportFriendOnlyGrantRequest,
+  ImportFriendPlusShareRequest,
+  ImportMetaverseRoomAssetRequest,
+  ImportPeerTicketRequest,
+  ImportPrivateChannelInviteRequest,
+  LeavePrivateChannelRequest,
+  ListDirectMessageMessagesRequest,
+  ListGameRoomsRequest,
+  ListJoinedPrivateChannelsRequest,
+  ListLiveSessionsRequest,
+  ListMetaverseRoomEventsRequest,
+  ListProfileTimelineRequest,
+  ListRecentReactionsRequest,
+  ListSocialConnectionsRequest,
+  ListThreadRequest,
+  ListTimelineRequest,
+  LiveSessionCommandRequest,
+  NotificationIdRequest,
+  PreviewChannelAccessTokenRequest,
+  PublishMetaverseRoomEventRequest,
+  RemoveBookmarkedCustomReactionRequest,
+  RemoveBookmarkedPostRequest,
+  RotatePrivateChannelRequest,
+  SendDirectMessageRequest,
+  SetChannelGossipEnabledRequest,
+  SetCommunityNodeConfigRequest,
+  SetDiscoverySeedsRequest,
+  SetTopicGossipEnabledRequest,
+  ToggleReactionRequest,
+  UnsubscribeTopicRequest,
+  UpdateGameRoomRequest,
+  UpdateMetaverseRoomRequest,
+} from '../types.generated';
+
 import { invokeDesktop } from '../invoke/desktop';
 import { command } from '../invoke/dispatch';
 
@@ -44,7 +104,7 @@ export const runtimeApi: DesktopApi = {
         reply_to: replyTo,
         channel_ref: channelRef,
         attachments,
-      },
+      } satisfies CreatePostRequest,
     });
   }),
   createRepost: command('createRepost', async (topic, sourceTopic, sourceObjectId, commentary) => {
@@ -54,7 +114,7 @@ export const runtimeApi: DesktopApi = {
         source_topic: sourceTopic,
         source_object_id: sourceObjectId,
         commentary,
-      },
+      } satisfies CreateRepostRequest,
     });
   }),
   toggleReaction: command('toggleReaction', async (targetTopicId, targetObjectId, reactionKey, channelRef = null) => {
@@ -77,7 +137,7 @@ export const runtimeApi: DesktopApi = {
                 height: reactionKey.asset.height,
               },
         channel_ref: channelRef,
-      },
+      } satisfies ToggleReactionRequest,
     });
   }),
   listMyCustomReactionAssets: command('listMyCustomReactionAssets', async () => {
@@ -87,7 +147,7 @@ export const runtimeApi: DesktopApi = {
     return invokeDesktop<RecentReactionView[]>('list_recent_reactions', {
       request: {
         limit,
-      },
+      } satisfies ListRecentReactionsRequest,
     });
   }),
   createCustomReactionAsset: command('createCustomReactionAsset', async (upload, cropRect, searchKey) => {
@@ -96,7 +156,7 @@ export const runtimeApi: DesktopApi = {
         upload,
         crop_rect: cropRect,
         search_key: searchKey,
-      },
+      } satisfies CreateCustomReactionAssetRequest,
     });
   }),
   listBookmarkedCustomReactions: command('listBookmarkedCustomReactions', async () => {
@@ -113,14 +173,14 @@ export const runtimeApi: DesktopApi = {
         bytes: asset.bytes,
         width: asset.width,
         height: asset.height,
-      },
+      } satisfies BookmarkCustomReactionRequest,
     });
   }),
   removeBookmarkedCustomReaction: command('removeBookmarkedCustomReaction', async (assetId) => {
     return invokeDesktop<void>('remove_bookmarked_custom_reaction', {
       request: {
         asset_id: assetId,
-      },
+      } satisfies RemoveBookmarkedCustomReactionRequest,
     });
   }),
   listBookmarkedPosts: command('listBookmarkedPosts', async () => {
@@ -131,14 +191,14 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         object_id: objectId,
-      },
+      } satisfies BookmarkPostRequest,
     });
   }),
   removeBookmarkedPost: command('removeBookmarkedPost', async (objectId) => {
     return invokeDesktop<void>('remove_bookmarked_post', {
       request: {
         object_id: objectId,
-      },
+      } satisfies RemoveBookmarkedPostRequest,
     });
   }),
   listTimeline: command('listTimeline', async (topic, cursor, limit, scope = { kind: 'public' }) => {
@@ -148,7 +208,7 @@ export const runtimeApi: DesktopApi = {
         scope,
         cursor,
         limit,
-      },
+      } satisfies ListTimelineRequest,
     });
   }),
   listThread: command('listThread', async (topic, threadId, cursor, limit) => {
@@ -158,7 +218,7 @@ export const runtimeApi: DesktopApi = {
         thread_id: threadId,
         cursor,
         limit,
-      },
+      } satisfies ListThreadRequest,
     });
   }),
   listProfileTimeline: command('listProfileTimeline', async (pubkey, cursor, limit) => {
@@ -167,7 +227,7 @@ export const runtimeApi: DesktopApi = {
         pubkey,
         cursor,
         limit,
-      },
+      } satisfies ListProfileTimelineRequest,
     });
   }),
   getMyProfile: command('getMyProfile', async () => {
@@ -180,32 +240,32 @@ export const runtimeApi: DesktopApi = {
   }),
   followAuthor: command('followAuthor', async (pubkey) => {
     return invokeDesktop<AuthorSocialView>('follow_author', {
-      request: { pubkey },
+      request: { pubkey } satisfies AuthorRequest,
     });
   }),
   unfollowAuthor: command('unfollowAuthor', async (pubkey) => {
     return invokeDesktop<AuthorSocialView>('unfollow_author', {
-      request: { pubkey },
+      request: { pubkey } satisfies AuthorRequest,
     });
   }),
   getAuthorSocialView: command('getAuthorSocialView', async (pubkey) => {
     return invokeDesktop<AuthorSocialView>('get_author_social_view', {
-      request: { pubkey },
+      request: { pubkey } satisfies AuthorRequest,
     });
   }),
   muteAuthor: command('muteAuthor', async (pubkey) => {
     return invokeDesktop<AuthorSocialView>('mute_author', {
-      request: { pubkey },
+      request: { pubkey } satisfies AuthorRequest,
     });
   }),
   unmuteAuthor: command('unmuteAuthor', async (pubkey) => {
     return invokeDesktop<AuthorSocialView>('unmute_author', {
-      request: { pubkey },
+      request: { pubkey } satisfies AuthorRequest,
     });
   }),
   listSocialConnections: command('listSocialConnections', async (kind) => {
     return invokeDesktop<AuthorSocialView[]>('list_social_connections', {
-      request: { kind },
+      request: { kind } satisfies ListSocialConnectionsRequest,
     });
   }),
   listNotifications: command('listNotifications', async () => {
@@ -213,7 +273,7 @@ export const runtimeApi: DesktopApi = {
   }),
   markNotificationRead: command('markNotificationRead', async (notificationId) => {
     return invokeDesktop<NotificationStatusView>('mark_notification_read', {
-      request: { notification_id: notificationId },
+      request: { notification_id: notificationId } satisfies NotificationIdRequest,
     });
   }),
   markAllNotificationsRead: command('markAllNotificationsRead', async () => {
@@ -224,7 +284,7 @@ export const runtimeApi: DesktopApi = {
   }),
   openDirectMessage: command('openDirectMessage', async (pubkey) => {
     return invokeDesktop<DirectMessageConversationView>('open_direct_message', {
-      request: { pubkey },
+      request: { pubkey } satisfies DirectMessageRequest,
     });
   }),
   listDirectMessages: command('listDirectMessages', async () => {
@@ -236,7 +296,7 @@ export const runtimeApi: DesktopApi = {
         pubkey,
         cursor,
         limit,
-      },
+      } satisfies ListDirectMessageMessagesRequest,
     });
   }),
   sendDirectMessage: command('sendDirectMessage', async (pubkey, text, attachments = [], replyToMessageId) => {
@@ -246,7 +306,7 @@ export const runtimeApi: DesktopApi = {
         text,
         reply_to_message_id: replyToMessageId,
         attachments,
-      },
+      } satisfies SendDirectMessageRequest,
     });
   }),
   deleteDirectMessageMessage: command('deleteDirectMessageMessage', async (pubkey, messageId) => {
@@ -254,17 +314,17 @@ export const runtimeApi: DesktopApi = {
       request: {
         pubkey,
         message_id: messageId,
-      },
+      } satisfies DeleteDirectMessageMessageRequest,
     });
   }),
   clearDirectMessage: command('clearDirectMessage', async (pubkey) => {
     return invokeDesktop<void>('clear_direct_message', {
-      request: { pubkey },
+      request: { pubkey } satisfies DirectMessageRequest,
     });
   }),
   getDirectMessageStatus: command('getDirectMessageStatus', async (pubkey) => {
     return invokeDesktop<DirectMessageStatusView>('get_direct_message_status', {
-      request: { pubkey },
+      request: { pubkey } satisfies DirectMessageRequest,
     });
   }),
   listLiveSessions: command('listLiveSessions', async (topic, scope = { kind: 'public' }) => {
@@ -272,7 +332,7 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         scope,
-      },
+      } satisfies ListLiveSessionsRequest,
     });
   }),
   createLiveSession: command('createLiveSession', async (topic, title, description, channelRef = { kind: 'public' }) => {
@@ -282,7 +342,7 @@ export const runtimeApi: DesktopApi = {
         channel_ref: channelRef,
         title,
         description,
-      },
+      } satisfies CreateLiveSessionRequest,
     });
   }),
   endLiveSession: command('endLiveSession', async (topic, sessionId) => {
@@ -290,7 +350,7 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         session_id: sessionId,
-      },
+      } satisfies LiveSessionCommandRequest,
     });
   }),
   joinLiveSession: command('joinLiveSession', async (topic, sessionId) => {
@@ -298,7 +358,7 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         session_id: sessionId,
-      },
+      } satisfies LiveSessionCommandRequest,
     });
   }),
   leaveLiveSession: command('leaveLiveSession', async (topic, sessionId) => {
@@ -306,7 +366,7 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         session_id: sessionId,
-      },
+      } satisfies LiveSessionCommandRequest,
     });
   }),
   listGameRooms: command('listGameRooms', async (topic, scope = { kind: 'public' }) => {
@@ -314,7 +374,7 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         scope,
-      },
+      } satisfies ListGameRoomsRequest,
     });
   }),
   createGameRoom: command('createGameRoom', async (
@@ -331,7 +391,7 @@ export const runtimeApi: DesktopApi = {
         title,
         description,
         participants,
-      },
+      } satisfies CreateGameRoomRequest,
     });
   }),
   createMetaverseRoom: command('createMetaverseRoom', async (
@@ -348,12 +408,12 @@ export const runtimeApi: DesktopApi = {
         title,
         description,
         max_peers: maxPeers,
-      },
+      } satisfies CreateMetaverseRoomRequest,
     });
   }),
   createPrivateChannel: command('createPrivateChannel', async (topic, label, audienceKind = 'invite_only') => {
     return invokeDesktop<JoinedPrivateChannelView>('create_private_channel', {
-      request: { topic, label, audience_kind: audienceKind },
+      request: { topic, label, audience_kind: audienceKind } satisfies CreatePrivateChannelRequest,
     });
   }),
   exportPrivateChannelInvite: command('exportPrivateChannelInvite', async (topic, channelId, expiresAt = null) => {
@@ -362,12 +422,12 @@ export const runtimeApi: DesktopApi = {
         topic,
         channel_id: channelId,
         expires_at: expiresAt,
-      },
+      } satisfies ExportPrivateChannelInviteRequest,
     });
   }),
   importPrivateChannelInvite: command('importPrivateChannelInvite', async (token) => {
     return invokeDesktop<PrivateChannelInvitePreview>('import_private_channel_invite', {
-      request: { token },
+      request: { token } satisfies ImportPrivateChannelInviteRequest,
     });
   }),
   exportChannelAccessToken: command('exportChannelAccessToken', async (topic, channelId, expiresAt = null) => {
@@ -376,19 +436,19 @@ export const runtimeApi: DesktopApi = {
         topic,
         channel_id: channelId,
         expires_at: expiresAt,
-      },
+      } satisfies ExportChannelAccessTokenRequest,
     });
   }),
   previewChannelAccessToken: command('previewChannelAccessToken', async (token) => {
     return invokeDesktop<ChannelAccessTokenPreview>('preview_channel_access_token', {
       request: {
         token,
-      },
+      } satisfies PreviewChannelAccessTokenRequest,
     });
   }),
   importChannelAccessToken: command('importChannelAccessToken', async (token) => {
     return invokeDesktop<ChannelAccessTokenPreview>('import_channel_access_token', {
-      request: { token },
+      request: { token } satisfies ImportChannelAccessTokenRequest,
     });
   }),
   exportFriendOnlyGrant: command('exportFriendOnlyGrant', async (topic, channelId, expiresAt = null) => {
@@ -397,12 +457,12 @@ export const runtimeApi: DesktopApi = {
         topic,
         channel_id: channelId,
         expires_at: expiresAt,
-      },
+      } satisfies ExportFriendOnlyGrantRequest,
     });
   }),
   importFriendOnlyGrant: command('importFriendOnlyGrant', async (token) => {
     return invokeDesktop<FriendOnlyGrantPreview>('import_friend_only_grant', {
-      request: { token },
+      request: { token } satisfies ImportFriendOnlyGrantRequest,
     });
   }),
   exportFriendPlusShare: command('exportFriendPlusShare', async (topic, channelId, expiresAt = null) => {
@@ -411,12 +471,12 @@ export const runtimeApi: DesktopApi = {
         topic,
         channel_id: channelId,
         expires_at: expiresAt,
-      },
+      } satisfies ExportFriendPlusShareRequest,
     });
   }),
   importFriendPlusShare: command('importFriendPlusShare', async (token) => {
     return invokeDesktop<FriendPlusSharePreview>('import_friend_plus_share', {
-      request: { token },
+      request: { token } satisfies ImportFriendPlusShareRequest,
     });
   }),
   freezePrivateChannel: command('freezePrivateChannel', async (topic, channelId) => {
@@ -424,7 +484,7 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         channel_id: channelId,
-      },
+      } satisfies FreezePrivateChannelRequest,
     });
   }),
   rotatePrivateChannel: command('rotatePrivateChannel', async (topic, channelId) => {
@@ -432,7 +492,7 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         channel_id: channelId,
-      },
+      } satisfies RotatePrivateChannelRequest,
     });
   }),
   leavePrivateChannel: command('leavePrivateChannel', async (topic, channelId) => {
@@ -440,12 +500,12 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         channel_id: channelId,
-      },
+      } satisfies LeavePrivateChannelRequest,
     });
   }),
   listJoinedPrivateChannels: command('listJoinedPrivateChannels', async (topic) => {
     return invokeDesktop<JoinedPrivateChannelView[]>('list_joined_private_channels', {
-      request: { topic },
+      request: { topic } satisfies ListJoinedPrivateChannelsRequest,
     });
   }),
   updateGameRoom: command('updateGameRoom', async (topic, roomId, status, phaseLabel, scores) => {
@@ -456,7 +516,7 @@ export const runtimeApi: DesktopApi = {
         status,
         phase_label: phaseLabel,
         scores,
-      },
+      } satisfies UpdateGameRoomRequest,
     });
   }),
   updateMetaverseRoom: command('updateMetaverseRoom', async (
@@ -475,7 +535,7 @@ export const runtimeApi: DesktopApi = {
         shared_object_position: sharedObjectPosition,
         shared_object_rotation: sharedObjectRotation,
         shared_object_scale: sharedObjectScale,
-      },
+      } satisfies UpdateMetaverseRoomRequest,
     });
   }),
   publishMetaverseRoomEvent: command('publishMetaverseRoomEvent', async (topic, roomId, peerId, seq, event) => {
@@ -486,7 +546,7 @@ export const runtimeApi: DesktopApi = {
         peer_id: peerId,
         seq,
         event,
-      },
+      } satisfies PublishMetaverseRoomEventRequest,
     });
   }),
   listMetaverseRoomEvents: command('listMetaverseRoomEvents', async (topic, roomId, afterEnvelopeId = null, limit = null) => {
@@ -496,7 +556,7 @@ export const runtimeApi: DesktopApi = {
         room_id: roomId,
         after_envelope_id: afterEnvelopeId,
         limit,
-      },
+      } satisfies ListMetaverseRoomEventsRequest,
     });
   }),
   importMetaverseRoomAsset: command('importMetaverseRoomAsset', async (topic, roomId, kind, mimeType, name, dataBase64) => {
@@ -508,7 +568,7 @@ export const runtimeApi: DesktopApi = {
         mime_type: mimeType,
         name,
         data_base64: dataBase64,
-      },
+      } satisfies ImportMetaverseRoomAssetRequest,
     });
   }),
   getSyncStatus: command('getSyncStatus', async () => {
@@ -527,7 +587,7 @@ export const runtimeApi: DesktopApi = {
     return invokeDesktop<CommunityNodeConfig>('set_community_node_config', {
       request: {
         nodes,
-      },
+      } satisfies SetCommunityNodeConfigRequest,
     });
   }),
   clearCommunityNodeConfig: command('clearCommunityNodeConfig', async () => {
@@ -537,21 +597,21 @@ export const runtimeApi: DesktopApi = {
     return invokeDesktop<CommunityNodeNodeStatus>('authenticate_community_node', {
       request: {
         base_url: baseUrl,
-      },
+      } satisfies CommunityNodeTargetRequest,
     });
   }),
   clearCommunityNodeToken: command('clearCommunityNodeToken', async (baseUrl) => {
     return invokeDesktop<CommunityNodeNodeStatus>('clear_community_node_token', {
       request: {
         base_url: baseUrl,
-      },
+      } satisfies CommunityNodeTargetRequest,
     });
   }),
   getCommunityNodeConsentStatus: command('getCommunityNodeConsentStatus', async (baseUrl) => {
     return invokeDesktop<CommunityNodeNodeStatus>('get_community_node_consent_status', {
       request: {
         base_url: baseUrl,
-      },
+      } satisfies CommunityNodeTargetRequest,
     });
   }),
   acceptCommunityNodeConsents: command('acceptCommunityNodeConsents', async (baseUrl, policySlugs) => {
@@ -559,21 +619,21 @@ export const runtimeApi: DesktopApi = {
       request: {
         base_url: baseUrl,
         policy_slugs: policySlugs,
-      },
+      } satisfies AcceptCommunityNodeConsentsRequest,
     });
   }),
   refreshCommunityNodeMetadata: command('refreshCommunityNodeMetadata', async (baseUrl) => {
     return invokeDesktop<CommunityNodeNodeStatus>('refresh_community_node_metadata', {
       request: {
         base_url: baseUrl,
-      },
+      } satisfies CommunityNodeTargetRequest,
     });
   }),
   fetchCommunityNodeManifest: command('fetchCommunityNodeManifest', async (baseUrl) => {
     return invokeDesktop<CommunityNodeManifestFetch>('fetch_community_node_manifest', {
       request: {
         base_url: baseUrl,
-      },
+      } satisfies CommunityNodeTargetRequest,
     });
   }),
   submitCommunityNodeReport: command('submitCommunityNodeReport', async (request) => {
@@ -585,21 +645,21 @@ export const runtimeApi: DesktopApi = {
     return invokeDesktop<void>('import_peer_ticket', {
       request: {
         ticket,
-      },
+      } satisfies ImportPeerTicketRequest,
     });
   }),
   setDiscoverySeeds: command('setDiscoverySeeds', async (seedEntries) => {
     return invokeDesktop<DiscoveryConfig>('set_discovery_seeds', {
       request: {
         seed_entries: seedEntries,
-      },
+      } satisfies SetDiscoverySeedsRequest,
     });
   }),
   unsubscribeTopic: command('unsubscribeTopic', async (topic) => {
     return invokeDesktop<void>('unsubscribe_topic', {
       request: {
         topic,
-      },
+      } satisfies UnsubscribeTopicRequest,
     });
   }),
   setTopicGossipEnabled: command('setTopicGossipEnabled', async (topic, enabled) => {
@@ -607,7 +667,7 @@ export const runtimeApi: DesktopApi = {
       request: {
         topic,
         enabled,
-      },
+      } satisfies SetTopicGossipEnabledRequest,
     });
   }),
   setChannelGossipEnabled: command('setChannelGossipEnabled', async (topic, channelId, enabled) => {
@@ -616,7 +676,7 @@ export const runtimeApi: DesktopApi = {
         topic,
         channel: channelId,
         enabled,
-      },
+      } satisfies SetChannelGossipEnabledRequest,
     });
   }),
   getLocalPeerTicket: command('getLocalPeerTicket', async () => {
@@ -627,7 +687,7 @@ export const runtimeApi: DesktopApi = {
       request: {
         hash,
         mime,
-      },
+      } satisfies GetBlobMediaRequest,
     });
   }),
   getBlobPreviewUrl: command('getBlobPreviewUrl', async (hash, mime) => {
@@ -635,7 +695,7 @@ export const runtimeApi: DesktopApi = {
       request: {
         hash,
         mime,
-      },
+      } satisfies GetBlobPreviewRequest,
     });
   }),
 };

--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -227,3 +227,111 @@ reference_id?: string | null, };
 
 export type RuntimeEvent = { "type": "notification_status_changed" } | { "type": "sync_status_changed", sync_status?: SyncStatus | null, community_node_statuses?: Array<CommunityNodeNodeStatus> | null, };
 
+export type CreatePostRequest = { topic: string, content: string, reply_to?: string | null, channel_ref: ChannelRef, attachments: Array<CreateAttachmentRequest>, };
+
+export type CreateRepostRequest = { topic: string, source_topic: string, source_object_id: string, commentary?: string | null, };
+
+export type CreateAttachmentRequest = { file_name?: string | null, mime: string, byte_size: number, data_base64: string, role?: string | null, };
+
+export type ReactionKeyRequest = { "kind": "emoji", emoji: string, } | { "kind": "custom_asset", asset_id: string, owner_pubkey: string, blob_hash: string, search_key: string, mime: string, bytes: number, width: number, height: number, };
+
+export type ToggleReactionRequest = { target_topic_id: string, target_object_id: string, reaction_key: ReactionKeyRequest, channel_ref?: ChannelRef | null, };
+
+export type CustomReactionCropRect = { x: number, y: number, size: number, };
+
+export type CreateCustomReactionAssetRequest = { upload: CreateAttachmentRequest, crop_rect: CustomReactionCropRect, search_key: string, };
+
+export type BookmarkCustomReactionRequest = { asset_id: string, owner_pubkey: string, blob_hash: string, search_key: string, mime: string, bytes: number, width: number, height: number, };
+
+export type RemoveBookmarkedCustomReactionRequest = { asset_id: string, };
+
+export type BookmarkPostRequest = { topic: string, object_id: string, };
+
+export type RemoveBookmarkedPostRequest = { object_id: string, };
+
+export type ListRecentReactionsRequest = { limit?: number | null, };
+
+export type ListTimelineRequest = { topic: string, scope: TimelineScope, cursor?: TimelineCursor | null, limit?: number | null, };
+
+export type ListThreadRequest = { topic: string, thread_id: string, cursor?: TimelineCursor | null, limit?: number | null, };
+
+export type ListProfileTimelineRequest = { pubkey: string, cursor?: TimelineCursor | null, limit?: number | null, };
+
+export type ImportPeerTicketRequest = { ticket: string, };
+
+export type UnsubscribeTopicRequest = { topic: string, };
+
+export type SetTopicGossipEnabledRequest = { topic: string, enabled: boolean, };
+
+export type SetChannelGossipEnabledRequest = { topic: string, channel: string, enabled: boolean, };
+
+export type GetBlobPreviewRequest = { hash: string, mime: string, };
+
+export type GetBlobMediaRequest = { hash: string, mime: string, };
+
+export type AuthorRequest = { pubkey: string, };
+
+export type ListSocialConnectionsRequest = { kind: SocialConnectionKind, };
+
+export type DirectMessageRequest = { pubkey: string, };
+
+export type NotificationIdRequest = { notification_id: string, };
+
+export type ListDirectMessageMessagesRequest = { pubkey: string, cursor?: TimelineCursor | null, limit?: number | null, };
+
+export type SendDirectMessageRequest = { pubkey: string, text?: string | null, reply_to_message_id?: string | null, attachments: Array<CreateAttachmentRequest>, };
+
+export type DeleteDirectMessageMessageRequest = { pubkey: string, message_id: string, };
+
+export type SetMyProfileRequest = { name?: string | null, display_name?: string | null, about?: string | null, picture?: string | null, picture_upload?: CreateAttachmentRequest | null, clear_picture: boolean, };
+
+export type ListLiveSessionsRequest = { topic: string, scope: TimelineScope, };
+
+export type CreateLiveSessionRequest = { topic: string, channel_ref: ChannelRef, title: string, description: string, };
+
+export type LiveSessionCommandRequest = { topic: string, session_id: string, };
+
+export type ListGameRoomsRequest = { topic: string, scope: TimelineScope, };
+
+export type CreateGameRoomRequest = { topic: string, channel_ref: ChannelRef, title: string, description: string, participants: Array<string>, };
+
+export type CreateMetaverseRoomRequest = { topic: string, channel_ref: ChannelRef, title: string, description: string, max_peers?: number | null, };
+
+export type PublishMetaverseRoomEventRequest = { topic: string, room_id: string, peer_id: string, seq: number, event: MetaverseRoomEventV1, };
+
+export type ListMetaverseRoomEventsRequest = { topic: string, room_id: string, after_envelope_id?: string | null, limit?: number | null, };
+
+export type ImportMetaverseRoomAssetRequest = { topic: string, room_id: string, kind: MetaverseAssetKind, mime_type: string, name?: string | null, data_base64: string, };
+
+export type CreatePrivateChannelRequest = { topic: string, label: string, audience_kind: ChannelAudienceKind, };
+
+export type ExportPrivateChannelInviteRequest = { topic: string, channel_id: string, expires_at?: number | null, };
+
+export type ImportPrivateChannelInviteRequest = { token: string, };
+
+export type ExportChannelAccessTokenRequest = { topic: string, channel_id: string, expires_at?: number | null, };
+
+export type ImportChannelAccessTokenRequest = { token: string, };
+
+export type PreviewChannelAccessTokenRequest = { token: string, };
+
+export type ExportFriendOnlyGrantRequest = { topic: string, channel_id: string, expires_at?: number | null, };
+
+export type ImportFriendOnlyGrantRequest = { token: string, };
+
+export type ExportFriendPlusShareRequest = { topic: string, channel_id: string, expires_at?: number | null, };
+
+export type ImportFriendPlusShareRequest = { token: string, };
+
+export type FreezePrivateChannelRequest = { topic: string, channel_id: string, };
+
+export type RotatePrivateChannelRequest = { topic: string, channel_id: string, };
+
+export type LeavePrivateChannelRequest = { topic: string, channel_id: string, };
+
+export type ListJoinedPrivateChannelsRequest = { topic: string, };
+
+export type UpdateGameRoomRequest = { topic: string, room_id: string, status: GameRoomStatus, phase_label?: string | null, scores: Array<GameScoreView>, };
+
+export type UpdateMetaverseRoomRequest = { topic: string, room_id: string, status: GameRoomStatus, shared_object_position: [number, number, number], shared_object_rotation: [number, number, number], shared_object_scale: [number, number, number], };
+

--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -335,3 +335,13 @@ export type UpdateGameRoomRequest = { topic: string, room_id: string, status: Ga
 
 export type UpdateMetaverseRoomRequest = { topic: string, room_id: string, status: GameRoomStatus, shared_object_position: [number, number, number], shared_object_rotation: [number, number, number], shared_object_scale: [number, number, number], };
 
+export type SetCommunityNodeConfigNode = { base_url: string, auto_approve: boolean, };
+
+export type SetCommunityNodeConfigRequest = { nodes: Array<SetCommunityNodeConfigNode>, };
+
+export type CommunityNodeTargetRequest = { base_url: string, };
+
+export type AcceptCommunityNodeConsentsRequest = { base_url: string, policy_slugs: Array<string>, };
+
+export type SetDiscoverySeedsRequest = { seed_entries: Array<string>, };
+

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -119,6 +119,8 @@ pub(crate) struct TopicRendezvousPeerCandidate {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SetCommunityNodeConfigNode {
     pub base_url: String,
     #[serde(default)]
@@ -126,16 +128,22 @@ pub struct SetCommunityNodeConfigNode {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SetCommunityNodeConfigRequest {
     pub nodes: Vec<SetCommunityNodeConfigNode>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeTargetRequest {
     pub base_url: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct AcceptCommunityNodeConsentsRequest {
     pub base_url: String,
     #[serde(default)]

--- a/crates/desktop-runtime/src/discovery.rs
+++ b/crates/desktop-runtime/src/discovery.rs
@@ -57,6 +57,8 @@ impl DiscoveryConfig {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SetDiscoverySeedsRequest {
     pub seed_entries: Vec<String>,
 }

--- a/crates/desktop-runtime/src/ipc_ts_export.rs
+++ b/crates/desktop-runtime/src/ipc_ts_export.rs
@@ -29,11 +29,12 @@ fn emit<T: TS>(cfg: &ts_rs::Config, out: &mut String) {
 #[test]
 fn export_ipc_types() {
     use crate::{
-        AuthorRequest, BookmarkCustomReactionRequest, BookmarkPostRequest, CommunityNodeAuthState,
-        CommunityNodeAuthorityScope, CommunityNodeCapabilityScope, CommunityNodeConfig,
-        CommunityNodeManifest, CommunityNodeManifestFetch, CommunityNodeManifestFetchStatus,
-        CommunityNodeNodeConfig, CommunityNodeNodeStatus, CommunityNodeP2pBoundary,
-        CommunityNodeSessionPhase, CreateAttachmentRequest, CreateCustomReactionAssetRequest,
+        AcceptCommunityNodeConsentsRequest, AuthorRequest, BookmarkCustomReactionRequest,
+        BookmarkPostRequest, CommunityNodeAuthState, CommunityNodeAuthorityScope,
+        CommunityNodeCapabilityScope, CommunityNodeConfig, CommunityNodeManifest,
+        CommunityNodeManifestFetch, CommunityNodeManifestFetchStatus, CommunityNodeNodeConfig,
+        CommunityNodeNodeStatus, CommunityNodeP2pBoundary, CommunityNodeSessionPhase,
+        CommunityNodeTargetRequest, CreateAttachmentRequest, CreateCustomReactionAssetRequest,
         CreateGameRoomRequest, CreateLiveSessionRequest, CreateMetaverseRoomRequest,
         CreatePostRequest, CreatePrivateChannelRequest, CreateRepostRequest,
         CustomReactionCropRect, DeleteDirectMessageMessageRequest, DirectMessageRequest,
@@ -50,7 +51,8 @@ fn export_ipc_types() {
         PreviewChannelAccessTokenRequest, PublishMetaverseRoomEventRequest, ReactionKeyRequest,
         RemoveBookmarkedCustomReactionRequest, RemoveBookmarkedPostRequest,
         RotatePrivateChannelRequest, RuntimeEvent, SendDirectMessageRequest,
-        SetChannelGossipEnabledRequest, SetMyProfileRequest, SetTopicGossipEnabledRequest,
+        SetChannelGossipEnabledRequest, SetCommunityNodeConfigNode, SetCommunityNodeConfigRequest,
+        SetDiscoverySeedsRequest, SetMyProfileRequest, SetTopicGossipEnabledRequest,
         SubmitCommunityNodeReportRequest, SubmitCommunityNodeReportResult,
         SubmitCommunityNodeReportStatus, ToggleReactionRequest, UnsubscribeTopicRequest,
         UpdateGameRoomRequest, UpdateMetaverseRoomRequest,
@@ -227,6 +229,12 @@ fn export_ipc_types() {
         ListJoinedPrivateChannelsRequest,
         UpdateGameRoomRequest,
         UpdateMetaverseRoomRequest,
+        // requests.rs 外の request DTO(community_node / discovery)
+        SetCommunityNodeConfigNode,
+        SetCommunityNodeConfigRequest,
+        CommunityNodeTargetRequest,
+        AcceptCommunityNodeConsentsRequest,
+        SetDiscoverySeedsRequest,
     );
 
     let path = concat!(

--- a/crates/desktop-runtime/src/ipc_ts_export.rs
+++ b/crates/desktop-runtime/src/ipc_ts_export.rs
@@ -9,8 +9,10 @@
 //! が `TS_RS_LARGE_INT=number` を設定して実行し、CI は再生成後の
 //! `git diff --exit-code` で Rust と TS の乖離を検出する。
 //!
-//! front 専用型(入力 DTO / エラー型 / DesktopApi interface)は手書きの
-//! types.ts 側に残す。
+//! 入力方向の request DTO(requests.rs)も生成対象(WP-B6)。runtimeApi.ts の
+//! request 構築 literal は生成型への `satisfies` 注釈で拘束され、Rust 側の変更は
+//! 再生成 diff + tsc の二重で検出される。front 専用型(展開引数の便宜型 /
+//! エラー型 / DesktopApi interface)は手書きの types.ts 側に残す。
 #![cfg(feature = "ts")]
 
 use ts_rs::TS;
@@ -27,12 +29,31 @@ fn emit<T: TS>(cfg: &ts_rs::Config, out: &mut String) {
 #[test]
 fn export_ipc_types() {
     use crate::{
-        CommunityNodeAuthState, CommunityNodeAuthorityScope, CommunityNodeCapabilityScope,
-        CommunityNodeConfig, CommunityNodeManifest, CommunityNodeManifestFetch,
-        CommunityNodeManifestFetchStatus, CommunityNodeNodeConfig, CommunityNodeNodeStatus,
-        CommunityNodeP2pBoundary, CommunityNodeSessionPhase, DiscoveryConfig, RuntimeEvent,
+        AuthorRequest, BookmarkCustomReactionRequest, BookmarkPostRequest, CommunityNodeAuthState,
+        CommunityNodeAuthorityScope, CommunityNodeCapabilityScope, CommunityNodeConfig,
+        CommunityNodeManifest, CommunityNodeManifestFetch, CommunityNodeManifestFetchStatus,
+        CommunityNodeNodeConfig, CommunityNodeNodeStatus, CommunityNodeP2pBoundary,
+        CommunityNodeSessionPhase, CreateAttachmentRequest, CreateCustomReactionAssetRequest,
+        CreateGameRoomRequest, CreateLiveSessionRequest, CreateMetaverseRoomRequest,
+        CreatePostRequest, CreatePrivateChannelRequest, CreateRepostRequest,
+        CustomReactionCropRect, DeleteDirectMessageMessageRequest, DirectMessageRequest,
+        DiscoveryConfig, ExportChannelAccessTokenRequest, ExportFriendOnlyGrantRequest,
+        ExportFriendPlusShareRequest, ExportPrivateChannelInviteRequest,
+        FreezePrivateChannelRequest, GetBlobMediaRequest, GetBlobPreviewRequest,
+        ImportChannelAccessTokenRequest, ImportFriendOnlyGrantRequest,
+        ImportFriendPlusShareRequest, ImportMetaverseRoomAssetRequest, ImportPeerTicketRequest,
+        ImportPrivateChannelInviteRequest, LeavePrivateChannelRequest,
+        ListDirectMessageMessagesRequest, ListGameRoomsRequest, ListJoinedPrivateChannelsRequest,
+        ListLiveSessionsRequest, ListMetaverseRoomEventsRequest, ListProfileTimelineRequest,
+        ListRecentReactionsRequest, ListSocialConnectionsRequest, ListThreadRequest,
+        ListTimelineRequest, LiveSessionCommandRequest, NotificationIdRequest,
+        PreviewChannelAccessTokenRequest, PublishMetaverseRoomEventRequest, ReactionKeyRequest,
+        RemoveBookmarkedCustomReactionRequest, RemoveBookmarkedPostRequest,
+        RotatePrivateChannelRequest, RuntimeEvent, SendDirectMessageRequest,
+        SetChannelGossipEnabledRequest, SetMyProfileRequest, SetTopicGossipEnabledRequest,
         SubmitCommunityNodeReportRequest, SubmitCommunityNodeReportResult,
-        SubmitCommunityNodeReportStatus,
+        SubmitCommunityNodeReportStatus, ToggleReactionRequest, UnsubscribeTopicRequest,
+        UpdateGameRoomRequest, UpdateMetaverseRoomRequest,
     };
     use kukuri_app_api::*;
     use kukuri_cn_protocol::{
@@ -151,6 +172,61 @@ fn export_ipc_types() {
         SubmitCommunityNodeReportStatus,
         SubmitCommunityNodeReportResult,
         RuntimeEvent,
+        // 入力方向の request DTO(requests.rs。WP-B6)
+        CreatePostRequest,
+        CreateRepostRequest,
+        CreateAttachmentRequest,
+        ReactionKeyRequest,
+        ToggleReactionRequest,
+        CustomReactionCropRect,
+        CreateCustomReactionAssetRequest,
+        BookmarkCustomReactionRequest,
+        RemoveBookmarkedCustomReactionRequest,
+        BookmarkPostRequest,
+        RemoveBookmarkedPostRequest,
+        ListRecentReactionsRequest,
+        ListTimelineRequest,
+        ListThreadRequest,
+        ListProfileTimelineRequest,
+        ImportPeerTicketRequest,
+        UnsubscribeTopicRequest,
+        SetTopicGossipEnabledRequest,
+        SetChannelGossipEnabledRequest,
+        GetBlobPreviewRequest,
+        GetBlobMediaRequest,
+        AuthorRequest,
+        ListSocialConnectionsRequest,
+        DirectMessageRequest,
+        NotificationIdRequest,
+        ListDirectMessageMessagesRequest,
+        SendDirectMessageRequest,
+        DeleteDirectMessageMessageRequest,
+        SetMyProfileRequest,
+        ListLiveSessionsRequest,
+        CreateLiveSessionRequest,
+        LiveSessionCommandRequest,
+        ListGameRoomsRequest,
+        CreateGameRoomRequest,
+        CreateMetaverseRoomRequest,
+        PublishMetaverseRoomEventRequest,
+        ListMetaverseRoomEventsRequest,
+        ImportMetaverseRoomAssetRequest,
+        CreatePrivateChannelRequest,
+        ExportPrivateChannelInviteRequest,
+        ImportPrivateChannelInviteRequest,
+        ExportChannelAccessTokenRequest,
+        ImportChannelAccessTokenRequest,
+        PreviewChannelAccessTokenRequest,
+        ExportFriendOnlyGrantRequest,
+        ImportFriendOnlyGrantRequest,
+        ExportFriendPlusShareRequest,
+        ImportFriendPlusShareRequest,
+        FreezePrivateChannelRequest,
+        RotatePrivateChannelRequest,
+        LeavePrivateChannelRequest,
+        ListJoinedPrivateChannelsRequest,
+        UpdateGameRoomRequest,
+        UpdateMetaverseRoomRequest,
     );
 
     let path = concat!(

--- a/crates/desktop-runtime/src/requests.rs
+++ b/crates/desktop-runtime/src/requests.rs
@@ -8,6 +8,8 @@ use kukuri_store::TimelineCursor;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CreatePostRequest {
     pub topic: String,
     pub content: String,
@@ -19,6 +21,8 @@ pub struct CreatePostRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CreateRepostRequest {
     pub topic: String,
     pub source_topic: String,
@@ -28,6 +32,8 @@ pub struct CreateRepostRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CreateAttachmentRequest {
     pub file_name: Option<String>,
     pub mime: String,
@@ -37,6 +43,8 @@ pub struct CreateAttachmentRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ReactionKeyRequest {
     Emoji {
@@ -55,6 +63,8 @@ pub enum ReactionKeyRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ToggleReactionRequest {
     pub target_topic_id: String,
     pub target_object_id: String,
@@ -63,6 +73,8 @@ pub struct ToggleReactionRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CustomReactionCropRect {
     pub x: u32,
     pub y: u32,
@@ -70,6 +82,8 @@ pub struct CustomReactionCropRect {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CreateCustomReactionAssetRequest {
     pub upload: CreateAttachmentRequest,
     pub crop_rect: CustomReactionCropRect,
@@ -77,6 +91,8 @@ pub struct CreateCustomReactionAssetRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct BookmarkCustomReactionRequest {
     pub asset_id: String,
     pub owner_pubkey: String,
@@ -89,27 +105,37 @@ pub struct BookmarkCustomReactionRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct RemoveBookmarkedCustomReactionRequest {
     pub asset_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct BookmarkPostRequest {
     pub topic: String,
     pub object_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct RemoveBookmarkedPostRequest {
     pub object_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ListRecentReactionsRequest {
     pub limit: Option<usize>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ListTimelineRequest {
     pub topic: String,
     #[serde(default)]
@@ -119,6 +145,8 @@ pub struct ListTimelineRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ListThreadRequest {
     pub topic: String,
     pub thread_id: String,
@@ -127,6 +155,8 @@ pub struct ListThreadRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ListProfileTimelineRequest {
     pub pubkey: String,
     pub cursor: Option<TimelineCursor>,
@@ -134,22 +164,30 @@ pub struct ListProfileTimelineRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ImportPeerTicketRequest {
     pub ticket: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct UnsubscribeTopicRequest {
     pub topic: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SetTopicGossipEnabledRequest {
     pub topic: String,
     pub enabled: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SetChannelGossipEnabledRequest {
     pub topic: String,
     pub channel: String,
@@ -157,38 +195,52 @@ pub struct SetChannelGossipEnabledRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct GetBlobPreviewRequest {
     pub hash: String,
     pub mime: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct GetBlobMediaRequest {
     pub hash: String,
     pub mime: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct AuthorRequest {
     pub pubkey: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ListSocialConnectionsRequest {
     pub kind: SocialConnectionKind,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct DirectMessageRequest {
     pub pubkey: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct NotificationIdRequest {
     pub notification_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ListDirectMessageMessagesRequest {
     pub pubkey: String,
     pub cursor: Option<TimelineCursor>,
@@ -196,6 +248,8 @@ pub struct ListDirectMessageMessagesRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SendDirectMessageRequest {
     pub pubkey: String,
     pub text: Option<String>,
@@ -205,12 +259,16 @@ pub struct SendDirectMessageRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct DeleteDirectMessageMessageRequest {
     pub pubkey: String,
     pub message_id: String,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SetMyProfileRequest {
     pub name: Option<String>,
     pub display_name: Option<String>,
@@ -222,6 +280,8 @@ pub struct SetMyProfileRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ListLiveSessionsRequest {
     pub topic: String,
     #[serde(default)]
@@ -229,6 +289,8 @@ pub struct ListLiveSessionsRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CreateLiveSessionRequest {
     pub topic: String,
     #[serde(default)]
@@ -238,12 +300,16 @@ pub struct CreateLiveSessionRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct LiveSessionCommandRequest {
     pub topic: String,
     pub session_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ListGameRoomsRequest {
     pub topic: String,
     #[serde(default)]
@@ -251,6 +317,8 @@ pub struct ListGameRoomsRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CreateGameRoomRequest {
     pub topic: String,
     #[serde(default)]
@@ -261,6 +329,8 @@ pub struct CreateGameRoomRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CreateMetaverseRoomRequest {
     pub topic: String,
     #[serde(default)]
@@ -271,6 +341,8 @@ pub struct CreateMetaverseRoomRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct PublishMetaverseRoomEventRequest {
     pub topic: String,
     pub room_id: String,
@@ -280,6 +352,8 @@ pub struct PublishMetaverseRoomEventRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ListMetaverseRoomEventsRequest {
     pub topic: String,
     pub room_id: String,
@@ -288,6 +362,8 @@ pub struct ListMetaverseRoomEventsRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ImportMetaverseRoomAssetRequest {
     pub topic: String,
     pub room_id: String,
@@ -298,6 +374,8 @@ pub struct ImportMetaverseRoomAssetRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CreatePrivateChannelRequest {
     pub topic: String,
     pub label: String,
@@ -306,6 +384,8 @@ pub struct CreatePrivateChannelRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ExportPrivateChannelInviteRequest {
     pub topic: String,
     pub channel_id: String,
@@ -313,11 +393,15 @@ pub struct ExportPrivateChannelInviteRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ImportPrivateChannelInviteRequest {
     pub token: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ExportChannelAccessTokenRequest {
     pub topic: String,
     pub channel_id: String,
@@ -325,16 +409,22 @@ pub struct ExportChannelAccessTokenRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ImportChannelAccessTokenRequest {
     pub token: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct PreviewChannelAccessTokenRequest {
     pub token: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ExportFriendOnlyGrantRequest {
     pub topic: String,
     pub channel_id: String,
@@ -342,11 +432,15 @@ pub struct ExportFriendOnlyGrantRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ImportFriendOnlyGrantRequest {
     pub token: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ExportFriendPlusShareRequest {
     pub topic: String,
     pub channel_id: String,
@@ -354,34 +448,46 @@ pub struct ExportFriendPlusShareRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ImportFriendPlusShareRequest {
     pub token: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct FreezePrivateChannelRequest {
     pub topic: String,
     pub channel_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct RotatePrivateChannelRequest {
     pub topic: String,
     pub channel_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct LeavePrivateChannelRequest {
     pub topic: String,
     pub channel_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct ListJoinedPrivateChannelsRequest {
     pub topic: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct UpdateGameRoomRequest {
     pub topic: String,
     pub room_id: String,
@@ -391,6 +497,8 @@ pub struct UpdateGameRoomRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct UpdateMetaverseRoomRequest {
     pub topic: String,
     pub room_id: String,


### PR DESCRIPTION
## Summary
Closes the last silent-break surface of the IPC contract (review finding D17; the "input direction left as a follow-up" recorded by both S4 and H7). Two commits:

1. **Generate** — derive ts-rs (behind the existing `ts` feature, H7 pattern) on all 54 request DTOs in `requests.rs` plus the five request types living outside it (`SetCommunityNodeConfigNode/Request`, `CommunityNodeTargetRequest`, `AcceptCommunityNodeConsentsRequest`, `SetDiscoverySeedsRequest`), and emit them from the exporter → 59 new types in `types.generated.ts` (pure addition)
2. **Enforce** — annotate all 66 request-construction literals in `runtimeApi.ts` with `satisfies <GeneratedRequestType>`, using the command→DTO mapping extracted from the src-tauri handlers; the generated types are imported directly from `types.generated.ts`

## What this buys
- a Rust DTO change now surfaces as a `cargo xtask ipc-types --check` diff **and** a tsc error on the exact literal that no longer matches — previously it surfaced only as a runtime deserialization error
- the hand-flattened `ReactionKeyInput → ReactionKeyRequest` path (the audit's canonical example) is structurally checked; **proven locally**: removing one field from the flatten makes typecheck fail with `not assignable to type 'ReactionKeyRequest'`, restoring it goes green
- front-facing convenience types (ReactionKeyInput, ProfileInput, the expanded-argument DesktopApi) stay handwritten by design — `satisfies` verifies the convenience→wire conversion at every compile, which is the actual contract

## Validation
- cargo xtask ipc-types --check (regeneration diff clean post-commit)
- pnpm typecheck / pnpm lint
- cargo xtask desktop-ui-check (full gate incl. 14 visual regression screens)
- cargo clippy -p kukuri-desktop-runtime --all-targets / cargo fmt --check (exit codes verified explicitly)
- REFACTORING.md IPC-contract entry updated to reflect the covered input direction

Recovers master plan §9.2 B6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)