### PR TITLE
docs: record the standing decisions for observer pull and fake transport scope

### DIFF
--- a/crates/desktop-runtime/src/runtime/sync_status_observer.rs
+++ b/crates/desktop-runtime/src/runtime/sync_status_observer.rs
@@ -6,6 +6,17 @@ use tracing::{info, warn};
 
 use super::*;
 
+/// Decision(WP-B13, 2026-07-16): この observer は 3 秒 pull を恒久採用する。
+/// pull 1 回は「transport のメモリロック読み + 高々 CN node 数分のローカル
+/// トークン読み」で DB / ネットワーク I/O は無く、emit は下の snapshot が
+/// PartialEq 差分を検出した時だけなのでフロント側の churn も無い。
+/// 変化点駆動(event push)化は Transport trait への通知 API 追加
+/// (iroh / fake / static の 3 実装 + 3 crate 跨ぎの契約変更)が必要で、
+/// SyncStatus は多入力の合成値のため notify を受けても full snapshot の
+/// 再計算は残る。コストがこの規模のうちは見合わない。
+/// 再検討のトリガ: pull のコストが実測で問題化した場合。その際は
+/// NotificationStatusChanged(runtime/mod.rs の Notify 待ち)と同型の
+/// 配線が前例になる。
 const SYNC_STATUS_OBSERVER_INTERVAL: Duration = Duration::from_secs(3);
 
 #[derive(Default)]

--- a/crates/transport/src/fake.rs
+++ b/crates/transport/src/fake.rs
@@ -1,3 +1,13 @@
+//! ネットワーク非依存の高速テストダブル(FakeNetwork / FakeTransport)。
+//!
+//! Decision(WP-B15, 2026-07-16): FakeTransport は実 iroh 実装との「等価ダブル」
+//! ではなく、ドメインロジックを高速に検証するための意図的な単純化と定義する
+//! (例: active_path は経路判定をせず機械的に返す)。trait 挙動の実物基準の
+//! 検証は実 iroh 統合テスト(transport の iroh/tests 16 本 + app-api の
+//! TestIrohStack 経由 50 箇所超)が担い、Fake と実物を同一テストベクタで回す
+//! 共有 conformance suite は作らない(恒久 Out of Scope)。
+//! 再検討のトリガ: Fake と実物の挙動乖離に起因するバグが実際に発生した場合。
+
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- [docs] two review backlog rows asked for "implement or record a decision"; both land as decisions written at the code they govern (comment-only change, no behaviour)
- **B13 — sync status observer stays a 3-second pull, permanently.** One pull is memory-lock reads plus at most one local token read per CN node — no DB or network I/O — and `RuntimeEvent::SyncStatusChanged` already fires only on PartialEq change, so the front end sees no churn. Event-driving it would require a change-notification API on the `Transport` trait (iroh/fake/static, three crates), and since `SyncStatus` is a multi-input composite the observer would still recompute the full snapshot per notify. Recorded at `SYNC_STATUS_OBSERVER_INTERVAL` with the re-evaluation trigger (measured pull cost) and the wiring precedent to copy (`NotificationStatusChanged`'s Notify)
- **B15 — the FakeTransport conformance suite is permanently out of scope.** FakeTransport is a fast, network-free test double by design (e.g. `active_path` answers mechanically), not an equivalence double; real-behaviour verification stays with the real-iroh integration tests (16 in transport's iroh/tests + 50+ TestIrohStack call sites in app-api, all in CI). No divergence-caused bug is on record — that occurring is the re-evaluation trigger. Recorded as the fake.rs module header

## Validation
- cargo clippy -p kukuri-transport -p kukuri-desktop-runtime --all-targets -- -D warnings / cargo fmt --check (exit codes verified explicitly; comment-only diff)

Recovers review backlog B13 and B15 (master plan §9.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)