### PR TITLE
fix: decode NULL option columns as None instead of empty values

### DIFF
--- a/crates/store/src/row_mapping.rs
+++ b/crates/store/src/row_mapping.rs
@@ -12,6 +12,17 @@ use crate::models::{
     NotificationKind, NotificationRow, ObjectProjectionRow, ReactionProjectionRow,
 };
 
+/// NULL 許容列の読み出し。sqlx-sqlite は NULL を `String` なら `Ok("")`、`i64` なら
+/// `Ok(0)` にデコードするため、`try_get::<T>().ok()` では NULL が Some に化ける
+/// (WP-B16 で解消した decode quirk)。Option 列は必ずこのヘルパで読むこと。
+/// `.ok()` は列欠損を None に落とす従来挙動の維持。
+fn opt_col<'r, T>(row: &'r sqlx::sqlite::SqliteRow, column: &str) -> Option<T>
+where
+    T: sqlx::Decode<'r, sqlx::Sqlite> + sqlx::Type<sqlx::Sqlite>,
+{
+    row.try_get::<Option<T>, _>(column).ok().flatten()
+}
+
 pub(crate) fn row_to_envelope(row: sqlx::sqlite::SqliteRow) -> Result<KukuriEnvelope> {
     Ok(KukuriEnvelope {
         id: row.get::<String, _>("envelope_id").into(),
@@ -45,7 +56,7 @@ pub(crate) fn row_to_object_projection(
             .filter(|value| !value.trim().is_empty())
             .map(EnvelopeId::from),
         payload_ref: serde_json::from_str(row.get::<String, _>("payload_ref_json").as_str())?,
-        content: row.try_get("content").ok(),
+        content: opt_col(&row, "content"),
         attachments: row
             .try_get::<String, _>("attachments_json")
             .ok()
@@ -62,10 +73,7 @@ pub(crate) fn row_to_object_projection(
         source_replica_id: ReplicaId::new(row.get::<String, _>("source_replica_id")),
         source_key: row.get("source_key"),
         source_envelope_id: row.get::<String, _>("source_envelope_id").into(),
-        source_blob_hash: row
-            .try_get::<String, _>("source_blob_hash")
-            .ok()
-            .map(BlobHash::new),
+        source_blob_hash: opt_col::<String>(&row, "source_blob_hash").map(BlobHash::new),
         derived_at: row.get("derived_at"),
         projection_version: row.get("projection_version"),
     })
@@ -85,8 +93,8 @@ pub(crate) fn row_to_reaction_projection(
             row.get::<String, _>("reaction_key_kind").as_str(),
         )?,
         normalized_reaction_key: row.get("normalized_reaction_key"),
-        emoji: row.try_get("emoji").ok(),
-        custom_asset_id: row.try_get("custom_asset_id").ok(),
+        emoji: opt_col(&row, "emoji"),
+        custom_asset_id: opt_col(&row, "custom_asset_id"),
         custom_asset_snapshot: row
             .try_get::<String, _>("custom_asset_snapshot_json")
             .ok()
@@ -132,15 +140,15 @@ pub(crate) fn row_to_bookmarked_post(row: sqlx::sqlite::SqliteRow) -> Result<Boo
         created_at: row.get("created_at"),
         object_kind: row.get("object_kind"),
         payload_ref: serde_json::from_str(row.get::<String, _>("payload_ref_json").as_str())?,
-        content: row.try_get("content").ok(),
+        content: opt_col(&row, "content"),
         attachments: serde_json::from_str(row.get::<String, _>("attachments_json").as_str())?,
-        reply_to_object_id: row
-            .try_get::<String, _>("reply_to_object_id")
-            .ok()
+        // 空文字は None に落とす(row_to_object_projection の root/reply と同じ規約。
+        // WP-B16 で非対称を解消)。
+        reply_to_object_id: opt_col::<String>(&row, "reply_to_object_id")
+            .filter(|value| !value.trim().is_empty())
             .map(EnvelopeId::from),
-        root_object_id: row
-            .try_get::<String, _>("root_object_id")
-            .ok()
+        root_object_id: opt_col::<String>(&row, "root_object_id")
+            .filter(|value| !value.trim().is_empty())
             .map(EnvelopeId::from),
         repost_of: row
             .try_get::<String, _>("repost_of_json")
@@ -159,9 +167,9 @@ pub(crate) fn row_to_direct_message_conversation(
         dm_id: row.get("dm_id"),
         peer_pubkey: row.get("peer_pubkey"),
         updated_at: row.get("updated_at"),
-        last_message_at: row.try_get("last_message_at").ok(),
-        last_message_id: row.try_get("last_message_id").ok(),
-        last_message_preview: row.try_get("last_message_preview").ok(),
+        last_message_at: opt_col(&row, "last_message_at"),
+        last_message_id: opt_col(&row, "last_message_id"),
+        last_message_preview: opt_col(&row, "last_message_preview"),
     })
 }
 
@@ -174,8 +182,8 @@ pub(crate) fn row_to_direct_message_message(
         sender_pubkey: row.get("sender_pubkey"),
         recipient_pubkey: row.get("recipient_pubkey"),
         created_at: row.get("created_at"),
-        text: row.try_get("text").ok(),
-        reply_to_message_id: row.try_get("reply_to_message_id").ok(),
+        text: opt_col(&row, "text"),
+        reply_to_message_id: opt_col(&row, "reply_to_message_id"),
         attachment_manifest: row
             .try_get::<String, _>("attachment_manifest_json")
             .ok()
@@ -183,7 +191,7 @@ pub(crate) fn row_to_direct_message_message(
             .map(|value| serde_json::from_str(value.as_str()))
             .transpose()?,
         outgoing: row.get::<i64, _>("outgoing") != 0,
-        acked_at: row.try_get("acked_at").ok(),
+        acked_at: opt_col(&row, "acked_at"),
     })
 }
 
@@ -230,7 +238,7 @@ pub(crate) fn row_to_notification(row: sqlx::sqlite::SqliteRow) -> Result<Notifi
             .filter(|value| !value.trim().is_empty()),
         created_at: row.get("created_at"),
         received_at: row.get("received_at"),
-        read_at: row.try_get("read_at").ok(),
+        read_at: opt_col(&row, "read_at"),
     })
 }
 
@@ -243,7 +251,7 @@ pub(crate) fn row_to_direct_message_outbox(
         peer_pubkey: row.get("peer_pubkey"),
         frame_blob_hash: BlobHash::new(row.get::<String, _>("frame_blob_hash")),
         created_at: row.get("created_at"),
-        last_attempt_at: row.try_get("last_attempt_at").ok(),
+        last_attempt_at: opt_col(&row, "last_attempt_at"),
     })
 }
 
@@ -279,7 +287,7 @@ pub(crate) fn row_to_live_session_projection(
         description: row.get("description"),
         status: parse_live_status(row.get::<String, _>("status").as_str())?,
         started_at: row.get("started_at"),
-        ended_at: row.try_get("ended_at").ok(),
+        ended_at: opt_col(&row, "ended_at"),
         updated_at: row.get("updated_at"),
         source_replica_id: ReplicaId::new(row.get::<String, _>("source_replica_id")),
         source_key: row.get("source_key"),
@@ -301,7 +309,7 @@ pub(crate) fn row_to_game_room_projection(
         title: row.get("title"),
         description: row.get("description"),
         status: parse_game_status(row.get::<String, _>("status").as_str())?,
-        phase_label: row.try_get("phase_label").ok(),
+        phase_label: opt_col(&row, "phase_label"),
         scores: serde_json::from_str(row.get::<String, _>("scores_json").as_str())?,
         room_kind: row
             .try_get::<String, _>("room_kind")

--- a/crates/store/src/tests/backend_parity/lists.rs
+++ b/crates/store/src/tests/backend_parity/lists.rs
@@ -13,6 +13,7 @@ use kukuri_core::FollowEdge;
 struct NotificationScenarioResult {
     inserted: Vec<bool>,
     unread_initial: usize,
+    list_initial: Vec<NotificationRow>,
     unread_after_single: usize,
     unread_after_all: usize,
     list_final: Vec<NotificationRow>,
@@ -48,10 +49,11 @@ async fn notification_scenario<S: Store + ProjectionStore>(
     let unread_initial = NotificationStore::count_unread_notifications(store)
         .await
         .expect("count unread initial");
-    // NOTE: read_at が NULL のままの行を含む list はここでは比較しない。
-    // sqlite の NULL decode quirk により read_at NULL → Some(0) となり
-    // memory(None)と一致しないため(mod.rs ヘッダ参照)、
-    // list の比較は全件 read 済みになった最後に行う。
+    // read_at が NULL のままの行を含む list も比較対象(WP-B16 で NULL decode quirk を
+    // 解消し、sqlite も memory と同じく None を返す)。
+    let list_initial = NotificationStore::list_notifications(store)
+        .await
+        .expect("list notifications initial");
 
     NotificationStore::mark_notification_read(store, "notif-1", 110)
         .await
@@ -78,6 +80,7 @@ async fn notification_scenario<S: Store + ProjectionStore>(
     NotificationScenarioResult {
         inserted,
         unread_initial,
+        list_initial,
         unread_after_single,
         unread_after_all,
         list_final,
@@ -95,6 +98,15 @@ async fn notifications_match_between_backends() {
     // sanity: sqlite 実測(received_at DESC, notification_id DESC。100 の tie は id 降順)
     assert_eq!(from_sqlite.inserted, vec![true, true, true, false]);
     assert_eq!(from_sqlite.unread_initial, 2);
+    // 未読(read_at NULL)の行が None として読めること(WP-B16)。
+    assert_eq!(
+        from_sqlite
+            .list_initial
+            .iter()
+            .map(|row| row.read_at)
+            .collect::<Vec<_>>(),
+        vec![None, None, Some(95)],
+    );
     assert_eq!(
         from_sqlite
             .list_final
@@ -700,8 +712,8 @@ async fn direct_message_outbox_matches_between_backends() {
             .map(|row| (row.message_id.clone(), row.created_at, row.last_attempt_at))
             .collect::<Vec<_>>(),
         vec![
-            ("om-0".to_string(), 5, Some(0)),
-            ("om-1".to_string(), 8, Some(0)),
+            ("om-0".to_string(), 5, None),
+            ("om-1".to_string(), 8, None),
             ("om-2".to_string(), 10, Some(99)),
         ],
     );

--- a/crates/store/src/tests/backend_parity/mod.rs
+++ b/crates/store/src/tests/backend_parity/mod.rs
@@ -19,17 +19,14 @@
 //! - 同一 envelope の重複 put_envelope: memory は topic_objects の Vec に id が重複蓄積し
 //!   timeline に同一 envelope が 2 回現れる(sqlite は ON CONFLICT upsert で 1 行)。
 //!   本ハーネスでは envelope の再 put を行わない(memory/envelopes.rs 未修正)。
-//! - sqlite(sqlx-sqlite)の NULL decode quirk: NULL TEXT は `Ok("")`、NULL INTEGER は
-//!   `Ok(0)` にデコードされるため、row_mapping で空文字フィルタの無い Option 列は
-//!   put(None) → get で `Some("")` / `Some(0)` になる(memory は None のまま)。該当列:
-//!   dm_messages.reply_to_message_id / acked_at、dm_outbox.last_attempt_at、
-//!   dm_conversations.last_message_at / last_message_id / last_message_preview、
-//!   notifications.read_at、live_session_cache.ended_at、game_room_cache.phase_label、
-//!   reaction_cache.emoji / custom_asset_id、object_index_cache.source_blob_hash、
-//!   bookmarked_posts.content / reply_to_object_id / root_object_id。
-//!   本ハーネスの fixture はこれらの列に NULL を投入しない(Some("既定値") を明示投入)。
-//!   memory へ quirk を移植する fix は T7 の範囲外(本筋は sqlite 読み出し側の Option
-//!   decode 適正化で Phase 2 候補)。
+//! - sqlite(sqlx-sqlite)の NULL decode quirk(NULL TEXT → `Ok("")`、NULL INTEGER →
+//!   `Ok(0)`)は WP-B16 で解消済み: row_mapping の Option 列は `try_get::<Option<T>>` で
+//!   読むため put(None) → get は両実装とも None になり、fixture は実 NULL を投入できる。
+//!   残る既知 divergence は空文字入力のみ: sqlite 側の trim + filter 列
+//!   (object_index_cache / bookmarked_posts の root/reply、notifications の参照列など)は
+//!   put(Some("")) → get で None になるが memory は Some("") のまま返す。
+//!   実書き込み経路は Option バインドで '' を書かないため、本ハーネスの fixture も
+//!   これらの列に空文字を投入しない。
 
 use super::*;
 
@@ -115,11 +112,10 @@ fn parity_dm_message(dm_id: &str, message_id: &str, created_at: i64) -> DirectMe
         recipient_pubkey: "b".repeat(64),
         created_at,
         text: Some(format!("text:{message_id}")),
-        // NULL decode quirk 回避のため Some を明示投入(mod.rs ヘッダ参照)
-        reply_to_message_id: Some(String::new()),
+        reply_to_message_id: None,
         attachment_manifest: None,
         outgoing: false,
-        acked_at: Some(0),
+        acked_at: None,
     }
 }
 
@@ -163,8 +159,7 @@ fn parity_live_session(
         description: format!("desc:{session_id}"),
         status,
         started_at,
-        // NULL decode quirk 回避のため Some を明示投入(mod.rs ヘッダ参照)
-        ended_at: Some(0),
+        ended_at: None,
         updated_at: started_at + 1,
         source_replica_id: ReplicaId::new(format!("topic::{topic_id}")),
         source_key: format!("live/{session_id}/manifest"),
@@ -189,8 +184,7 @@ fn parity_game_room(
         title: format!("room:{room_id}"),
         description: format!("desc:{room_id}"),
         status,
-        // NULL decode quirk 回避のため Some を明示投入(mod.rs ヘッダ参照)
-        phase_label: Some(String::new()),
+        phase_label: None,
         scores: Vec::new(),
         room_kind: GameRoomKind::ScoreGame,
         metaverse: None,
@@ -276,8 +270,7 @@ fn parity_reaction(
         reaction_key_kind: ReactionKeyKind::Emoji,
         normalized_reaction_key: normalized_key.to_string(),
         emoji: Some(emoji.to_string()),
-        // NULL decode quirk 回避のため Some を明示投入(mod.rs ヘッダ参照)
-        custom_asset_id: Some(String::new()),
+        custom_asset_id: None,
         custom_asset_snapshot: None,
         status: ObjectStatus::Active,
         source_key: format!("reactions/{reaction_id}"),
@@ -305,8 +298,7 @@ fn parity_reaction_custom(
         updated_at,
     );
     row.reaction_key_kind = ReactionKeyKind::CustomAsset;
-    // NULL decode quirk 回避のため Some を明示投入(mod.rs ヘッダ参照)
-    row.emoji = Some(String::new());
+    row.emoji = None;
     row.custom_asset_id = Some("asset-1".into());
     row.custom_asset_snapshot = Some(CustomReactionAssetSnapshotV1 {
         asset_id: "asset-1".into(),
@@ -336,13 +328,10 @@ fn parity_bookmarked_post(source_object_id: &str, bookmarked_at: i64) -> Bookmar
             mime: "text/plain".into(),
             bytes: 4,
         },
-        // NULL decode quirk 回避のため Some を明示投入(mod.rs ヘッダ参照)。
-        // reply_to / root の空文字はどちらの実装でも Some("") のまま返る
-        // (row_to_bookmarked_post は trim + filter しない非対称の現挙動)。
-        content: Some(String::new()),
+        content: None,
         attachments: Vec::new(),
-        reply_to_object_id: Some(EnvelopeId::from("")),
-        root_object_id: Some(EnvelopeId::from("")),
+        reply_to_object_id: None,
+        root_object_id: None,
         repost_of: None,
         bookmarked_at,
     }
@@ -398,8 +387,7 @@ fn parity_outbox(dm_id: &str, message_id: &str, created_at: i64) -> DirectMessag
         peer_pubkey: "b".repeat(64),
         frame_blob_hash: BlobHash::new("2".repeat(64)),
         created_at,
-        // NULL decode quirk 回避のため Some を明示投入(mod.rs ヘッダ参照)
-        last_attempt_at: Some(0),
+        last_attempt_at: None,
     }
 }
 

--- a/crates/store/src/tests/row_mapping_edge.rs
+++ b/crates/store/src/tests/row_mapping_edge.rs
@@ -233,10 +233,10 @@ async fn game_room_status_legacy_aliases_map_to_current_variants() {
             title: "レガシー部屋".into(),
             description: "edge-case room".into(),
             status: GameRoomStatus::Waiting,
-            // NULL の phase_label は Some("") になる(sqlx-sqlite の try_get::<String> は
-            // NULL でも Ok("") を返すため .ok() が None にならない現挙動 —
-            // sqlx-sqlite 0.8.x 時点の decode 実装に依存)。
-            phase_label: Some("".into()),
+            // NULL の phase_label は None(WP-B16 で Option decode を適正化。
+            // sqlx-sqlite の try_get::<String> は NULL でも Ok("") を返すため、
+            // Option 列は try_get::<Option<String>> で読む)。
+            phase_label: None,
             scores: vec![],
             room_kind: GameRoomKind::ScoreGame,
             metaverse: None,
@@ -356,10 +356,8 @@ async fn object_projection_blank_root_and_reply_map_to_none() {
             source_replica_id: ReplicaId::new("replica-object-edge"),
             source_key: "objects/obj-blank-refs/header".into(),
             source_envelope_id: EnvelopeId::from("env-obj-blank-refs"),
-            // NULL の source_blob_hash は Some(BlobHash("")) になる(root/reply と違い
-            // 空文字フィルタが無く、sqlx-sqlite は NULL でも Ok("") を返す現挙動 —
-            // sqlx-sqlite 0.8.x 時点の decode 実装に依存)。
-            source_blob_hash: Some(BlobHash::new("")),
+            // NULL の source_blob_hash は None(WP-B16 で Option decode を適正化)。
+            source_blob_hash: None,
             derived_at: 1001,
             projection_version: 2,
         }
@@ -376,16 +374,11 @@ async fn object_projection_blank_root_and_reply_map_to_none() {
     assert_eq!(whitespace.reply_to_object_id, None);
 }
 
-/// ケース 5: bookmarked_posts の root_object_id / reply_to_object_id = '' は
-/// **Some("") のまま読める**(row_mapping.rs row_to_bookmarked_post の
-/// reply_to_object_id / root_object_id — 空文字フィルタ無しの素通し)。
-/// NULL の行も同じく Some("") になる(sqlx-sqlite は NULL でも Ok("") を decode する —
-/// sqlx-sqlite 0.8.x 時点の decode 実装に依存)。
-///
-/// object_index_cache 側(ケース 4: '' → None)と非対称の現挙動をそのまま固定している。
-/// バグの可能性があり Phase 2 の fix 候補。仕様修正時はこのテストを更新すること。
+/// ケース 5: bookmarked_posts の root_object_id / reply_to_object_id は ''(空文字)も
+/// NULL も None として読める(row_mapping.rs row_to_bookmarked_post — WP-B16 で
+/// object_index_cache 側(ケース 4)と同じ trim + filter に統一し、非対称を解消)。
 #[tokio::test]
-async fn bookmarked_post_empty_root_and_reply_map_to_some_empty_string() {
+async fn bookmarked_post_blank_root_and_reply_map_to_none() {
     let store = SqliteStore::connect_memory().await.expect("sqlite store");
     insert_raw_bookmarked_post(&store, "bp-empty-refs", Some(""), Some(""), 300)
         .await
@@ -399,7 +392,7 @@ async fn bookmarked_post_empty_root_and_reply_map_to_some_empty_string() {
         .expect("list bookmarked posts");
     assert_eq!(rows.len(), 2);
 
-    // bookmarked_at DESC 順の先頭 = 空文字行。'' が Some("") として素通しになる(非対称の現挙動)。
+    // bookmarked_at DESC 順の先頭 = 空文字行。'' は None に落ちる(ケース 4 と対称)。
     assert_eq!(
         rows[0],
         BookmarkedPostRow {
@@ -416,19 +409,17 @@ async fn bookmarked_post_empty_root_and_reply_map_to_some_empty_string() {
             },
             content: Some("ブックマーク本文".into()),
             attachments: vec![],
-            reply_to_object_id: Some(EnvelopeId::from("")),
-            root_object_id: Some(EnvelopeId::from("")),
+            reply_to_object_id: None,
+            root_object_id: None,
             repost_of: None,
             bookmarked_at: 300,
         }
     );
 
-    // NULL でも Some(EnvelopeId("")) になる(sqlx-sqlite の try_get::<String> は NULL で
-    // Ok("") を返すため .ok().map(...) が素通しになる現挙動。'' と区別されない —
-    // sqlx-sqlite 0.8.x 時点の decode 実装に依存)。
+    // NULL も None(WP-B16 の Option decode 適正化。'' と同じ結果に正規化される)。
     assert_eq!(rows[1].source_object_id, EnvelopeId::from("bp-null-refs"));
-    assert_eq!(rows[1].root_object_id, Some(EnvelopeId::from("")));
-    assert_eq!(rows[1].reply_to_object_id, Some(EnvelopeId::from("")));
+    assert_eq!(rows[1].root_object_id, None);
+    assert_eq!(rows[1].reply_to_object_id, None);
 }
 
 /// ケース 6a: 未知の status 値('nonsense')が残った行は list_topic_game_rooms が Err になる

--- a/crates/store/src/tests/row_mapping_roundtrip.rs
+++ b/crates/store/src/tests/row_mapping_roundtrip.rs
@@ -12,10 +12,10 @@
 //! row_mapping_roundtrip_dm.rs、live_session / game_room は
 //! row_mapping_roundtrip_live_game.rs に分割)
 //!
-//! 4 ファイル共通の重要な現挙動(本 WP で実測): sqlx-sqlite は NULL を
-//! i64→0 / TEXT→"" にデコードして try_get が Ok を返すため、読み出し側に
-//! trim+filter の無い Option 列は「None で put → Some(既定値) で get」の
-//! 非対称になる。各テストの expected_min はこの観測値を生値で固定している。
+//! 4 ファイル共通の注意: sqlx-sqlite は NULL を i64→0 / TEXT→"" にデコードして
+//! try_get::<T> が Ok を返すが、row_mapping の Option 列は `try_get::<Option<T>>`
+//! (opt_col ヘルパ)で読むため None で put → None で get の対称が成り立つ
+//! (WP-B16 で decode quirk を解消。min fixture がその回帰検出を兼ねる)。
 
 use super::*;
 use kukuri_core::{
@@ -203,17 +203,13 @@ async fn object_projection_roundtrip_preserves_all_18_columns() {
         Some(max)
     );
 
-    // 現挙動(観測値): sqlx-sqlite は NULL を TEXT→"" にデコードするため、
-    // trim+filter の無い content / source_blob_hash は None で put しても
-    // Some(空値) で読み出される(root/reply/repost_of は filter があり None)。
-    let mut expected_min = min.clone();
-    expected_min.content = Some(String::new());
-    expected_min.source_blob_hash = Some(BlobHash::new(""));
+    // None で put した Option 列(content / source_blob_hash / root / reply /
+    // repost_of)は None のまま読み出される(WP-B16 で NULL decode quirk を解消)。
     assert_eq!(
         ObjectProjectionStore::get_object_projection(&store, &min.object_id)
             .await
             .expect("get min projection"),
-        Some(expected_min)
+        Some(min)
     );
 }
 
@@ -297,11 +293,8 @@ async fn reaction_projection_roundtrip_preserves_all_16_columns() {
         .expect("get max reaction"),
         Some(max)
     );
-    // 現挙動(観測値): emoji / custom_asset_id は filter が無いため
-    // None で put しても Some("") で読み出される(snapshot は filter で None)。
-    let mut expected_min = min.clone();
-    expected_min.emoji = Some(String::new());
-    expected_min.custom_asset_id = Some(String::new());
+    // None で put した emoji / custom_asset_id / snapshot は None のまま
+    // 読み出される(WP-B16 で NULL decode quirk を解消)。
     assert_eq!(
         ReactionBookmarkStore::get_reaction_cache(
             &store,
@@ -311,7 +304,7 @@ async fn reaction_projection_roundtrip_preserves_all_16_columns() {
         )
         .await
         .expect("get min reaction"),
-        Some(expected_min)
+        Some(min)
     );
 }
 
@@ -470,15 +463,9 @@ async fn bookmarked_post_roundtrip_preserves_all_15_columns() {
         .await
         .expect("put max bookmarked post");
 
-    // 現挙動(観測値): bookmarked_posts の content / reply_to / root は
-    // filter 無しの素通しのため、None で put しても Some(空値) で読み出される
-    // (object_index_cache 側と非対称 — 修正は Phase 2 候補、T5 でも raw INSERT
-    // の '' ケースを固定)。repost_of のみ filter があり None のまま。
-    let mut expected_min = min.clone();
-    expected_min.content = Some(String::new());
-    expected_min.reply_to_object_id = Some(EnvelopeId::from(""));
-    expected_min.root_object_id = Some(EnvelopeId::from(""));
-
+    // None で put した content / reply_to / root / repost_of は None のまま
+    // 読み出される(WP-B16 で object_index_cache 側と同じ trim + filter に統一し、
+    // NULL decode quirk と非対称を解消。'' ケースは T5 の raw INSERT テストで固定)。
     // 読み出しは list のみ。順序は主キー bookmarked_at DESC のみ行使して固定
     // (副キー source_object_id DESC の tie-break はここでは未行使 —
     // T6 の pagination テストと T8 の backend_parity が担保)。
@@ -486,6 +473,6 @@ async fn bookmarked_post_roundtrip_preserves_all_15_columns() {
         ReactionBookmarkStore::list_bookmarked_posts(&store)
             .await
             .expect("list bookmarked posts"),
-        vec![max, expected_min]
+        vec![max, min]
     );
 }

--- a/crates/store/src/tests/row_mapping_roundtrip_dm.rs
+++ b/crates/store/src/tests/row_mapping_roundtrip_dm.rs
@@ -51,13 +51,8 @@ async fn direct_message_conversation_roundtrip_preserves_all_columns() {
         .await
         .expect("upsert min conversation");
 
-    // 現挙動(観測値): sqlx-sqlite は NULL を TEXT→"" / INTEGER→0 に
-    // デコードするため、last_* 3 列は None で put しても Some(空値) で読み出される。
-    let mut expected_min = min.clone();
-    expected_min.last_message_at = Some(0);
-    expected_min.last_message_id = Some(String::new());
-    expected_min.last_message_preview = Some(String::new());
-
+    // None で put した last_* 3 列は None のまま読み出される
+    // (WP-B16 で NULL decode quirk を解消)。
     assert_eq!(
         DirectMessageStore::get_direct_message_conversation_by_dm_id(&store, "dm-max")
             .await
@@ -71,7 +66,7 @@ async fn direct_message_conversation_roundtrip_preserves_all_columns() {
         )
         .await
         .expect("get by peer"),
-        Some(expected_min.clone())
+        Some(min.clone())
     );
     // 主キー updated_at DESC の順序ごと固定(副キー dm_id DESC の
     // tie-break はここでは未行使 — T6 の pagination テストと T8 の backend_parity が担保)。
@@ -79,7 +74,7 @@ async fn direct_message_conversation_roundtrip_preserves_all_columns() {
         DirectMessageStore::list_direct_message_conversations(&store)
             .await
             .expect("list conversations"),
-        vec![max, expected_min]
+        vec![max, min]
     );
 }
 
@@ -156,18 +151,13 @@ async fn direct_message_message_roundtrip_preserves_all_columns() {
         Some(max)
     );
 
-    // 現挙動(観測値): text / reply_to_message_id / acked_at は filter が
-    // 無いため、None で put しても Some(空値) で読み出される
-    // (attachment_manifest_json は filter で None のまま)。
-    let mut expected_min = min.clone();
-    expected_min.text = Some(String::new());
-    expected_min.reply_to_message_id = Some(String::new());
-    expected_min.acked_at = Some(0);
+    // None で put した text / reply_to_message_id / acked_at / attachment_manifest は
+    // None のまま読み出される(WP-B16 で NULL decode quirk を解消)。
     assert_eq!(
         DirectMessageStore::get_direct_message_message(&store, "dm-min", "msg-min")
             .await
             .expect("get min message"),
-        Some(expected_min)
+        Some(min)
     );
 
     // outgoing の永続形式は i64(true→1 / false→0)。既存 DB 互換の契約として固定。
@@ -264,11 +254,8 @@ async fn direct_message_outbox_roundtrip_preserves_all_columns() {
         .await
         .expect("put min outbox");
 
-    // 現挙動(観測値): last_attempt_at は filter が無いため、
-    // None で put しても Some(0) で読み出される。
-    let mut expected_min = min.clone();
-    expected_min.last_attempt_at = Some(0);
-
+    // None で put した last_attempt_at は None のまま読み出される
+    // (WP-B16 で NULL decode quirk を解消)。
     assert_eq!(
         DirectMessageStore::get_direct_message_outbox(&store, "dm-max", "msg-out-max")
             .await
@@ -281,7 +268,7 @@ async fn direct_message_outbox_roundtrip_preserves_all_columns() {
         DirectMessageStore::list_direct_message_outbox(&store)
             .await
             .expect("list outbox"),
-        vec![expected_min, max]
+        vec![min, max]
     );
 }
 
@@ -392,19 +379,14 @@ async fn notification_roundtrip_preserves_all_15_columns() {
             .expect("put duplicate notification")
     );
 
-    // 現挙動(観測値): read_at(i64)は filter が無いため、None で put しても
-    // Some(0) で読み出される(count_unread は SQL の IS NULL で数えるため
-    // 「未読 1 件」と「read_at: Some(0)」が同時に成立する点に注意)。
-    // 他の Option 列は trim+filter があり None のまま。
-    let mut expected_min = min.clone();
-    expected_min.read_at = Some(0);
-
+    // None で put した read_at は None のまま読み出される(WP-B16 で
+    // NULL decode quirk を解消。count_unread の SQL IS NULL 判定とも整合)。
     // received_at DESC, notification_id DESC の順序ごと全列固定。
     assert_eq!(
         NotificationStore::list_notifications(&store)
             .await
             .expect("list notifications"),
-        vec![max, expected_min]
+        vec![max, min]
     );
 }
 

--- a/crates/store/src/tests/row_mapping_roundtrip_live_game.rs
+++ b/crates/store/src/tests/row_mapping_roundtrip_live_game.rs
@@ -170,14 +170,12 @@ async fn live_session_roundtrip_preserves_all_columns_and_computes_viewer_count(
     // put 時の viewer_count=99 は破棄され、COUNT(=2)が返る。
     let mut expected_max = live_session_max();
     expected_max.viewer_count = 2;
-    // 現挙動(観測値): ended_at(i64)は filter が無いため、None で put しても
-    // Some(0) で読み出される。
-    let mut expected_min = live_session_min();
-    expected_min.ended_at = Some(0);
+    // None で put した ended_at は None のまま読み出される
+    // (WP-B16 で NULL decode quirk を解消)。
     // started_at DESC, session_id DESC の順序ごと全列固定。
     assert_eq!(
         listed,
-        vec![expected_max, expected_min, live_session_ended()]
+        vec![expected_max, live_session_min(), live_session_ended()]
     );
 }
 
@@ -304,11 +302,8 @@ async fn game_room_roundtrip_preserves_all_columns() {
         .await
         .expect("upsert max room");
 
-    // 現挙動(観測値): phase_label は filter が無いため、None で put しても
-    // Some("") で読み出される(metaverse_json は filter で None のまま)。
-    let mut expected_min = min.clone();
-    expected_min.phase_label = Some(String::new());
-
+    // None で put した phase_label / metaverse は None のまま読み出される
+    // (WP-B16 で NULL decode quirk を解消)。
     // 読み出しは list のみ。主キー updated_at DESC の順序ごと全列固定
     // (副キー room_id DESC の tie-break はここでは未行使 —
     // T6 の pagination テストと T8 の backend_parity が担保)。
@@ -316,6 +311,6 @@ async fn game_room_roundtrip_preserves_all_columns() {
         LiveGameProjectionStore::list_topic_game_rooms(&store, GAME_TOPIC)
             .await
             .expect("list game rooms"),
-        vec![max, expected_min]
+        vec![max, min]
     );
 }


### PR DESCRIPTION
## Summary
- [fix] resolve the sqlite NULL decode quirk documented in the backend-parity header (review backlog B16, master plan §9.2): sqlx-sqlite decodes NULL as `Ok("")`/`Ok(0)` for `String`/`i64`, so option columns read via `try_get::<T>().ok()` turned `put(None)` into `Some("")`/`Some(0)` on read — 17 columns across dm_messages/dm_outbox/dm_conversations/notifications/live_session_cache/game_room_cache/reaction_cache/object_index_cache/bookmarked_posts (the 15 documented ones plus `dm_messages.text` and `object_index_cache.content`, which the header had missed)
- introduce an `opt_col` helper (`try_get::<Option<T>>().ok().flatten()`) so NULL decodes to `None` while column-not-found keeps degrading to `None` as before
- give `row_to_bookmarked_post`'s root/reply the same trim + empty filter as `row_to_object_projection`, fixing the documented asymmetry (a rootless bookmarked post came back with `Some(EnvelopeId(""))` — flagged as a probable bug in the edge-test docstring)
- strengthen the parity harness: fixtures now inject real NULLs instead of the `Some(default)` workaround, and the notification scenario compares the unread (`read_at` NULL) listing that previously had to be deferred until all rows were read

## Failing-test-first
Edge/roundtrip/parity characterization tests were flipped to the intended behaviour first: 7 backend-parity tests red on the old mappers (sqlite `Some("")`/`Some(0)` vs memory `None`), then the fix turned the suite green.

## Reference-path audit
- No production code depends on the quirk: grep across app-api/desktop-runtime for `Some(EnvelopeId::from(""))` / `Some(0)`-based acked/read handling found nothing; unread counting uses SQL `IS NULL` (unchanged); `app-api/src/timeline.rs` writes these columns via Option binds, so the leak path was read-side only
- The remaining intentional divergence (sqlite trim-filters `''` on filtered columns; memory does not) is re-documented in the backend_parity mod.rs header — real writers never store `''` in those columns

## Validation
- cargo nextest run -p kukuri-store — 103/103
- cargo nextest run -p kukuri-app-api — 137/137 (store behaviour consumers)
- cargo clippy -p kukuri-store -p kukuri-app-api --all-targets -- -D warnings / cargo fmt --check (exit codes verified explicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)