### PR TITLE
ArcadeDB CREATE PROPERTYのIF NOT EXISTS位置を文法どおり修正する

### DIFF
--- a/crates/cn-indexer/src/arcadedb.rs
+++ b/crates/cn-indexer/src/arcadedb.rs
@@ -106,18 +106,20 @@ impl ArcadeDbProjection {
             &format!("CREATE DOCUMENT TYPE {ENTRY_TYPE} IF NOT EXISTS"),
         )
         .await?;
-        for property in [
-            "scope_kind STRING",
-            "scope_id STRING",
-            "object_id STRING",
-            "author_pubkey STRING",
-            "text STRING",
-            "created_at LONG",
-            "source_replica_id STRING",
+        // `IF NOT EXISTS` は property 名の直後・データ型の前に置く（ArcadeDB SQL 文法。
+        // 型の後ろに置くと 26.x で CommandSQLParsingException になる）。
+        for (name, data_type) in [
+            ("scope_kind", "STRING"),
+            ("scope_id", "STRING"),
+            ("object_id", "STRING"),
+            ("author_pubkey", "STRING"),
+            ("text", "STRING"),
+            ("created_at", "LONG"),
+            ("source_replica_id", "STRING"),
         ] {
             self.command(
                 "sql",
-                &format!("CREATE PROPERTY {ENTRY_TYPE}.{property} IF NOT EXISTS"),
+                &format!("CREATE PROPERTY {ENTRY_TYPE}.{name} IF NOT EXISTS {data_type}"),
             )
             .await?;
         }

--- a/crates/cn-indexer/src/relation_graph.rs
+++ b/crates/cn-indexer/src/relation_graph.rs
@@ -51,11 +51,13 @@ impl ArcadeDbRelationGraph {
                 &format!("CREATE VERTEX TYPE {USER_TYPE} IF NOT EXISTS"),
             )
             .await?;
-        for property in ["pubkey STRING", "cluster STRING"] {
+        // `IF NOT EXISTS` は property 名の直後・データ型の前に置く（ArcadeDB SQL 文法。
+        // 型の後ろに置くと 26.x で CommandSQLParsingException になる）。
+        for (name, data_type) in [("pubkey", "STRING"), ("cluster", "STRING")] {
             self.client
                 .command(
                     "sql",
-                    &format!("CREATE PROPERTY {USER_TYPE}.{property} IF NOT EXISTS"),
+                    &format!("CREATE PROPERTY {USER_TYPE}.{name} IF NOT EXISTS {data_type}"),
                 )
                 .await?;
         }
@@ -74,7 +76,7 @@ impl ArcadeDbRelationGraph {
         self.client
             .command(
                 "sql",
-                &format!("CREATE PROPERTY {EDGE_TYPE}.features_json STRING IF NOT EXISTS"),
+                &format!("CREATE PROPERTY {EDGE_TYPE}.features_json IF NOT EXISTS STRING"),
             )
             .await?;
         Ok(())


### PR DESCRIPTION
## 概要

#615 のローカル full-stack smoke で発見した不具合の修正。ArcadeDB 26.x では
`CREATE PROPERTY <type>.<name> <datatype> IF NOT EXISTS` が `CommandSQLParsingException`
になる（`IF NOT EXISTS` は property 名の直後・データ型の前が正しい文法）。

このため実 ArcadeDB（26.8.1）に対して以下がすべて失敗していた:
- cn-indexer の index 投影 `ensure_schema`（fail-closed 起動 gate で起動失敗）
- relation graph の `ensure_schema` / `cn-cli relation analyze`

## 再現 → 修正

ガードレールに従い、gated live テストで先に失敗を再現:

```
KUKURI_CN_RUN_ARCADEDB_TESTS=1 cargo test -p kukuri-cn-indexer --test relation_contracts
# → CommandSQLParsingException で FAILED（arcadedata/arcadedb:26.8.1）
```

修正後、live テスト green:
- `relation_contracts`（3 passed）
- `runtime_integration`（KUKURI_CN_RUN_INTEGRATION_TESTS=1 + ArcadeDB。`worker_writes_and_deindexes_real_arcadedb_projection` 含む 3 passed）
- 通常テスト / clippy green

Refs #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)