### PR TITLE
cn-indexerを常駐ワーカー化し観測状態を追加する（#613 T2/T3）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,6 +3002,7 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "futures-util",
  "hex",

--- a/crates/cn-core/src/index_entries.rs
+++ b/crates/cn-core/src/index_entries.rs
@@ -231,6 +231,12 @@ pub trait IndexEntryStore: Send + Sync {
         scope_kind: IndexScopeKind,
         candidates: &[(String, String)],
     ) -> Result<Vec<(String, String)>>;
+
+    /// 真実源にいま entry が存在する scope の一覧（#613 T2）。
+    ///
+    /// 常駐ワーカーが「サポート対象から外れたのに索引が残っている scope」を再起動をまたいで
+    /// 検知し、索引解除するために使う。
+    async fn list_scopes(&self) -> Result<Vec<(IndexScopeKind, String)>>;
 }
 
 /// Postgres 実装。`cn_index.index_entries` の persist API に委譲する。
@@ -270,6 +276,20 @@ impl IndexEntryStore for PgIndexEntryStore {
         candidates: &[(String, String)],
     ) -> Result<Vec<(String, String)>> {
         filter_surfaceable_objects(&self.pool, scope_kind, candidates).await
+    }
+
+    async fn list_scopes(&self) -> Result<Vec<(IndexScopeKind, String)>> {
+        let rows = sqlx::query("SELECT DISTINCT scope_kind, scope_id FROM cn_index.index_entries")
+            .fetch_all(&self.pool)
+            .await?;
+        rows.iter()
+            .map(|row| {
+                Ok((
+                    IndexScopeKind::parse(&row.try_get::<String, _>("scope_kind")?)?,
+                    row.try_get::<String, _>("scope_id")?,
+                ))
+            })
+            .collect()
     }
 }
 
@@ -390,6 +410,19 @@ impl IndexEntryStore for MemoryIndexEntryStore {
             })
             .cloned()
             .collect())
+    }
+
+    async fn list_scopes(&self) -> Result<Vec<(IndexScopeKind, String)>> {
+        let entries = self.entries.lock().expect("entries mutex poisoned");
+        let mut scopes: Vec<(IndexScopeKind, String)> = Vec::new();
+        for (kind, scope_id, _) in entries.keys() {
+            if !scopes.iter().any(|(existing_kind, existing_id)| {
+                existing_kind == kind && existing_id == scope_id
+            }) {
+                scopes.push((*kind, scope_id.clone()));
+            }
+        }
+        Ok(scopes)
     }
 }
 

--- a/crates/cn-indexer/Cargo.toml
+++ b/crates/cn-indexer/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+axum.workspace = true
 chrono.workspace = true
 futures-util.workspace = true
 hex.workspace = true
@@ -25,7 +26,8 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
-tokio.workspace = true
+# 常駐ワーカーの停止シグナル（signal）と状態エンドポイントの待ち受け（net）に使う。
+tokio = { workspace = true, features = ["signal", "net"] }
 tracing.workspace = true
 kukuri-blob-service = { path = "../blob-service" }
 kukuri-cn-runtime-support = { path = "../cn-runtime-support" }

--- a/crates/cn-indexer/src/config.rs
+++ b/crates/cn-indexer/src/config.rs
@@ -117,6 +117,10 @@ pub struct IndexerConfig {
     /// `COMMUNITY_NODE_INDEXER_SEED_PEERS`（カンマ区切り、`endpoint_id` または
     /// `endpoint_id@host:port`）から読む。不正な値は起動エラー（fail-closed）。
     pub seed_peers: Vec<SeedPeer>,
+    /// 常駐ワーカーの全件見直し間隔（#613 T2）。
+    pub poll_interval: std::time::Duration,
+    /// 観測状態の HTTP エンドポイントの待ち受けアドレス（#613 T3）。None なら公開しない。
+    pub status_addr: Option<std::net::SocketAddr>,
 }
 
 impl std::fmt::Debug for IndexerConfig {
@@ -131,6 +135,8 @@ impl std::fmt::Debug for IndexerConfig {
             .field("safety", &self.safety)
             .field("media_fetch", &self.media_fetch)
             .field("seed_peers", &self.seed_peers)
+            .field("poll_interval", &self.poll_interval)
+            .field("status_addr", &self.status_addr)
             .finish()
     }
 }
@@ -153,6 +159,16 @@ pub(crate) const MEDIA_FETCH_TIMEOUT_SECS_ENV: &str = "COMMUNITY_NODE_MEDIA_FETC
 /// docs replica sync / remote blob fetch のシードピア指定（#613 T1）。
 /// カンマ区切りで `endpoint_id` または `endpoint_id@host:port` を並べる。
 pub const SEED_PEERS_ENV: &str = "COMMUNITY_NODE_INDEXER_SEED_PEERS";
+
+/// 常駐ワーカーの全件見直し間隔（秒。#613 T2）。未設定なら既定 300 秒。0 は起動エラー。
+pub const POLL_INTERVAL_SECS_ENV: &str = "COMMUNITY_NODE_INDEXER_POLL_INTERVAL_SECS";
+
+/// 観測状態の HTTP エンドポイントの待ち受けアドレス（#613 T3）。
+/// 未設定なら HTTP では公開しない。例: `127.0.0.1:8630`。
+pub const STATUS_ADDR_ENV: &str = "COMMUNITY_NODE_INDEXER_STATUS_ADDR";
+
+/// 全件見直し間隔の既定値。
+pub const DEFAULT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(300);
 
 impl Default for MediaFetchConfig {
     fn default() -> Self {
@@ -300,8 +316,35 @@ impl IndexerConfig {
             safety,
             media_fetch: MediaFetchConfig::from_env()?,
             seed_peers: parse_seed_peers_env()?,
+            poll_interval: parse_poll_interval_env()?,
+            status_addr: parse_status_addr_env()?,
         })
     }
+}
+
+/// 全件見直し間隔 env を読む。0 や非数値は起動エラー（fail-closed）。
+fn parse_poll_interval_env() -> Result<std::time::Duration> {
+    let Some(raw) = non_empty_env(POLL_INTERVAL_SECS_ENV) else {
+        return Ok(DEFAULT_POLL_INTERVAL);
+    };
+    let secs: u64 = raw.parse().with_context(|| {
+        format!("{POLL_INTERVAL_SECS_ENV} must be a positive integer (seconds)")
+    })?;
+    if secs == 0 {
+        bail!("{POLL_INTERVAL_SECS_ENV} must not be zero");
+    }
+    Ok(std::time::Duration::from_secs(secs))
+}
+
+/// 状態エンドポイントの待ち受けアドレス env を読む。不正な値は起動エラー（fail-closed）。
+fn parse_status_addr_env() -> Result<Option<std::net::SocketAddr>> {
+    let Some(raw) = non_empty_env(STATUS_ADDR_ENV) else {
+        return Ok(None);
+    };
+    let addr = raw.parse::<std::net::SocketAddr>().with_context(|| {
+        format!("{STATUS_ADDR_ENV} must be a socket address like 127.0.0.1:8630")
+    })?;
+    Ok(Some(addr))
 }
 
 /// シードピア env を読む。未設定・空は「シード無し」。不正な値は起動エラー（fail-closed）。
@@ -412,6 +455,8 @@ mod tests {
         MEDIA_FETCH_MAX_BYTES_ENV,
         MEDIA_FETCH_TIMEOUT_SECS_ENV,
         SEED_PEERS_ENV,
+        POLL_INTERVAL_SECS_ENV,
+        STATUS_ADDR_ENV,
     ];
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -612,6 +657,61 @@ mod tests {
     #[test]
     fn seed_peers_csv_rejects_invalid_entries() {
         assert!(parse_seed_peers_csv("not-a-valid-endpoint-id").is_err());
+    }
+
+    #[test]
+    fn poll_interval_env_defaults_and_rejects_zero() {
+        with_clean_indexer_env(|| {
+            set_minimal_indexer_env();
+
+            // 未設定なら既定値。
+            assert_eq!(
+                IndexerConfig::from_env().unwrap().poll_interval,
+                DEFAULT_POLL_INTERVAL
+            );
+
+            // 有効値は読み取れる。
+            unsafe {
+                std::env::set_var(POLL_INTERVAL_SECS_ENV, "10");
+            }
+            assert_eq!(
+                IndexerConfig::from_env().unwrap().poll_interval,
+                std::time::Duration::from_secs(10)
+            );
+
+            // 0 / 非数値は起動エラー（fail-closed）。
+            unsafe {
+                std::env::set_var(POLL_INTERVAL_SECS_ENV, "0");
+            }
+            assert!(IndexerConfig::from_env().is_err());
+            unsafe {
+                std::env::set_var(POLL_INTERVAL_SECS_ENV, "soon");
+            }
+            assert!(IndexerConfig::from_env().is_err());
+        });
+    }
+
+    #[test]
+    fn status_addr_env_defaults_to_none_and_rejects_invalid() {
+        with_clean_indexer_env(|| {
+            set_minimal_indexer_env();
+
+            // 未設定なら HTTP では公開しない。
+            assert!(IndexerConfig::from_env().unwrap().status_addr.is_none());
+
+            unsafe {
+                std::env::set_var(STATUS_ADDR_ENV, "127.0.0.1:8630");
+            }
+            assert_eq!(
+                IndexerConfig::from_env().unwrap().status_addr,
+                Some("127.0.0.1:8630".parse().unwrap())
+            );
+
+            unsafe {
+                std::env::set_var(STATUS_ADDR_ENV, "not-an-addr");
+            }
+            assert!(IndexerConfig::from_env().is_err());
+        });
     }
 
     #[test]

--- a/crates/cn-indexer/src/ingest.rs
+++ b/crates/cn-indexer/src/ingest.rs
@@ -32,8 +32,9 @@ use anyhow::{Context, Result, bail};
 use tracing::{debug, warn};
 
 use kukuri_cn_core::{IndexEntryStore, IndexScopeKind, NewIndexEntry};
+use kukuri_cn_safety::ReasonCode;
 use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
-use kukuri_cn_safety_runtime::SafetyScanService;
+use kukuri_cn_safety_runtime::{SafetyScanOutcome, SafetyScanService};
 use kukuri_core::{
     AssetRef, KukuriEnvelope, KukuriMediaManifestV1, ObjectStatus, PayloadRef, ReplicaId,
 };
@@ -64,6 +65,8 @@ pub struct IngestPipeline {
     safety: Arc<SafetyScanService>,
     entries: Arc<dyn IndexEntryStore>,
     projection: Arc<dyn IndexProjection>,
+    /// 観測状態（#613 T3）。設定時のみスキャン失敗 / プロバイダ利用不可を分類して数える。
+    metrics: Option<Arc<crate::state::IndexerRuntimeState>>,
 }
 
 impl IngestPipeline {
@@ -78,7 +81,38 @@ impl IngestPipeline {
             safety,
             entries,
             projection,
+            metrics: None,
         }
+    }
+
+    /// 観測状態を接続する（#613 T3。常駐ワーカーの組み立て時に使う）。
+    pub fn with_metrics(mut self, metrics: Arc<crate::state::IndexerRuntimeState>) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
+    /// スキャンを実行し、観測状態に分類（スキャン失敗 / プロバイダ利用不可）を記録する。
+    async fn scan_and_record_with_metrics(
+        &self,
+        request: &ProviderScanRequest,
+    ) -> Result<SafetyScanOutcome> {
+        let outcome = match self.safety.scan_and_record(request).await {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                if let Some(metrics) = &self.metrics {
+                    metrics.record_scan_error();
+                }
+                return Err(error);
+            }
+        };
+        if let Some(metrics) = &self.metrics {
+            match outcome.report.verdict.reason_code {
+                ReasonCode::ProviderUnavailable => metrics.record_provider_unavailable(),
+                ReasonCode::ScanFailed | ReasonCode::Unscanned => metrics.record_scan_error(),
+                _ => {}
+            }
+        }
+        Ok(outcome)
     }
 
     /// scope の共有 replica を走査し、実在する post entry のみを scan→allow 判定して投影へ反映する。
@@ -183,7 +217,7 @@ impl IngestPipeline {
         // 永続化失敗は `?` で呼び出し側の per-entry fail-closed（投影しない）に乗る。
         let request = ProviderScanRequest::for_subject(SubjectKind::Post, object.object_id.clone())
             .with_text(text.clone());
-        let outcome = self.safety.scan_and_record(&request).await?;
+        let outcome = self.scan_and_record_with_metrics(&request).await?;
         let report = &outcome.report;
 
         if !report.verdict.is_indexable() {
@@ -229,7 +263,7 @@ impl IngestPipeline {
             if let Some(mime) = &target.mime {
                 request = request.with_media_mime(mime.clone());
             }
-            let media_outcome = self.safety.scan_and_record(&request).await?;
+            let media_outcome = self.scan_and_record_with_metrics(&request).await?;
             let media_report = &media_outcome.report;
             if !media_report.verdict.is_indexable() {
                 self.deindex_object(scope_kind, scope_id, object.object_id.as_str())

--- a/crates/cn-indexer/src/lib.rs
+++ b/crates/cn-indexer/src/lib.rs
@@ -27,6 +27,9 @@ pub mod query;
 pub mod relation_graph;
 pub mod relation_worker;
 pub mod runtime;
+pub mod state;
+pub mod status;
+pub mod worker;
 
 pub use arcadedb::ArcadeDbProjection;
 pub use config::{ArcadeDbConfig, IndexerConfig, MediaFetchConfig, RelayConfig, RelayValidation};
@@ -40,3 +43,6 @@ pub use relation_worker::{
     DEFAULT_ANALYSIS_LIMIT, RelationAnalysisReport, analyze_relations, topic_cluster,
 };
 pub use runtime::run_from_env;
+pub use state::{IndexerRuntimeState, IndexerStateSnapshot};
+pub use status::{StatusServerHandle, spawn_status_server};
+pub use worker::{IndexerWorker, WorkerConfig, WorkerHandle};

--- a/crates/cn-indexer/src/media_fetcher.rs
+++ b/crates/cn-indexer/src/media_fetcher.rs
@@ -27,6 +27,8 @@ use crate::config::MediaFetchConfig;
 pub struct BlobMediaFetcher {
     blob_service: Arc<dyn BlobService>,
     config: MediaFetchConfig,
+    /// 観測状態（#613 T3）。設定時のみ取得の成否（成功 / 利用不可 / 時間切れ / 大きさ超過）を数える。
+    metrics: Option<Arc<crate::state::IndexerRuntimeState>>,
 }
 
 impl BlobMediaFetcher {
@@ -34,7 +36,18 @@ impl BlobMediaFetcher {
         Self {
             blob_service,
             config,
+            metrics: None,
         }
+    }
+
+    /// 観測状態を接続する（#613 T3。常駐ワーカーの組み立て時に使う）。
+    pub fn with_metrics(mut self, metrics: Arc<crate::state::IndexerRuntimeState>) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
+    fn metrics(&self) -> Option<&crate::state::IndexerRuntimeState> {
+        self.metrics.as_deref()
     }
 }
 
@@ -68,14 +81,25 @@ impl MediaFetcher for BlobMediaFetcher {
         )
         .await
         .map_err(|_| {
+            if let Some(metrics) = self.metrics() {
+                metrics.record_media_fetch_timeout();
+            }
             ScanError::Timeout(format!(
                 "media fetch timed out after {}s",
                 self.config.timeout.as_secs()
             ))
         })?
-        .map_err(|error| ScanError::Unavailable(format!("media fetch failed: {error:#}")))?;
+        .map_err(|error| {
+            if let Some(metrics) = self.metrics() {
+                metrics.record_media_fetch_unavailable();
+            }
+            ScanError::Unavailable(format!("media fetch failed: {error:#}"))
+        })?;
 
         let Some(bytes) = fetched else {
+            if let Some(metrics) = self.metrics() {
+                metrics.record_media_fetch_unavailable();
+            }
             return Err(ScanError::Unavailable(
                 "referenced media blob is not retrievable yet (not replicated or no reachable \
                  peers); scan stays fail-closed"
@@ -84,6 +108,9 @@ impl MediaFetcher for BlobMediaFetcher {
         };
 
         if bytes.len() as u64 > self.config.max_bytes {
+            if let Some(metrics) = self.metrics() {
+                metrics.record_media_fetch_oversize();
+            }
             return Err(ScanError::Protocol(format!(
                 "referenced media exceeds the scan size limit ({} > {} bytes)",
                 bytes.len(),
@@ -102,6 +129,9 @@ impl MediaFetcher for BlobMediaFetcher {
             })?,
         };
 
+        if let Some(metrics) = self.metrics() {
+            metrics.record_media_fetch_success();
+        }
         Ok(FetchedMedia {
             bytes,
             content_type,

--- a/crates/cn-indexer/src/participant.rs
+++ b/crates/cn-indexer/src/participant.rs
@@ -80,6 +80,32 @@ impl IndexerParticipant {
         }
     }
 
+    /// いま index 対象であるべき scope を返す（#613 T2。読み取りのみ、副作用なし）。
+    ///
+    /// サポート対象一覧のうち、private channel は秘密鍵（capability）が登録済みのものだけを
+    /// 含める（鍵が無ければ索引しない）。常駐ワーカーはこの結果と索引の実在スコープ
+    /// （[`Self::indexed_scopes`]）の差分から索引解除を決める。open の成否に依存しないため、
+    /// 一時的な open 失敗で誤って索引解除することがない。
+    pub async fn desired_scopes(&self) -> Result<Vec<ScopeReplica>> {
+        let secrets = list_channel_secrets(&self.pool, &self.channel_secret_cipher).await?;
+        let mut scopes = Vec::new();
+        for supported in list_supported_topics(&self.pool).await? {
+            let scope = ScopeReplica::from_scope(supported.kind, supported.id.as_str());
+            if scope.kind == IndexScopeKind::PrivateChannel
+                && !secrets.iter().any(|secret| secret.channel_id == scope.id)
+            {
+                continue;
+            }
+            scopes.push(scope);
+        }
+        Ok(scopes)
+    }
+
+    /// 索引の真実源にいま entry が存在する scope の一覧（#613 T2）。
+    pub async fn indexed_scopes(&self) -> Result<Vec<(IndexScopeKind, String)>> {
+        self.entries.list_scopes().await
+    }
+
     /// 起動時 / 再起動時に scope 管理 state から replica を open して sync 復元する（E13）。
     ///
     /// supported topic（public / private channel）の replica を open し、private channel は登録済み

--- a/crates/cn-indexer/src/runtime.rs
+++ b/crates/cn-indexer/src/runtime.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use sqlx::postgres::PgPool;
-use tracing::info;
+use tracing::{info, warn};
 
 use kukuri_blob_service::IrohBlobService;
 use kukuri_cn_core::{ChannelSecretCipher, PgIndexEntryStore, PgSafetyArtifactStore};
@@ -34,6 +34,9 @@ use crate::config::IndexerConfig;
 use crate::ingest::IngestPipeline;
 use crate::media_fetcher::BlobMediaFetcher;
 use crate::participant::IndexerParticipant;
+use crate::state::IndexerRuntimeState;
+use crate::status::spawn_status_server;
+use crate::worker::{IndexerWorker, WorkerConfig};
 
 /// 環境変数から設定を読み、relay validation 起動 gate を適用して cn-indexer を起動する。
 ///
@@ -71,6 +74,14 @@ async fn run(config: IndexerConfig) -> Result<()> {
         "cn-indexer configuration validated"
     );
 
+    // 観測状態（#613 T3）。ワーカー・取り込みパイプライン・メディア取得器・状態エンドポイントが
+    // 共有する。
+    let state = Arc::new(IndexerRuntimeState::default());
+    let status_server = match config.status_addr {
+        Some(addr) => Some(spawn_status_server(addr, Arc::clone(&state)).await?),
+        None => None,
+    };
+
     // 共有 iroh node（#613 T1）。provider が構成されている場合のみ persistent node を 1 つ立ち上げ、
     // media scan の一時 fetch（#609）と docs replica sync の双方で共有する。provider 未構成なら
     // scan service 自体を構成しない（fail-closed）ため node も立てない。
@@ -100,10 +111,10 @@ async fn run(config: IndexerConfig) -> Result<()> {
             timeout_secs = config.media_fetch.timeout.as_secs(),
             "media fetcher constructed (ephemeral blob fetch; no permanent blob storage)"
         );
-        Arc::new(BlobMediaFetcher::new(
-            blob_service,
-            config.media_fetch.clone(),
-        )) as Arc<dyn MediaFetcher>
+        Arc::new(
+            BlobMediaFetcher::new(blob_service, config.media_fetch.clone())
+                .with_metrics(Arc::clone(&state)),
+        ) as Arc<dyn MediaFetcher>
     });
 
     // safety scan runtime の構築境界（#406）。provider が構成されていれば service を構築・検証する
@@ -122,14 +133,86 @@ async fn run(config: IndexerConfig) -> Result<()> {
                 issuer_node_id = %service.issuer_node_id(),
                 "safety scan service constructed"
             );
-            let _participant = compose_ingest_stack(&config, pool, cipher, service, node).await?;
-            // NOTE: 常駐 ingest loop の起動は #613 T2 で行う。ここでは本番依存の組み立てと
-            // 起動時検証（ArcadeDB 接続 / seed 適用）までを行い、終了する。
-            info!("ingest stack composed; resident ingest loop lands with #613 T2");
+            let (participant, docs_sync) = compose_ingest_stack(
+                &config,
+                pool,
+                cipher,
+                service,
+                Arc::clone(&node),
+                Arc::clone(&state),
+            )
+            .await?;
+            state.set_ingest_enabled(true);
+
+            // 常駐 ingest loop（#613 T2）。変更通知 + 定期の全件見直しで取り込み続ける。
+            let worker = IndexerWorker::new(
+                Arc::new(participant),
+                docs_sync.clone(),
+                Arc::clone(&state),
+                WorkerConfig {
+                    poll_interval: config.poll_interval,
+                    ..WorkerConfig::default()
+                },
+            );
+            let handle = worker.spawn();
+            info!("cn-indexer is resident; ingest loop running");
+
+            wait_for_shutdown_signal().await;
+            info!("shutdown signal received; stopping cn-indexer");
+
+            // 停止順: ワーカー → docs 同期の購読 → iroh node。
+            handle.shutdown().await;
+            docs_sync.shutdown().await;
+            if let Err(error) = node.shutdown().await {
+                warn!(error = %format!("{error:#}"), "failed to shut down the iroh node cleanly");
+            }
         }
-        _ => info!("safety providers not configured; ingest stays disabled (fail-closed)"),
+        _ => {
+            // 取り込みを始めずに常駐する（fail-closed）。観測状態の `ingest_enabled: false` で
+            // 機械的に判定できる。
+            state.set_ingest_enabled(false);
+            info!(
+                "safety providers not configured; staying resident with ingest disabled \
+                 (fail-closed)"
+            );
+            wait_for_shutdown_signal().await;
+            info!("shutdown signal received; stopping cn-indexer");
+        }
+    }
+    if let Some(server) = status_server {
+        server.shutdown().await;
     }
     Ok(())
+}
+
+/// 停止シグナル（Ctrl+C、Unix では SIGTERM も）を待つ。
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(sigterm) => sigterm,
+            Err(error) => {
+                warn!(%error, "failed to install the SIGTERM handler; falling back to Ctrl+C");
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => {
+                if let Err(error) = result {
+                    warn!(%error, "failed to listen for Ctrl+C");
+                }
+            }
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        if let Err(error) = tokio::signal::ctrl_c().await {
+            warn!(%error, "failed to listen for Ctrl+C");
+        }
+    }
 }
 
 /// ingest 経路の本番依存を組み立てる（#613 T1）。
@@ -144,7 +227,8 @@ async fn compose_ingest_stack(
     cipher: ChannelSecretCipher,
     safety: SafetyScanService,
     node: Arc<IrohDocsNode>,
-) -> Result<IndexerParticipant> {
+    state: Arc<IndexerRuntimeState>,
+) -> Result<(IndexerParticipant, Arc<IrohDocsSync>)> {
     let docs_sync = Arc::new(IrohDocsSync::new(node));
     if !config.seed_peers.is_empty() {
         docs_sync
@@ -171,10 +255,17 @@ async fn compose_ingest_stack(
         Arc::new(safety),
         entries.clone(),
         projection.clone(),
+    )
+    .with_metrics(state);
+    let participant = IndexerParticipant::new(
+        pool,
+        docs_sync.clone(),
+        entries,
+        projection,
+        pipeline,
+        cipher,
     );
-    Ok(IndexerParticipant::new(
-        pool, docs_sync, entries, projection, pipeline, cipher,
-    ))
+    Ok((participant, docs_sync))
 }
 
 fn init_tracing() {

--- a/crates/cn-indexer/src/state.rs
+++ b/crates/cn-indexer/src/state.rs
@@ -1,0 +1,236 @@
+//! 観測用の実行状態（#613 T3）。
+//!
+//! 常駐ワーカーが更新し、テスト・起動完了判定（#612）・HTTP 状態エンドポイント（`status`）が
+//! 読む共有状態。観測用の状態の置き場はここだけにする（他の場所に分散させない）。
+//!
+//! 時刻はすべて呼び出し側が unix 秒で渡す（この構造体は時計を持たない）。
+
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use serde::Serialize;
+
+use crate::ingest::IngestSummary;
+
+/// 観測状態の写し。`GET /v1/status` はこの形をそのまま JSON で返す。
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct IndexerStateSnapshot {
+    /// ワーカーが動いているか。
+    pub worker_running: bool,
+    /// 取り込みが有効か（安全性プロバイダ未設定なら false のまま常駐する）。
+    pub ingest_enabled: bool,
+    /// 開いているスコープ数。
+    pub opened_scopes: u64,
+    /// 最後に全件見直し（restore → 取り込み 1 巡）が成功した時刻（unix 秒）。
+    pub last_sync_at: Option<i64>,
+    /// 最後にスコープ取り込みが成功した時刻（unix 秒）。
+    pub last_ingest_at: Option<i64>,
+    /// 最後のエラー内容。
+    pub last_error: Option<String>,
+    /// 最後のエラーが起きた対象スコープ（`replica id` 表現。全体エラーなら None）。
+    pub last_error_scope: Option<String>,
+    /// 走査した項目数の累計。
+    pub scanned: u64,
+    /// 許可されて索引に入れた件数の累計。
+    pub indexed: u64,
+    /// 不許可などで索引に入れなかった件数の累計（下の 2 つの分類を含む）。
+    pub skipped_non_allow: u64,
+    /// スキャン失敗（scan_failed / unscanned / スキャン呼び出しの失敗）の件数。
+    pub scan_errors: u64,
+    /// プロバイダ利用不可の件数。
+    pub provider_unavailable: u64,
+    /// 索引から外した件数の累計。
+    pub deindexed: u64,
+    /// メディア取得の成功件数。
+    pub media_fetch_success: u64,
+    /// メディア取得の利用不可（未複製・ピア不在など）件数。
+    pub media_fetch_unavailable: u64,
+    /// メディア取得の時間切れ件数。
+    pub media_fetch_timeout: u64,
+    /// メディア取得の大きさ超過件数。
+    pub media_fetch_oversize: u64,
+}
+
+/// 共有の観測状態。ワーカー・取り込みパイプライン・メディア取得器が更新する。
+#[derive(Debug, Default)]
+pub struct IndexerRuntimeState {
+    worker_running: AtomicBool,
+    ingest_enabled: AtomicBool,
+    opened_scopes: AtomicU64,
+    last_sync_at: RwLock<Option<i64>>,
+    last_ingest_at: RwLock<Option<i64>>,
+    last_error: RwLock<Option<(String, Option<String>)>>,
+    scanned: AtomicU64,
+    indexed: AtomicU64,
+    skipped_non_allow: AtomicU64,
+    scan_errors: AtomicU64,
+    provider_unavailable: AtomicU64,
+    deindexed: AtomicU64,
+    media_fetch_success: AtomicU64,
+    media_fetch_unavailable: AtomicU64,
+    media_fetch_timeout: AtomicU64,
+    media_fetch_oversize: AtomicU64,
+}
+
+impl IndexerRuntimeState {
+    pub fn set_worker_running(&self, running: bool) {
+        self.worker_running.store(running, Ordering::Relaxed);
+    }
+
+    pub fn set_ingest_enabled(&self, enabled: bool) {
+        self.ingest_enabled.store(enabled, Ordering::Relaxed);
+    }
+
+    pub fn set_opened_scopes(&self, count: u64) {
+        self.opened_scopes.store(count, Ordering::Relaxed);
+    }
+
+    /// 全件見直しの成功を記録する（unix 秒）。
+    pub fn record_sync_success(&self, at_unix: i64) {
+        *self.last_sync_at.write().expect("last_sync_at poisoned") = Some(at_unix);
+    }
+
+    /// スコープ取り込みの成功と、その取り込み結果の件数を記録する。
+    pub fn record_ingest_success(&self, at_unix: i64, summary: &IngestSummary) {
+        *self
+            .last_ingest_at
+            .write()
+            .expect("last_ingest_at poisoned") = Some(at_unix);
+        self.scanned
+            .fetch_add(summary.scanned as u64, Ordering::Relaxed);
+        self.indexed
+            .fetch_add(summary.indexed as u64, Ordering::Relaxed);
+        self.skipped_non_allow
+            .fetch_add(summary.skipped_non_allow as u64, Ordering::Relaxed);
+        self.deindexed
+            .fetch_add(summary.deindexed as u64, Ordering::Relaxed);
+    }
+
+    /// エラーを記録する（scope は replica id 表現。全体エラーなら None）。
+    pub fn record_error(&self, scope: Option<&str>, error: &str) {
+        *self.last_error.write().expect("last_error poisoned") =
+            Some((error.to_string(), scope.map(str::to_string)));
+    }
+
+    /// 索引解除（スコープ単位の削除など、取り込み結果の外で行った分）を記録する。
+    pub fn record_deindexed(&self, count: u64) {
+        self.deindexed.fetch_add(count, Ordering::Relaxed);
+    }
+
+    pub fn record_scan_error(&self) {
+        self.scan_errors.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_provider_unavailable(&self) {
+        self.provider_unavailable.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_media_fetch_success(&self) {
+        self.media_fetch_success.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_media_fetch_unavailable(&self) {
+        self.media_fetch_unavailable.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_media_fetch_timeout(&self) {
+        self.media_fetch_timeout.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_media_fetch_oversize(&self) {
+        self.media_fetch_oversize.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// 現在の状態の写しを返す。
+    pub fn snapshot(&self) -> IndexerStateSnapshot {
+        let (last_error, last_error_scope) =
+            match self.last_error.read().expect("last_error poisoned").clone() {
+                Some((error, scope)) => (Some(error), scope),
+                None => (None, None),
+            };
+        IndexerStateSnapshot {
+            worker_running: self.worker_running.load(Ordering::Relaxed),
+            ingest_enabled: self.ingest_enabled.load(Ordering::Relaxed),
+            opened_scopes: self.opened_scopes.load(Ordering::Relaxed),
+            last_sync_at: *self.last_sync_at.read().expect("last_sync_at poisoned"),
+            last_ingest_at: *self.last_ingest_at.read().expect("last_ingest_at poisoned"),
+            last_error,
+            last_error_scope,
+            scanned: self.scanned.load(Ordering::Relaxed),
+            indexed: self.indexed.load(Ordering::Relaxed),
+            skipped_non_allow: self.skipped_non_allow.load(Ordering::Relaxed),
+            scan_errors: self.scan_errors.load(Ordering::Relaxed),
+            provider_unavailable: self.provider_unavailable.load(Ordering::Relaxed),
+            deindexed: self.deindexed.load(Ordering::Relaxed),
+            media_fetch_success: self.media_fetch_success.load(Ordering::Relaxed),
+            media_fetch_unavailable: self.media_fetch_unavailable.load(Ordering::Relaxed),
+            media_fetch_timeout: self.media_fetch_timeout.load(Ordering::Relaxed),
+            media_fetch_oversize: self.media_fetch_oversize.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_reflects_flags_and_counters() {
+        let state = IndexerRuntimeState::default();
+        assert_eq!(state.snapshot(), IndexerStateSnapshot::default());
+
+        state.set_worker_running(true);
+        state.set_ingest_enabled(true);
+        state.set_opened_scopes(2);
+        state.record_sync_success(100);
+        state.record_ingest_success(
+            101,
+            &IngestSummary {
+                scanned: 3,
+                indexed: 2,
+                skipped_non_allow: 1,
+                deindexed: 0,
+            },
+        );
+        state.record_scan_error();
+        state.record_provider_unavailable();
+        state.record_deindexed(4);
+        state.record_media_fetch_success();
+        state.record_media_fetch_unavailable();
+        state.record_media_fetch_timeout();
+        state.record_media_fetch_oversize();
+        state.record_error(Some("topic::rust"), "boom");
+
+        let snapshot = state.snapshot();
+        assert!(snapshot.worker_running);
+        assert!(snapshot.ingest_enabled);
+        assert_eq!(snapshot.opened_scopes, 2);
+        assert_eq!(snapshot.last_sync_at, Some(100));
+        assert_eq!(snapshot.last_ingest_at, Some(101));
+        assert_eq!(snapshot.last_error.as_deref(), Some("boom"));
+        assert_eq!(snapshot.last_error_scope.as_deref(), Some("topic::rust"));
+        assert_eq!(snapshot.scanned, 3);
+        assert_eq!(snapshot.indexed, 2);
+        assert_eq!(snapshot.skipped_non_allow, 1);
+        assert_eq!(snapshot.scan_errors, 1);
+        assert_eq!(snapshot.provider_unavailable, 1);
+        assert_eq!(snapshot.deindexed, 4);
+        assert_eq!(snapshot.media_fetch_success, 1);
+        assert_eq!(snapshot.media_fetch_unavailable, 1);
+        assert_eq!(snapshot.media_fetch_timeout, 1);
+        assert_eq!(snapshot.media_fetch_oversize, 1);
+    }
+
+    #[test]
+    fn snapshot_serializes_to_json_with_stable_field_names() {
+        let state = IndexerRuntimeState::default();
+        let json = serde_json::to_value(state.snapshot()).expect("serialize");
+        // 起動完了判定（#612）が機械的に読む代表フィールド名を固定する。
+        assert!(json.get("worker_running").is_some());
+        assert!(json.get("ingest_enabled").is_some());
+        assert!(json.get("opened_scopes").is_some());
+        assert!(json.get("last_sync_at").is_some());
+        assert!(json.get("provider_unavailable").is_some());
+        assert!(json.get("media_fetch_timeout").is_some());
+    }
+}

--- a/crates/cn-indexer/src/status.rs
+++ b/crates/cn-indexer/src/status.rs
@@ -1,0 +1,121 @@
+//! 観測状態の HTTP 公開（#613 T3）。
+//!
+//! `COMMUNITY_NODE_INDEXER_STATUS_ADDR` が設定されたときだけ待ち受ける最小のエンドポイント。
+//! 起動完了判定（#612）や運用監視が機械的に読む:
+//! - `GET /healthz` — プロセス生存確認（常に `ok`）。
+//! - `GET /v1/status` — [`IndexerStateSnapshot`] の JSON。
+//!
+//! 運用者がローカルホストや内部ネットワークに割り当てる前提で認証は持たない。
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use axum::{Json, Router, extract::State, routing::get};
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+use crate::state::{IndexerRuntimeState, IndexerStateSnapshot};
+
+/// 状態エンドポイントの停止用の持ち手。
+pub struct StatusServerHandle {
+    local_addr: SocketAddr,
+    stop_tx: watch::Sender<bool>,
+    join: JoinHandle<()>,
+}
+
+impl StatusServerHandle {
+    /// 実際に待ち受けているアドレス（ポート 0 指定時の解決結果を含む）。
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// サーバを止め、終了を待つ。
+    pub async fn shutdown(self) {
+        let _ = self.stop_tx.send(true);
+        if let Err(error) = tokio::time::timeout(std::time::Duration::from_secs(5), self.join).await
+        {
+            warn!(%error, "status server did not stop within 5s");
+        }
+    }
+}
+
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+async fn status(State(state): State<Arc<IndexerRuntimeState>>) -> Json<IndexerStateSnapshot> {
+    Json(state.snapshot())
+}
+
+/// 状態エンドポイントを起動する。bind できなければ起動失敗（fail-closed）。
+pub async fn spawn_status_server(
+    addr: SocketAddr,
+    state: Arc<IndexerRuntimeState>,
+) -> Result<StatusServerHandle> {
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/v1/status", get(status))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind the indexer status endpoint at {addr}"))?;
+    let local_addr = listener
+        .local_addr()
+        .context("failed to resolve the indexer status endpoint address")?;
+    let (stop_tx, mut stop_rx) = watch::channel(false);
+    let join = tokio::spawn(async move {
+        let shutdown = async move {
+            // 送信側 drop でも確実に止まるよう、変更通知エラーは停止として扱う。
+            while stop_rx.changed().await.is_ok() {
+                if *stop_rx.borrow() {
+                    break;
+                }
+            }
+        };
+        if let Err(error) = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown)
+            .await
+        {
+            warn!(%error, "indexer status server exited with an error");
+        }
+    });
+    info!(addr = %local_addr, "indexer status endpoint listening");
+    Ok(StatusServerHandle {
+        local_addr,
+        stop_tx,
+        join,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn status_endpoint_serves_snapshot_and_healthz() {
+        let state = Arc::new(IndexerRuntimeState::default());
+        state.set_ingest_enabled(true);
+        let server = spawn_status_server("127.0.0.1:0".parse().expect("addr"), state.clone())
+            .await
+            .expect("spawn status server");
+        let base = format!("http://{}", server.local_addr());
+
+        let health = reqwest::get(format!("{base}/healthz"))
+            .await
+            .expect("healthz request");
+        assert!(health.status().is_success());
+        assert_eq!(health.text().await.expect("healthz body"), "ok");
+
+        let status = reqwest::get(format!("{base}/v1/status"))
+            .await
+            .expect("status request");
+        assert!(status.status().is_success());
+        let snapshot: serde_json::Value = status.json().await.expect("status json");
+        assert_eq!(snapshot["ingest_enabled"], serde_json::json!(true));
+        assert_eq!(snapshot["worker_running"], serde_json::json!(false));
+
+        server.shutdown().await;
+    }
+}

--- a/crates/cn-indexer/src/worker.rs
+++ b/crates/cn-indexer/src/worker.rs
@@ -1,0 +1,378 @@
+//! 常駐取り込みワーカー（#613 T2）。
+//!
+//! 起動時に scope 管理 state から復元し、以後は「レプリカの変更通知（少し待ってまとめる）+
+//! 一定間隔の全件見直し」で supported scope を取り込み続ける。全件見直しは何度実行しても同じ
+//! 結果に収束する（冪等）ため、サポート対象・チャンネル秘密鍵の更新や通知の取りこぼしを
+//! ここで回収する。
+//!
+//! - 索引解除の判定は「索引の真実源に実在する scope − いま対象であるべき scope」の差分で行う
+//!   （`IndexerParticipant::indexed_scopes` / `desired_scopes`）。open の成否に依存しないため、
+//!   一時的な失敗で誤って索引解除しない。ワーカー停止中に外れた scope も再起動後の見直しで
+//!   索引解除される。
+//! - scope 単位の連続失敗は再試行間隔を指数的に広げる（上限つき）。1 つの scope / entry の
+//!   失敗でワーカー全体を止めない。
+//! - 停止は [`WorkerHandle::shutdown`]。ループと購読タスクを止め、終了を待つ。
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn};
+
+use kukuri_docs_sync::DocsSync;
+
+use crate::participant::{IndexerParticipant, ScopeReplica};
+use crate::state::IndexerRuntimeState;
+
+/// ワーカーの動作設定。テストから各間隔を注入して短縮できる。
+#[derive(Clone, Debug)]
+pub struct WorkerConfig {
+    /// 全件見直しの間隔。
+    pub poll_interval: Duration,
+    /// 変更通知を受けてから取り込むまでの待ち（連続する通知をまとめる）。
+    pub event_debounce: Duration,
+    /// scope 単位の再試行間隔の初期値。
+    pub backoff_base: Duration,
+    /// scope 単位の再試行間隔の上限。
+    pub backoff_max: Duration,
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(300),
+            event_debounce: Duration::from_secs(2),
+            backoff_base: Duration::from_secs(5),
+            backoff_max: Duration::from_secs(300),
+        }
+    }
+}
+
+/// scope 単位の再試行状態。
+#[derive(Debug)]
+struct BackoffEntry {
+    failures: u32,
+    ready_at: tokio::time::Instant,
+}
+
+/// 常駐取り込みワーカー。
+pub struct IndexerWorker {
+    participant: Arc<IndexerParticipant>,
+    docs_sync: Arc<dyn DocsSync>,
+    state: Arc<IndexerRuntimeState>,
+    config: WorkerConfig,
+}
+
+/// ワーカーの停止用の持ち手。
+pub struct WorkerHandle {
+    stop_tx: watch::Sender<bool>,
+    join: JoinHandle<()>,
+    state: Arc<IndexerRuntimeState>,
+}
+
+impl WorkerHandle {
+    /// 観測状態への参照を返す。
+    pub fn state(&self) -> Arc<IndexerRuntimeState> {
+        Arc::clone(&self.state)
+    }
+
+    /// ワーカーを止め、終了を待つ。購読タスクも含めて止まる。
+    pub async fn shutdown(self) {
+        let _ = self.stop_tx.send(true);
+        if let Err(error) = tokio::time::timeout(Duration::from_secs(10), self.join).await {
+            warn!(%error, "indexer worker did not stop within 10s");
+        }
+    }
+}
+
+impl IndexerWorker {
+    pub fn new(
+        participant: Arc<IndexerParticipant>,
+        docs_sync: Arc<dyn DocsSync>,
+        state: Arc<IndexerRuntimeState>,
+        config: WorkerConfig,
+    ) -> Self {
+        Self {
+            participant,
+            docs_sync,
+            state,
+            config,
+        }
+    }
+
+    /// ワーカーを起動する。返った持ち手の `shutdown` で止める。
+    pub fn spawn(self) -> WorkerHandle {
+        let (stop_tx, stop_rx) = watch::channel(false);
+        let state = Arc::clone(&self.state);
+        let join = tokio::spawn(self.run(stop_rx));
+        WorkerHandle {
+            stop_tx,
+            join,
+            state,
+        }
+    }
+
+    async fn run(self, mut stop_rx: watch::Receiver<bool>) {
+        self.state.set_worker_running(true);
+        info!("indexer worker started");
+
+        // 変更通知の集約チャネル（値は replica id）。購読タスクがここへ流す。
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel::<String>();
+        // replica id → 購読タスク。
+        let mut subscriptions: HashMap<String, JoinHandle<()>> = HashMap::new();
+        // replica id → 取り込み対象 scope（直近の全件見直し時点）。
+        let mut active: HashMap<String, ScopeReplica> = HashMap::new();
+        // replica id → 再試行状態。
+        let mut backoff: HashMap<String, BackoffEntry> = HashMap::new();
+
+        'main: loop {
+            self.full_pass(&mut active, &mut subscriptions, &event_tx, &mut backoff)
+                .await;
+
+            // 次の全件見直しまで、変更通知を処理しながら待つ。
+            let next_pass = tokio::time::Instant::now() + self.config.poll_interval;
+            loop {
+                tokio::select! {
+                    _ = stop_rx.changed() => {
+                        if *stop_rx.borrow() {
+                            break 'main;
+                        }
+                    }
+                    _ = tokio::time::sleep_until(next_pass) => break,
+                    received = event_rx.recv() => {
+                        let Some(replica_id) = received else { break };
+                        // まとめ待ち: 待機中に届いた通知を 1 回の取り込みにまとめる。
+                        let mut pending: HashSet<String> = HashSet::new();
+                        pending.insert(replica_id);
+                        let debounce_end =
+                            tokio::time::sleep(self.config.event_debounce);
+                        tokio::pin!(debounce_end);
+                        loop {
+                            tokio::select! {
+                                _ = stop_rx.changed() => {
+                                    if *stop_rx.borrow() {
+                                        break 'main;
+                                    }
+                                }
+                                _ = &mut debounce_end => break,
+                                more = event_rx.recv() => {
+                                    match more {
+                                        Some(id) => { pending.insert(id); }
+                                        None => break,
+                                    }
+                                }
+                            }
+                        }
+                        for replica_id in pending {
+                            if let Some(scope) = active.get(&replica_id).cloned() {
+                                self.ingest_scope_with_backoff(&scope, &mut backoff).await;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 停止処理: 購読タスクを止める。
+        for (_, handle) in subscriptions.drain() {
+            handle.abort();
+        }
+        self.state.set_worker_running(false);
+        info!("indexer worker stopped");
+    }
+
+    /// 全件見直し 1 巡（冪等）:
+    /// 1. いま対象であるべき scope を求める。
+    /// 2. 索引に実在するが対象でなくなった scope を索引解除する（秘密鍵失効を含む）。
+    /// 3. 秘密鍵の登録とレプリカ open（`restore_scopes`）、購読の起動。
+    /// 4. 各 scope を取り込む（再試行間隔中の scope は飛ばす）。
+    async fn full_pass(
+        &self,
+        active: &mut HashMap<String, ScopeReplica>,
+        subscriptions: &mut HashMap<String, JoinHandle<()>>,
+        event_tx: &mpsc::UnboundedSender<String>,
+        backoff: &mut HashMap<String, BackoffEntry>,
+    ) {
+        // 1. 対象であるべき scope。
+        let desired = match self.participant.desired_scopes().await {
+            Ok(desired) => desired,
+            Err(error) => {
+                warn!(error = %format!("{error:#}"), "failed to list desired scopes; will retry");
+                self.state.record_error(None, &format!("{error:#}"));
+                return;
+            }
+        };
+        let desired_keys: HashSet<&str> = desired
+            .iter()
+            .map(|scope| scope.replica_id.as_str())
+            .collect();
+
+        // 2. 対象でなくなった scope の索引解除（索引の実在 scope との差分。再起動をまたいでも効く）。
+        match self.participant.indexed_scopes().await {
+            Ok(indexed) => {
+                for (kind, id) in indexed {
+                    let scope = ScopeReplica::from_scope(kind, id.as_str());
+                    if desired_keys.contains(scope.replica_id.as_str()) {
+                        continue;
+                    }
+                    match self.participant.stop_and_deindex_scope(kind, &id).await {
+                        Ok(()) => {
+                            self.state.record_deindexed(1);
+                            if let Some(handle) = subscriptions.remove(scope.replica_id.as_str()) {
+                                handle.abort();
+                            }
+                            active.remove(scope.replica_id.as_str());
+                            backoff.remove(scope.replica_id.as_str());
+                        }
+                        Err(error) => {
+                            warn!(
+                                kind = kind.as_str(),
+                                scope_id = %id,
+                                error = %format!("{error:#}"),
+                                "failed to de-index removed scope; will retry"
+                            );
+                            self.state.record_error(
+                                Some(scope.replica_id.as_str()),
+                                &format!("{error:#}"),
+                            );
+                        }
+                    }
+                }
+            }
+            Err(error) => {
+                warn!(error = %format!("{error:#}"), "failed to list indexed scopes; will retry");
+                self.state.record_error(None, &format!("{error:#}"));
+            }
+        }
+
+        // 購読が残っている「対象外」scope（索引が空で差分に出ないもの）も止める。
+        let stale: Vec<String> = subscriptions
+            .keys()
+            .filter(|key| !desired_keys.contains(key.as_str()))
+            .cloned()
+            .collect();
+        for key in stale {
+            if let Some(handle) = subscriptions.remove(&key) {
+                handle.abort();
+            }
+            active.remove(&key);
+            backoff.remove(&key);
+        }
+
+        // 3. 秘密鍵の登録とレプリカ open。open できたものだけを active / 購読対象にする。
+        let opened = match self.participant.restore_scopes().await {
+            Ok(opened) => opened,
+            Err(error) => {
+                warn!(error = %format!("{error:#}"), "failed to restore scopes; will retry");
+                self.state.record_error(None, &format!("{error:#}"));
+                return;
+            }
+        };
+        for scope in &opened {
+            let key = scope.replica_id.as_str().to_string();
+            active.insert(key.clone(), scope.clone());
+            let needs_spawn = match subscriptions.get(&key) {
+                Some(handle) => handle.is_finished(),
+                None => true,
+            };
+            if needs_spawn {
+                subscriptions.insert(key, self.spawn_subscription(scope, event_tx.clone()));
+            }
+        }
+        self.state.set_opened_scopes(opened.len() as u64);
+
+        // 4. 各 scope の取り込み。
+        for scope in &opened {
+            self.ingest_scope_with_backoff(scope, backoff).await;
+        }
+        self.state
+            .record_sync_success(chrono::Utc::now().timestamp());
+    }
+
+    /// scope を 1 つ取り込む。再試行間隔中なら何もしない。
+    async fn ingest_scope_with_backoff(
+        &self,
+        scope: &ScopeReplica,
+        backoff: &mut HashMap<String, BackoffEntry>,
+    ) {
+        let key = scope.replica_id.as_str();
+        if let Some(entry) = backoff.get(key)
+            && tokio::time::Instant::now() < entry.ready_at
+        {
+            debug!(replica_id = %key, "scope is backing off; skipping this round");
+            return;
+        }
+        match self.participant.ingest_scope(scope).await {
+            Ok(summary) => {
+                backoff.remove(key);
+                self.state
+                    .record_ingest_success(chrono::Utc::now().timestamp(), &summary);
+                debug!(
+                    replica_id = %key,
+                    scanned = summary.scanned,
+                    indexed = summary.indexed,
+                    "scope ingested"
+                );
+            }
+            Err(error) => {
+                let failures = backoff.get(key).map(|entry| entry.failures).unwrap_or(0) + 1;
+                // 失敗回数に応じて再試行間隔を指数的に広げる（上限つき）。
+                let exponent = failures.saturating_sub(1).min(16);
+                let delay = self
+                    .config
+                    .backoff_base
+                    .saturating_mul(2u32.saturating_pow(exponent))
+                    .min(self.config.backoff_max);
+                backoff.insert(
+                    key.to_string(),
+                    BackoffEntry {
+                        failures,
+                        ready_at: tokio::time::Instant::now() + delay,
+                    },
+                );
+                warn!(
+                    replica_id = %key,
+                    failures,
+                    retry_in_secs = delay.as_secs(),
+                    error = %format!("{error:#}"),
+                    "failed to ingest scope; backing off"
+                );
+                self.state.record_error(Some(key), &format!("{error:#}"));
+            }
+        }
+    }
+
+    /// scope の変更通知を購読し、届いた通知を集約チャネルへ流すタスクを起動する。
+    fn spawn_subscription(
+        &self,
+        scope: &ScopeReplica,
+        event_tx: mpsc::UnboundedSender<String>,
+    ) -> JoinHandle<()> {
+        let docs_sync = Arc::clone(&self.docs_sync);
+        let replica_id = scope.replica_id.clone();
+        tokio::spawn(async move {
+            match docs_sync.subscribe_replica(&replica_id).await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        if event.is_ok() && event_tx.send(replica_id.as_str().to_string()).is_err()
+                        {
+                            break;
+                        }
+                    }
+                    debug!(replica_id = %replica_id.as_str(), "replica event stream ended");
+                }
+                Err(error) => {
+                    // 購読に失敗しても定期の全件見直しが取り込みを続ける（次の見直しで再購読）。
+                    warn!(
+                        replica_id = %replica_id.as_str(),
+                        error = %format!("{error:#}"),
+                        "failed to subscribe to replica events; periodic passes still cover it"
+                    );
+                }
+            }
+        })
+    }
+}

--- a/crates/cn-indexer/tests/worker_contracts.rs
+++ b/crates/cn-indexer/tests/worker_contracts.rs
@@ -1,0 +1,529 @@
+//! #613 T2/T3 常駐ワーカーのループ契約テスト。
+//!
+//! `KUKURI_CN_RUN_INTEGRATION_TESTS=1` のときだけ実 Postgres（scope 管理 state）に接続して実行する。
+//! docs 同期・投影・真実源はメモリ内実装 + mock 安全性プロバイダで、ワーカーのループ契約を固定する:
+//! - 起動時にサポート対象を取り込み、レプリカの変更通知で追加の投稿を取り込む。
+//! - サポート対象から外れた scope / 秘密鍵が失効した private channel は、次の見直しで索引解除される。
+//! - 1 つの scope の失敗が他の scope の取り込みを妨げない（再試行間隔つき）。
+//! - 再起動後にサポート対象が復元される。停止後はワーカーが動いていないと観測できる。
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use kukuri_cn_core::TestDatabase;
+use kukuri_cn_core::{
+    ChannelSecretCipher, IndexScopeKind, MemoryIndexEntryStore, add_supported_topic,
+    connect_postgres, initialize_database, register_channel_secret, remove_channel_secret,
+    remove_supported_topic,
+};
+use kukuri_cn_indexer::ingest::IngestPipeline;
+use kukuri_cn_indexer::participant::IndexerParticipant;
+use kukuri_cn_indexer::projection::{IndexProjection, MemoryIndexProjection};
+use kukuri_cn_indexer::state::IndexerRuntimeState;
+use kukuri_cn_indexer::worker::{IndexerWorker, WorkerConfig};
+use kukuri_cn_safety::{MockSafetyProvider, ModerationEventSigner};
+use kukuri_cn_safety_runtime::clock::SystemScanClock;
+use kukuri_cn_safety_runtime::id::UuidEventIdGenerator;
+use kukuri_cn_safety_runtime::{
+    MemorySafetyArtifactStore, SafetyOrchestrator, SafetyScanService,
+    Secp256k1ModerationEventSigner,
+};
+use kukuri_core::{KukuriKeys, ReplicaId, TopicId, build_post_envelope};
+use kukuri_docs_sync::{
+    DocFetchPolicy, DocOp, DocQuery, DocRecord, DocsSync, MemoryDocsSync, stable_key,
+};
+use sqlx::postgres::PgPool;
+
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+const TEST_SIGNER_SECRET: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+const TEST_CIPHER_KEY: &str = "worker-contract-test-channel-secret-key-0123456789";
+const TEST_NAMESPACE_SECRET: &str =
+    "0303030303030303030303030303030303030303030303030303030303030303";
+
+fn integration_test_admin_database_url() -> Option<String> {
+    kukuri_test_support::gated_env_url(
+        "KUKURI_CN_RUN_INTEGRATION_TESTS",
+        "COMMUNITY_NODE_DATABASE_URL",
+        DEFAULT_ADMIN_DATABASE_URL,
+    )
+}
+
+fn cipher() -> ChannelSecretCipher {
+    ChannelSecretCipher::from_key_material(TEST_CIPHER_KEY).expect("cipher")
+}
+
+/// participant を組む（docs 同期は差し替え可能）。真実源（メモリ内実装）は scan service と
+/// 同じ artifact store を参照し、verdict への外部キー相当を成立させる。
+fn participant_with_docs(
+    pool: &PgPool,
+    docs: Arc<dyn DocsSync>,
+    projection: &Arc<MemoryIndexProjection>,
+    state: &Arc<IndexerRuntimeState>,
+) -> (Arc<IndexerParticipant>, Arc<MemoryIndexEntryStore>) {
+    let signer = Secp256k1ModerationEventSigner::from_secret(TEST_SIGNER_SECRET).expect("signer");
+    let issuer = signer.issuer_node_id().to_string();
+    let store = Arc::new(MemorySafetyArtifactStore::new());
+    let orchestrator = SafetyOrchestrator::builder(
+        &issuer,
+        Arc::new(SystemScanClock),
+        Arc::new(UuidEventIdGenerator),
+    )
+    .provider(Arc::new(MockSafetyProvider::known_csam("mock-known-csam")))
+    .build()
+    .expect("orchestrator");
+    let service = Arc::new(
+        SafetyScanService::builder(Arc::new(orchestrator), store.clone())
+            .signer(Arc::new(signer))
+            .build()
+            .expect("service"),
+    );
+    let entries = Arc::new(MemoryIndexEntryStore::new(store));
+    let pipeline = IngestPipeline::new(docs.clone(), service, entries.clone(), projection.clone())
+        .with_metrics(Arc::clone(state));
+    let participant = Arc::new(IndexerParticipant::new(
+        pool.clone(),
+        docs,
+        entries.clone(),
+        projection.clone(),
+        pipeline,
+        cipher(),
+    ));
+    (participant, entries)
+}
+
+/// テスト用に間隔を短縮したワーカー設定。
+fn fast_config(poll_interval: Duration) -> WorkerConfig {
+    WorkerConfig {
+        poll_interval,
+        event_debounce: Duration::from_millis(50),
+        backoff_base: Duration::from_millis(100),
+        backoff_max: Duration::from_millis(500),
+    }
+}
+
+/// 本文 text の post envelope を共有 replica に実在させ、object_id を返す。
+async fn persist_post(
+    docs: &dyn DocsSync,
+    replica: &ReplicaId,
+    topic: &TopicId,
+    body: &str,
+) -> String {
+    let keys = KukuriKeys::generate();
+    let envelope = build_post_envelope(&keys, topic, body, None).expect("envelope");
+    let object = envelope
+        .to_post_object()
+        .expect("post object")
+        .expect("post object present");
+    let object_id = object.object_id.as_str().to_string();
+    docs.open_replica(replica).await.expect("open");
+    docs.apply_doc_op(
+        replica,
+        DocOp::SetJson {
+            key: stable_key("objects", &format!("{object_id}/state")),
+            value: serde_json::to_value(&object).expect("state json"),
+        },
+    )
+    .await
+    .expect("state op");
+    docs.apply_doc_op(
+        replica,
+        DocOp::SetJson {
+            key: stable_key("objects", &format!("{object_id}/envelope")),
+            value: serde_json::to_value(&envelope).expect("envelope json"),
+        },
+    )
+    .await
+    .expect("envelope op");
+    object_id
+}
+
+/// 条件が成立するまで待つ（最長 30 秒。CI の並行負荷を考慮して余裕を持たせる）。
+async fn wait_until<F, Fut>(what: &str, mut condition: F)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    for _ in 0..600 {
+        if condition().await {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("timed out waiting for {what}");
+}
+
+#[tokio::test]
+async fn worker_ingests_on_startup_and_reacts_to_replica_events() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping worker contract test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_worker_events").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    add_supported_topic(&pool, IndexScopeKind::PublicTopic, "rust").await?;
+    let topic = TopicId::new("rust".to_string());
+    let replica = kukuri_docs_sync::topic_replica_id("rust");
+    let docs = Arc::new(MemoryDocsSync::default());
+    persist_post(docs.as_ref(), &replica, &topic, "hello worker").await;
+
+    let state = Arc::new(IndexerRuntimeState::default());
+    let projection = Arc::new(MemoryIndexProjection::default());
+    let (participant, entries) = participant_with_docs(&pool, docs.clone(), &projection, &state);
+
+    // 定期見直しを長くして、2 件目が「変更通知」経由で取り込まれることを確かめる。
+    let worker = IndexerWorker::new(
+        participant,
+        docs.clone(),
+        Arc::clone(&state),
+        fast_config(Duration::from_secs(120)),
+    );
+    let handle = worker.spawn();
+
+    // 起動直後の 1 巡でサポート対象が取り込まれる。
+    wait_until("initial ingest", || {
+        let projection = projection.clone();
+        async move {
+            projection
+                .count_scope(IndexScopeKind::PublicTopic, "rust")
+                .await
+                .unwrap_or(0)
+                == 1
+        }
+    })
+    .await;
+    assert!(state.snapshot().worker_running);
+    assert!(state.snapshot().last_sync_at.is_some());
+    assert_eq!(state.snapshot().opened_scopes, 1);
+
+    // レプリカの変更通知で 2 件目が取り込まれる（定期見直しはまだ先）。
+    let second = persist_post(docs.as_ref(), &replica, &topic, "event driven post").await;
+    wait_until("event driven ingest", || {
+        let projection = projection.clone();
+        let second = second.clone();
+        async move {
+            projection
+                .contains_object(IndexScopeKind::PublicTopic, "rust", second.as_str())
+                .await
+                .unwrap_or(false)
+        }
+    })
+    .await;
+    assert!(entries.contains(IndexScopeKind::PublicTopic, "rust", second.as_str()));
+
+    handle.shutdown().await;
+    assert!(!state.snapshot().worker_running);
+    Ok(())
+}
+
+#[tokio::test]
+async fn removed_scope_is_deindexed_on_next_pass() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping worker contract test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_worker_deindex").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    add_supported_topic(&pool, IndexScopeKind::PublicTopic, "rust").await?;
+    let topic = TopicId::new("rust".to_string());
+    let replica = kukuri_docs_sync::topic_replica_id("rust");
+    let docs = Arc::new(MemoryDocsSync::default());
+    let object_id = persist_post(docs.as_ref(), &replica, &topic, "to be removed").await;
+
+    let state = Arc::new(IndexerRuntimeState::default());
+    let projection = Arc::new(MemoryIndexProjection::default());
+    let (participant, entries) = participant_with_docs(&pool, docs.clone(), &projection, &state);
+    let worker = IndexerWorker::new(
+        participant,
+        docs.clone(),
+        Arc::clone(&state),
+        fast_config(Duration::from_millis(200)),
+    );
+    let handle = worker.spawn();
+
+    wait_until("initial ingest", || {
+        let projection = projection.clone();
+        let object_id = object_id.clone();
+        async move {
+            projection
+                .contains_object(IndexScopeKind::PublicTopic, "rust", object_id.as_str())
+                .await
+                .unwrap_or(false)
+        }
+    })
+    .await;
+
+    // サポート対象から外すと、次の見直しで真実源 → 投影の順に索引解除される。
+    remove_supported_topic(&pool, IndexScopeKind::PublicTopic, "rust").await?;
+    wait_until("scope de-index", || {
+        let projection = projection.clone();
+        async move {
+            projection
+                .count_scope(IndexScopeKind::PublicTopic, "rust")
+                .await
+                .unwrap_or(usize::MAX)
+                == 0
+        }
+    })
+    .await;
+    assert!(!entries.contains(IndexScopeKind::PublicTopic, "rust", object_id.as_str()));
+
+    handle.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn revoked_channel_secret_deindexes_private_channel() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping worker contract test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_worker_secret").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    // 購読リクエスト経路の結果（サポート対象入り + 秘密鍵登録済み）を直接作る。
+    add_supported_topic(&pool, IndexScopeKind::PrivateChannel, "secret-room").await?;
+    register_channel_secret(&pool, &cipher(), "secret-room", TEST_NAMESPACE_SECRET).await?;
+
+    let topic = TopicId::new("secret-room".to_string());
+    let replica = kukuri_docs_sync::private_channel_replica_id("secret-room");
+    let docs = Arc::new(MemoryDocsSync::default());
+    // 投稿の下準備として、docs 側にも capability を登録してから replica を開く
+    // （本番ではワーカーの restore_scopes が登録する。ここでは投稿を先に置くため）。
+    docs.register_private_replica_secret(&replica, TEST_NAMESPACE_SECRET)
+        .await?;
+    let object_id = persist_post(docs.as_ref(), &replica, &topic, "private post").await;
+
+    let state = Arc::new(IndexerRuntimeState::default());
+    let projection = Arc::new(MemoryIndexProjection::default());
+    let (participant, entries) = participant_with_docs(&pool, docs.clone(), &projection, &state);
+    let worker = IndexerWorker::new(
+        participant,
+        docs.clone(),
+        Arc::clone(&state),
+        fast_config(Duration::from_millis(200)),
+    );
+    let handle = worker.spawn();
+
+    // 秘密鍵が登録済みの private channel は公開トピックと同じループで取り込まれる。
+    wait_until("private channel ingest", || {
+        let projection = projection.clone();
+        let object_id = object_id.clone();
+        async move {
+            projection
+                .contains_object(
+                    IndexScopeKind::PrivateChannel,
+                    "secret-room",
+                    object_id.as_str(),
+                )
+                .await
+                .unwrap_or(false)
+        }
+    })
+    .await;
+
+    // 秘密鍵の失効で、次の見直しで索引解除される（鍵が無ければ索引しない）。
+    remove_channel_secret(&pool, "secret-room").await?;
+    wait_until("private channel de-index", || {
+        let projection = projection.clone();
+        async move {
+            projection
+                .count_scope(IndexScopeKind::PrivateChannel, "secret-room")
+                .await
+                .unwrap_or(usize::MAX)
+                == 0
+        }
+    })
+    .await;
+    assert!(!entries.contains(
+        IndexScopeKind::PrivateChannel,
+        "secret-room",
+        object_id.as_str()
+    ));
+
+    handle.shutdown().await;
+    Ok(())
+}
+
+/// 特定 replica の走査だけ失敗する docs 同期（他 scope の取り込みを妨げない検証用）。
+struct FailingScopeDocsSync {
+    inner: Arc<MemoryDocsSync>,
+    failing_replica: String,
+}
+
+#[async_trait]
+impl DocsSync for FailingScopeDocsSync {
+    async fn open_replica(&self, replica_id: &ReplicaId) -> anyhow::Result<()> {
+        self.inner.open_replica(replica_id).await
+    }
+
+    async fn apply_doc_op(&self, replica_id: &ReplicaId, op: DocOp) -> anyhow::Result<()> {
+        self.inner.apply_doc_op(replica_id, op).await
+    }
+
+    async fn query_replica_with_policy(
+        &self,
+        replica_id: &ReplicaId,
+        query: DocQuery,
+        policy: DocFetchPolicy,
+    ) -> anyhow::Result<Vec<DocRecord>> {
+        if replica_id.as_str() == self.failing_replica {
+            anyhow::bail!("simulated replica query failure");
+        }
+        self.inner
+            .query_replica_with_policy(replica_id, query, policy)
+            .await
+    }
+
+    async fn subscribe_replica(
+        &self,
+        replica_id: &ReplicaId,
+    ) -> anyhow::Result<kukuri_docs_sync::DocEventStream> {
+        self.inner.subscribe_replica(replica_id).await
+    }
+
+    async fn import_peer_ticket(&self, ticket: &str) -> anyhow::Result<()> {
+        self.inner.import_peer_ticket(ticket).await
+    }
+}
+
+#[tokio::test]
+async fn failing_scope_backs_off_without_blocking_others() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping worker contract test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_worker_backoff").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    add_supported_topic(&pool, IndexScopeKind::PublicTopic, "healthy").await?;
+    add_supported_topic(&pool, IndexScopeKind::PublicTopic, "broken").await?;
+
+    let memory = Arc::new(MemoryDocsSync::default());
+    let healthy_topic = TopicId::new("healthy".to_string());
+    let healthy_replica = kukuri_docs_sync::topic_replica_id("healthy");
+    let object_id = persist_post(
+        memory.as_ref(),
+        &healthy_replica,
+        &healthy_topic,
+        "still works",
+    )
+    .await;
+    let docs: Arc<dyn DocsSync> = Arc::new(FailingScopeDocsSync {
+        inner: memory.clone(),
+        failing_replica: kukuri_docs_sync::topic_replica_id("broken")
+            .as_str()
+            .to_string(),
+    });
+
+    let state = Arc::new(IndexerRuntimeState::default());
+    let projection = Arc::new(MemoryIndexProjection::default());
+    let (participant, _entries) = participant_with_docs(&pool, docs.clone(), &projection, &state);
+    let worker = IndexerWorker::new(
+        participant,
+        docs,
+        Arc::clone(&state),
+        fast_config(Duration::from_millis(200)),
+    );
+    let handle = worker.spawn();
+
+    // 壊れた scope があっても健全な scope は取り込まれ、ワーカーは動き続ける。
+    wait_until("healthy scope ingest", || {
+        let projection = projection.clone();
+        let object_id = object_id.clone();
+        async move {
+            projection
+                .contains_object(IndexScopeKind::PublicTopic, "healthy", object_id.as_str())
+                .await
+                .unwrap_or(false)
+        }
+    })
+    .await;
+    wait_until("failure is observable", || {
+        let state = Arc::clone(&state);
+        async move {
+            let snapshot = state.snapshot();
+            snapshot.worker_running
+                && snapshot.last_error.is_some()
+                && snapshot.last_error_scope.as_deref() == Some("topic::broken")
+        }
+    })
+    .await;
+
+    handle.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn worker_restart_restores_supported_scopes() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping worker contract test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_worker_restart").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    add_supported_topic(&pool, IndexScopeKind::PublicTopic, "rust").await?;
+    let topic = TopicId::new("rust".to_string());
+    let replica = kukuri_docs_sync::topic_replica_id("rust");
+    let docs = Arc::new(MemoryDocsSync::default());
+    let object_id = persist_post(docs.as_ref(), &replica, &topic, "survives restart").await;
+
+    let projection = Arc::new(MemoryIndexProjection::default());
+
+    // 1 回目のワーカー: 取り込んで停止する。
+    let first_state = Arc::new(IndexerRuntimeState::default());
+    let (participant, _entries) =
+        participant_with_docs(&pool, docs.clone(), &projection, &first_state);
+    let first = IndexerWorker::new(
+        participant,
+        docs.clone(),
+        Arc::clone(&first_state),
+        fast_config(Duration::from_millis(200)),
+    );
+    let first_handle = first.spawn();
+    wait_until("first ingest", || {
+        let projection = projection.clone();
+        let object_id = object_id.clone();
+        async move {
+            projection
+                .contains_object(IndexScopeKind::PublicTopic, "rust", object_id.as_str())
+                .await
+                .unwrap_or(false)
+        }
+    })
+    .await;
+    first_handle.shutdown().await;
+    assert!(!first_state.snapshot().worker_running);
+
+    // 2 回目のワーカー: scope 管理 state からサポート対象が復元され、取り込みが再開する。
+    let second_state = Arc::new(IndexerRuntimeState::default());
+    let (participant, _entries) =
+        participant_with_docs(&pool, docs.clone(), &projection, &second_state);
+    let second = IndexerWorker::new(
+        participant,
+        docs.clone(),
+        Arc::clone(&second_state),
+        fast_config(Duration::from_millis(200)),
+    );
+    let second_handle = second.spawn();
+    wait_until("restart restore", || {
+        let state = Arc::clone(&second_state);
+        async move {
+            let snapshot = state.snapshot();
+            snapshot.worker_running && snapshot.opened_scopes == 1 && snapshot.indexed >= 1
+        }
+    })
+    .await;
+
+    second_handle.shutdown().await;
+    Ok(())
+}


### PR DESCRIPTION
## 概要

Issue #613 の T2（常駐取り込みループ）+ T3（観測用の状態提供）。計画は `.claude/plans/2026-08-03-issue-613-cn-indexer-resident-worker.md`。前提の T1（結線）は #619 でマージ済み。

### T2: 常駐ワーカー（`worker.rs`）

- 起動時に `restore_scopes()` で復元 → サポート対象を 1 巡取り込み → 以後は「レプリカの変更通知（まとめ待ちつき）+ 一定間隔の冪等な全件見直し（`COMMUNITY_NODE_INDEXER_POLL_INTERVAL_SECS`、既定 300 秒）」で継続更新
- 索引解除は「索引の真実源に実在する scope − いま対象であるべき scope」の差分で判定（`IndexEntryStore::list_scopes` を新設）。一時的な open 失敗で誤解除せず、ワーカー停止中に外れた scope も再起動後に解除される
- private channel は「承認済みサポート対象 + 秘密鍵登録済み」のものだけを公開トピックと同じループで取り込む（既存の restore_scopes の関門を踏襲）。秘密鍵失効で次の見直しに索引解除
- scope 単位の連続失敗は指数バックオフ（上限つき）。1 つの scope / entry の失敗でワーカー全体を止めない
- 停止シグナル（Ctrl+C / SIGTERM）でワーカー → docs 同期 → iroh node の順に停止。プロバイダ未設定時は取り込みを始めずに常駐する（fail-closed、観測状態で機械判定可能）

### T3: 観測状態（`state.rs` / `status.rs`）

- `IndexerRuntimeState`: 稼働状態 / 取り込み有効 / 開いている scope 数 / 最終成功時刻 / 最後のエラーと対象 scope / scan・allow・非 allow・scan 失敗・プロバイダ利用不可・索引解除の件数 / メディア取得の成功・利用不可・時間切れ・大きさ超過の件数
- `COMMUNITY_NODE_INDEXER_STATUS_ADDR` 設定時のみ axum の `GET /healthz` / `GET /v1/status`（JSON）で公開。未設定なら待ち受けない

## テスト

- ループ契約テスト 5 本（`worker_contracts.rs`、実 Postgres + メモリ内 docs / 投影 + mock プロバイダ）: 起動時取り込み + 変更通知反応 / scope 除外の索引解除 / private channel の秘密鍵失効 / 失敗 scope のバックオフと隔離 / 再起動復元と停止観測
- 状態・エンドポイント・設定の単体テスト（cn-indexer lib 35 件）
- `cargo xtask cn-check` / `cargo xtask cn-test` ローカル green

Refs #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)