### PR TITLE
fix: private secret file persistence を temp+fsync+rename の atomic 書き込みに変更

### DIFF
--- a/crates/desktop-runtime/src/identity.rs
+++ b/crates/desktop-runtime/src/identity.rs
@@ -245,11 +245,8 @@ fn persist_secret_to_file(db_path: &Path, secret: &str) -> Result<()> {
 }
 
 fn persist_secret_to_file_path(path: &Path, secret: &str) -> Result<()> {
-    let mut file = open_private_write_file(path)
-        .with_context(|| format!("failed to create identity file `{}`", path.display()))?;
-    file.write_all(secret.as_bytes())
-        .with_context(|| format!("failed to write identity file `{}`", path.display()))?;
-    Ok(())
+    write_private_file_atomically(path, secret.as_bytes())
+        .with_context(|| format!("failed to persist identity file `{}`", path.display()))
 }
 
 fn load_backend_marker(db_path: &Path) -> Result<Option<String>> {
@@ -275,18 +272,55 @@ fn load_backend_marker(db_path: &Path) -> Result<Option<String>> {
 
 fn write_backend_marker(db_path: &Path, backend: &str) -> Result<()> {
     let path = backend_marker_path(db_path);
-    let mut file = open_private_write_file(&path).with_context(|| {
+    write_private_file_atomically(&path, backend.as_bytes()).with_context(|| {
         format!(
-            "failed to create identity backend marker `{}`",
+            "failed to persist identity backend marker `{}`",
+            path.display()
+        )
+    })
+}
+
+// 途中クラッシュで既存内容が破損しないよう、同一ディレクトリの temp ファイルへ
+// write → fsync → rename で置換する(issue #574)。失敗は fail-loud で伝播させる。
+fn write_private_file_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("invalid private file path `{}`", path.display()))?;
+    let temp_path = path.with_file_name(format!("{file_name}.tmp"));
+    let mut file = open_private_write_file(&temp_path)
+        .with_context(|| format!("failed to create temp file `{}`", temp_path.display()))?;
+    file.write_all(bytes)
+        .with_context(|| format!("failed to write temp file `{}`", temp_path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync temp file `{}`", temp_path.display()))?;
+    drop(file);
+    std::fs::rename(&temp_path, path).with_context(|| {
+        format!(
+            "failed to rename temp file `{}` to `{}`",
+            temp_path.display(),
             path.display()
         )
     })?;
-    file.write_all(backend.as_bytes()).with_context(|| {
-        format!(
-            "failed to write identity backend marker `{}`",
-            path.display()
-        )
-    })?;
+    sync_parent_dir(path)
+}
+
+// rename 自体の durability を確保するため、unix では親ディレクトリも fsync する。
+// Windows は std にディレクトリ fsync の手段がないため rename の atomic 置換のみ。
+#[cfg(unix)]
+fn sync_parent_dir(path: &Path) -> Result<()> {
+    let parent = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => return Ok(()),
+    };
+    let dir = std::fs::File::open(parent)
+        .with_context(|| format!("failed to open directory `{}`", parent.display()))?;
+    dir.sync_all()
+        .with_context(|| format!("failed to sync directory `{}`", parent.display()))
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_path: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -630,6 +664,73 @@ mod tests {
             .expect("read fallback file"),
             Some("value".to_string())
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persist_secret_replaces_existing_file_via_rename() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("kukuri.test-secret");
+        persist_secret_to_file_path(&path, "old-value").expect("persist old value");
+        let inode_before = std::fs::metadata(&path).expect("metadata before").ino();
+
+        persist_secret_to_file_path(&path, "new-value").expect("persist new value");
+
+        let inode_after = std::fs::metadata(&path).expect("metadata after").ino();
+        assert_ne!(
+            inode_before, inode_after,
+            "persist must replace the file via rename, not truncate it in place"
+        );
+        assert_eq!(
+            load_secret_from_file_path(&path).expect("load after persist"),
+            Some("new-value".to_string())
+        );
+    }
+
+    #[test]
+    fn stale_temp_file_does_not_corrupt_persisted_secret() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("kukuri.test-secret");
+        persist_secret_to_file_path(&path, "old-value").expect("persist old value");
+
+        // 書き込み途中(rename 前)にクラッシュした状態を再現する。
+        let temp_path = path.with_file_name("kukuri.test-secret.tmp");
+        std::fs::write(&temp_path, "garbage-from-interrupted-write").expect("write stale temp");
+
+        assert_eq!(
+            load_secret_from_file_path(&path).expect("load with stale temp present"),
+            Some("old-value".to_string()),
+            "interrupted write must leave the previous content readable"
+        );
+
+        persist_secret_to_file_path(&path, "new-value").expect("persist over stale temp");
+        assert_eq!(
+            load_secret_from_file_path(&path).expect("load after recovery"),
+            Some("new-value".to_string())
+        );
+        assert!(
+            !temp_path.exists(),
+            "persist must consume the temp file via rename"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persisted_secret_file_keeps_private_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("kukuri.test-secret");
+        persist_secret_to_file_path(&path, "old-value").expect("persist first value");
+        persist_secret_to_file_path(&path, "new-value").expect("persist second value");
+
+        let mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600, "secret file must stay private");
     }
 
     #[test]


### PR DESCRIPTION
Closes #574

## 概要

private channel capability の永続化ファイル書き込みが truncate + write の直書きで、途中クラッシュ時に永続 JSON が破損して次回起動時に capability を失う問題を修正します。

## 変更内容

- `crates/desktop-runtime/src/identity.rs` の共有書き込み経路に `write_private_file_atomically` を追加: 同一ディレクトリの `<name>.tmp` へ write → `sync_all`(fsync) → `fs::rename` で置換。unix では rename の durability 確保のため親ディレクトリも fsync(Windows は std に手段がないため rename の atomic 置換のみ)
- `persist_secret_to_file_path` と `write_backend_marker` を新ヘルパ経由に変更。この 1 経路で private channel capabilities / gossip subscription state / identity key / backend marker のすべてがカバーされます(gossip state の手動 persist 2 箇所も `persist_optional_secret` 経由でここに集約)
- 既存の 0o600(unix)権限設定・anyhow の fail-loud なエラー伝播は維持

## テスト

契約テストを先に追加(RED)してから実装(GREEN):

- `persist_secret_replaces_existing_file_via_rename`(unix): 既存ファイルへの persist で inode が変わることを検証(truncate 直書きなら不変 → 修正前は RED)
- `stale_temp_file_does_not_corrupt_persisted_secret`: 書き込み中断(rename 前クラッシュ)を再現した stale temp + 旧内容の状態から、旧内容が読めること・次の persist で回復し temp が消えることを検証
- `persisted_secret_file_keeps_private_mode`(unix): 最終ファイルが 0o600 を維持することを検証

## 検証

- `cargo test -p kukuri-desktop-runtime identity` — 17 件 pass
- `cargo xtask check` — pass(fmt / clippy / tauri check / lint / typecheck)
- `cargo xtask test` — 実行中(完了後に結果を追記)
- 永続 JSON 形状の fixture テスト(`capability_registry_snapshot`)は無変更のまま green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SMexAVmypJCsCwg2akXmh

---
_Generated by [Claude Code](https://claude.ai/code/session_012SMexAVmypJCsCwg2akXmh)_