### PR TITLE
docs: fix references that rotted behind later refactors

### DIFF
--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -138,15 +138,17 @@ PR を作成または説明するときは、タスク種別を明確にする�
 
 1. **`ConnectionPath::RelayFallback` は削除禁止の第3経路**: `AGENTS.md`「通信経路」節が規定する
    `Direct P2P -> Relay Supported P2P -> Relay Fallback` の 3 番目。variant は
-   `crates/transport/src/config.rs` に定義され、TS 側表示分岐(`apps/desktop/src/lib/api/types.ts` /
-   `apps/desktop/src/shell/selectors.ts` の `relay_fallback`)も実在する。**実行時に値として構築される
+   `crates/transport/src/config.rs` に定義され、TS 側表示分岐(生成型
+   `apps/desktop/src/lib/api/types.generated.ts` / `apps/desktop/src/shell/presentation.ts` の
+   `relay_fallback`)も実在する。**実行時に値として構築される
    箇所が現状ゼロ**(ライブ代入は DirectP2p / RelaySupportedP2p のみ)なので「未使用だから削除」に
    見えるが、これは削除対象ではなく診断の実装ギャップである。**variant は削除しない。診断は現状
    RelayFallback を報告しない**(判定実装は別 issue。本リファクタでは事実固定に留める)。
-2. **`apps/desktop/src/styles/shell-phase1-legacy.css` は名前に反して現役の本番 CSS**: 大半の
-   クラスが現在も使われ、Radix Portal 経由の dialog / popover では `.shell-phase1` の外に描画される
-   ため unscoped な phase1 側だけが効く。「legacy だから削除」は禁止。安全なのは改名のみ(H8)。
-   統合は宣言単位・コンテキスト別の実効値判定 + 視覚回帰ネット(検証マトリクスの
+2. **`apps/desktop/src/styles/shell-scoped-overrides.css`(旧 shell-phase1-legacy.css。H8 PR2 で
+   改名)は現役の本番 CSS**: `.shell-phase1` スコープ付き上書き層で、shell 配下では
+   `shell-phase1-part*` を specificity で上書きする。portal と shell で意図的に値が異なるクラスの
+   shell 側の値を置く層であり(DESIGN.md 4.7)、「上書きの重複に見えるから削除・統合」は禁止。
+   統合を検討する場合も宣言単位・コンテキスト別の実効値判定 + 視覚回帰ネット(検証マトリクスの
    `apps/desktop/**` = `test:e2e:visual`)を前提にする。
 3. **署名バイトは非決定的なので golden 化しない**: `KukuriKeys::sign_schnorr`
    (`crates/core/src/crypto.rs`)は毎回 aux_rand を生成するため署名バイトは実行毎に変わる。凍結対象は

--- a/apps/desktop/src-tauri/src/commands/background_notifications.rs
+++ b/apps/desktop/src-tauri/src/commands/background_notifications.rs
@@ -279,8 +279,9 @@ fn compute_cursor(notifications: &[NotificationView]) -> DispatchCursor {
     }
 }
 
-/// Whether an OS toast should be shown for this notification. Mirrors
-/// `shouldSendOsNotification` in apps/desktop/src/lib/releaseReadiness.ts.
+/// Whether an OS toast should be shown for this notification. This is the
+/// single implementation: the former TS twin (`shouldSendOsNotification` in
+/// releaseReadiness.ts) was production-dead and deleted in WP-Q1 (#517).
 fn should_send(
     notification: &NotificationView,
     settings: &OsNotificationSettings,
@@ -301,7 +302,8 @@ fn should_send(
     }
 }
 
-/// Mirrors `notificationTitle` in apps/desktop/src/lib/releaseReadiness.ts.
+/// OS toast title per notification kind (single implementation; the TS twin
+/// was deleted in WP-Q1 #517).
 fn notification_title(kind: &NotificationKind) -> &'static str {
     match kind {
         NotificationKind::DirectMessage => "Direct message",
@@ -313,7 +315,8 @@ fn notification_title(kind: &NotificationKind) -> &'static str {
     }
 }
 
-/// Mirrors `notificationBody` in apps/desktop/src/lib/releaseReadiness.ts.
+/// OS toast body per notification kind (single implementation; the TS twin
+/// was deleted in WP-Q1 #517).
 fn notification_body(
     kind: &NotificationKind,
     preview_text: Option<&str>,

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 ## 目的
 - 現行 kukuri 実装に必要な情報だけを置く。
 - 仕様は ADR、実行手順は runbook、状態は progress に分ける。
-- `docs/progress/` は 2 種を置く: (a) named な current-state / 計画文書（最新のマイルストーン状態・ロードマップ）と (b) `YYYY-MM-DD-<issue#>-<slug>.md` の per-issue 作業報告（個別 issue の実装ログ）。current-state は「今どうなっているか」、per-issue は「その issue で何をしたか」を書き分ける。
+- `docs/progress/` は 2 種を置く: (a) named な current-state / 計画文書（最新のマイルストーン状態・ロードマップ）と (b) `YYYY-MM-DD-<issue# または WP 名>-<slug>.md` の per-issue / per-WP 作業報告（個別 issue・ワークパッケージの実装ログ。例: `2026-07-06-wp-c1-...`）。current-state は「今どうなっているか」、per-issue / per-WP は「その作業で何をしたか」を書き分ける。
 
 ## 優先参照順
 1. `docs/progress/2026-04-16-mvp-builder-preview-plan.md`

--- a/xtask/src/ipc.rs
+++ b/xtask/src/ipc.rs
@@ -7,8 +7,9 @@ const GENERATED_TS: &str = "apps/desktop/src/lib/api/types.generated.ts";
 
 /// Rust の IPC 型から `types.generated.ts` を再生成する(WP-H7 PR3)。
 ///
-/// - `cargo test -p kukuri-app-api --features ts export_ipc_types` で TS を書き出す
-///   (`TS_RS_LARGE_INT=number` で u64/i64 を number にする)。
+/// - `cargo test -p kukuri-desktop-runtime --features ts export_ipc_types` で TS を書き出す
+///   (生成器は H7 Stage3b で app-api から desktop-runtime へ移設済み。
+///   `TS_RS_LARGE_INT=number` で u64/i64 を number にする)。
 /// - リポジトリに prettier 等のフォーマッタは無く、出力は ts-rs の決定論的な
 ///   raw 形式のまま採用する(機械生成ファイル。手編集しない)。
 /// - `check = true`(CI)のときは再生成後に `git diff --exit-code` で


### PR DESCRIPTION
## Summary
- [docs] fix the doc/comment references the 2026-07-13 completion review found pointing at renamed, split, or deleted code:
  - **REFACTORING.md landmine 1 (RelayFallback)**: the TS display branch moved to `types.generated.ts` (H7 codegen) + `shell/presentation.ts` (Q3 T7); the old `types.ts` / `selectors.ts` paths no longer exist in that role
  - **REFACTORING.md landmine 2**: `shell-phase1-legacy.css` was renamed to `shell-scoped-overrides.css` by H8 PR2 — the entry now describes the current name and its two-layer override role (per DESIGN.md 4.7) instead of prescribing a rename that already happened
  - **background_notifications.rs**: three `Mirrors ... releaseReadiness.ts` doc comments referenced TS functions deleted by WP-Q1 (#517; the deletion PR's audit incorrectly claimed no such docs existed) — they now state these are the single implementations
  - **xtask/src/ipc.rs**: the regeneration command doc predated H7 Stage3b's exporter move (`-p kukuri-app-api` → `-p kukuri-desktop-runtime`)
  - **docs/README.md**: progress-report naming rule widened to `issue# or WP name`, matching actual filings since the C1/C2 reports

Markdown and doc comments only — zero code changes. (The companion .claude/plans updates — master plan §7's three now-settled decisions, C5's superseded Goal wording, H6's unticked DoD boxes — are local-only since that directory is gitignored.)

## Validation
- cargo fmt --check / cargo xtask tauri-check / cargo clippy -p xtask --all-targets -- -D warnings (exit codes verified explicitly)

Recovers master plan §9.2 B18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)