### PR TITLE
fix: refresh topic rendezvous presence independently of the bootstrap heartbeat (#572)

### DIFF
--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -71,6 +71,11 @@ pub(crate) const COMMUNITY_NODE_RECONNECT_BACKOFF_SECONDS: [i64; 3] = [30, 60, 1
 // 15 秒は失効防止を満たしつつ、tick 毎の consent GET を可視時の現行ポーリング(3 秒 ×2 getter)
 // より低頻度に抑える値(WP-C1 プランの決定事項 1)。
 pub(crate) const COMMUNITY_NODE_SESSION_SCHEDULER_TICK_SECONDS: u64 = 15;
+// topic rendezvous presence の次回 refresh 期限は「サーバ返却 expires_in_seconds(45 秒)−
+// このマージン」で管理する(#572)。マージンは tick(15 秒)より大きいことが必須: tick 量子化で
+// 実際の POST が deadline から最大 tick 分遅れても TTL に達しないため(deadline +25 秒、
+// 最悪 POST +40 秒 < TTL 45 秒)。
+pub(crate) const COMMUNITY_NODE_TOPIC_RENDEZVOUS_REFRESH_MARGIN_SECONDS: i64 = 20;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
@@ -178,6 +183,8 @@ pub enum CommunityNodeSessionPhase {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CommunityNodeSessionState {
     pub(crate) heartbeat_deadline: i64,
+    // default 0 = 即時 due。refresh 成功時のみ bump する(#572)。
+    pub(crate) rendezvous_refresh_deadline: i64,
     pub(crate) metadata_refresh_deadline: i64,
     pub(crate) session_retry_deadline: i64,
     pub(crate) session_phase: CommunityNodeSessionPhase,

--- a/crates/desktop-runtime/src/community_node/requests_support.rs
+++ b/crates/desktop-runtime/src/community_node/requests_support.rs
@@ -403,6 +403,17 @@ impl DesktopRuntime {
                     error,
                 )
             })?;
+        // 便乗・独立どちらの呼び出しでも、サーバ返却 TTL − マージンで次回期限を更新する。
+        // heartbeat の「expires_at − マージン」(下の heartbeat_deadline)と同型(#572)。
+        self.community_node_sessions
+            .lock()
+            .await
+            .entry(base_url.to_string())
+            .or_insert_with(CommunityNodeSessionState::default)
+            .rendezvous_refresh_deadline = Utc::now().timestamp().saturating_add(
+            (response.expires_in_seconds.min(i64::MAX as u64) as i64)
+                .saturating_sub(COMMUNITY_NODE_TOPIC_RENDEZVOUS_REFRESH_MARGIN_SECONDS),
+        );
         let mut peers_by_endpoint = std::collections::BTreeMap::new();
         for topic in response.topics {
             for peer in topic.peers {
@@ -498,14 +509,14 @@ impl DesktopRuntime {
     ) -> std::result::Result<(), CommunityNodeRequestError> {
         let base_url = normalize_http_url(base_url).map_err(CommunityNodeRequestError::Other)?;
         let now = Utc::now().timestamp();
-        let (next_due_at, ready_refresh_pending) = {
+        let (next_due_at, ready_refresh_pending, rendezvous_due_at) = {
             let mut sessions = self.community_node_sessions.lock().await;
             let entry = sessions
                 .entry(base_url.to_string())
                 .or_insert_with(CommunityNodeSessionState::default);
             let due = entry.heartbeat_deadline;
             let pending = std::mem::replace(&mut entry.ready_refresh_pending, false);
-            (due, pending)
+            (due, pending, entry.rendezvous_refresh_deadline)
         };
         if !force_heartbeat && next_due_at > now {
             if !self
@@ -513,6 +524,13 @@ impl DesktopRuntime {
                 .await
                 && !ready_refresh_pending
             {
+                // rendezvous presence(サーバ TTL 45 秒)は heartbeat(実効約 60 秒毎)より
+                // 短命のため、heartbeat が not-due でも独立に refresh する(#572)。
+                if rendezvous_due_at <= now {
+                    self.refresh_topic_rendezvous_with_token(base_url.as_str(), access_token)
+                        .await?;
+                    return Ok(());
+                }
                 debug!(
                     %base_url,
                     next_due_at,

--- a/crates/desktop-runtime/src/tests/community_node/scheduler.rs
+++ b/crates/desktop-runtime/src/tests/community_node/scheduler.rs
@@ -311,3 +311,117 @@ async fn session_scheduler_reauthenticates_near_expiry_token_without_getter_poll
     runtime.shutdown().await;
     server.abort();
 }
+
+/// topic rendezvous presence の refresh が bootstrap heartbeat の合間にも発火することを固定する
+/// characterization test(#572)。修正前は rendezvous refresh が heartbeat 便乗(実効約 60 秒毎)
+/// のみで、サーバ TTL 45 秒に対し毎サイクル約 15 秒 presence が失効していた。
+/// heartbeat が not-due のままでも maintenance pass 毎に rendezvous deadline が判定され、
+/// due なら refresh POST が独立して打たれることを検証する。
+#[tokio::test]
+async fn topic_rendezvous_refresh_fires_between_bootstrap_heartbeats() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-rendezvous-refresh.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+
+    // rendezvous refresh は subscribed_topics が空だと no-op のため、先に topic を購読する。
+    let _ = runtime
+        .list_timeline(ListTimelineRequest {
+            topic: "kukuri:topic:rendezvous-refresh-gap".into(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await
+        .expect("subscribe topic");
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let state = Arc::new(MockRendezvousCommunityNodeState {
+        base_url: base_url.clone(),
+        // bootstrap nodes が空 seed だと metadata retry(5 秒周期)の便乗 refresh が
+        // 走ってテストを汚染するため、非空 seed を返す。
+        seed_peers: vec![
+            CommunityNodeSeedPeer::new(
+                "2222222222222222222222222222222222222222222222222222222222222222",
+                None,
+            )
+            .expect("seed peer"),
+        ],
+        heartbeat_hits: Arc::new(AtomicUsize::new(0)),
+        bootstrap_hits: Arc::new(AtomicUsize::new(0)),
+        rendezvous_hits: Arc::new(AtomicUsize::new(0)),
+    });
+    let app = Router::new()
+        .route("/v1/consents/status", get(mock_bootstrap_consent_status))
+        .route(
+            "/v1/bootstrap/heartbeat",
+            post(mock_rendezvous_bootstrap_heartbeat),
+        )
+        .route("/v1/bootstrap/nodes", get(mock_rendezvous_bootstrap_nodes))
+        .route(
+            "/v1/rendezvous/topics/heartbeat",
+            post(mock_rendezvous_topics_heartbeat),
+        )
+        .with_state(state.clone());
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    persist_community_node_token(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        base_url.as_str(),
+        &StoredCommunityNodeToken {
+            access_token: "fake-token".to_string(),
+            expires_at: Utc::now().timestamp() + 3600,
+        },
+    )
+    .expect("persist community-node token");
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.clone(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
+                    .expect("resolved urls"),
+            ),
+        }],
+    };
+
+    // 1 回目: セッション確立(heartbeat 1 発 + 便乗 rendezvous refresh)。
+    // 2 回目: ready 遷移で立った ready_refresh_pending の metadata refresh(便乗 refresh)を消化。
+    runtime.run_community_node_session_maintenance_once().await;
+    runtime.run_community_node_session_maintenance_once().await;
+    assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 1);
+    let baseline = state.rendezvous_hits.load(Ordering::SeqCst);
+    assert!(baseline >= 1, "establishment should refresh rendezvous");
+
+    // heartbeat は not-due のまま(mock の expires_at = now+300 → 次回期限 +270 秒)。
+    // mock の expires_in_seconds(5)はクライアントのマージンより小さいため、修正後は
+    // rendezvous deadline が毎 pass 即時 due になり、pass 毎に独立 refresh が打たれる。
+    for _ in 0..3 {
+        runtime.run_community_node_session_maintenance_once().await;
+    }
+    assert_eq!(
+        state.heartbeat_hits.load(Ordering::SeqCst),
+        1,
+        "bootstrap heartbeat must stay not-due during the observation window"
+    );
+    assert!(
+        state.rendezvous_hits.load(Ordering::SeqCst) > baseline,
+        "rendezvous presence must be refreshed between bootstrap heartbeats \
+         (hits stayed at {baseline}; presence would expire against the 45s server TTL)"
+    );
+
+    runtime.shutdown().await;
+    server.abort();
+}

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -17,7 +17,7 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     ("community_node/config.rs", "ProcessEnvironment", 3),
     ("community_node/connectivity.rs", "IrohNetwork", 6),
     ("community_node/metadata.rs", "CommunityNodeServer", 9),
-    ("community_node/scheduler.rs", "CommunityNodeServer", 3),
+    ("community_node/scheduler.rs", "CommunityNodeServer", 4),
     ("community_node/session.rs", "CommunityNodeServer", 6),
     ("identity_restart.rs", "IdentityStorage", 2),
     ("media_blob_restore.rs", "IrohNetwork", 11),
@@ -92,7 +92,7 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 53,
+        total, 54,
         "classification total drifted from the Q7 T6 baseline"
     );
 }

--- a/crates/desktop-runtime/src/tests/support/mock_cn.rs
+++ b/crates/desktop-runtime/src/tests/support/mock_cn.rs
@@ -123,6 +123,62 @@ pub(crate) async fn mock_heartbeat_echo_bootstrap_nodes(
     })
 }
 
+// topic rendezvous heartbeat を観測するシナリオ用 state(#572)。
+// 既存 MockCommunityNodeState の構築箇所を増やさないため、シナリオ別 state として分ける
+// (MockHeartbeatEchoCommunityNodeState と同じ前例)。
+#[derive(Clone)]
+pub(crate) struct MockRendezvousCommunityNodeState {
+    pub(crate) base_url: String,
+    pub(crate) seed_peers: Vec<CommunityNodeSeedPeer>,
+    pub(crate) heartbeat_hits: Arc<AtomicUsize>,
+    pub(crate) bootstrap_hits: Arc<AtomicUsize>,
+    pub(crate) rendezvous_hits: Arc<AtomicUsize>,
+}
+
+pub(crate) async fn mock_rendezvous_bootstrap_heartbeat(
+    State(state): State<Arc<MockRendezvousCommunityNodeState>>,
+    Json(_request): Json<serde_json::Value>,
+) -> Json<BootstrapHeartbeatResponse> {
+    state.heartbeat_hits.fetch_add(1, Ordering::SeqCst);
+    Json(BootstrapHeartbeatResponse {
+        expires_at: Utc::now().timestamp() + 300,
+    })
+}
+
+pub(crate) async fn mock_rendezvous_bootstrap_nodes(
+    State(state): State<Arc<MockRendezvousCommunityNodeState>>,
+) -> Json<BootstrapNodesResponse> {
+    state.bootstrap_hits.fetch_add(1, Ordering::SeqCst);
+    Json(BootstrapNodesResponse {
+        nodes: vec![kukuri_cn_protocol::CommunityNodeBootstrapNode {
+            base_url: state.base_url.clone(),
+            resolved_urls: CommunityNodeResolvedUrls::new(
+                state.base_url.clone(),
+                Vec::new(),
+                state.seed_peers.clone(),
+            )
+            .expect("resolved urls"),
+        }],
+    })
+}
+
+pub(crate) async fn mock_rendezvous_topics_heartbeat(
+    State(state): State<Arc<MockRendezvousCommunityNodeState>>,
+    Json(request): Json<kukuri_cn_protocol::TopicRendezvousHeartbeat>,
+) -> Json<kukuri_cn_protocol::TopicRendezvousHeartbeatResponse> {
+    assert!(
+        !request.refreshes.is_empty() || !request.joins.is_empty(),
+        "rendezvous heartbeat without topics"
+    );
+    state.rendezvous_hits.fetch_add(1, Ordering::SeqCst);
+    // expires_in_seconds はクライアントのマージン(20 秒)より小さくし、deadline が
+    // 毎 maintenance pass で即時 due になるようにする(wall-clock 待ちなしの決定的テスト用)。
+    Json(kukuri_cn_protocol::TopicRendezvousHeartbeatResponse {
+        expires_in_seconds: 5,
+        topics: Vec::new(),
+    })
+}
+
 #[derive(Clone)]
 pub(crate) struct MockManagedCommunityNodeState {
     pub(crate) base_url: String,

--- a/docs/progress/2026-07-28-572-topic-rendezvous-refresh-decoupling.md
+++ b/docs/progress/2026-07-28-572-topic-rendezvous-refresh-decoupling.md
@@ -1,0 +1,46 @@
+# 2026-07-28 #572 topic rendezvous refresh の heartbeat 便乗からの独立
+
+参照: `docs/progress/2026-07-06-wp-c1-cn-session-keepalive.md`(A-4 で記録・先送りされた
+rendezvous TTL 45 秒ギャップ。本変更でその先送りをクローズする)
+
+## 問題
+
+topic rendezvous presence のサーバ TTL は 45 秒(`cn-core` の `TOPIC_RENDEZVOUS_TTL_SECONDS`)
+だが、クライアントの rendezvous refresh は bootstrap heartbeat 成功後の便乗呼び出しのみで、
+heartbeat の実効周期は「サーバ TTL 90 秒 − 30 秒 = 約 60 秒」。そのため毎サイクル約 15 秒間
+presence が失効していた(#572)。bootstrap seed(TTL 90 秒)のフラット合成で実害は限定的だが、
+rendezvous 経由の topic peer 発見だけに頼る経路では失効窓の間 candidate から漏れる。
+
+## 実装した範囲(クライアント側のみ。cn-user-api 契約は凍結境界のため無変更)
+
+- **fix 規律**: 先に characterization test
+  `topic_rendezvous_refresh_fires_between_bootstrap_heartbeats`
+  (`crates/desktop-runtime/src/tests/community_node/scheduler.rs`)を置き、修正前 red
+  (heartbeat の合間に rendezvous POST が発火しない)を確認してから修正した。テスト支援として
+  mock CN に `/v1/rendezvous/topics/heartbeat` route と `MockRendezvousCommunityNodeState`
+  (rendezvous_hits カウンタ)を追加(`src/tests/support/mock_cn.rs`)。
+- **独立 deadline 管理**(`crates/desktop-runtime/src/community_node/`)
+  - `CommunityNodeSessionState` に `rendezvous_refresh_deadline`(default 0 = 即時 due)を追加。
+  - `refresh_topic_rendezvous_with_token` が成功時にサーバ返却 `expires_in_seconds`(45 秒。
+    従来はデコード後破棄)−
+    `COMMUNITY_NODE_TOPIC_RENDEZVOUS_REFRESH_MARGIN_SECONDS`(20 秒)で次回期限を更新。
+    heartbeat の「`expires_at` − マージン」管理と同型。便乗呼び出し(heartbeat 後 /
+    metadata refresh 後)でも同じ場所で bump されるため、直後の冗長 POST は出ない。
+  - `refresh_community_node_registration_with_token_if_due_once` の「heartbeat not-due skip」
+    分岐で deadline を判定し、due なら独立に refresh する。駆動は既存のセッション維持
+    スケジューラ tick(15 秒)のままで、新規タスク・新規設定は追加していない。
+
+## 周期の根拠
+
+マージン 20 秒は tick(15 秒)より大きいことが必須。deadline は「refresh 時刻 + 45 − 20 =
++25 秒」で、tick 量子化により実際の POST が最大 tick 分遅れても +40 秒 < TTL 45 秒に収まる。
+失敗時は deadline を bump しない(過去のまま)ため次の maintenance pass で自然に再試行され、
+エラーストームは既存の session retry state(30 秒)が抑制する。専用 retry 機構は追加しない。
+
+## 維持した境界(本変更に含まない)
+
+- サーバ側 TTL(`TOPIC_RENDEZVOUS_TTL_SECONDS = 45`)と wire 契約(`expires_in_seconds`)は
+  無変更。
+- topic subscribe/unsubscribe に連動した rendezvous `joins`/`leaves` ライフサイクル
+  (現状どおり `refreshes` のみ)。
+- WP-C1 doc に残る Q2 委譲項目(event push 基盤、`CommunityNodeSessionManager` 統合)。


### PR DESCRIPTION
## 概要

Issue #572(対処案1)の修正。topic rendezvous presence のサーバ TTL は 45 秒だが、クライアントの rendezvous refresh は bootstrap heartbeat 便乗のみ(実効約 60 秒毎)のため、毎サイクル約 15 秒 presence が失効していた。refresh を heartbeat から独立した deadline 管理に切り替え、失効窓を解消する。サーバ / cn-user-api 契約(凍結境界)は無変更。

## 変更内容

- **characterization test を先行**(fix 規律): `topic_rendezvous_refresh_fires_between_bootstrap_heartbeats`(`crates/desktop-runtime/src/tests/community_node/scheduler.rs`)を先に追加し、修正前 red(heartbeat の合間に rendezvous POST が発火しない)を確認してから修正。mock CN に `/v1/rendezvous/topics/heartbeat` route と `MockRendezvousCommunityNodeState` を追加(`src/tests/support/mock_cn.rs`)。
- `CommunityNodeSessionState` に `rendezvous_refresh_deadline` を追加(default 0 = 即時 due)。
- `refresh_topic_rendezvous_with_token` 成功時に、サーバ返却 `expires_in_seconds`(45 秒。従来はデコード後破棄)− マージン `COMMUNITY_NODE_TOPIC_RENDEZVOUS_REFRESH_MARGIN_SECONDS`(20 秒)で次回期限を更新。heartbeat の「`expires_at` − マージン」パターンと同型で、便乗呼び出し直後の冗長 POST も抑止される。
- `refresh_community_node_registration_with_token_if_due_once` の heartbeat not-due skip 分岐で deadline を判定し、due なら独立に refresh。駆動は既存のセッション維持スケジューラ tick(15 秒)のままで、新規タスク・新規設定なし。
- 新テストの lock 取得追加に伴い `support/lock_contract.rs` の分類表を更新(scheduler.rs 3 → 4、baseline 53 → 54)。
- progress doc `docs/progress/2026-07-28-572-topic-rendezvous-refresh-decoupling.md` を追加(WP-C1 doc の先送り記録 A-4 をクローズ)。

## 周期の根拠

マージン 20 秒 &gt; tick 15 秒が必須条件。deadline は refresh 後 +25 秒、tick 量子化の最悪ケースでも POST は +40 秒 &lt; TTL 45 秒。失敗時は deadline を bump しないため次 tick で自然再試行(既存の session retry state 30 秒がエラーストームを抑制)。

## 検証

- `cargo test -p kukuri-desktop-runtime topic_rendezvous_refresh_fires_between_bootstrap_heartbeats`: 修正前 red → 修正後 green を確認
- `cargo test -p kukuri-desktop-runtime`: 98 passed / 0 failed
- `cargo xtask check`: 全 green
- `cargo xtask test`: desktop-runtime 含め通過(`kukuri-docs-sync` の relay 系 2 テストのみローカル環境のネットワーク制約でタイムアウト。本変更と依存関係がなく、CI の `linux-rust-tests` では green)
- CI: 9 チェック全 green(head f711e17)

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnriyR8YnA6xcX9JmGJ7Mf

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnriyR8YnA6xcX9JmGJ7Mf)_