### PR TITLE
cn-indexer imageをGHCR workflowに追加しpublish前のvalidate-config smokeを組み込む（#614 T3-T5）

### DIFF
--- a/.github/workflows/kukuri-cn-images.yml
+++ b/.github/workflows/kukuri-cn-images.yml
@@ -58,6 +58,9 @@ jobs:
           - package: kukuri-cn-cli
             bin: cn-cli
             image: kukuri-cn-cli
+          - package: kukuri-cn-indexer
+            bin: cn-indexer
+            image: kukuri-cn-indexer
 
     steps:
       - name: Checkout
@@ -118,6 +121,115 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # cn-indexer は publish 前に production 契約を image smoke で固定する（#614）:
+      # mock / unknown provider の fail-closed 拒否、slot 制約、credential env 欠落の明示的
+      # 失敗、credential 値の非漏出、正常構成の exit 0。`validate-config` は外部接続なしの
+      # 起動前検証モードなので、secret 実値や DB を要しない。build layer は最終 build と
+      # cache 共有されるため二重 build のコストは小さい。
+      - name: Build cn-indexer image for smoke
+        if: ${{ matrix.bin == 'cn-indexer' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/cn/Dockerfile
+          load: true
+          push: false
+          tags: cn-indexer-smoke:local
+          build-args: |
+            TARGET_PACKAGE=${{ matrix.package }}
+            TARGET_BIN=${{ matrix.bin }}
+          cache-from: type=gha,scope=cn-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=cn-${{ matrix.image }}
+
+      - name: Smoke test cn-indexer image
+        if: ${{ matrix.bin == 'cn-indexer' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="cn-indexer-smoke:local"
+          # secret 実値は使わない。SENTINEL はダミー credential の漏出検知マーカー。
+          base_args=(
+            --rm
+            -e COMMUNITY_NODE_DATABASE_URL=postgres://smoke.invalid/cn
+            -e COMMUNITY_NODE_CHANNEL_SECRET_KEY=image-smoke-channel-secret-key-0123456789abcdef
+            -e COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS=https://relay.example.net
+          )
+          leak_log=""
+
+          run_case() {
+            local name="$1" expected="$2" pattern="$3"
+            shift 3
+            local out status
+            set +e
+            out=$(docker run "${base_args[@]}" "$@" "$image" validate-config 2>&1)
+            status=$?
+            set -e
+            leak_log+="$out"$'\n'
+            if [[ "$expected" == "ok" && "$status" -ne 0 ]]; then
+              echo "::error::smoke case '$name' expected exit 0 but got $status"
+              echo "$out"
+              exit 1
+            fi
+            if [[ "$expected" == "fail" && "$status" -eq 0 ]]; then
+              echo "::error::smoke case '$name' expected a startup failure but got exit 0"
+              echo "$out"
+              exit 1
+            fi
+            if [[ -n "$pattern" ]] && ! grep -qF "$pattern" <<<"$out"; then
+              echo "::error::smoke case '$name' output does not contain: $pattern"
+              echo "$out"
+              exit 1
+            fi
+            echo "smoke case '$name': ok"
+          }
+
+          # 正常系: provider 未構成は ingest 無効で常駐する正規の fail-closed 状態。
+          run_case "provider-less config" ok "cn-indexer configuration is valid"
+
+          # 正常系: production provider 構成（ダミー credential で構成検証のみ）。
+          run_case "production providers" ok "cn-indexer configuration is valid" \
+            -e COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM=project-arachnid-shield \
+            -e COMMUNITY_NODE_SAFETY_PROVIDER_GENERAL=openai-compatible-vlm \
+            -e COMMUNITY_NODE_SAFETY_PROVIDER_UNKNOWN_CSAM=openai-compatible-vlm \
+            -e PROJECT_ARACHNID_API_USERNAME=dummy-arachnid-user-SENTINEL \
+            -e PROJECT_ARACHNID_API_PASSWORD=dummy-arachnid-password-SENTINEL \
+            -e COMMUNITY_NODE_VLM_API_BASE_URL=http://vlm.smoke.invalid:8000 \
+            -e COMMUNITY_NODE_VLM_MODEL=dummy-org/dummy-model \
+            -e COMMUNITY_NODE_VLM_API_KEY=dummy-vlm-key-SENTINEL \
+            -e COMMUNITY_NODE_SAFETY_EMIT_SIGNED_EVENTS=false \
+            -e COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID=smoke-issuer
+
+          # mock は production image で構造的に選択不能（unknown provider として fail-closed）。
+          run_case "mock rejected" fail 'unknown safety provider `mock`' \
+            -e COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM=mock
+
+          # 未知 provider 名は fail-closed で起動失敗。
+          run_case "unknown provider rejected" fail "unknown safety provider" \
+            -e COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM=no-such-provider
+
+          # slot 制約: VLM は general / unknown_csam のみ、Arachnid は known_csam のみ。
+          run_case "vlm rejected on known_csam slot" fail 'only supports the `general` / `unknown_csam` slots' \
+            -e COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM=openai-compatible-vlm
+          run_case "arachnid rejected on general slot" fail 'only supports the `known_csam` slot' \
+            -e COMMUNITY_NODE_SAFETY_PROVIDER_GENERAL=project-arachnid-shield
+
+          # credential / endpoint / 署名鍵の欠落は env 名を明示して起動失敗。
+          run_case "missing arachnid credentials" fail "PROJECT_ARACHNID_API_USERNAME" \
+            -e COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM=project-arachnid-shield
+          run_case "missing vlm endpoint" fail "COMMUNITY_NODE_VLM_API_BASE_URL" \
+            -e COMMUNITY_NODE_SAFETY_PROVIDER_GENERAL=openai-compatible-vlm
+          run_case "missing signing key" fail "no signing key is configured" \
+            -e COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM=project-arachnid-shield \
+            -e PROJECT_ARACHNID_API_USERNAME=dummy-arachnid-user-SENTINEL \
+            -e PROJECT_ARACHNID_API_PASSWORD=dummy-arachnid-password-SENTINEL
+
+          # どのケースでも credential 値（SENTINEL 付きダミー値）が出力へ漏れないこと。
+          if grep -qF "SENTINEL" <<<"$leak_log"; then
+            echo "::error::a credential value leaked into the smoke output"
+            exit 1
+          fi
+          echo "credential leak check: ok"
 
       - name: Build and optionally push
         uses: docker/build-push-action@v6

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -76,17 +76,28 @@ printf '%s' "$(openssl rand -hex 24)" | \
 # 例: Set-Content -Encoding ascii -NoNewline secret.txt <hex-string>
 # BOM/改行が混じると Postgres DSN / JWT secret として読めず、起動時 migration が失敗する。
 
-# 4) GHCR の public image を用意（cn-user-api / cn-iroh-relay / cn-cli）
+# 4) GHCR の public image を用意（cn-user-api / cn-iroh-relay / cn-cli / cn-indexer）
 #    public image 前提なので VM 側の認証は不要。
 ```
 
-GHCR image は `.github/workflows/kukuri-cn-images.yml` が `docker/cn/Dockerfile` を使って 3 binary 分 build/publish する。
+GHCR image は `.github/workflows/kukuri-cn-images.yml` が `docker/cn/Dockerfile` を使って 4 binary 分 build/publish する。
 
 | binary | package | GHCR image |
 |---|---|---|
 | `cn-user-api` | `kukuri-cn-user-api` | `ghcr.io/kingyosun/kukuri-cn-user-api:<tag>` |
 | `cn-iroh-relay` | `kukuri-cn-iroh-relay` | `ghcr.io/kingyosun/kukuri-cn-iroh-relay:<tag>` |
 | `cn-cli` | `kukuri-cn-cli` | `ghcr.io/kingyosun/kukuri-cn-cli:<tag>` |
+| `cn-indexer` | `kukuri-cn-indexer` | `ghcr.io/kingyosun/kukuri-cn-indexer:<tag>` |
+
+`cn-indexer` image（#614）は production feature 構成（Project Arachnid Shield + OpenAI-compatible VLM。mock は選択不能）で build され、workflow が publish 前に `validate-config` smoke（provider 解決 / slot 制約 / credential env 欠落 / credential 非漏出）を通す。credential / endpoint / 署名鍵は image に含まれないため、デプロイ時に runtime secret（env）として注入する。手元でも次で構成だけを検証できる:
+
+```bash
+docker run --rm -e COMMUNITY_NODE_DATABASE_URL=... -e COMMUNITY_NODE_CHANNEL_SECRET_KEY=... \
+  -e COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS=... \
+  ghcr.io/kingyosun/kukuri-cn-indexer:<tag> validate-config
+```
+
+なお `cn-indexer` は現状 low-cost Terraform stack の service には含まれない（#614 のスコープは image 配布まで）。
 
 初回 publish は workflow を default branch（通常 `main`）へ merge した後に手動 dispatch する。workflow file がまだ default branch に無い状態では `workflow_dispatch` が見つからないため、PR 中は build-only 検証に留める:
 


### PR DESCRIPTION
## 概要

#614 のT3〜T5。#622（production feature 分離 + `validate-config` モード）の後続。`kukuri-cn-indexer` image を既存 GHCR release flow に追加し、publish 前の image smoke で production 契約を CI 固定する。

## 変更内容

### T3: workflow matrix への追加
- `.github/workflows/kukuri-cn-images.yml` の matrix に package: `kukuri-cn-indexer` / bin: `cn-indexer` / image: `kukuri-cn-indexer` を追加
- PR では build-only、`main` / `develop` / `v*` tag / manual dispatch では GHCR publish（既存 3 image と同一ルール）
- `docker/cn/Dockerfile` は変更なし（`TARGET_PACKAGE` / `TARGET_BIN` の汎用構成で成立。ローカルで build 成功を確認済み）

### T4: publish 前の image smoke
- cn-indexer のみ、`load: true` で build した image に `validate-config` smoke を実行してから最終 build-push を行う（cache 共有により二重 build コストは小。smoke 失敗時は publish されない）
- smoke ケース（secret 実値・DB 接続なし）:
  - provider 未構成 → exit 0（ingest 無効の正規 fail-closed 状態）
  - Arachnid + VLM のダミー credential 構成 → exit 0
  - `mock` → fail-closed 拒否（production image で構造的に選択不能）
  - 未知 provider 名 → fail-closed 拒否
  - VLM を `known_csam` slot / Arachnid を `general` slot → slot 制約エラー
  - Arachnid credential / VLM endpoint / 署名鍵の欠落 → env 名を明示した起動失敗
  - 全ケースの出力に SENTINEL 付きダミー credential 値が漏れないことを grep で assert

### T5: runbook 更新
- `docs/runbooks/community-node-gcp-terraform.md` の image 一覧へ `cn-indexer` を追加（4 binary 化）
- runtime secret 注入の前提と `validate-config` による構成検証手順を記載
- cn-indexer は low-cost Terraform stack の service には含まれない旨を明記（#614 非目的）

## 検証

- workflow YAML 構文検証 OK
- `docker build -f docker/cn/Dockerfile --build-arg TARGET_PACKAGE=kukuri-cn-indexer --build-arg TARGET_BIN=cn-indexer` ローカル成功
- ローカル build した実 image に対して smoke script 全 9 ケース + credential 非漏出チェックが pass
- 本 PR の CI（Kukuri Community Node Images workflow）で 4 image build + cn-indexer smoke が走る

## 関連

- Parent issue: #614 / 先行 PR: #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)