### PR TITLE
refactor: share the CN response types instead of client mirrors

### DIFF
--- a/crates/cn-protocol/src/models.rs
+++ b/crates/cn-protocol/src/models.rs
@@ -102,6 +102,12 @@ pub struct BootstrapHeartbeatResponse {
     pub expires_at: i64,
 }
 
+/// `GET /v1/bootstrap/nodes` の response(WP-B17 で server / client の二重定義を共有化)。
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BootstrapNodesResponse {
+    pub nodes: Vec<CommunityNodeBootstrapNode>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts", ts(optional_fields = nullable))]

--- a/crates/cn-user-api/src/handlers/bootstrap.rs
+++ b/crates/cn-user-api/src/handlers/bootstrap.rs
@@ -8,18 +8,12 @@ use kukuri_cn_core::{
     refresh_bootstrap_peer_registration, require_bearer_identity, require_consents,
 };
 use kukuri_cn_protocol::{
-    BootstrapHeartbeatRequest, BootstrapHeartbeatResponse, CommunityNodeBootstrapNode,
+    BootstrapHeartbeatRequest, BootstrapHeartbeatResponse, BootstrapNodesResponse,
     TopicRendezvousHeartbeat, TopicRendezvousHeartbeatResponse,
 };
-use serde::Serialize;
 
 use crate::errors::{SupportEndpointError, SupportEndpointOperation, support_endpoint_error};
 use crate::state::UserApiState;
-
-#[derive(Debug, Serialize)]
-pub(crate) struct BootstrapNodesResponse {
-    nodes: Vec<CommunityNodeBootstrapNode>,
-}
 
 pub(crate) async fn bootstrap_nodes(
     State(state): State<UserApiState>,

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -92,31 +92,10 @@ pub struct CommunityNodeConfig {
     pub nodes: Vec<CommunityNodeNodeConfig>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct BootstrapNodesResponse {
-    pub(crate) nodes: Vec<kukuri_cn_protocol::CommunityNodeBootstrapNode>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct TopicRendezvousHeartbeatResponse {
-    pub(crate) expires_in_seconds: u64,
-    pub(crate) topics: Vec<TopicRendezvousTopicResponse>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct TopicRendezvousTopicResponse {
-    pub(crate) topic_key: String,
-    pub(crate) peers: Vec<TopicRendezvousPeerCandidate>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct TopicRendezvousPeerCandidate {
-    pub(crate) endpoint_id: String,
-    #[serde(default)]
-    pub(crate) addr_hint: Option<String>,
-    #[serde(default)]
-    pub(crate) relay_urls: Vec<String>,
-}
+// CN HTTP response 型は kukuri-cn-protocol の共有定義を使う(WP-B17)。
+// 旧ローカルミラー(TopicRendezvousPeerCandidate = 共有側の TopicRendezvousCandidate)は
+// フィールド一致の二重定義だったため撤去した。serde 名不変 = wire 互換。
+pub(crate) use kukuri_cn_protocol::{BootstrapNodesResponse, TopicRendezvousHeartbeatResponse};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]


### PR DESCRIPTION
## Summary
- [refactor] finish what WP-H3 started for the CN HTTP contract: the request side was shared via kukuri-cn-protocol, but the response side stayed duplicated (review finding D4, adversarially verified):
  - move `BootstrapNodesResponse` into cn-protocol's models (`nodes: Vec<CommunityNodeBootstrapNode>`), replacing the private twin definitions on **both** the server (cn-user-api handler) and the client (desktop-runtime)
  - drop desktop-runtime's three private rendezvous response mirrors — `TopicRendezvousPeerCandidate` was a renamed field-identical twin of the shared `TopicRendezvousCandidate` — and re-export the cn-protocol definitions instead
- wire-safe by construction: field and serde names are identical; the shared candidate's `skip_serializing_if` on `addr_hint` differs only on the serialization side, and the client path only deserializes. A server response-field change now lands on the client as a compile-time type change instead of drifting silently

## Validation
- cargo nextest run -p kukuri-desktop-runtime -E 'test(community_node)' — 51/51 passed (the mock-CN suites exercise deserialization of the shared types end to end)
- cargo xtask cn-test — full contract suite against real Postgres/Valkey (server-side bootstrap/rendezvous responses unchanged on the wire)
- cargo xtask ipc-types --check — generated TS unchanged (the old mirrors were never IPC-surface types)
- cargo clippy (desktop-runtime / cn-user-api / cn-protocol, --all-targets, -D warnings) / cargo fmt --check (exit codes verified explicitly)

Recovers master plan §9.2 B17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)