### PR TITLE
ci: gate unused shell CSS selectors with a vitest sweep

### DIFF
--- a/apps/desktop/src/styles/shell-phase1-part3.css
+++ b/apps/desktop/src/styles/shell-phase1-part3.css
@@ -81,7 +81,6 @@
   backdrop-filter: none;
 }
 
-.shell-primary-nav,
 .shell-settings-nav-list {
   display: grid;
   gap: var(--space-xs);

--- a/apps/desktop/src/styles/shell-scoped-overrides.css
+++ b/apps/desktop/src/styles/shell-scoped-overrides.css
@@ -17,12 +17,6 @@
  *   - .composer / .panel … dialog 内フォーム(portal)と shell 内フォームの双方に現れる。
  * これらは phase1 = portal 基準値 / この層 = shell 上書き値 の二層を維持する。
  */
-.shell-phase1 .shell {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: var(--space-xl) var(--space-lg) var(--space-2xl);
-}
-
 .shell-phase1 .eyebrow {
   margin: 0 0 var(--space-xs);
   letter-spacing: 0.16em;

--- a/apps/desktop/src/styles/unused-selectors.test.ts
+++ b/apps/desktop/src/styles/unused-selectors.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Shell stylesheets that ship together (see index.css). Every class token they
+// declare must appear somewhere in the source tree, otherwise the rule is dead
+// weight that manual sweeps keep missing (WP-H8 left 4 behind, #520 orphaned 4
+// more — this gate replaces that manual inventory; WP-B12).
+const CSS_FILES = [
+  'tokens.css',
+  'base.css',
+  'shell-phase1-part1.css',
+  'shell-phase1-part2.css',
+  'shell-phase1-part3.css',
+  'shell-phase1-part4.css',
+  'shell-scoped-overrides.css',
+] as const;
+
+// Classes that are intentionally declared without a source reference (injected
+// by third-party libraries at runtime, kept for documented compatibility, …).
+// Keep this list short and justified — an entry here is a documented decision,
+// not a way to silence the gate.
+const ALLOWED_UNUSED: ReadonlySet<string> = new Set([]);
+
+// Vitest runs with apps/desktop as the working directory (see package.json).
+const APP_DIR = process.cwd();
+const STYLES_DIR = resolve(APP_DIR, 'src/styles');
+const SOURCE_ROOTS = [resolve(APP_DIR, 'src'), resolve(APP_DIR, 'index.html')];
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.html'];
+
+/** Class tokens declared in selector position (`.foo`), pseudo-classes,
+ * attribute selectors and element selectors excluded. */
+function collectDeclaredClasses(css: string): Set<string> {
+  const noComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const classes = new Set<string>();
+  // Selector text is whatever sits between the previous `{`/`}` and the next
+  // `{`. `@media`/`@supports` wrappers contribute no class tokens themselves
+  // and their inner rules are still visited; `@keyframes` frames are numeric.
+  for (const match of noComments.matchAll(/(?:^|[{}])([^{}]*)\{/g)) {
+    const selector = match[1];
+    if (selector.trim().startsWith('@')) {
+      continue;
+    }
+    for (const token of selector.matchAll(/\.([A-Za-z][\w-]*)/g)) {
+      classes.add(token[1]);
+    }
+  }
+  return classes;
+}
+
+function collectSourceFiles(root: string, files: string[] = []): string[] {
+  if (statSync(root).isFile()) {
+    files.push(root);
+    return files;
+  }
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      collectSourceFiles(path, files);
+    } else if (SOURCE_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+/** Every `[\w-]+` word in the source tree. Class names always surface as
+ * complete tokens (audited: no `\`foo-${bar}\`` style className fragments in
+ * this codebase — conditional concatenation only ever appends whole tokens),
+ * so token-set membership is an exact usage check. */
+function collectSourceTokens(): Set<string> {
+  const tokens = new Set<string>();
+  for (const file of SOURCE_ROOTS.flatMap((root) => collectSourceFiles(root))) {
+    for (const token of readFileSync(file, 'utf8').split(/[^\w-]+/)) {
+      if (token) {
+        tokens.add(token);
+      }
+    }
+  }
+  return tokens;
+}
+
+describe('shell CSS selector usage', () => {
+  const declared = new Set<string>(
+    CSS_FILES.flatMap((name) => [
+      ...collectDeclaredClasses(readFileSync(resolve(STYLES_DIR, name), 'utf8')),
+    ]),
+  );
+  const used = collectSourceTokens();
+
+  it('references every declared class token from the source tree', () => {
+    const unused = [...declared]
+      .filter((name) => !used.has(name))
+      .filter((name) => !ALLOWED_UNUSED.has(name))
+      .sort();
+    expect(unused).toEqual([]);
+  });
+
+  it('keeps the allowlist free of entries that are referenced again', () => {
+    const stale = [...ALLOWED_UNUSED].filter((name) => used.has(name)).sort();
+    expect(stale).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- [ci] replace the manual unused-CSS inventory with a continuously-running gate (review backlog B12, master plan §9.2): `apps/desktop/src/styles/unused-selectors.test.ts` extracts every class token declared in the 7 shell stylesheets (attribute/pseudo/element selectors normalized away, `@`-wrappers skipped) and requires each to appear as a complete `[\w-]` token somewhere in `src/` or `index.html`
- token matching is exact for this codebase: an audit found no fragment-built classNames (`` `foo-${bar}` `` style) — conditional concatenation only ever appends whole tokens, so a declared class that never surfaces as a token is genuinely dead
- `ALLOWED_UNUSED` allowlist (empty today) carries documented exceptions; a second assertion fails when an allowlisted class becomes referenced again, so the list cannot rot
- design decision recorded: vitest over xtask — rides the existing desktop-test CI job with zero new wiring, reuses the `css-vars.test.ts` pattern, and needs no ratchet baseline since the target state is zero unused selectors

## Initial sweep (found by the new gate + manual follow-up)
- `.shell-primary-nav` dropped from its group selector in shell-phase1-part3.css — only `shell-primary-nav-label` is emitted (SettingsDrawer); per the H8/B9 rule the group keeps its other member
- `.shell-phase1 .shell` override removed from shell-scoped-overrides.css — no bare `shell` className exists anywhere (verified by targeted grep); this one is invisible to the gate because the word "shell" appears in import paths, which token matching conservatively counts as usage
- both rules could never match an element, so there is no visual change; the REFACTORING.md "look-dead-but-alive override" warning does not apply (those overrides pair with classes that are actually emitted)

## Validation
- pnpm vitest run src/styles/ — 3/3 (new gate green after the sweep; red before it, flagging `shell-primary-nav`)
- pnpm lint / pnpm typecheck / pnpm test — 602/602 (exit codes verified explicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)