### PR TITLE
cn-indexerのproduction featureをArachnid+VLMに分離しvalidate-configモードを追加する（#614 T1/T2）

### DIFF
--- a/crates/cn-core/src/safety_runtime.rs
+++ b/crates/cn-core/src/safety_runtime.rs
@@ -98,11 +98,27 @@ fn resolve_provider(
         kukuri_cn_safety_arachnid::PROVIDER_NAME => arachnid_shield_provider(slot, media_fetcher),
         #[cfg(feature = "safety-vlm-provider")]
         kukuri_cn_safety_vlm::PROVIDER_NAME => vlm_provider(slot, media_fetcher),
-        other => bail!(
-            "unknown safety provider `{other}` for slot `{slot}` (fail-closed; enable the \
-             matching cargo feature and use `mock` / `project-arachnid-shield` / \
-             `openai-compatible-vlm`)"
-        ),
+        other => {
+            // 候補は build に実在する provider だけを挙げる（production binary のエラーが
+            // 選択不能な mock を案内しないように。#614）。
+            #[allow(unused_mut)]
+            let mut supported: Vec<String> = Vec::new();
+            #[cfg(feature = "safety-mock-provider")]
+            supported.push("`mock`".to_string());
+            #[cfg(feature = "safety-arachnid-provider")]
+            supported.push(format!("`{}`", kukuri_cn_safety_arachnid::PROVIDER_NAME));
+            #[cfg(feature = "safety-vlm-provider")]
+            supported.push(format!("`{}`", kukuri_cn_safety_vlm::PROVIDER_NAME));
+            let supported = if supported.is_empty() {
+                "none (no safety provider feature is enabled in this build)".to_string()
+            } else {
+                supported.join(" / ")
+            };
+            bail!(
+                "unknown safety provider `{other}` for slot `{slot}` (fail-closed; providers \
+                 available in this build: {supported})"
+            )
+        }
     }
 }
 

--- a/crates/cn-indexer/Cargo.toml
+++ b/crates/cn-indexer/Cargo.toml
@@ -35,12 +35,13 @@ kukuri-core = { path = "../core" }
 kukuri-docs-sync = { path = "../docs-sync" }
 kukuri-iroh-node = { path = "../iroh-node" }
 kukuri-transport = { path = "../transport" }
-# safety-mock-provider: 本番 provider 未使用構成でも runtime 構築（provider 実装名 `mock`）と
-# contract test を成立させるため有効化する。mock provider は operator が env で明示指定しない
-# 限り構成されず、未知の provider 名は fail-closed で Err になる。
-# safety-arachnid-provider: Project Arachnid Shield（#391、provider 実装名
-# `project-arachnid-shield`）。operator-owned credentials は env から読む。
-kukuri-cn-core = { path = "../cn-core", features = ["safety-mock-provider", "safety-arachnid-provider"] }
+# production の provider 解決表（#614）: Project Arachnid Shield（#391、provider 実装名
+# `project-arachnid-shield`、known_csam slot 専用）と OpenAI-compatible VLM（#420、provider
+# 実装名 `openai-compatible-vlm`、general / unknown_csam slot 専用）のみ。operator-owned
+# credentials は env から読む。mock は dev-dependencies 側でのみ有効化し（feature unification で
+# テストビルドに限って解決可能になる）、release binary では unknown provider として fail-closed
+# で拒否される。
+kukuri-cn-core = { path = "../cn-core", features = ["safety-arachnid-provider", "safety-vlm-provider"] }
 kukuri-cn-safety = { path = "../cn-safety" }
 kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 kukuri-cn-trust = { path = "../cn-trust" }
@@ -48,6 +49,10 @@ kukuri-cn-trust = { path = "../cn-trust" }
 [dev-dependencies]
 kukuri-test-support = { path = "../test-support" }
 kukuri-cn-safety = { path = "../cn-safety", features = ["mock"] }
+# テストビルドでのみ provider 実装名 `mock` を解決可能にする（cn-core 自身の dev-deps と同じ
+# 流儀。resolver v2 の feature unification は dev target を含むビルドに限って働くため、
+# `cargo build --release -p kukuri-cn-indexer`（production artifact）には mock が入らない）。
+kukuri-cn-core = { path = "../cn-core", features = ["safety-mock-provider"] }
 # relation graph（ArcadeDB / in-memory）へ同一 contract を課す共有スイート。
 kukuri-cn-trust = { path = "../cn-trust", features = ["testing"] }
 tempfile.workspace = true

--- a/crates/cn-indexer/src/lib.rs
+++ b/crates/cn-indexer/src/lib.rs
@@ -42,7 +42,7 @@ pub use relation_graph::ArcadeDbRelationGraph;
 pub use relation_worker::{
     DEFAULT_ANALYSIS_LIMIT, RelationAnalysisReport, analyze_relations, topic_cluster,
 };
-pub use runtime::run_from_env;
+pub use runtime::{run_from_env, validate_config_from_env};
 pub use state::{IndexerRuntimeState, IndexerStateSnapshot};
 pub use status::{StatusServerHandle, spawn_status_server};
 pub use worker::{IndexerWorker, WorkerConfig, WorkerHandle};

--- a/crates/cn-indexer/src/main.rs
+++ b/crates/cn-indexer/src/main.rs
@@ -2,10 +2,21 @@
 //!
 //! community node の docs replica sync participant（Model C）を起動する。起動時に relay validation
 //! gate（ADR 0025 §6.4）を適用し、自前 relay も外部 relay も無ければ起動しない（fail-closed）。
+//!
+//! `validate-config` 引数（#614）を渡すと、外部接続なしの起動前検証（relay gate / channel
+//! secret 鍵 / safety provider 解決 / scan service 構成）だけを行って終了する。image smoke /
+//! operator の構成確認用。
 
 use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    kukuri_cn_indexer::run_from_env().await
+    let mut args = std::env::args().skip(1);
+    match args.next().as_deref() {
+        None => kukuri_cn_indexer::run_from_env().await,
+        Some("validate-config") => kukuri_cn_indexer::validate_config_from_env(),
+        Some(other) => {
+            anyhow::bail!("unknown argument `{other}` (usage: cn-indexer [validate-config])")
+        }
+    }
 }

--- a/crates/cn-indexer/src/runtime.rs
+++ b/crates/cn-indexer/src/runtime.rs
@@ -86,9 +86,7 @@ fn validate_config(config: &IndexerConfig) -> Result<()> {
             issuer_node_id = %service.issuer_node_id(),
             "safety scan service configuration is valid"
         ),
-        None => info!(
-            "safety providers not configured; ingest would stay disabled (fail-closed)"
-        ),
+        None => info!("safety providers not configured; ingest would stay disabled (fail-closed)"),
     }
     Ok(())
 }

--- a/crates/cn-indexer/src/runtime.rs
+++ b/crates/cn-indexer/src/runtime.rs
@@ -49,6 +49,50 @@ pub async fn run_from_env() -> Result<()> {
     run(config).await
 }
 
+/// 環境変数から設定を読み、外部接続なしで起動前検証だけを行って終了する（#614）。
+///
+/// image smoke / operator の構成確認用の軽量モード。`run()` が DB 接続より前後で行う
+/// fail-closed 検証（relay gate / channel secret 鍵 / provider 解決 / scan service 構成）を
+/// 同じ判定ロジックで実行するが、Postgres / ArcadeDB / iroh へは接続しない。
+pub fn validate_config_from_env() -> Result<()> {
+    init_tracing();
+    let config = IndexerConfig::from_env()?;
+    validate_config(&config)?;
+    info!("cn-indexer configuration is valid");
+    Ok(())
+}
+
+/// 起動前検証の本体。`run()` と同じ順序・同じエラー文言で構成不正を検出する。
+///
+/// provider 解決は media fetcher なしで行う（解決・credential 検証は fetcher に依存しない）。
+/// scan service はメモリ store で構成検証のみ行い、破棄する。
+fn validate_config(config: &IndexerConfig) -> Result<()> {
+    let validation = config.relay.validate_for_startup().context(
+        "cn-indexer startup blocked: no validated relay (ADR 0025 §6.4 fail-closed startup gate)",
+    )?;
+    info!(?validation, "relay validation passed");
+
+    ChannelSecretCipher::from_key_material(config.channel_secret_key.as_str())
+        .context("invalid COMMUNITY_NODE_CHANNEL_SECRET_KEY")?;
+
+    let providers = kukuri_cn_core::resolve_safety_providers(&config.safety.providers, None)?;
+    let service = kukuri_cn_safety_runtime::build_safety_scan_service(
+        &config.safety,
+        providers,
+        Arc::new(kukuri_cn_safety_runtime::MemorySafetyArtifactStore::new()),
+    )?;
+    match service {
+        Some(service) => info!(
+            issuer_node_id = %service.issuer_node_id(),
+            "safety scan service configuration is valid"
+        ),
+        None => info!(
+            "safety providers not configured; ingest would stay disabled (fail-closed)"
+        ),
+    }
+    Ok(())
+}
+
 async fn run(config: IndexerConfig) -> Result<()> {
     // fail-closed の起動 gate: 自前 relay も外部 relay も無ければ indexing を起動しない。
     let validation = config.relay.validate_for_startup().context(
@@ -270,4 +314,117 @@ async fn compose_ingest_stack(
 
 fn init_tracing() {
     kukuri_cn_runtime_support::init_tracing("info,kukuri_cn_indexer=debug");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ArcadeDbConfig, MediaFetchConfig, RelayConfig};
+    use kukuri_cn_safety_runtime::{
+        SafetyRuntimeConfig, SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig,
+    };
+
+    // テストビルドでは dev-dependencies の feature unification により mock provider が解決可能な
+    // 点に注意（production binary では unknown 扱い）。mock の「production での拒否」は image
+    // smoke（#614 T4）が固定する。ここでは validate_config の合成（gate の順序と fail-closed）を
+    // 検証する。
+    fn base_config(safety: SafetyRuntimeConfig) -> IndexerConfig {
+        IndexerConfig {
+            database_url: "postgres://example.invalid/cn".to_string(),
+            data_dir: "./data/validate-config-test".into(),
+            relay: RelayConfig::new(false, vec!["https://relay.example.net".to_string()]),
+            channel_secret_key: "validate-config-test-channel-secret-key-0123456789".to_string(),
+            arcadedb: ArcadeDbConfig {
+                base_url: "http://127.0.0.1:2480".to_string(),
+                database: "kukuri_index".to_string(),
+                username: "root".to_string(),
+                password: String::new(),
+            },
+            safety,
+            media_fetch: MediaFetchConfig::default(),
+            seed_peers: Vec::new(),
+            poll_interval: std::time::Duration::from_secs(300),
+            status_addr: None,
+        }
+    }
+
+    fn mock_slots(provider: &str) -> SafetyRuntimeConfig {
+        SafetyRuntimeConfig {
+            providers: SafetyRuntimeProvidersConfig {
+                known_csam: Some(SafetyRuntimeProviderEntry {
+                    provider: provider.to_string(),
+                    required: true,
+                }),
+                general: None,
+                unknown_csam: None,
+            },
+            signing_key: None,
+            emit_signed_events: false,
+            issuer_node_id: Some("issuer-node-1".to_string()),
+            suspected_threshold: None,
+            suspected_signal_visibility: None,
+        }
+    }
+
+    #[test]
+    fn validate_config_accepts_provider_less_configuration() {
+        let config = base_config(SafetyRuntimeConfig {
+            emit_signed_events: false,
+            ..SafetyRuntimeConfig::default()
+        });
+        validate_config(&config).expect("provider-less configuration is valid (ingest disabled)");
+    }
+
+    #[test]
+    fn validate_config_accepts_resolvable_provider_without_db() {
+        let config = base_config(mock_slots("mock"));
+        validate_config(&config)
+            .expect("resolvable provider must validate without touching Postgres / ArcadeDB");
+    }
+
+    #[test]
+    fn validate_config_rejects_unknown_provider_fail_closed() {
+        let config = base_config(mock_slots("no-such-provider"));
+        let error = validate_config(&config).expect_err("unknown provider must fail startup");
+        assert!(
+            format!("{error:#}").contains("unknown safety provider"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn validate_config_rejects_missing_relay() {
+        let mut config = base_config(mock_slots("mock"));
+        config.relay = RelayConfig::new(false, Vec::new());
+        let error = validate_config(&config).expect_err("missing relay must fail startup");
+        assert!(
+            format!("{error:#}").contains("no validated relay"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn validate_config_rejects_invalid_channel_secret_key() {
+        let mut config = base_config(mock_slots("mock"));
+        config.channel_secret_key = "too-short".to_string();
+        let error = validate_config(&config).expect_err("short channel key must fail startup");
+        assert!(
+            format!("{error:#}").contains("COMMUNITY_NODE_CHANNEL_SECRET_KEY"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn validate_config_rejects_signed_events_without_signing_key() {
+        let mut safety = mock_slots("mock");
+        safety.emit_signed_events = true;
+        safety.issuer_node_id = None;
+        let config = base_config(safety);
+        let error =
+            validate_config(&config).expect_err("emit without signing key must fail startup");
+        assert!(
+            format!("{error:#}").contains("no signing key is configured"),
+            "unexpected error: {error:#}"
+        );
+    }
 }


### PR DESCRIPTION
## 概要

#614 のT1/T2。production `cn-indexer` binary の provider 解決表を Project Arachnid Shield + OpenAI-compatible VLM にし、mock を production artifact から構造的に排除する。

## 変更内容

### T1: production feature 構成の分離
- `crates/cn-indexer/Cargo.toml` の production 依存を `safety-arachnid-provider` + `safety-vlm-provider` に変更（`safety-vlm-provider` を新規有効化、`safety-mock-provider` を除去）
- mock は dev-dependencies の feature 付き cn-core 依存へ移動（cn-core 自身の dev-deps と同じ流儀）。resolver v2 の feature unification によりテストビルドのみ mock が解決可能になり、`cargo build --release -p kukuri-cn-indexer` には mock が入らない
- `cargo tree -e normal,features` で production グラフに mock が無いことを確認済み

### T2: `validate-config` 起動モード
- `cn-indexer validate-config` で外部接続（Postgres / ArcadeDB / iroh）なしの起動前検証だけを行い exit 0/1 で終了する（image smoke / operator の構成確認用）
- 検証内容は `run()` と同じ順序: relay validation gate → channel secret 鍵 → safety provider 解決（slot 制約 / credential env 検証）→ scan service 構成（署名鍵）
- unknown provider エラーの候補列挙を feature 連動化（production binary が選択不能な `mock` を案内しない）

## release binary での smoke 結果（ローカル）

| ケース | 結果 |
|---|---|
| mock 指定 | exit 1（`unknown safety provider `mock` … providers available in this build: `project-arachnid-shield` / `openai-compatible-vlm``） |
| 未知 provider 名 | exit 1（fail-closed） |
| VLM を known_csam slot に指定 | exit 1（slot 制約エラー） |
| Arachnid + VLM のダミー credential 構成 | exit 0 |
| Arachnid credential / VLM endpoint 欠落 | exit 1（env 名を明示、credential 値の漏出なし） |

## 検証

- `cargo xtask cn-check` green
- `cargo xtask cn-test` green（postgres / valkey 込み）
- `cargo test -p kukuri-cn-indexer --lib` 41 passed（validate_config の合成テスト6件を追加）

## 関連

- Parent: #614（Phase 2 で image workflow / smoke、Phase 3 で runbook を後続PRで対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)