### PR TITLE
標準composeへArcadeDB・cn-indexer・relation定期解析を追加する（#615 T2/T3）

### DIFF
--- a/.env.community-node.example
+++ b/.env.community-node.example
@@ -7,6 +7,14 @@ CN_VALKEY_HOST_BIND_IP=127.0.0.1
 CN_VALKEY_PORT=56379
 COMMUNITY_NODE_RENDEZVOUS_KEY_PREFIX=cn:rendezvous:v1
 
+# ArcadeDB（index 投影 + relation graph。#615）。host へ port を公開しない
+# （デバッグは docker compose exec cn-arcadedb）。root password は 8 文字以上。
+# ArcadeDB は rebuildable projection であり canonical store ではない（真実源は Postgres）。
+CN_ARCADEDB_IMAGE=arcadedata/arcadedb:26.8.1
+CN_ARCADEDB_ROOT_PASSWORD=dev-arcadedb-password
+CN_ARCADEDB_DATABASE=kukuri_index
+CN_ARCADEDB_USER=root
+
 COMMUNITY_NODE_JWT_ISSUER=kukuri-cn
 COMMUNITY_NODE_JWT_SECRET=dev-jwt-change-me-32-bytes-minimum
 COMMUNITY_NODE_JWT_TTL_SECONDS=86400
@@ -32,28 +40,33 @@ COMMUNITY_NODE_CONNECTIVITY_URLS=http://127.0.0.1:13340
 # COMMUNITY_NODE_OPERATOR_CONFIG=/etc/kukuri/operator-config.yaml
 
 # private channel indexing (#413) の channel secret を at-rest 暗号化する鍵 material。
-# 設定すると POST /v1/indexing/requests が private_channel の indexing request（channel secret 提示）を
-# 受け付け、secret を暗号化して保存する。未設定なら private channel の indexing request は 404 で拒否する
-# （secret を平文保存しないため）。32 bytes 以上・placeholder 不可。cn-indexer にも同じ値を渡す。
-# COMMUNITY_NODE_CHANNEL_SECRET_KEY=dev-channel-secret-change-me-32-bytes-minimum
+# cn-user-api と cn-indexer が同じ値を共有する（compose が両方へ渡す）。cn-indexer の起動には必須。
+# 32 bytes 以上・placeholder（change-me 等）不可。本番では必ず独自の乱数値へ差し替えること。
+COMMUNITY_NODE_CHANNEL_SECRET_KEY=dev-only-channel-secret-key-0123456789abcdef
 
-# cn-indexer (#413) の relay validation 起動 gate。
-# 自前 relay（features.iroh_relay 有効な operator-config）または外部 relay URL のどちらかが必要。
+# cn-indexer (#613/#615) の設定。relay validation 起動 gate は自前 relay
+# （この compose は cn-iroh-relay を同梱するため既定 true）または外部 relay URL のどちらかが必要。
 # 両方未設定なら cn-indexer は indexing を起動しない（fail-closed）。
+# COMMUNITY_NODE_INDEXER_OWN_RELAY=true
 # COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS=https://relay.example.net
-# COMMUNITY_NODE_INDEXER_DATA_DIR=/var/lib/kukuri/cn-indexer
-# COMMUNITY_NODE_ARCADEDB_URL=http://127.0.0.1:2480
-# COMMUNITY_NODE_ARCADEDB_DATABASE=kukuri_index
+# COMMUNITY_NODE_INDEXER_SEED_PEERS=
+# COMMUNITY_NODE_INDEXER_POLL_INTERVAL_SECS=300
+# status endpoint（GET /healthz, /statusz）の host bind（loopback のみ）。
+# CN_INDEXER_STATUS_HOST_BIND_IP=127.0.0.1
+# CN_INDEXER_STATUS_PORT=18630
+
+# relation graph の定期 batch 解析（cn-cli relation analyze。#415/#615）の実行間隔。
+# ループは直列実行のため overlap しない。
+# CN_RELATION_ANALYZE_INTERVAL_MINUTES=60
 
 # ユーザー向け index query（#404: GET /v1/index/search|discovery|recommendations）を公開するか。
-# 既定 false（CommunityIndex capability が Planned の間は無効のまま。無効時は 404）。
-# 有効化する場合は cn-user-api にも COMMUNITY_NODE_ARCADEDB_*（cn-indexer と同一値）を渡す。
+# 既定 false（full-stack E2E 完了までは無効のまま維持する。無効時は 404）。
+# ArcadeDB 接続は compose が cn-user-api / cn-indexer の両方へ同一値を配線済み。
 # COMMUNITY_NODE_INDEX_QUERY_ENABLED=false
 
 # trust / relation read surface（#415: GET /v1/trust/*, /v1/relation/*。ADR 0026）を公開するか。
-# 既定 false（CommunityLocalTrust capability が Planned の間は無効のまま。無効時は 404）。
-# 有効化する場合は cn-user-api に COMMUNITY_NODE_ARCADEDB_*（relation graph。cn-indexer と同一値）
-# を渡し、relation graph は `cn-cli relation analyze`（batch・非常駐）で構築する。
+# 既定 false（full-stack E2E 完了までは無効のまま維持する。無効時は 404）。
+# relation graph は cn-relation-analyze service（定期 batch）が構築する。
 # COMMUNITY_NODE_TRUST_READ_ENABLED=false
 # trust 合成の operator 可変パラメータ（ADR 0026 §6.2。未設定は初期決め打ち値）:
 # w_abs（絶対成分マイナス時の重み。既定 2.0）/ w_abs（0 以上時。既定 1.0）/ 相対成分の半減期（日。既定 30）。

--- a/docker-compose.community-node.yml
+++ b/docker-compose.community-node.yml
@@ -41,6 +41,26 @@ services:
       timeout: 5s
       retries: 20
 
+  # index 投影 + relation graph（#615）。rebuildable projection であり canonical store ではない
+  # （真実源は Postgres。ADR 0025 / 0026）。container private network 内のみで listen し、
+  # host / internet へ port を公開しない（デバッグは `docker compose exec cn-arcadedb` を使う）。
+  cn-arcadedb:
+    image: ${CN_ARCADEDB_IMAGE:-arcadedata/arcadedb:26.8.1}
+    restart: unless-stopped
+    environment:
+      JAVA_OPTS: >-
+        -Darcadedb.server.rootPassword=${CN_ARCADEDB_ROOT_PASSWORD:?set CN_ARCADEDB_ROOT_PASSWORD}
+        -Darcadedb.server.defaultDatabases=${CN_ARCADEDB_DATABASE:-kukuri_index}[]
+    healthcheck:
+      # image は Alpine ベースで curl が無いため busybox wget を使う。
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:2480/api/v1/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    volumes:
+      - cn-arcadedb-data:/home/arcadedb/databases
+
   cn-migrate:
     build:
       context: .
@@ -83,6 +103,18 @@ services:
       COMMUNITY_NODE_RATE_LIMIT_PER_SECOND: ${COMMUNITY_NODE_RATE_LIMIT_PER_SECOND:-10}
       COMMUNITY_NODE_RATE_LIMIT_BURST: ${COMMUNITY_NODE_RATE_LIMIT_BURST:-30}
       COMMUNITY_NODE_RATE_LIMIT_TRUST_FORWARDED_FOR: ${COMMUNITY_NODE_RATE_LIMIT_TRUST_FORWARDED_FOR:-false}
+      # private channel indexing / index・trust read surface（#615）。flag は full-stack E2E
+      # 完了まで既定 false（無効時は 404）。
+      COMMUNITY_NODE_CHANNEL_SECRET_KEY: ${COMMUNITY_NODE_CHANNEL_SECRET_KEY:-}
+      COMMUNITY_NODE_ARCADEDB_URL: http://cn-arcadedb:2480
+      COMMUNITY_NODE_ARCADEDB_DATABASE: ${CN_ARCADEDB_DATABASE:-kukuri_index}
+      COMMUNITY_NODE_ARCADEDB_USER: ${CN_ARCADEDB_USER:-root}
+      COMMUNITY_NODE_ARCADEDB_PASSWORD: ${CN_ARCADEDB_ROOT_PASSWORD:?set CN_ARCADEDB_ROOT_PASSWORD}
+      COMMUNITY_NODE_INDEX_QUERY_ENABLED: ${COMMUNITY_NODE_INDEX_QUERY_ENABLED:-false}
+      COMMUNITY_NODE_TRUST_READ_ENABLED: ${COMMUNITY_NODE_TRUST_READ_ENABLED:-false}
+      COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE: ${COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE:-}
+      COMMUNITY_NODE_TRUST_W_ABS_POSITIVE: ${COMMUNITY_NODE_TRUST_W_ABS_POSITIVE:-}
+      COMMUNITY_NODE_TRUST_RELATIVE_HALF_LIFE_DAYS: ${COMMUNITY_NODE_TRUST_RELATIVE_HALF_LIFE_DAYS:-}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/healthz"]
@@ -114,5 +146,111 @@ services:
       - "${CN_IROH_RELAY_HTTPS_HOST_BIND_IP:-127.0.0.1}:${CN_IROH_RELAY_HTTPS_PORT:-13443}:3443"
       - "${CN_IROH_RELAY_QUIC_HOST_BIND_IP:-127.0.0.1}:${CN_IROH_RELAY_QUIC_PORT:-17842}:7842/udp"
 
+  # 常駐 indexing ワーカー（#613 / #615）。docs replica sync → safety scan → index 投影。
+  # provider 未構成なら ingest 無効の fail-closed 常駐（scan なしで index に載せない）。
+  # port は status endpoint の loopback bind のみで、iroh 通信は outbound で成立する。
+  cn-indexer:
+    build:
+      context: .
+      dockerfile: docker/cn/Dockerfile
+      args:
+        TARGET_PACKAGE: kukuri-cn-indexer
+        TARGET_BIN: cn-indexer
+    depends_on:
+      cn-migrate:
+        condition: service_completed_successfully
+      cn-arcadedb:
+        condition: service_healthy
+    environment:
+      COMMUNITY_NODE_DATABASE_URL: postgres://${CN_POSTGRES_USER:-cn}:${CN_POSTGRES_PASSWORD:?set CN_POSTGRES_PASSWORD}@cn-postgres:5432/${CN_POSTGRES_DB:-cn}
+      # channel secret の at-rest 暗号鍵（cn-user-api と同じ値。32 bytes 以上・placeholder 不可）。
+      COMMUNITY_NODE_CHANNEL_SECRET_KEY: ${COMMUNITY_NODE_CHANNEL_SECRET_KEY:?set COMMUNITY_NODE_CHANNEL_SECRET_KEY}
+      COMMUNITY_NODE_INDEXER_DATA_DIR: /var/lib/kukuri/cn-indexer
+      # relay validation 起動 gate（ADR 0025 §6.4）。この compose は cn-iroh-relay を同梱する
+      # ため既定 true。relay を外す構成では外部 relay URL を指定する。
+      COMMUNITY_NODE_INDEXER_OWN_RELAY: ${COMMUNITY_NODE_INDEXER_OWN_RELAY:-true}
+      COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS: ${COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS:-}
+      COMMUNITY_NODE_INDEXER_SEED_PEERS: ${COMMUNITY_NODE_INDEXER_SEED_PEERS:-}
+      COMMUNITY_NODE_INDEXER_POLL_INTERVAL_SECS: ${COMMUNITY_NODE_INDEXER_POLL_INTERVAL_SECS:-300}
+      COMMUNITY_NODE_INDEXER_STATUS_ADDR: 0.0.0.0:8630
+      COMMUNITY_NODE_ARCADEDB_URL: http://cn-arcadedb:2480
+      COMMUNITY_NODE_ARCADEDB_DATABASE: ${CN_ARCADEDB_DATABASE:-kukuri_index}
+      COMMUNITY_NODE_ARCADEDB_USER: ${CN_ARCADEDB_USER:-root}
+      COMMUNITY_NODE_ARCADEDB_PASSWORD: ${CN_ARCADEDB_ROOT_PASSWORD:?set CN_ARCADEDB_ROOT_PASSWORD}
+      # safety provider slot（未設定なら ingest 無効の fail-closed 常駐）。
+      COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM: ${COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM:-}
+      COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM_REQUIRED: ${COMMUNITY_NODE_SAFETY_PROVIDER_KNOWN_CSAM_REQUIRED:-false}
+      COMMUNITY_NODE_SAFETY_PROVIDER_GENERAL: ${COMMUNITY_NODE_SAFETY_PROVIDER_GENERAL:-}
+      COMMUNITY_NODE_SAFETY_PROVIDER_GENERAL_REQUIRED: ${COMMUNITY_NODE_SAFETY_PROVIDER_GENERAL_REQUIRED:-false}
+      COMMUNITY_NODE_SAFETY_PROVIDER_UNKNOWN_CSAM: ${COMMUNITY_NODE_SAFETY_PROVIDER_UNKNOWN_CSAM:-}
+      COMMUNITY_NODE_SAFETY_PROVIDER_UNKNOWN_CSAM_REQUIRED: ${COMMUNITY_NODE_SAFETY_PROVIDER_UNKNOWN_CSAM_REQUIRED:-false}
+      COMMUNITY_NODE_SAFETY_SIGNING_KEY: ${COMMUNITY_NODE_SAFETY_SIGNING_KEY:-}
+      COMMUNITY_NODE_SAFETY_EMIT_SIGNED_EVENTS: ${COMMUNITY_NODE_SAFETY_EMIT_SIGNED_EVENTS:-true}
+      COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID: ${COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID:-}
+      COMMUNITY_NODE_SAFETY_SUSPECTED_THRESHOLD: ${COMMUNITY_NODE_SAFETY_SUSPECTED_THRESHOLD:-}
+      COMMUNITY_NODE_SAFETY_SUSPECTED_SIGNAL_VISIBILITY: ${COMMUNITY_NODE_SAFETY_SUSPECTED_SIGNAL_VISIBILITY:-}
+      COMMUNITY_NODE_MEDIA_FETCH_MAX_BYTES: ${COMMUNITY_NODE_MEDIA_FETCH_MAX_BYTES:-}
+      COMMUNITY_NODE_MEDIA_FETCH_TIMEOUT_SECS: ${COMMUNITY_NODE_MEDIA_FETCH_TIMEOUT_SECS:-}
+      # Project Arachnid Shield（known_csam slot 用。operator 自身の credentials）。
+      PROJECT_ARACHNID_API_USERNAME: ${PROJECT_ARACHNID_API_USERNAME:-}
+      PROJECT_ARACHNID_API_PASSWORD: ${PROJECT_ARACHNID_API_PASSWORD:-}
+      PROJECT_ARACHNID_API_BASE_URL: ${PROJECT_ARACHNID_API_BASE_URL:-}
+      PROJECT_ARACHNID_API_TIMEOUT_SECS: ${PROJECT_ARACHNID_API_TIMEOUT_SECS:-}
+      # OpenAI-compatible VLM（general / unknown_csam slot 用）。
+      COMMUNITY_NODE_VLM_API_BASE_URL: ${COMMUNITY_NODE_VLM_API_BASE_URL:-}
+      COMMUNITY_NODE_VLM_MODEL: ${COMMUNITY_NODE_VLM_MODEL:-}
+      COMMUNITY_NODE_VLM_API_KEY: ${COMMUNITY_NODE_VLM_API_KEY:-}
+      COMMUNITY_NODE_VLM_RESPONSE_FORMAT: ${COMMUNITY_NODE_VLM_RESPONSE_FORMAT:-}
+      COMMUNITY_NODE_VLM_API_TIMEOUT_SECS: ${COMMUNITY_NODE_VLM_API_TIMEOUT_SECS:-}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8630/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    ports:
+      - "${CN_INDEXER_STATUS_HOST_BIND_IP:-127.0.0.1}:${CN_INDEXER_STATUS_PORT:-18630}:8630"
+    volumes:
+      - cn-indexer-data:/var/lib/kukuri/cn-indexer
+
+  # relation graph の定期 batch 解析（#415 / #615）。ループは直列実行なので overlap は
+  # 構造的に発生しない。成否は stdout log（[relation-analyze] 行）で観測する。
+  cn-relation-analyze:
+    build:
+      context: .
+      dockerfile: docker/cn/Dockerfile
+      args:
+        TARGET_PACKAGE: kukuri-cn-cli
+        TARGET_BIN: cn-cli
+    depends_on:
+      cn-migrate:
+        condition: service_completed_successfully
+      cn-arcadedb:
+        condition: service_healthy
+    environment:
+      COMMUNITY_NODE_DATABASE_URL: postgres://${CN_POSTGRES_USER:-cn}:${CN_POSTGRES_PASSWORD:?set CN_POSTGRES_PASSWORD}@cn-postgres:5432/${CN_POSTGRES_DB:-cn}
+      COMMUNITY_NODE_ARCADEDB_URL: http://cn-arcadedb:2480
+      COMMUNITY_NODE_ARCADEDB_DATABASE: ${CN_ARCADEDB_DATABASE:-kukuri_index}
+      COMMUNITY_NODE_ARCADEDB_USER: ${CN_ARCADEDB_USER:-root}
+      COMMUNITY_NODE_ARCADEDB_PASSWORD: ${CN_ARCADEDB_ROOT_PASSWORD:?set CN_ARCADEDB_ROOT_PASSWORD}
+      CN_RELATION_ANALYZE_INTERVAL_MINUTES: ${CN_RELATION_ANALYZE_INTERVAL_MINUTES:-60}
+    restart: unless-stopped
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -u
+        while true; do
+          echo "[relation-analyze] start $$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          if /usr/local/bin/app relation analyze; then
+            echo "[relation-analyze] success $$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          else
+            echo "[relation-analyze] failure exit=$$? $$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          fi
+          sleep $$(( $${CN_RELATION_ANALYZE_INTERVAL_MINUTES:-60} * 60 ))
+        done
+
 volumes:
   cn-postgres-data:
+  cn-arcadedb-data:
+  cn-indexer-data:


### PR DESCRIPTION
## 概要

#615 の T2/T3。`docker-compose.community-node.yml` で index / moderation stack 一式をローカル起動できるようにする。

## 変更内容

### cn-arcadedb（新規）
- `arcadedata/arcadedb:26.8.1`（stable pin。`latest` は SNAPSHOT を指すため使わない）
- `-Darcadedb.server.defaultDatabases=kukuri_index[]` で空 database を冪等作成（実コンテナで動作確認済み。`ensure_schema` 側は `IF NOT EXISTS` で冪等）
- host へ port を公開しない（container private network 内のみ。issue の境界要件）
- image は Alpine ベースで curl が無いため busybox wget で healthcheck（実コンテナで確認済み）

### cn-indexer（新規）
- production feature 構成（#614 と同じ Dockerfile build）
- `cn-migrate` 完了 + ArcadeDB healthy 後に起動、data dir は named volume
- `COMMUNITY_NODE_INDEXER_STATUS_ADDR` の `/healthz` を healthcheck に使用（host bind は loopback のみ）
- provider slot / Arachnid / VLM / signing key / suspected / media fetch の env passthrough（未設定なら ingest 無効の fail-closed 常駐）

### cn-relation-analyze（新規）
- cn-cli image で `relation analyze` を直列 loop 実行（overlap は構造的に発生しない）
- `CN_RELATION_ANALYZE_INTERVAL_MINUTES`（既定 60）で間隔変更可、成否を stdout log で観測

### cn-user-api
- ArcadeDB 接続・channel secret key・`COMMUNITY_NODE_INDEX_QUERY_ENABLED` / `COMMUNITY_NODE_TRUST_READ_ENABLED`（既定 false 維持）・trust params を配線

## 検証

- `docker compose -f docker-compose.community-node.yml --env-file .env.community-node.example config` green
- ArcadeDB 26.8.1 実コンテナで ready endpoint / database 自動作成 / wget healthcheck を確認
- full-stack 起動 smoke は T8（最終 PR）で通しで実施

Refs #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)