### PR TITLE
refactor: extract the shared remote fetch loop into iroh-node

### DIFF
--- a/crates/blob-service/src/lib.rs
+++ b/crates/blob-service/src/lib.rs
@@ -5,14 +5,10 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use kukuri_core::BlobHash;
-use kukuri_iroh_node::IrohDocsNode;
-use kukuri_transport::{
-    PeerAddrBook, RemoteFetchRetryState, RemoteFetchStart, SeedPeer, parse_endpoint_ticket,
-};
+use kukuri_iroh_node::{IrohDocsNode, remote_fetch};
+use kukuri_transport::{PeerAddrBook, RemoteFetchRetryState, SeedPeer, parse_endpoint_ticket};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
-use tokio::time::{Duration, Instant, timeout};
-use tracing::{info, warn};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StoredBlob {
@@ -27,9 +23,6 @@ pub enum BlobStatus {
     Available,
     Pinned,
 }
-
-const REMOTE_FETCH_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-const REMOTE_FETCH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[async_trait]
 pub trait BlobService: Send + Sync {
@@ -82,6 +75,8 @@ impl IrohBlobService {
         }
     }
 
+    // 本体ループは remote_fetch(WP-B14)へ移設。characterization テスト専用に残す。
+    #[cfg(test)]
     async fn connect_candidates(
         &self,
         imported_peer: &iroh::EndpointAddr,
@@ -89,6 +84,7 @@ impl IrohBlobService {
         self.peers.connect_candidates(imported_peer).await
     }
 
+    #[cfg(test)]
     async fn fetch_peers(&self) -> Vec<iroh::EndpointAddr> {
         self.peers.merged_peers().await
     }
@@ -122,113 +118,6 @@ impl IrohBlobService {
             .record_learned_peer(endpoint_id, &relay_urls)
             .await?;
         Ok(())
-    }
-
-    async fn fetch_blob_from_remote(
-        &self,
-        hash_text: &str,
-        hash: iroh_blobs::Hash,
-        local_error: impl std::fmt::Display,
-    ) -> Result<Option<Vec<u8>>> {
-        let peers = self.fetch_peers().await;
-        info!(
-            hash = %hash_text,
-            error = %local_error,
-            configured_peer_count = peers.len(),
-            "blob fetch local miss, trying remote peers"
-        );
-        for imported_peer in peers {
-            let candidates = self.connect_candidates(&imported_peer).await;
-            info!(
-                hash = %hash_text,
-                peer_id = %imported_peer.id,
-                imported_addrs = ?imported_peer.addrs,
-                candidate_count = candidates.len(),
-                "blob fetch prepared remote peer candidates"
-            );
-            for peer in candidates {
-                match timeout(
-                    REMOTE_FETCH_CONNECT_TIMEOUT,
-                    self.node.endpoint().connect(peer.clone(), iroh_blobs::ALPN),
-                )
-                .await
-                {
-                    Ok(Ok(conn)) => {
-                        info!(
-                            hash = %hash_text,
-                            peer_id = %peer.id,
-                            addrs = ?peer.addrs,
-                            "blob fetch connected to remote peer"
-                        );
-                        match timeout(
-                            REMOTE_FETCH_TRANSFER_TIMEOUT,
-                            self.node.blobs().remote().fetch(conn, hash),
-                        )
-                        .await
-                        {
-                            Ok(Ok(_)) => {
-                                info!(
-                                    hash = %hash_text,
-                                    peer_id = %peer.id,
-                                    "blob fetch remote transfer completed"
-                                );
-                            }
-                            Ok(Err(error)) => {
-                                warn!(
-                                    hash = %hash_text,
-                                    peer_id = %peer.id,
-                                    addrs = ?peer.addrs,
-                                    error = %error,
-                                    "blob fetch remote transfer failed"
-                                );
-                                continue;
-                            }
-                            Err(_) => {
-                                warn!(
-                                    hash = %hash_text,
-                                    peer_id = %peer.id,
-                                    addrs = ?peer.addrs,
-                                    timeout_ms = REMOTE_FETCH_TRANSFER_TIMEOUT.as_millis(),
-                                    "blob fetch remote transfer timed out"
-                                );
-                                continue;
-                            }
-                        }
-                        match self.node.blobs().blobs().get_bytes(hash).await {
-                            Ok(bytes) => return Ok(Some(bytes.to_vec())),
-                            Err(error) => {
-                                warn!(
-                                    hash = %hash_text,
-                                    peer_id = %peer.id,
-                                    error = %error,
-                                    "blob fetch transfer completed but blob still missing locally"
-                                );
-                            }
-                        }
-                    }
-                    Ok(Err(error)) => {
-                        warn!(
-                            hash = %hash_text,
-                            peer_id = %peer.id,
-                            addrs = ?peer.addrs,
-                            error = %error,
-                            "blob fetch connect failed"
-                        );
-                    }
-                    Err(_) => {
-                        warn!(
-                            hash = %hash_text,
-                            peer_id = %peer.id,
-                            addrs = ?peer.addrs,
-                            timeout_ms = REMOTE_FETCH_CONNECT_TIMEOUT.as_millis(),
-                            "blob fetch connect timed out"
-                        );
-                    }
-                }
-            }
-        }
-        warn!(hash = %hash_text, "blob fetch exhausted remote peers without success");
-        Ok(None)
     }
 }
 
@@ -289,31 +178,17 @@ impl BlobService for IrohBlobService {
         match self.node.blobs().blobs().get_bytes(hash).await {
             Ok(bytes) => Ok(Some(bytes.to_vec())),
             Err(error) => {
-                match self
-                    .remote_fetch_retries
-                    .lock()
-                    .await
-                    .try_begin(hash_text.as_str(), Instant::now())
-                {
-                    RemoteFetchStart::Ready => {}
-                    RemoteFetchStart::CoolingDown => {
-                        info!(
-                            hash = %hash_text,
-                            error = %error,
-                            "blob remote fetch skipped during retry cooldown"
-                        );
-                        return Ok(None);
-                    }
-                }
-                let result = self
-                    .fetch_blob_from_remote(hash_text.as_str(), hash, error)
-                    .await;
-                self.remote_fetch_retries.lock().await.finish(
+                // ループ本体(cooldown ゲート込み)は iroh-node の共通実装(WP-B14)。
+                remote_fetch::fetch_bytes_with_cooldown(
+                    &self.node,
+                    &self.peers,
+                    &self.remote_fetch_retries,
+                    "blob",
                     hash_text.as_str(),
-                    matches!(&result, Ok(Some(_))),
-                    Instant::now(),
-                );
-                result
+                    hash,
+                    error,
+                )
+                .await
             }
         }
     }
@@ -361,7 +236,7 @@ mod tests {
     use iroh::Endpoint;
     use kukuri_transport::{TransportNetworkConfig, encode_endpoint_ticket};
     use tempfile::tempdir;
-    use tokio::time::{sleep, timeout};
+    use tokio::time::{Duration, sleep, timeout};
 
     fn loopback_ticket(endpoint: &Endpoint, config: &TransportNetworkConfig) -> String {
         let endpoint_addr = endpoint.addr();

--- a/crates/docs-sync/src/iroh_sync.rs
+++ b/crates/docs-sync/src/iroh_sync.rs
@@ -10,21 +10,18 @@ use iroh_docs::api::Doc;
 use iroh_docs::store::Query;
 use iroh_docs::{Capability, DocTicket, NamespaceSecret};
 use kukuri_core::ReplicaId;
-use kukuri_transport::{
-    PeerAddrBook, RemoteFetchRetryState, RemoteFetchStart, SeedPeer, parse_endpoint_ticket,
-};
+use kukuri_transport::{PeerAddrBook, RemoteFetchRetryState, SeedPeer, parse_endpoint_ticket};
 use tokio::sync::{Mutex, broadcast};
 use tokio::task::JoinHandle;
-use tokio::time::{Duration, Instant, timeout};
 use tokio_stream::wrappers::BroadcastStream;
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::access::parse_namespace_secret_hex;
 use crate::replicas::public_replica_secret;
 use crate::types::{
     DocEvent, DocEventStream, DocFetchPolicy, DocOp, DocQuery, DocRecord, DocsSync,
 };
-use kukuri_iroh_node::IrohDocsNode;
+use kukuri_iroh_node::{IrohDocsNode, remote_fetch};
 
 struct ReplicaHandle {
     doc: Doc,
@@ -32,9 +29,6 @@ struct ReplicaHandle {
     sync_peer_ids: BTreeSet<String>,
     live_task: JoinHandle<()>,
 }
-
-const REMOTE_FETCH_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-const REMOTE_FETCH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Clone, Debug, Default)]
 pub struct DocsPeerState {
@@ -100,6 +94,8 @@ impl IrohDocsSync {
         self.reapply_sync_peers().await
     }
 
+    // 本体ループは remote_fetch(WP-B14)へ移設。characterization テスト専用に残す。
+    #[cfg(test)]
     async fn connect_candidates(&self, imported_peer: &EndpointAddr) -> Vec<EndpointAddr> {
         self.peers.connect_candidates(imported_peer).await
     }
@@ -235,121 +231,19 @@ impl IrohDocsSync {
                     );
                     return Ok(None);
                 }
-                match self
-                    .remote_fetch_retries
-                    .lock()
-                    .await
-                    .try_begin(content_hash, Instant::now())
-                {
-                    RemoteFetchStart::Ready => {}
-                    RemoteFetchStart::CoolingDown => {
-                        info!(
-                            hash = %content_hash,
-                            error = %error,
-                            "docs entry remote fetch skipped during retry cooldown"
-                        );
-                        return Ok(None);
-                    }
-                }
-                let result = self
-                    .fetch_entry_bytes_from_remote(content_hash, hash, error)
-                    .await;
-                self.remote_fetch_retries.lock().await.finish(
+                // ループ本体(cooldown ゲート込み)は iroh-node の共通実装(WP-B14)。
+                remote_fetch::fetch_bytes_with_cooldown(
+                    &self.node,
+                    &self.peers,
+                    &self.remote_fetch_retries,
+                    "docs entry",
                     content_hash,
-                    matches!(&result, Ok(Some(_))),
-                    Instant::now(),
-                );
-                result
-            }
-        }
-    }
-
-    async fn fetch_entry_bytes_from_remote(
-        &self,
-        content_hash: &str,
-        hash: iroh_blobs::Hash,
-        local_error: impl std::fmt::Display,
-    ) -> Result<Option<Vec<u8>>> {
-        let peers = self.sync_peers().await;
-        info!(
-            hash = %content_hash,
-            error = %local_error,
-            configured_peer_count = peers.len(),
-            "docs entry fetch local miss, trying remote peers"
-        );
-        for imported_peer in peers {
-            let candidates = self.connect_candidates(&imported_peer).await;
-            for peer in candidates {
-                match timeout(
-                    REMOTE_FETCH_CONNECT_TIMEOUT,
-                    self.node.endpoint().connect(peer.clone(), iroh_blobs::ALPN),
+                    hash,
+                    error,
                 )
                 .await
-                {
-                    Ok(Ok(conn)) => {
-                        match timeout(
-                            REMOTE_FETCH_TRANSFER_TIMEOUT,
-                            self.node.blobs().remote().fetch(conn, hash),
-                        )
-                        .await
-                        {
-                            Ok(Ok(_)) => match self.node.blobs().blobs().get_bytes(hash).await {
-                                Ok(bytes) => return Ok(Some(bytes.to_vec())),
-                                Err(error) => {
-                                    warn!(
-                                        hash = %content_hash,
-                                        peer_id = %peer.id,
-                                        error = %error,
-                                        "docs entry transfer completed but content is still missing locally"
-                                    );
-                                }
-                            },
-                            Ok(Err(error)) => {
-                                warn!(
-                                    hash = %content_hash,
-                                    peer_id = %peer.id,
-                                    addrs = ?peer.addrs,
-                                    error = %error,
-                                    "docs entry remote transfer failed"
-                                );
-                            }
-                            Err(_) => {
-                                warn!(
-                                    hash = %content_hash,
-                                    peer_id = %peer.id,
-                                    addrs = ?peer.addrs,
-                                    timeout_ms = REMOTE_FETCH_TRANSFER_TIMEOUT.as_millis(),
-                                    "docs entry remote transfer timed out"
-                                );
-                            }
-                        }
-                    }
-                    Ok(Err(error)) => {
-                        warn!(
-                            hash = %content_hash,
-                            peer_id = %peer.id,
-                            addrs = ?peer.addrs,
-                            error = %error,
-                            "docs entry fetch connect failed"
-                        );
-                    }
-                    Err(_) => {
-                        warn!(
-                            hash = %content_hash,
-                            peer_id = %peer.id,
-                            addrs = ?peer.addrs,
-                            timeout_ms = REMOTE_FETCH_CONNECT_TIMEOUT.as_millis(),
-                            "docs entry fetch connect timed out"
-                        );
-                    }
-                }
             }
         }
-        warn!(
-            hash = %content_hash,
-            "docs entry fetch exhausted remote peers without success"
-        );
-        Ok(None)
     }
 }
 
@@ -532,7 +426,7 @@ mod tests {
     use super::*;
     use kukuri_transport::TransportNetworkConfig;
     use tempfile::tempdir;
-    use tokio::time::sleep;
+    use tokio::time::{Duration, sleep, timeout};
 
     // 接続候補の順序は外部挙動(characterization、WP-H2)。
     // direct(remote_info 由来)→ relay 付き → 元の値、の優先順位を固定する。

--- a/crates/iroh-node/src/lib.rs
+++ b/crates/iroh-node/src/lib.rs
@@ -7,6 +7,7 @@
 //! 解消するため独立させた(挙動不変の移動)。
 
 mod node;
+pub mod remote_fetch;
 
 #[cfg(test)]
 mod tests;

--- a/crates/iroh-node/src/remote_fetch.rs
+++ b/crates/iroh-node/src/remote_fetch.rs
@@ -1,0 +1,177 @@
+//! docs-sync / blob-service 共通のリモートフェッチ本体(WP-B14)。
+//!
+//! 「local miss → cooldown ゲート → peers 走査 → connect(5s)→ fetch(15s)→
+//! ローカル再読込」のループは両 crate で同一アルゴリズム(どちらも
+//! `iroh_blobs::ALPN` で connect し `blobs().remote().fetch` で取得)だったため、
+//! ここに一本化した。呼び出し側に残るのはローカル取得と policy 判定のみ。
+//! ピア台帳・リトライ状態そのものは kukuri-transport の共通実装(WP-H2)。
+
+use std::fmt::Display;
+use std::time::Duration;
+
+use anyhow::Result;
+use kukuri_transport::{PeerAddrBook, RemoteFetchRetryState, RemoteFetchStart};
+use tokio::sync::Mutex;
+use tokio::time::{Instant, timeout};
+use tracing::{info, warn};
+
+use crate::IrohDocsNode;
+
+pub const REMOTE_FETCH_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+pub const REMOTE_FETCH_TRANSFER_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// local miss 後のリモートフェッチ一式(cooldown ゲート込み)。
+///
+/// `subject` はログ上の対象名("docs entry" / "blob")。`local_error` は
+/// 呼び出し側のローカル取得が返したエラーで、ログにのみ使う。
+/// 成功時はローカルストアへ取り込んだうえで bytes を返す。
+pub async fn fetch_bytes_with_cooldown(
+    node: &IrohDocsNode,
+    peers: &PeerAddrBook,
+    retries: &Mutex<RemoteFetchRetryState>,
+    subject: &str,
+    hash_text: &str,
+    hash: iroh_blobs::Hash,
+    local_error: impl Display,
+) -> Result<Option<Vec<u8>>> {
+    match retries.lock().await.try_begin(hash_text, Instant::now()) {
+        RemoteFetchStart::Ready => {}
+        RemoteFetchStart::CoolingDown => {
+            info!(
+                subject,
+                hash = %hash_text,
+                error = %local_error,
+                "remote fetch skipped during retry cooldown"
+            );
+            return Ok(None);
+        }
+    }
+    let result = fetch_bytes_from_remote(node, peers, subject, hash_text, hash, local_error).await;
+    retries
+        .lock()
+        .await
+        .finish(hash_text, matches!(&result, Ok(Some(_))), Instant::now());
+    result
+}
+
+async fn fetch_bytes_from_remote(
+    node: &IrohDocsNode,
+    peers: &PeerAddrBook,
+    subject: &str,
+    hash_text: &str,
+    hash: iroh_blobs::Hash,
+    local_error: impl Display,
+) -> Result<Option<Vec<u8>>> {
+    let imported_peers = peers.merged_peers().await;
+    info!(
+        subject,
+        hash = %hash_text,
+        error = %local_error,
+        configured_peer_count = imported_peers.len(),
+        "fetch local miss, trying remote peers"
+    );
+    for imported_peer in imported_peers {
+        let candidates = peers.connect_candidates(&imported_peer).await;
+        info!(
+            subject,
+            hash = %hash_text,
+            peer_id = %imported_peer.id,
+            imported_addrs = ?imported_peer.addrs,
+            candidate_count = candidates.len(),
+            "fetch prepared remote peer candidates"
+        );
+        for peer in candidates {
+            match timeout(
+                REMOTE_FETCH_CONNECT_TIMEOUT,
+                node.endpoint().connect(peer.clone(), iroh_blobs::ALPN),
+            )
+            .await
+            {
+                Ok(Ok(conn)) => {
+                    info!(
+                        subject,
+                        hash = %hash_text,
+                        peer_id = %peer.id,
+                        addrs = ?peer.addrs,
+                        "fetch connected to remote peer"
+                    );
+                    match timeout(
+                        REMOTE_FETCH_TRANSFER_TIMEOUT,
+                        node.blobs().remote().fetch(conn, hash),
+                    )
+                    .await
+                    {
+                        Ok(Ok(_)) => {
+                            info!(
+                                subject,
+                                hash = %hash_text,
+                                peer_id = %peer.id,
+                                "fetch remote transfer completed"
+                            );
+                        }
+                        Ok(Err(error)) => {
+                            warn!(
+                                subject,
+                                hash = %hash_text,
+                                peer_id = %peer.id,
+                                addrs = ?peer.addrs,
+                                error = %error,
+                                "fetch remote transfer failed"
+                            );
+                            continue;
+                        }
+                        Err(_) => {
+                            warn!(
+                                subject,
+                                hash = %hash_text,
+                                peer_id = %peer.id,
+                                addrs = ?peer.addrs,
+                                timeout_ms = REMOTE_FETCH_TRANSFER_TIMEOUT.as_millis(),
+                                "fetch remote transfer timed out"
+                            );
+                            continue;
+                        }
+                    }
+                    match node.blobs().blobs().get_bytes(hash).await {
+                        Ok(bytes) => return Ok(Some(bytes.to_vec())),
+                        Err(error) => {
+                            warn!(
+                                subject,
+                                hash = %hash_text,
+                                peer_id = %peer.id,
+                                error = %error,
+                                "fetch transfer completed but content is still missing locally"
+                            );
+                        }
+                    }
+                }
+                Ok(Err(error)) => {
+                    warn!(
+                        subject,
+                        hash = %hash_text,
+                        peer_id = %peer.id,
+                        addrs = ?peer.addrs,
+                        error = %error,
+                        "fetch connect failed"
+                    );
+                }
+                Err(_) => {
+                    warn!(
+                        subject,
+                        hash = %hash_text,
+                        peer_id = %peer.id,
+                        addrs = ?peer.addrs,
+                        timeout_ms = REMOTE_FETCH_CONNECT_TIMEOUT.as_millis(),
+                        "fetch connect timed out"
+                    );
+                }
+            }
+        }
+    }
+    warn!(
+        subject,
+        hash = %hash_text,
+        "fetch exhausted remote peers without success"
+    );
+    Ok(None)
+}


### PR DESCRIPTION
## Summary
- [refactor: extract] finish B-2's second half (review finding D3, backlog B14): docs-sync (`fetch_entry_bytes_from_remote`, ~87 lines) and blob-service (`fetch_blob_from_remote`, ~106 lines) ran the same algorithm — local miss → cooldown gate → peer scan → connect(`iroh_blobs::ALPN`, 5s) → `blobs().remote().fetch` (15s) → local re-read — with the connect/transfer timeout constants defined twice
- the loop now lives once in `kukuri-iroh-node::remote_fetch` (cooldown gate included); callers keep only the local read and, for docs-sync, the `DocFetchPolicy::LocalOnly` early return
- placement rationale: transport can't host it (iroh-node → transport dependency would become a cycle), and both services already hold `Arc<IrohDocsNode>`, so iroh-node needs no closure injection and no new dependency edges; the peer ledger / retry state stay in kukuri-transport (WP-H2) and each service keeps its own cooldown ledger
- log lines unified behind a `subject` field ("docs entry" / "blob") — log text is not a contract; the docs path gains the candidate/connected diagnostics that only blobs had

## Reference-path audit
- `fetch_entry_bytes_from_remote` / `fetch_blob_from_remote` had no callers outside the two gates they were inlined into
- the per-service `connect_candidates` / `fetch_peers` helpers are now test-only (characterization tests exercise them) and are marked `#[cfg(test)]`
- timeout constants: no other references to the deleted `REMOTE_FETCH_*` pairs; the cooldown constant was already single-homed in transport

## Validation
- cargo nextest run -p kukuri-iroh-node -p kukuri-blob-service -p kukuri-docs-sync — 22/24; the 2 failures are `tests::relay::public_replica_syncs_over_custom_relay_seed_peers` / `learned_peer_recovers_relay_backfilled_doc_entry_after_seed_peers_are_cleared`, the known Windows-local 90s relay flake — verified by stashing the change and re-running: identical failures on the unchanged tree (doc-sync propagation path, not the fetch loop)
- blob-service's real-iroh suites (roundtrip / stale-ticket fallback / candidate ordering) now exercise the shared helper end to end
- cargo clippy (3 crates, --all-targets, -D warnings) / cargo fmt --check (exit codes verified explicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)