### PR TITLE
cn-operatorのdeploy configをindexer stack対応に拡張しtfvars生成へ配線する（#615 T1）

### DIFF
--- a/crates/cn-operator/src/config.rs
+++ b/crates/cn-operator/src/config.rs
@@ -160,8 +160,22 @@ fn default_cn_cli_image() -> String {
     "ghcr.io/kingyosun/kukuri-cn-cli:latest".to_string()
 }
 
+fn default_cn_indexer_image() -> String {
+    "ghcr.io/kingyosun/kukuri-cn-indexer:latest".to_string()
+}
+
+fn default_arcadedb_image() -> String {
+    "arcadedata/arcadedb:latest".to_string()
+}
+
 fn default_machine_type() -> String {
-    "e2-small".to_string()
+    // Postgres + Valkey + ArcadeDB(JVM) + cn-indexer の同居を想定した既定（#615）。
+    // API / relay のみの最小構成なら e2-small へ下げてもよい。
+    "e2-medium".to_string()
+}
+
+fn default_relation_analyze_interval_minutes() -> u32 {
+    60
 }
 
 fn default_disk_size_gb() -> u32 {
@@ -261,6 +275,63 @@ pub struct DeployConfig {
     pub rate_limit_per_second: u32,
     #[serde(default = "default_rate_limit_burst")]
     pub rate_limit_burst: u32,
+    /// index / moderation stack（cn-indexer + ArcadeDB + relation 定期解析。#615）を配備するか。
+    ///
+    /// 既定 false（従来の API / relay のみ構成）。false へ戻すことが rollback 手順になる。
+    /// capability（`features.community_index` 等）の公開宣言とは独立: stack を配備しても
+    /// ユーザー向け read surface は `COMMUNITY_NODE_INDEX_QUERY_ENABLED` /
+    /// `COMMUNITY_NODE_TRUST_READ_ENABLED`（既定 false）が gate する。
+    #[serde(default)]
+    pub deploy_indexer_stack: bool,
+    #[serde(default = "default_cn_indexer_image")]
+    pub cn_indexer_image: String,
+    #[serde(default = "default_arcadedb_image")]
+    pub arcadedb_image: String,
+    /// cn-indexer data dir + ArcadeDB data 用の専用 persistent disk サイズ（GB）。
+    /// 0 なら boot disk 上の docker volume（VM 置換でデータ消失。ArcadeDB は rebuildable だが
+    /// indexer の iroh endpoint 同一性が失われるため本番では > 0 を推奨）。
+    #[serde(default)]
+    pub indexer_data_disk_gb: u32,
+    /// `cn-cli relation analyze` の定期実行間隔（分。>= 1）。
+    #[serde(default = "default_relation_analyze_interval_minutes")]
+    pub relation_analyze_interval_minutes: u32,
+    /// cn-indexer が discovery / relay-assist に使う外部 relay URL。
+    /// 自前 relay（`features.iroh_relay`）が無効な場合、deploy_indexer_stack=true では必須。
+    #[serde(default)]
+    pub indexer_external_relay_urls: Vec<String>,
+    /// `COMMUNITY_NODE_CHANNEL_SECRET_KEY` を保持する Secret Manager secret ID（値ではない）。
+    #[serde(default)]
+    pub channel_secret_key_secret_id: Option<String>,
+    /// ArcadeDB root password を保持する Secret Manager secret ID（値ではない）。
+    #[serde(default)]
+    pub arcadedb_password_secret_id: Option<String>,
+    /// Project Arachnid Shield の username / password を保持する Secret Manager secret ID
+    /// （値ではない）。`safety.providers.*` に `project-arachnid-shield` を使う場合は必須。
+    #[serde(default)]
+    pub arachnid_username_secret_id: Option<String>,
+    #[serde(default)]
+    pub arachnid_password_secret_id: Option<String>,
+    /// 任意の `COMMUNITY_NODE_VLM_API_KEY` を保持する Secret Manager secret ID（値ではない）。
+    /// self-host の無認証 endpoint では未指定のままでよい。
+    #[serde(default)]
+    pub vlm_api_key_secret_id: Option<String>,
+    /// OpenAI-compatible VLM endpoint（#420）。`safety.providers.*` に
+    /// `openai-compatible-vlm` を使う場合は base_url / model が必須。
+    #[serde(default)]
+    pub vlm_api_base_url: Option<String>,
+    #[serde(default)]
+    pub vlm_model: Option<String>,
+    /// VLM 応答形式（`json` / `guard`）。未指定なら binary 既定（json）。
+    #[serde(default)]
+    pub vlm_response_format: Option<String>,
+    /// VLM API timeout（秒）。0 なら binary 既定。
+    #[serde(default)]
+    pub vlm_api_timeout_secs: u32,
+    /// media scan 用一時 fetch の上限（bytes / 秒）。0 なら binary 既定。
+    #[serde(default)]
+    pub media_fetch_max_bytes: u64,
+    #[serde(default)]
+    pub media_fetch_timeout_secs: u32,
 }
 
 /// profile / features を解決し検証済みの設定。
@@ -446,8 +517,37 @@ fn validate_deploy(resolved: &ResolvedConfig, deploy: &DeployConfig) -> Result<(
     validate_deploy_string("deploy.cn_user_api_image", &deploy.cn_user_api_image)?;
     validate_deploy_string("deploy.cn_iroh_relay_image", &deploy.cn_iroh_relay_image)?;
     validate_deploy_string("deploy.cn_cli_image", &deploy.cn_cli_image)?;
+    validate_deploy_string("deploy.cn_indexer_image", &deploy.cn_indexer_image)?;
+    validate_deploy_string("deploy.arcadedb_image", &deploy.arcadedb_image)?;
     validate_deploy_string("deploy.machine_type", &deploy.machine_type)?;
     validate_deploy_string("deploy.blob_cache_path", &deploy.blob_cache_path)?;
+    for url in &deploy.indexer_external_relay_urls {
+        let trimmed = require_deploy_string("deploy.indexer_external_relay_urls", url)?;
+        if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
+            bail!(
+                "deploy.indexer_external_relay_urls は http(s):// で始まる URL で指定してください"
+            );
+        }
+    }
+    if let Some(format) = deploy.vlm_response_format.as_deref() {
+        let trimmed = format.trim();
+        if !trimmed.is_empty() && trimmed != "json" && trimmed != "guard" {
+            bail!(
+                "deploy.vlm_response_format は `json` または `guard` で指定してください (got `{trimmed}`)"
+            );
+        }
+    }
+    if let Some(base_url) = deploy.vlm_api_base_url.as_deref() {
+        let trimmed = require_deploy_string("deploy.vlm_api_base_url", base_url)?;
+        if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
+            bail!("deploy.vlm_api_base_url は http(s):// で始まる URL で指定してください");
+        }
+    }
+    if let Some(model) = deploy.vlm_model.as_deref() {
+        validate_deploy_string("deploy.vlm_model", model)?;
+    }
+
+    validate_indexer_stack(resolved, deploy)?;
 
     // low-cost template は cn-iroh-relay を常に配置し、relay_domain を Caddy / compose / certbot で使う。
     let relay_domain = if deploy.profile == DeployProfile::LowCost {
@@ -526,6 +626,38 @@ fn validate_deploy(resolved: &ResolvedConfig, deploy: &DeployConfig) -> Result<(
             deploy.cn_iroh_relay_image.trim(),
         )?;
         validate_container_image("deploy.cn_cli_image", deploy.cn_cli_image.trim())?;
+        validate_container_image("deploy.cn_indexer_image", deploy.cn_indexer_image.trim())?;
+        validate_container_image("deploy.arcadedb_image", deploy.arcadedb_image.trim())?;
+        for (field, secret_id) in [
+            (
+                "deploy.channel_secret_key_secret_id",
+                &deploy.channel_secret_key_secret_id,
+            ),
+            (
+                "deploy.arcadedb_password_secret_id",
+                &deploy.arcadedb_password_secret_id,
+            ),
+            (
+                "deploy.arachnid_username_secret_id",
+                &deploy.arachnid_username_secret_id,
+            ),
+            (
+                "deploy.arachnid_password_secret_id",
+                &deploy.arachnid_password_secret_id,
+            ),
+            (
+                "deploy.vlm_api_key_secret_id",
+                &deploy.vlm_api_key_secret_id,
+            ),
+        ] {
+            if let Some(secret_id) = secret_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                validate_secret_id(field, secret_id)?;
+            }
+        }
         validate_machine_type("deploy.machine_type", deploy.machine_type.trim())?;
         validate_absolute_path("deploy.blob_cache_path", deploy.blob_cache_path.trim())?;
         if let Some(dns_zone_name) = deploy
@@ -535,6 +667,107 @@ fn validate_deploy(resolved: &ResolvedConfig, deploy: &DeployConfig) -> Result<(
             .filter(|z| !z.is_empty())
         {
             validate_gcp_name("deploy.dns_zone_name", dns_zone_name)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// index / moderation stack（#615）配備時の整合検証。
+///
+/// runtime（cn-indexer）の起動 gate と同じ判定を config 段階で fail-closed に写す:
+/// 必須 secret ID の欠落、relay 不在、provider に対する credential / endpoint 欠落は
+/// apply 前に検出する。
+fn validate_indexer_stack(resolved: &ResolvedConfig, deploy: &DeployConfig) -> Result<()> {
+    if !deploy.deploy_indexer_stack {
+        return Ok(());
+    }
+
+    if deploy.relation_analyze_interval_minutes == 0 {
+        bail!("deploy.relation_analyze_interval_minutes は 1 以上で指定してください");
+    }
+
+    let require_secret = |field: &str, value: &Option<String>| -> Result<()> {
+        if value
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .is_none()
+        {
+            bail!("deploy.deploy_indexer_stack=true の場合、{field} は必須です");
+        }
+        Ok(())
+    };
+    require_secret(
+        "deploy.channel_secret_key_secret_id",
+        &deploy.channel_secret_key_secret_id,
+    )?;
+    require_secret(
+        "deploy.arcadedb_password_secret_id",
+        &deploy.arcadedb_password_secret_id,
+    )?;
+
+    // relay validation gate（ADR 0025 §6.4）を config 段階で写す。
+    if !resolved.enabled(Capability::IrohRelay) && deploy.indexer_external_relay_urls.is_empty() {
+        bail!(
+            "deploy.deploy_indexer_stack=true には validated relay が必要です。\n\
+             features.iroh_relay を有効化するか、deploy.indexer_external_relay_urls を指定してください。"
+        );
+    }
+
+    let safety = resolved.raw.safety.clone().unwrap_or_default();
+
+    // signed moderation event（既定 true）には signing key secret が必要。
+    if safety.events.emit_signed_moderation_events
+        && safety
+            .events
+            .signing_key_secret_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .is_none()
+    {
+        bail!(
+            "deploy.deploy_indexer_stack=true かつ safety.events.emit_signed_moderation_events=true \
+             の場合、safety.events.signing_key_secret_id は必須です"
+        );
+    }
+
+    // provider ごとの credential / endpoint 要件。
+    let providers = [
+        safety.providers.known_csam.as_ref(),
+        safety.providers.general.as_ref(),
+        safety.providers.unknown_csam.as_ref(),
+    ];
+    let uses = |name: &str| {
+        providers
+            .iter()
+            .flatten()
+            .any(|entry| entry.provider.trim() == name)
+    };
+    if uses("project-arachnid-shield") {
+        require_secret(
+            "deploy.arachnid_username_secret_id",
+            &deploy.arachnid_username_secret_id,
+        )?;
+        require_secret(
+            "deploy.arachnid_password_secret_id",
+            &deploy.arachnid_password_secret_id,
+        )?;
+    }
+    if uses("openai-compatible-vlm") {
+        for (field, value) in [
+            ("deploy.vlm_api_base_url", &deploy.vlm_api_base_url),
+            ("deploy.vlm_model", &deploy.vlm_model),
+        ] {
+            if value
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .is_none()
+            {
+                bail!("safety.providers に openai-compatible-vlm を使う場合、{field} は必須です");
+            }
         }
     }
 

--- a/crates/cn-operator/src/config.rs
+++ b/crates/cn-operator/src/config.rs
@@ -165,7 +165,7 @@ fn default_cn_indexer_image() -> String {
 }
 
 fn default_arcadedb_image() -> String {
-    "arcadedata/arcadedb:latest".to_string()
+    "arcadedata/arcadedb:26.8.1".to_string()
 }
 
 fn default_machine_type() -> String {

--- a/crates/cn-operator/src/deploy.rs
+++ b/crates/cn-operator/src/deploy.rs
@@ -43,6 +43,16 @@ fn hcl_string(value: &str) -> String {
     format!("\"{escaped}\"")
 }
 
+/// HCL の文字列 list を決定論的に出力する（要素は trim 済みを想定）。
+fn hcl_string_list(values: &[String]) -> String {
+    let items = values
+        .iter()
+        .map(|value| hcl_string(value.trim()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{items}]")
+}
+
 /// low-cost env 用の tfvars を決定論的に組み立てる。
 fn render_low_cost_tfvars(config: &ResolvedConfig, deploy: &DeployConfig) -> String {
     let project_id = deploy.project_id.trim();
@@ -165,6 +175,186 @@ fn render_low_cost_tfvars(config: &ResolvedConfig, deploy: &DeployConfig) -> Str
         out,
         "backup_retention_days = {}",
         deploy.backup_retention_days
+    );
+
+    // --- index / moderation stack（#615） ---
+    // secret はここでも ID のみ。値・credential は startup 時に Secret Manager から取得される。
+    let safety = config.raw.safety.clone().unwrap_or_default();
+    let provider_name = |entry: Option<&crate::safety_config::SafetyProviderEntry>| {
+        entry
+            .map(|e| e.provider.trim().to_string())
+            .unwrap_or_default()
+    };
+    let provider_required = |entry: Option<&crate::safety_config::SafetyProviderEntry>| {
+        entry.map(|e| e.required).unwrap_or(false)
+    };
+    let optional_secret = |value: &Option<String>| {
+        value
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_string()
+    };
+    let suspected_visibility = safety
+        .moderation
+        .suspected_signal_visibility
+        .map(|visibility| match visibility {
+            crate::safety_config::SignalVisibility::Local => "local",
+            crate::safety_config::SignalVisibility::SubscribedNodes => "subscribed_nodes",
+            crate::safety_config::SignalVisibility::Public => "public",
+        })
+        .unwrap_or_default();
+
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "deploy_indexer_stack = {}",
+        deploy.deploy_indexer_stack
+    );
+    let _ = writeln!(
+        out,
+        "cn_indexer_image     = {}",
+        hcl_string(deploy.cn_indexer_image.trim())
+    );
+    let _ = writeln!(
+        out,
+        "arcadedb_image       = {}",
+        hcl_string(deploy.arcadedb_image.trim())
+    );
+    let _ = writeln!(
+        out,
+        "indexer_data_disk_gb = {}",
+        deploy.indexer_data_disk_gb
+    );
+    let _ = writeln!(
+        out,
+        "relation_analyze_interval_minutes = {}",
+        deploy.relation_analyze_interval_minutes
+    );
+    let _ = writeln!(
+        out,
+        "indexer_own_relay           = {}",
+        config.enabled(crate::Capability::IrohRelay)
+    );
+    let _ = writeln!(
+        out,
+        "indexer_external_relay_urls = {}",
+        hcl_string_list(&deploy.indexer_external_relay_urls)
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "channel_secret_key_secret_id = {}",
+        hcl_string(&optional_secret(&deploy.channel_secret_key_secret_id))
+    );
+    let _ = writeln!(
+        out,
+        "arcadedb_password_secret_id  = {}",
+        hcl_string(&optional_secret(&deploy.arcadedb_password_secret_id))
+    );
+    let _ = writeln!(
+        out,
+        "arachnid_username_secret_id  = {}",
+        hcl_string(&optional_secret(&deploy.arachnid_username_secret_id))
+    );
+    let _ = writeln!(
+        out,
+        "arachnid_password_secret_id  = {}",
+        hcl_string(&optional_secret(&deploy.arachnid_password_secret_id))
+    );
+    let _ = writeln!(
+        out,
+        "vlm_api_key_secret_id        = {}",
+        hcl_string(&optional_secret(&deploy.vlm_api_key_secret_id))
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "safety_provider_known_csam            = {}",
+        hcl_string(&provider_name(safety.providers.known_csam.as_ref()))
+    );
+    let _ = writeln!(
+        out,
+        "safety_provider_known_csam_required   = {}",
+        provider_required(safety.providers.known_csam.as_ref())
+    );
+    let _ = writeln!(
+        out,
+        "safety_provider_general               = {}",
+        hcl_string(&provider_name(safety.providers.general.as_ref()))
+    );
+    let _ = writeln!(
+        out,
+        "safety_provider_general_required      = {}",
+        provider_required(safety.providers.general.as_ref())
+    );
+    let _ = writeln!(
+        out,
+        "safety_provider_unknown_csam          = {}",
+        hcl_string(&provider_name(safety.providers.unknown_csam.as_ref()))
+    );
+    let _ = writeln!(
+        out,
+        "safety_provider_unknown_csam_required = {}",
+        provider_required(safety.providers.unknown_csam.as_ref())
+    );
+    let _ = writeln!(
+        out,
+        "safety_emit_signed_events             = {}",
+        safety.events.emit_signed_moderation_events
+    );
+    let _ = writeln!(
+        out,
+        "safety_suspected_threshold            = {}",
+        safety.moderation.suspected_threshold.unwrap_or(0)
+    );
+    let _ = writeln!(
+        out,
+        "safety_suspected_signal_visibility    = {}",
+        hcl_string(suspected_visibility)
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "vlm_api_base_url     = {}",
+        hcl_string(
+            deploy
+                .vlm_api_base_url
+                .as_deref()
+                .map(str::trim)
+                .unwrap_or("")
+        )
+    );
+    let _ = writeln!(
+        out,
+        "vlm_model            = {}",
+        hcl_string(deploy.vlm_model.as_deref().map(str::trim).unwrap_or(""))
+    );
+    let _ = writeln!(
+        out,
+        "vlm_response_format  = {}",
+        hcl_string(
+            deploy
+                .vlm_response_format
+                .as_deref()
+                .map(str::trim)
+                .unwrap_or("")
+        )
+    );
+    let _ = writeln!(
+        out,
+        "vlm_api_timeout_secs = {}",
+        deploy.vlm_api_timeout_secs
+    );
+    let _ = writeln!(
+        out,
+        "media_fetch_max_bytes    = {}",
+        deploy.media_fetch_max_bytes
+    );
+    let _ = writeln!(
+        out,
+        "media_fetch_timeout_secs = {}",
+        deploy.media_fetch_timeout_secs
     );
 
     // operator-config.yaml 自体を VM に配置して manifest endpoint / report_endpoint gating を

--- a/crates/cn-operator/src/lib.rs
+++ b/crates/cn-operator/src/lib.rs
@@ -131,11 +131,26 @@ manifest:
 #   acme_email: ops@example-kukuri.net
 #   jwt_secret_id: kukuri-cn-jwt-secret
 #   postgres_password_secret_id: kukuri-cn-postgres-password
-#   machine_type: e2-small
+#   machine_type: e2-medium
 #   disk_size_gb: 30
 #   postgres_data_disk_gb: 0
 #   blob_cache_size_gb: 0
 #   backup_enabled: true
+#   # index / moderation stack（cn-indexer + ArcadeDB + relation 定期解析。#615, 任意）。
+#   # secret は値ではなく Secret Manager の ID のみ。credential / 鍵の実値は VM 起動時に取得される。
+#   deploy_indexer_stack: true
+#   cn_indexer_image: ghcr.io/kingyosun/kukuri-cn-indexer:latest
+#   arcadedb_image: arcadedata/arcadedb:latest
+#   indexer_data_disk_gb: 10
+#   relation_analyze_interval_minutes: 60
+#   channel_secret_key_secret_id: kukuri-cn-channel-secret-key
+#   arcadedb_password_secret_id: kukuri-cn-arcadedb-password
+#   arachnid_username_secret_id: kukuri-cn-arachnid-username
+#   arachnid_password_secret_id: kukuri-cn-arachnid-password
+#   vlm_api_base_url: http://10.73.0.10:8000   # self-host は private tunnel 経由の到達を推奨
+#   vlm_model: inclusionAI/SingGuard-2b
+#   vlm_response_format: guard
+#   vlm_api_key_secret_id: kukuri-cn-vlm-api-key   # 無認証 self-host endpoint なら省略
 
 # community_index / moderation / community_local_trust / report_endpoint は
 # 現行実装では未提供（計画中）。spec として記述することを明示的に承認する。

--- a/crates/cn-operator/src/lib.rs
+++ b/crates/cn-operator/src/lib.rs
@@ -140,7 +140,7 @@ manifest:
 #   # secret は値ではなく Secret Manager の ID のみ。credential / 鍵の実値は VM 起動時に取得される。
 #   deploy_indexer_stack: true
 #   cn_indexer_image: ghcr.io/kingyosun/kukuri-cn-indexer:latest
-#   arcadedb_image: arcadedata/arcadedb:latest
+#   arcadedb_image: arcadedata/arcadedb:26.8.1
 #   indexer_data_disk_gb: 10
 #   relation_analyze_interval_minutes: 60
 #   channel_secret_key_secret_id: kukuri-cn-channel-secret-key

--- a/crates/cn-operator/tests/deploy.rs
+++ b/crates/cn-operator/tests/deploy.rs
@@ -280,7 +280,7 @@ fn indexer_stack_defaults_to_disabled_with_images() {
     assert!(
         tfvars.contains("cn_indexer_image     = \"ghcr.io/kingyosun/kukuri-cn-indexer:latest\"")
     );
-    assert!(tfvars.contains("arcadedb_image       = \"arcadedata/arcadedb:latest\""));
+    assert!(tfvars.contains("arcadedb_image       = \"arcadedata/arcadedb:26.8.1\""));
     assert!(tfvars.contains("relation_analyze_interval_minutes = 60"));
     assert!(tfvars.contains("safety_provider_known_csam            = \"\""));
 }

--- a/crates/cn-operator/tests/deploy.rs
+++ b/crates/cn-operator/tests/deploy.rs
@@ -220,6 +220,199 @@ fn generated_tfvars_guides_operator_config_path() {
     assert!(!tfvars.contains("operator_config_file = file("));
 }
 
+/// indexer stack（#615）一式を有効化した config。
+fn config_with_indexer_stack(extra_deploy: &str, extra_features: &str) -> String {
+    format!(
+        "server:\n\
+         \x20 domain: example-kukuri.net\n\
+         \x20 operator_name: Example Operator\n\
+         \x20 country: JP\n\
+         features:\n\
+         \x20 iroh_relay: true\n{extra_features}\
+         safety:\n\
+         \x20 events:\n\
+         \x20   emit_signed_moderation_events: true\n\
+         \x20   signing_key_secret_id: kukuri-cn-safety-signing-key\n\
+         \x20 providers:\n\
+         \x20   known_csam:\n\
+         \x20     provider: project-arachnid-shield\n\
+         \x20     required: true\n\
+         \x20   general:\n\
+         \x20     provider: openai-compatible-vlm\n\
+         \x20   unknown_csam:\n\
+         \x20     provider: openai-compatible-vlm\n\
+         deploy:\n\
+         \x20 profile: low-cost\n\
+         \x20 project_id: my-project\n\
+         \x20 relay_domain: relay.example-kukuri.net\n\
+         \x20 acme_email: ops@example-kukuri.net\n\
+         \x20 jwt_secret_id: kukuri-cn-jwt-secret\n\
+         \x20 postgres_password_secret_id: kukuri-cn-postgres-password\n\
+         \x20 deploy_indexer_stack: true\n\
+         \x20 channel_secret_key_secret_id: kukuri-cn-channel-secret-key\n\
+         \x20 arcadedb_password_secret_id: kukuri-cn-arcadedb-password\n\
+         \x20 arachnid_username_secret_id: kukuri-cn-arachnid-username\n\
+         \x20 arachnid_password_secret_id: kukuri-cn-arachnid-password\n\
+         \x20 vlm_api_base_url: http://10.73.0.10:8000\n\
+         \x20 vlm_model: inclusionAI/SingGuard-2b\n\
+         \x20 vlm_response_format: guard\n{extra_deploy}"
+    )
+}
+
+#[test]
+fn machine_type_defaults_to_e2_medium() {
+    let yaml = config_with_deploy("  relay_domain: relay.example-kukuri.net\n", "", false);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let tfvars = generate_tfvars(&resolved).unwrap();
+    assert!(
+        tfvars.contains("machine_type          = \"e2-medium\""),
+        "tfvars:\n{tfvars}"
+    );
+}
+
+#[test]
+fn indexer_stack_defaults_to_disabled_with_images() {
+    // 既存 config（stack 未指定）でも tfvars には明示的な false と image 既定値が出る。
+    let yaml = config_with_deploy("  relay_domain: relay.example-kukuri.net\n", "", false);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let tfvars = generate_tfvars(&resolved).unwrap();
+    assert!(tfvars.contains("deploy_indexer_stack = false"));
+    assert!(
+        tfvars.contains("cn_indexer_image     = \"ghcr.io/kingyosun/kukuri-cn-indexer:latest\"")
+    );
+    assert!(tfvars.contains("arcadedb_image       = \"arcadedata/arcadedb:latest\""));
+    assert!(tfvars.contains("relation_analyze_interval_minutes = 60"));
+    assert!(tfvars.contains("safety_provider_known_csam            = \"\""));
+}
+
+#[test]
+fn indexer_stack_full_config_emits_expected_tfvars() {
+    let yaml = config_with_indexer_stack(
+        "  indexer_data_disk_gb: 10\n  relation_analyze_interval_minutes: 30\n",
+        "",
+    );
+    let resolved = load_and_validate(&yaml).unwrap();
+    let tfvars = generate_tfvars(&resolved).unwrap();
+    assert!(tfvars.contains("deploy_indexer_stack = true"));
+    assert!(tfvars.contains("indexer_data_disk_gb = 10"));
+    assert!(tfvars.contains("relation_analyze_interval_minutes = 30"));
+    assert!(tfvars.contains("indexer_own_relay           = true"));
+    assert!(tfvars.contains("channel_secret_key_secret_id = \"kukuri-cn-channel-secret-key\""));
+    assert!(tfvars.contains("arcadedb_password_secret_id  = \"kukuri-cn-arcadedb-password\""));
+    assert!(tfvars.contains("arachnid_username_secret_id  = \"kukuri-cn-arachnid-username\""));
+    assert!(tfvars.contains("arachnid_password_secret_id  = \"kukuri-cn-arachnid-password\""));
+    assert!(tfvars.contains("safety_provider_known_csam            = \"project-arachnid-shield\""));
+    assert!(tfvars.contains("safety_provider_known_csam_required   = true"));
+    assert!(tfvars.contains("safety_provider_general               = \"openai-compatible-vlm\""));
+    assert!(tfvars.contains("safety_emit_signed_events             = true"));
+    assert!(tfvars.contains("safety_signing_key_secret_id = \"kukuri-cn-safety-signing-key\""));
+    assert!(tfvars.contains("vlm_api_base_url     = \"http://10.73.0.10:8000\""));
+    assert!(tfvars.contains("vlm_model            = \"inclusionAI/SingGuard-2b\""));
+    assert!(tfvars.contains("vlm_response_format  = \"guard\""));
+    // 任意 secret（VLM API key）未指定は空文字（Terraform 側で「fetch しない」の合図）。
+    assert!(tfvars.contains("vlm_api_key_secret_id        = \"\""));
+}
+
+#[test]
+fn indexer_stack_requires_channel_and_arcadedb_secret_ids() {
+    let yaml = config_with_indexer_stack("", "").replace(
+        "  channel_secret_key_secret_id: kukuri-cn-channel-secret-key\n",
+        "",
+    );
+    let err = load_and_validate(&yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("channel_secret_key_secret_id"),
+        "got: {err}"
+    );
+
+    let yaml = config_with_indexer_stack("", "").replace(
+        "  arcadedb_password_secret_id: kukuri-cn-arcadedb-password\n",
+        "",
+    );
+    let err = load_and_validate(&yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("arcadedb_password_secret_id"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn indexer_stack_requires_relay() {
+    // 自前 relay 無効 + 外部 relay 未指定は config 段階で fail-closed。
+    let yaml =
+        config_with_indexer_stack("", "").replace("  iroh_relay: true\n", "  iroh_relay: false\n");
+    let err = load_and_validate(&yaml).unwrap_err();
+    assert!(err.to_string().contains("relay"), "got: {err}");
+
+    // 外部 relay URL があれば成立し、tfvars に出力される。
+    let yaml = config_with_indexer_stack(
+        "  indexer_external_relay_urls:\n    - https://relay.example.net\n",
+        "",
+    )
+    .replace("  iroh_relay: true\n", "  iroh_relay: false\n");
+    let resolved = load_and_validate(&yaml).unwrap();
+    let tfvars = generate_tfvars(&resolved).unwrap();
+    assert!(tfvars.contains("indexer_own_relay           = false"));
+    assert!(
+        tfvars.contains("indexer_external_relay_urls = [\"https://relay.example.net\"]"),
+        "tfvars:\n{tfvars}"
+    );
+}
+
+#[test]
+fn indexer_stack_requires_provider_credentials() {
+    // Arachnid provider には username / password の secret ID が必要。
+    let yaml = config_with_indexer_stack("", "").replace(
+        "  arachnid_username_secret_id: kukuri-cn-arachnid-username\n",
+        "",
+    );
+    let err = load_and_validate(&yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("arachnid_username_secret_id"),
+        "got: {err}"
+    );
+
+    // VLM provider には endpoint / model が必要。
+    let yaml = config_with_indexer_stack("", "")
+        .replace("  vlm_api_base_url: http://10.73.0.10:8000\n", "");
+    let err = load_and_validate(&yaml).unwrap_err();
+    assert!(err.to_string().contains("vlm_api_base_url"), "got: {err}");
+}
+
+#[test]
+fn indexer_stack_requires_signing_key_when_emitting_signed_events() {
+    let yaml = config_with_indexer_stack("", "").replace(
+        "    signing_key_secret_id: kukuri-cn-safety-signing-key\n",
+        "",
+    );
+    let err = load_and_validate(&yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("signing_key_secret_id"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn indexer_stack_rejects_invalid_vlm_response_format_and_zero_interval() {
+    let yaml = config_with_indexer_stack("", "").replace(
+        "  vlm_response_format: guard\n",
+        "  vlm_response_format: xml\n",
+    );
+    let err = load_and_validate(&yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("vlm_response_format"),
+        "got: {err}"
+    );
+
+    let yaml = config_with_indexer_stack("  relation_analyze_interval_minutes: 0\n", "");
+    let err = load_and_validate(&yaml).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("relation_analyze_interval_minutes"),
+        "got: {err}"
+    );
+}
+
 #[test]
 fn tfvars_never_contains_secret_values() {
     // deploy は secret ID のみを持つ。tfvars には ID のみ出力され、値は出ない。


### PR DESCRIPTION
## 概要

#615 の T1。GCP low-cost デプロイへ index / moderation stack（cn-indexer + ArcadeDB + relation 定期解析）を配備するための設定入力を cn-operator に追加する。

## 変更内容

- `DeployConfig` に以下を追加（すべて既定値付きで後方互換）
  - `deploy_indexer_stack`（既定 false。false へ戻すことが rollback 手順になる）
  - `cn_indexer_image` / `arcadedb_image` / `indexer_data_disk_gb` / `relation_analyze_interval_minutes` / `indexer_external_relay_urls`
  - secret ID（値ではない）: `channel_secret_key_secret_id` / `arcadedb_password_secret_id` / `arachnid_username_secret_id` / `arachnid_password_secret_id` / 任意 `vlm_api_key_secret_id`
  - VLM endpoint 設定: `vlm_api_base_url` / `vlm_model` / `vlm_response_format`（json / guard）/ `vlm_api_timeout_secs`
  - media fetch 上限: `media_fetch_max_bytes` / `media_fetch_timeout_secs`
- `validate_indexer_stack` で runtime（cn-indexer）の起動 gate を config 段階へ写す（fail-closed）:
  - stack 有効時の必須 secret ID（channel key / ArcadeDB password）
  - relay validation（`features.iroh_relay` または外部 relay URL）
  - `project-arachnid-shield` 使用時の Arachnid credential secret ID、`openai-compatible-vlm` 使用時の endpoint / model
  - signed moderation event（既定 true）時の `safety.events.signing_key_secret_id`
- `generate-tfvars` へ上記 + provider slot（名前 / required）+ suspected threshold / visibility + emit flag を出力。secret は ID のみで値は一切出さない（既存の不変条件を維持）
- `machine_type` 既定を `e2-small` → `e2-medium` へ引き上げ（ArcadeDB(JVM) + cn-indexer 同居のため）

## 対応する Terraform 変数について

新しい tfvars キーに対応する `envs/low-cost` の variable 定義は後続 PR（T4-T6）で追加する。それまでに生成した tfvars を既存 root に食わせると undeclared variable の warning が出るが、error にはならない。

## テスト

- `cargo test -p kukuri-cn-operator`（deploy 24 件 green、新規 8 件）
- `cargo clippy -p kukuri-cn-operator --all-targets`
- `cargo test -p kukuri-cn-user-api`（依存 crate 回帰なし）

Refs #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)