### PR TITLE
実iroh 2台と実ArcadeDBの統合テストを追加し、#613の進捗を文書化する（#613 T4/T5）

### DIFF
--- a/crates/cn-indexer/tests/runtime_integration.rs
+++ b/crates/cn-indexer/tests/runtime_integration.rs
@@ -1,0 +1,325 @@
+//! #613 T4 実行系の統合テスト。
+//!
+//! 3 つの層で「本番と同じ経路」を検証する:
+//! 1. **実 iroh ノード 2 台のレプリカ同期 → 取り込み**（ゲートなし。ループバックで完結）:
+//!    ノード A に置いた投稿が、ピア接続したノード B の取り込みパイプラインから見え、
+//!    スキャンを通って索引に入る。
+//! 2. **実 iroh ノード 2 台のリモートメディア一時取得**(ゲートなし):
+//!    ノード A にだけある blob を、ノード B の `BlobMediaFetcher` が取得できる。取得後も
+//!    B のローカル blob 保存領域にデータが残らない（恒久保存しない前提の構造的担保）。
+//! 3. **実 Postgres + 実 ArcadeDB の常駐ワーカー**（`KUKURI_CN_RUN_INTEGRATION_TESTS=1` かつ
+//!    `KUKURI_CN_RUN_ARCADEDB_TESTS=1`）: ワーカーが実投影へ書き、サポート対象から外すと
+//!    実投影からも消える。
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use kukuri_blob_service::{BlobService, BlobStatus, IrohBlobService};
+use kukuri_cn_core::TestDatabase;
+use kukuri_cn_core::{
+    IndexScopeKind, MemoryIndexEntryStore, add_supported_topic, connect_postgres,
+    initialize_database, remove_supported_topic,
+};
+use kukuri_cn_indexer::ArcadeDbProjection;
+use kukuri_cn_indexer::config::{ArcadeDbConfig, MediaFetchConfig};
+use kukuri_cn_indexer::ingest::IngestPipeline;
+use kukuri_cn_indexer::media_fetcher::BlobMediaFetcher;
+use kukuri_cn_indexer::participant::IndexerParticipant;
+use kukuri_cn_indexer::projection::{IndexProjection, MemoryIndexProjection};
+use kukuri_cn_indexer::query::IndexQuery;
+use kukuri_cn_indexer::state::IndexerRuntimeState;
+use kukuri_cn_indexer::worker::{IndexerWorker, WorkerConfig};
+use kukuri_cn_safety::provider::MediaFetcher;
+use kukuri_cn_safety::{MockSafetyProvider, ModerationEventSigner};
+use kukuri_cn_safety_runtime::clock::SystemScanClock;
+use kukuri_cn_safety_runtime::id::UuidEventIdGenerator;
+use kukuri_cn_safety_runtime::{
+    MemorySafetyArtifactStore, SafetyOrchestrator, SafetyScanService,
+    Secp256k1ModerationEventSigner,
+};
+use kukuri_core::{BlobHash, KukuriKeys, ReplicaId, TopicId, build_post_envelope};
+use kukuri_docs_sync::{DocOp, DocsSync, IrohDocsSync, stable_key, topic_replica_id};
+use kukuri_iroh_node::IrohDocsNode;
+
+const TEST_SIGNER_SECRET: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+
+fn integration_test_admin_database_url() -> Option<String> {
+    kukuri_test_support::gated_env_url(
+        "KUKURI_CN_RUN_INTEGRATION_TESTS",
+        "COMMUNITY_NODE_DATABASE_URL",
+        DEFAULT_ADMIN_DATABASE_URL,
+    )
+}
+
+/// mock provider（known CSAM = NoKnownMatch → allow）の scan service と、その artifact store。
+fn allow_service() -> (Arc<SafetyScanService>, Arc<MemorySafetyArtifactStore>) {
+    let signer = Secp256k1ModerationEventSigner::from_secret(TEST_SIGNER_SECRET).expect("signer");
+    let issuer = signer.issuer_node_id().to_string();
+    let store = Arc::new(MemorySafetyArtifactStore::new());
+    let orchestrator = SafetyOrchestrator::builder(
+        &issuer,
+        Arc::new(SystemScanClock),
+        Arc::new(UuidEventIdGenerator),
+    )
+    .provider(Arc::new(MockSafetyProvider::known_csam("mock-known-csam")))
+    .build()
+    .expect("orchestrator");
+    let service = Arc::new(
+        SafetyScanService::builder(Arc::new(orchestrator), store.clone())
+            .signer(Arc::new(signer))
+            .build()
+            .expect("service"),
+    );
+    (service, store)
+}
+
+/// ノードのピア接続チケット（`<endpoint_id>@<host:port>`）を組む。ループバック割り当て前提。
+fn loopback_ticket(node: &IrohDocsNode) -> String {
+    let socket = node
+        .endpoint()
+        .bound_sockets()
+        .into_iter()
+        .next()
+        .expect("bound socket");
+    format!("{}@{}", node.endpoint().addr().id, socket)
+}
+
+/// 本文 text の post envelope を共有 replica に実在させ、object_id を返す。
+async fn persist_post(
+    docs: &dyn DocsSync,
+    replica: &ReplicaId,
+    topic: &TopicId,
+    body: &str,
+) -> String {
+    let keys = KukuriKeys::generate();
+    let envelope = build_post_envelope(&keys, topic, body, None).expect("envelope");
+    let object = envelope
+        .to_post_object()
+        .expect("post object")
+        .expect("post object present");
+    let object_id = object.object_id.as_str().to_string();
+    docs.open_replica(replica).await.expect("open");
+    docs.apply_doc_op(
+        replica,
+        DocOp::SetJson {
+            key: stable_key("objects", &format!("{object_id}/state")),
+            value: serde_json::to_value(&object).expect("state json"),
+        },
+    )
+    .await
+    .expect("state op");
+    docs.apply_doc_op(
+        replica,
+        DocOp::SetJson {
+            key: stable_key("objects", &format!("{object_id}/envelope")),
+            value: serde_json::to_value(&envelope).expect("envelope json"),
+        },
+    )
+    .await
+    .expect("envelope op");
+    object_id
+}
+
+/// 実 iroh 2 台: A の投稿が B のレプリカ同期 → スキャン → 索引まで通る。
+#[tokio::test(flavor = "multi_thread")]
+async fn two_node_replica_sync_feeds_ingest() -> Result<()> {
+    let node_a = IrohDocsNode::memory().await?;
+    let node_b = IrohDocsNode::memory().await?;
+    let docs_a = Arc::new(IrohDocsSync::new(Arc::clone(&node_a)));
+    let docs_b = Arc::new(IrohDocsSync::new(Arc::clone(&node_b)));
+
+    // A に投稿を置き、B は A をピアとして学ぶ。
+    let topic = TopicId::new("rust".to_string());
+    let replica = topic_replica_id("rust");
+    let object_id = persist_post(docs_a.as_ref(), &replica, &topic, "hello from node a").await;
+    docs_b.import_peer_ticket(&loopback_ticket(&node_a)).await?;
+
+    // B 側の取り込みパイプライン（mock 安全性プロバイダ + メモリ内の真実源 / 投影）。
+    let (service, artifact_store) = allow_service();
+    let entries = Arc::new(MemoryIndexEntryStore::new(artifact_store));
+    let projection = Arc::new(MemoryIndexProjection::default());
+    let pipeline =
+        IngestPipeline::new(docs_b.clone(), service, entries.clone(), projection.clone());
+
+    // レプリカ同期は非同期に進むため、取り込みが成立するまで再実行する（冪等）。
+    let mut indexed = false;
+    for _ in 0..600 {
+        let _ = pipeline
+            .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+            .await;
+        if projection
+            .contains_object(IndexScopeKind::PublicTopic, "rust", object_id.as_str())
+            .await
+            .unwrap_or(false)
+        {
+            indexed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(indexed, "post from node A was not ingested on node B");
+    assert!(entries.contains(IndexScopeKind::PublicTopic, "rust", object_id.as_str()));
+
+    docs_a.shutdown().await;
+    docs_b.shutdown().await;
+    node_a.shutdown().await?;
+    node_b.shutdown().await?;
+    Ok(())
+}
+
+/// 実 iroh 2 台: B は A の blob を一時取得でき、取得後も B のローカル保存領域に残らない。
+#[tokio::test(flavor = "multi_thread")]
+async fn two_node_remote_media_fetch_is_ephemeral() -> Result<()> {
+    const TINY_PNG: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+    ];
+
+    let node_a = IrohDocsNode::memory().await?;
+    let node_b = IrohDocsNode::memory().await?;
+
+    // A にだけ blob を置く。
+    let blobs_a = Arc::new(IrohBlobService::new(Arc::clone(&node_a)));
+    let stored = blobs_a.put_blob(TINY_PNG.to_vec(), "image/png").await?;
+
+    // B の一時取得器（観測状態つき）。A をピアとして学ぶ。
+    let blobs_b = Arc::new(IrohBlobService::new(Arc::clone(&node_b)));
+    blobs_b
+        .import_peer_ticket(&loopback_ticket(&node_a))
+        .await?;
+    let state = Arc::new(IndexerRuntimeState::default());
+    let fetcher = BlobMediaFetcher::new(blobs_b.clone(), MediaFetchConfig::default())
+        .with_metrics(Arc::clone(&state));
+
+    let media = fetcher
+        .fetch(stored.hash.as_str(), Some("image/png"))
+        .await
+        .expect("remote ephemeral fetch succeeds");
+    assert_eq!(media.bytes, TINY_PNG.to_vec());
+    assert_eq!(media.content_type, "image/png");
+    assert_eq!(state.snapshot().media_fetch_success, 1);
+
+    // 取得後も B のローカル保存領域に blob が残らない（store 非経由の一時取得）。
+    // `blob_status` はピア経由の取得も試すため、ピアを知らない別サービスから見る
+    // （ローカル store に実在しなければ Missing になる）。
+    let blobs_b_local_only = Arc::new(IrohBlobService::new(Arc::clone(&node_b)));
+    let status = blobs_b_local_only
+        .blob_status(&BlobHash::new(stored.hash.as_str().to_string()))
+        .await?;
+    assert_eq!(status, BlobStatus::Missing);
+
+    node_a.shutdown().await?;
+    node_b.shutdown().await?;
+    Ok(())
+}
+
+/// 実 Postgres + 実 ArcadeDB: 常駐ワーカーの取り込みが実投影に入り、サポート対象から
+/// 外すと実投影からも消える。
+///
+/// `KUKURI_CN_RUN_INTEGRATION_TESTS=1`（Postgres）かつ `KUKURI_CN_RUN_ARCADEDB_TESTS=1`
+/// （live ArcadeDB、`COMMUNITY_NODE_ARCADEDB_*`）のときのみ実行する。
+#[tokio::test]
+async fn worker_writes_and_deindexes_real_arcadedb_projection() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping runtime integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    if !kukuri_test_support::env_flag_enabled("KUKURI_CN_RUN_ARCADEDB_TESTS") {
+        eprintln!("skipping ArcadeDB runtime test; set KUKURI_CN_RUN_ARCADEDB_TESTS=1");
+        return Ok(());
+    }
+
+    let database = TestDatabase::create(admin_url.as_str(), "cn_runtime_arcadedb").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    // 走行間の残留データと衝突しない一意 topic（ArcadeDB は共有インスタンスのため）。
+    let topic_id = format!(
+        "cnworker-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos()
+    );
+    add_supported_topic(&pool, IndexScopeKind::PublicTopic, topic_id.as_str()).await?;
+
+    let topic = TopicId::new(topic_id.clone());
+    let replica = topic_replica_id(topic_id.as_str());
+    let docs = Arc::new(kukuri_docs_sync::MemoryDocsSync::default());
+    let object_id = persist_post(docs.as_ref(), &replica, &topic, "real projection post").await;
+
+    let projection = Arc::new(ArcadeDbProjection::new(ArcadeDbConfig::from_env())?);
+    projection.ensure_schema().await?;
+
+    let (service, artifact_store) = allow_service();
+    let entries = Arc::new(MemoryIndexEntryStore::new(artifact_store));
+    let state = Arc::new(IndexerRuntimeState::default());
+    let pipeline = IngestPipeline::new(docs.clone(), service, entries.clone(), projection.clone())
+        .with_metrics(Arc::clone(&state));
+    let participant = Arc::new(IndexerParticipant::new(
+        pool.clone(),
+        docs.clone(),
+        entries.clone(),
+        projection.clone(),
+        pipeline,
+        kukuri_cn_core::ChannelSecretCipher::from_key_material(
+            "runtime-integration-test-channel-secret-key-0123456789",
+        )?,
+    ));
+    let worker = IndexerWorker::new(
+        participant,
+        docs.clone(),
+        Arc::clone(&state),
+        WorkerConfig {
+            poll_interval: Duration::from_millis(300),
+            event_debounce: Duration::from_millis(50),
+            backoff_base: Duration::from_millis(100),
+            backoff_max: Duration::from_millis(500),
+        },
+    );
+    let handle = worker.spawn();
+
+    // ワーカー経由で実 ArcadeDB 投影に入る。
+    let mut visible = false;
+    for _ in 0..600 {
+        if projection
+            .contains_object(IndexScopeKind::PublicTopic, topic_id.as_str(), &object_id)
+            .await
+            .unwrap_or(false)
+        {
+            visible = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(visible, "worker did not project into real ArcadeDB");
+    // 実投影の検索面からも見える（Lucene 全文 index）。
+    let hits = projection
+        .list_recent(Some((IndexScopeKind::PublicTopic, topic_id.as_str())), 10)
+        .await?;
+    assert!(hits.iter().any(|entry| entry.object_id == object_id));
+
+    // サポート対象から外すと、実投影からも消える（真実源 → 投影の順）。
+    remove_supported_topic(&pool, IndexScopeKind::PublicTopic, topic_id.as_str()).await?;
+    let mut removed = false;
+    for _ in 0..600 {
+        if projection
+            .count_scope(IndexScopeKind::PublicTopic, topic_id.as_str())
+            .await
+            .unwrap_or(usize::MAX)
+            == 0
+        {
+            removed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        removed,
+        "removed scope was not de-indexed from real ArcadeDB"
+    );
+    assert!(!entries.contains(IndexScopeKind::PublicTopic, topic_id.as_str(), &object_id));
+
+    handle.shutdown().await;
+    Ok(())
+}

--- a/docs/progress/2026-08-03-613-cn-indexer-resident-worker.md
+++ b/docs/progress/2026-08-03-613-cn-indexer-resident-worker.md
@@ -1,0 +1,77 @@
+# 2026-08-03 — #613 cn-indexer の常駐ワーカー化（レプリカ同期 → 安全性スキャン → 検索投影の本番駆動）
+
+参照: [Issue #613](https://github.com/KingYoSun/kukuri/issues/613) /
+ADR 0025 §6（Model C）/ ADR 0028（media scan）/
+計画: `.claude/plans/2026-08-03-issue-613-cn-indexer-resident-worker.md`
+
+## 実装範囲
+
+- **実行系の組み立て（`runtime.rs`、T1）**: relay validation gate の通過後、persistent iroh node を
+  1 つ構築し、media scan の一時取得（`BlobMediaFetcher`）と docs レプリカ同期（`IrohDocsSync`）で
+  共有する。`PgIndexEntryStore` / `ArcadeDbProjection`（起動時に `ensure_schema` で接続確認）/
+  `SafetyScanService` / `IngestPipeline` / `IndexerParticipant` を本番実装で結線する。
+- **常駐ワーカー（`worker.rs`、T2）**: 起動時に `restore_scopes()` で復元 → サポート対象を 1 巡
+  取り込み → 以後は「レプリカの変更通知（まとめ待ちつき）+ 一定間隔の冪等な全件見直し」で
+  継続更新する。索引解除は「索引の真実源に実在する scope − いま対象であるべき scope」の差分で
+  判定する（`IndexEntryStore::list_scopes` を新設。一時的な open 失敗で誤解除せず、ワーカー
+  停止中に外れた scope も再起動後に解除される）。scope 単位の連続失敗は指数バックオフ
+  （上限つき）で再試行し、1 つの scope / entry の失敗でワーカー全体を止めない。停止シグナル
+  （Ctrl+C / SIGTERM）でワーカー → docs 同期 → iroh node の順に停止する。
+- **観測状態（`state.rs` / `status.rs`、T3）**: `IndexerRuntimeState` に稼働状態 / 取り込み有効 /
+  開いている scope 数 / 最終成功時刻（全件見直し・取り込み）/ 最後のエラーと対象 scope /
+  scan・allow・非 allow・scan 失敗・プロバイダ利用不可・索引解除の件数 / メディア取得の
+  成功・利用不可・時間切れ・大きさ超過の件数を集約する。ライブラリ API（`snapshot()`）と、
+  env 設定時のみの HTTP エンドポイント（`GET /healthz` / `GET /v1/status`）の 2 面で公開する
+  （#612 の起動完了判定・E2E がここを読む）。
+
+## fail-closed の分類
+
+- **起動失敗**: relay 不成立 / Postgres 未準備 / チャンネル秘密鍵の鍵 material 不正 / 未知の
+  プロバイダ名 / 署名イベント発行が有効なのに署名鍵なし / ArcadeDB に接続不能 /
+  シードピア・見直し間隔・状態アドレス env の不正値。
+- **取り込みを始めずに常駐**: 安全性プロバイダ未設定（観測状態の `ingest_enabled: false` で
+  機械判定できる）。
+- 取り込み中の障害（プロバイダ利用不可 / メディア取得失敗 / 投影書き込み失敗）は従来どおり
+  entry / scope 単位で「索引しない」側に倒れ、ワーカーは動き続ける。
+
+## private channel の有効化
+
+グローバルな有効化スイッチは持たない。有効化は scope 単位の既存フローそのもの:
+利用者の indexing request（`insert_indexing_request`）→ 運営者の承認
+（`approve_indexing_request` がサポート対象へ追加）→ チャンネル秘密鍵の登録、が揃った
+private channel だけを `restore_scopes()` が開く（鍵が無ければ索引しない）。運用上止めたい
+場合は「承認しない / 秘密鍵を登録しない / 失効させる」で行い、失効は次の見直しで
+索引解除に反映される。
+
+## 環境変数（新設）
+
+| 変数 | 意味 | 既定 |
+|---|---|---|
+| `COMMUNITY_NODE_INDEXER_SEED_PEERS` | docs 同期 / blob 取得のシードピア（カンマ区切り、`endpoint_id` または `endpoint_id@host:port`。不正値は起動失敗） | なし |
+| `COMMUNITY_NODE_INDEXER_POLL_INTERVAL_SECS` | 全件見直しの間隔（秒。0 は起動失敗） | 300 |
+| `COMMUNITY_NODE_INDEXER_STATUS_ADDR` | 観測状態の HTTP 待ち受けアドレス（例 `127.0.0.1:8630`。未設定なら公開しない。認証なしのため内部 network / localhost に割り当てる） | なし |
+
+既存の `COMMUNITY_NODE_DATABASE_URL` / `COMMUNITY_NODE_INDEXER_DATA_DIR` /
+`COMMUNITY_NODE_INDEXER_OWN_RELAY` / `COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS` /
+`COMMUNITY_NODE_CHANNEL_SECRET_KEY` / `COMMUNITY_NODE_ARCADEDB_*` /
+`COMMUNITY_NODE_SAFETY_*` / `COMMUNITY_NODE_MEDIA_FETCH_*` は変更なし。
+
+## テスト
+
+- **ループ契約（`tests/worker_contracts.rs`、`KUKURI_CN_RUN_INTEGRATION_TESTS=1`）**: 起動時
+  取り込みと変更通知への反応 / scope 除外の索引解除 / private channel の秘密鍵失効 /
+  失敗 scope のバックオフと隔離 / 再起動復元と停止観測。
+- **統合（`tests/runtime_integration.rs`）**: 実 iroh ノード 2 台のレプリカ同期 → 取り込み、
+  リモートメディアの一時取得（取得後も取得側のローカル blob 保存領域に残らないことを、
+  ピアを知らないサービス経由の miss で構造的に確認）。実 ArcadeDB への投影と索引解除は
+  `KUKURI_CN_RUN_ARCADEDB_TESTS=1` でゲート（relation テストと同じ流儀）。
+- 既存の `ingestion_contracts.rs`（プロバイダ利用不可・スキャン失敗・壊れた内容が索引され
+  ないこと、tombstone の索引解除）と `query_contracts.rs`（投影残留 hit を返さない
+  fail-closed query gate = ArcadeDB 書き込み失敗時に不許可内容が表に出ないことの根拠）は
+  無変更で green。
+
+## 残課題（Issue スコープ外）
+
+- `CommunityIndex` capability の `Available` 昇格判断（#404 / #612 側）。
+- cn-user-api readiness との統合と E2E（#612）。
+- 本番 image / 配備（非目的として Issue に明記済み）。


### PR DESCRIPTION
## 概要

Issue #613 の T4（統合テストの残り）+ T5（文書化）。計画は `.claude/plans/2026-08-03-issue-613-cn-indexer-resident-worker.md`。T1 は #619、T2/T3 は #620 でマージ済み。

### T4: 統合テスト（`tests/runtime_integration.rs`）

- **実 iroh ノード 2 台のレプリカ同期 → 取り込み**（ゲートなし、ループバック完結）: ノード A の投稿がピア接続したノード B の取り込みパイプラインで同期され、スキャンを通って索引に入る
- **実 iroh ノード 2 台のリモートメディア一時取得**（ゲートなし）: ノード A にだけある blob をノード B の `BlobMediaFetcher` が取得でき、観測状態に成功が数えられる。取得後も B のローカル blob 保存領域に残らないことを「ピアを知らないサービス経由では Missing」で構造的に確認（`blob_status` はピア経由の取得も試すため、この方式で判定）
- **実 Postgres + 実 ArcadeDB の常駐ワーカー**（`KUKURI_CN_RUN_INTEGRATION_TESTS=1` かつ `KUKURI_CN_RUN_ARCADEDB_TESTS=1` でゲート、relation テストと同じ流儀）: ワーカー経由で実投影に入り、サポート対象から外すと実投影からも消える

補足: 「プロバイダ利用不可・時間切れ・壊れた内容が索引されない」は既存 `ingestion_contracts.rs`、「ArcadeDB 書き込み失敗時に不許可内容が表に出ない」は既存 `query_contracts.rs` の fail-closed query gate が担保しており、本 PR では重複させていません。

### T5: 文書化

- `docs/progress/2026-08-03-613-cn-indexer-resident-worker.md`: 実装範囲、fail-closed の分類（起動失敗 / 取り込みなし常駐）、private channel の有効化 = 購読リクエスト承認 + 秘密鍵登録という scope 単位フロー、新設環境変数（SEED_PEERS / POLL_INTERVAL_SECS / STATUS_ADDR）、テスト構成

## テスト

- `cargo test -p kukuri-cn-indexer --test runtime_integration` 3 本 green（ローカル）
- `cargo xtask cn-check` / `cargo xtask cn-test` ローカル green

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)