### PR TITLE
refactor: extract the shared hint roundtrip test helpers

### DIFF
--- a/crates/transport/src/fake.rs
+++ b/crates/transport/src/fake.rs
@@ -17,8 +17,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use chrono::Utc;
 use futures_util::StreamExt;
-#[cfg(test)]
-use kukuri_core::HintObjectRef;
 use kukuri_core::{GossipHint, TopicId};
 use tokio::sync::{Mutex, broadcast};
 #[cfg(test)]
@@ -303,114 +301,16 @@ impl HintTransport for FakeTransport {
 mod tests {
     use super::*;
 
+    use crate::test_support::{
+        HintRoundtripParticipant, format_peer_snapshot, wait_for_hint_roundtrip,
+    };
+
     fn initial_topic_join_timeout() -> Duration {
         if cfg!(target_os = "windows") || std::env::var_os("GITHUB_ACTIONS").is_some() {
             Duration::from_secs(180)
         } else {
             Duration::from_secs(15)
         }
-    }
-
-    async fn wait_for_hint_roundtrip<T>(
-        transport_a: &T,
-        stream_a: &mut HintStream,
-        transport_b: &T,
-        stream_b: &mut HintStream,
-        topic: &TopicId,
-        step_timeout: Duration,
-        label: &str,
-    ) where
-        T: Transport + HintTransport + Sync,
-    {
-        let hint_from_a = GossipHint::TopicObjectsChanged {
-            topic_id: topic.clone(),
-            objects: vec![HintObjectRef {
-                object_id: format!("{label}-from-a"),
-                object_kind: "post".into(),
-            }],
-        };
-        let hint_from_b = GossipHint::TopicObjectsChanged {
-            topic_id: topic.clone(),
-            objects: vec![HintObjectRef {
-                object_id: format!("{label}-from-b"),
-                object_kind: "post".into(),
-            }],
-        };
-        match timeout(step_timeout, async {
-            let mut received_on_a = false;
-            let mut received_on_b = false;
-            loop {
-                if !received_on_a {
-                    transport_b
-                        .publish_hint(topic, hint_from_b.clone())
-                        .await
-                        .expect("publish hint from b");
-                }
-                if !received_on_b {
-                    transport_a
-                        .publish_hint(topic, hint_from_a.clone())
-                        .await
-                        .expect("publish hint from a");
-                }
-                if !received_on_a
-                    && let Ok(Some(envelope)) =
-                        timeout(Duration::from_millis(500), stream_a.next()).await
-                {
-                    received_on_a = envelope.hint == hint_from_b;
-                }
-                if !received_on_b
-                    && let Ok(Some(envelope)) =
-                        timeout(Duration::from_millis(500), stream_b.next()).await
-                {
-                    received_on_b = envelope.hint == hint_from_a;
-                }
-                if received_on_a && received_on_b {
-                    return;
-                }
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-        })
-        .await
-        {
-            Ok(()) => {}
-            Err(_) => {
-                let peers_a = transport_a.peers().await.expect("peers a");
-                let peers_b = transport_b.peers().await.expect("peers b");
-                panic!(
-                    "{label} hint roundtrip timeout: a={} b={}",
-                    format_peer_snapshot(&peers_a),
-                    format_peer_snapshot(&peers_b)
-                );
-            }
-        }
-    }
-
-    fn format_peer_snapshot(snapshot: &PeerSnapshot) -> String {
-        let topics = snapshot
-            .topic_diagnostics
-            .iter()
-            .map(|topic| {
-                format!(
-                    "{}: joined={}, peer_count={}, connected_peers={:?}, missing_peer_ids={:?}, status_detail={}, last_error={:?}",
-                    topic.topic,
-                    topic.joined,
-                    topic.peer_count,
-                    topic.connected_peers,
-                    topic.missing_peer_ids,
-                    topic.status_detail,
-                    topic.last_error
-                )
-            })
-            .collect::<Vec<_>>();
-        format!(
-            "connected={}, peer_count={}, connected_peers={:?}, configured_peers={:?}, status_detail={}, last_error={:?}, topics={topics:?}",
-            snapshot.connected,
-            snapshot.peer_count,
-            snapshot.connected_peers,
-            snapshot.configured_peers,
-            snapshot.status_detail,
-            snapshot.last_error
-        )
     }
 
     #[tokio::test]
@@ -494,10 +394,16 @@ mod tests {
         )
         .expect("subscribe demo hints");
         wait_for_hint_roundtrip(
-            &transport_a,
-            &mut demo_stream_a,
-            &transport_b,
-            &mut demo_stream_b,
+            HintRoundtripParticipant {
+                transport: &transport_a,
+                stream: &mut demo_stream_a,
+                expected_source_peer: None,
+            },
+            HintRoundtripParticipant {
+                transport: &transport_b,
+                stream: &mut demo_stream_b,
+                expected_source_peer: None,
+            },
             &demo,
             join_timeout,
             "demo",
@@ -599,10 +505,16 @@ mod tests {
             .await
             .expect("subscribe test7 b");
         wait_for_hint_roundtrip(
-            &transport_a,
-            &mut test7_stream_a,
-            &transport_b,
-            &mut test7_stream_b,
+            HintRoundtripParticipant {
+                transport: &transport_a,
+                stream: &mut test7_stream_a,
+                expected_source_peer: None,
+            },
+            HintRoundtripParticipant {
+                transport: &transport_b,
+                stream: &mut test7_stream_b,
+                expected_source_peer: None,
+            },
             &test7,
             join_timeout,
             "test7",

--- a/crates/transport/src/iroh/tests/mod.rs
+++ b/crates/transport/src/iroh/tests/mod.rs
@@ -2,6 +2,10 @@ use super::*;
 
 use n0_mainline::{DhtBuilder, Testnet};
 
+use crate::test_support::{
+    HintRoundtripParticipant, format_peer_snapshot, wait_for_hint_roundtrip,
+};
+
 async fn wait_for_endpoint_in_testnet(endpoint: &Endpoint, testnet: &Testnet) {
     let mut dht_builder = DhtBuilder::default();
     dht_builder.bootstrap(&testnet.bootstrap);
@@ -24,120 +28,6 @@ async fn wait_for_endpoint_in_testnet(endpoint: &Endpoint, testnet: &Testnet) {
     })
     .await
     .expect("resolve endpoint info from DHT");
-}
-
-struct HintRoundtripParticipant<'a, T> {
-    transport: &'a T,
-    stream: &'a mut HintStream,
-    expected_source_peer: Option<&'a str>,
-}
-
-async fn wait_for_hint_roundtrip<T>(
-    participant_a: HintRoundtripParticipant<'_, T>,
-    participant_b: HintRoundtripParticipant<'_, T>,
-    topic: &TopicId,
-    step_timeout: Duration,
-    label: &str,
-) where
-    T: Transport + HintTransport + Sync,
-{
-    let hint_from_a = GossipHint::TopicObjectsChanged {
-        topic_id: topic.clone(),
-        objects: vec![HintObjectRef {
-            object_id: format!("{label}-from-a"),
-            object_kind: "post".into(),
-        }],
-    };
-    let hint_from_b = GossipHint::TopicObjectsChanged {
-        topic_id: topic.clone(),
-        objects: vec![HintObjectRef {
-            object_id: format!("{label}-from-b"),
-            object_kind: "post".into(),
-        }],
-    };
-    match timeout(step_timeout, async {
-        let mut received_on_a = false;
-        let mut received_on_b = false;
-        loop {
-            if !received_on_a {
-                participant_b
-                    .transport
-                    .publish_hint(topic, hint_from_b.clone())
-                    .await
-                    .expect("publish hint from b");
-            }
-            if !received_on_b {
-                participant_a
-                    .transport
-                    .publish_hint(topic, hint_from_a.clone())
-                    .await
-                    .expect("publish hint from a");
-            }
-            if !received_on_a
-                && let Ok(Some(envelope)) =
-                    timeout(Duration::from_millis(500), participant_a.stream.next()).await
-            {
-                received_on_a = envelope.hint == hint_from_b
-                    && participant_b
-                        .expected_source_peer
-                        .is_none_or(|peer_id| envelope.source_peer == peer_id);
-            }
-            if !received_on_b
-                && let Ok(Some(envelope)) =
-                    timeout(Duration::from_millis(500), participant_b.stream.next()).await
-            {
-                received_on_b = envelope.hint == hint_from_a
-                    && participant_a
-                        .expected_source_peer
-                        .is_none_or(|peer_id| envelope.source_peer == peer_id);
-            }
-            if received_on_a && received_on_b {
-                return;
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    {
-        Ok(()) => {}
-        Err(_) => {
-            let peers_a = participant_a.transport.peers().await.expect("peers a");
-            let peers_b = participant_b.transport.peers().await.expect("peers b");
-            panic!(
-                "{label} hint roundtrip timeout: a={} b={}",
-                format_peer_snapshot(&peers_a),
-                format_peer_snapshot(&peers_b)
-            );
-        }
-    }
-}
-
-fn format_peer_snapshot(snapshot: &PeerSnapshot) -> String {
-    let topics = snapshot
-            .topic_diagnostics
-            .iter()
-            .map(|topic| {
-                format!(
-                    "{}: joined={}, peer_count={}, connected_peers={:?}, missing_peer_ids={:?}, status_detail={}, last_error={:?}",
-                    topic.topic,
-                    topic.joined,
-                    topic.peer_count,
-                    topic.connected_peers,
-                    topic.missing_peer_ids,
-                    topic.status_detail,
-                    topic.last_error
-                )
-            })
-            .collect::<Vec<_>>();
-    format!(
-        "connected={}, peer_count={}, connected_peers={:?}, configured_peers={:?}, status_detail={}, last_error={:?}, topics={topics:?}",
-        snapshot.connected,
-        snapshot.peer_count,
-        snapshot.connected_peers,
-        snapshot.configured_peers,
-        snapshot.status_detail,
-        snapshot.last_error
-    )
 }
 
 fn seed_peer_from_ticket(ticket: &str) -> SeedPeer {

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -18,6 +18,8 @@ mod discovery;
 mod fake;
 mod iroh;
 mod peers;
+#[cfg(test)]
+mod test_support;
 mod tickets;
 mod traits;
 

--- a/crates/transport/src/test_support.rs
+++ b/crates/transport/src/test_support.rs
@@ -1,0 +1,127 @@
+//! crate 内テスト共有ユーティリティ。
+//!
+//! `fake.rs` のユニットテストと `iroh/tests/`(relay_connectivity 含む)が共用する
+//! hint roundtrip 待機と peer snapshot 整形を置く。実装は 1 系統のみで、
+//! source peer 検証が不要な呼び出し側は `expected_source_peer: None` を渡す。
+
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use kukuri_core::{GossipHint, HintObjectRef, TopicId};
+use tokio::time::timeout;
+
+use crate::traits::{HintStream, HintTransport, PeerSnapshot, Transport};
+
+pub(crate) struct HintRoundtripParticipant<'a, T> {
+    pub(crate) transport: &'a T,
+    pub(crate) stream: &'a mut HintStream,
+    pub(crate) expected_source_peer: Option<&'a str>,
+}
+
+pub(crate) async fn wait_for_hint_roundtrip<T>(
+    participant_a: HintRoundtripParticipant<'_, T>,
+    participant_b: HintRoundtripParticipant<'_, T>,
+    topic: &TopicId,
+    step_timeout: Duration,
+    label: &str,
+) where
+    T: Transport + HintTransport + Sync,
+{
+    let hint_from_a = GossipHint::TopicObjectsChanged {
+        topic_id: topic.clone(),
+        objects: vec![HintObjectRef {
+            object_id: format!("{label}-from-a"),
+            object_kind: "post".into(),
+        }],
+    };
+    let hint_from_b = GossipHint::TopicObjectsChanged {
+        topic_id: topic.clone(),
+        objects: vec![HintObjectRef {
+            object_id: format!("{label}-from-b"),
+            object_kind: "post".into(),
+        }],
+    };
+    match timeout(step_timeout, async {
+        let mut received_on_a = false;
+        let mut received_on_b = false;
+        loop {
+            if !received_on_a {
+                participant_b
+                    .transport
+                    .publish_hint(topic, hint_from_b.clone())
+                    .await
+                    .expect("publish hint from b");
+            }
+            if !received_on_b {
+                participant_a
+                    .transport
+                    .publish_hint(topic, hint_from_a.clone())
+                    .await
+                    .expect("publish hint from a");
+            }
+            if !received_on_a
+                && let Ok(Some(envelope)) =
+                    timeout(Duration::from_millis(500), participant_a.stream.next()).await
+            {
+                received_on_a = envelope.hint == hint_from_b
+                    && participant_b
+                        .expected_source_peer
+                        .is_none_or(|peer_id| envelope.source_peer == peer_id);
+            }
+            if !received_on_b
+                && let Ok(Some(envelope)) =
+                    timeout(Duration::from_millis(500), participant_b.stream.next()).await
+            {
+                received_on_b = envelope.hint == hint_from_a
+                    && participant_a
+                        .expected_source_peer
+                        .is_none_or(|peer_id| envelope.source_peer == peer_id);
+            }
+            if received_on_a && received_on_b {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    {
+        Ok(()) => {}
+        Err(_) => {
+            let peers_a = participant_a.transport.peers().await.expect("peers a");
+            let peers_b = participant_b.transport.peers().await.expect("peers b");
+            panic!(
+                "{label} hint roundtrip timeout: a={} b={}",
+                format_peer_snapshot(&peers_a),
+                format_peer_snapshot(&peers_b)
+            );
+        }
+    }
+}
+
+pub(crate) fn format_peer_snapshot(snapshot: &PeerSnapshot) -> String {
+    let topics = snapshot
+        .topic_diagnostics
+        .iter()
+        .map(|topic| {
+            format!(
+                "{}: joined={}, peer_count={}, connected_peers={:?}, missing_peer_ids={:?}, status_detail={}, last_error={:?}",
+                topic.topic,
+                topic.joined,
+                topic.peer_count,
+                topic.connected_peers,
+                topic.missing_peer_ids,
+                topic.status_detail,
+                topic.last_error
+            )
+        })
+        .collect::<Vec<_>>();
+    format!(
+        "connected={}, peer_count={}, connected_peers={:?}, configured_peers={:?}, status_detail={}, last_error={:?}, topics={topics:?}",
+        snapshot.connected,
+        snapshot.peer_count,
+        snapshot.connected_peers,
+        snapshot.configured_peers,
+        snapshot.status_detail,
+        snapshot.last_error
+    )
+}


### PR DESCRIPTION
## 概要

`crates/transport` でテストヘルパ `wait_for_hint_roundtrip` / `format_peer_snapshot` が `src/fake.rs` と `src/iroh/tests/mod.rs` に逐語重複していた(WP-B15 調査 2026-07-16)。`#[cfg(test)]` の crate 内共有モジュール `src/test_support.rs` へ集約し、重複を解消する。

- 共有実装は iroh 側の一般形(`HintRoundtripParticipant` + `expected_source_peer`)を採用
- fake 側の 2 呼び出しは `expected_source_peer: None` に置き換え。`Option::is_none_or` により source peer 検証が恒真になるため、従来の「hint 一致のみ」の判定と同一挙動
- `iroh/tests/relay_connectivity.rs` は従来どおり `use super::*` 経由で参照(tests/mod.rs の re-import を継承)
- 差分: 重複 226 行削除、共有モジュール 125 行追加(テストコードのみ、プロダクトコード変更なし)

## 種別

refactor:extract(1 PR = 1 意図。機能追加・仕様変更・依存更新なし。GitHub ラベル `refactor` は未定義のためタイトル prefix で表明)

## 挙動変更

なし(テストヘルパの移動のみ。凍結境界・wire 文字列・serde 属性に変更なし)

## 参照パス監査

`wait_for_hint_roundtrip` / `format_peer_snapshot` / `HintRoundtripParticipant` の全参照を grep で監査:

- `crates/transport/src/test_support.rs` — 定義(新設、`pub(crate)` + `#[cfg(test)]` モジュール)
- `crates/transport/src/fake.rs` — 利用(呼び出し 2 箇所 + format 6 箇所、ローカル定義は削除)
- `crates/transport/src/iroh/tests/mod.rs` — 利用(re-import、ローカル定義は削除)
- `crates/transport/src/iroh/tests/relay_connectivity.rs` — 利用(`use super::*` 経由、変更なし)
- **crate 外の参照: 0 件**(`grep -rn` を repo 全体で実行し確認)

## 検証

- `cargo clippy -p kukuri-transport --all-targets -- -D warnings` → exit 0
- `cargo fmt -p kukuri-transport --check` → exit 0
- `cargo nextest run -p kukuri-transport` → exit 0(39 passed / 0 skipped、実 iroh・relay connectivity テスト含む)

## リスク

低。テスト専用コードの移動で、プロダクトコード・public API・protocol・storage への変更なし。

## 後続対応

`initial_topic_join_timeout` も fake.rs と iroh(topics.rs)に類似実装が並存するが、値・責務が別系統のため本 PR のスコープ外とした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)