### PR TITLE
xtaskのcn compose envへ#615で必須化した変数を追加しCIのcompose起動を直す

### DIFF
--- a/xtask/src/cn.rs
+++ b/xtask/src/cn.rs
@@ -25,12 +25,20 @@ pub(crate) fn cn_test() -> Result<()> {
     })
 }
 
-pub(crate) fn cn_compose_envs() -> [(&'static str, &'static str); 2] {
+pub(crate) fn cn_compose_envs() -> [(&'static str, &'static str); 4] {
     [
         ("CN_POSTGRES_PASSWORD", "cn_password"),
         (
             "COMMUNITY_NODE_JWT_SECRET",
             "xtask-test-secret-0123456789abcdef",
+        ),
+        // #615 で compose に加わった必須 interpolation（cn-arcadedb / cn-indexer 系）。
+        // 起動するのは cn-postgres / cn-valkey だけでも、compose は file 全体を
+        // interpolate するため未設定だと `up` 自体が失敗する。
+        ("CN_ARCADEDB_ROOT_PASSWORD", "cn_arcadedb_password"),
+        (
+            "COMMUNITY_NODE_CHANNEL_SECRET_KEY",
+            "xtask-channel-secret-key-0123456789abcdef",
         ),
     ]
 }


### PR DESCRIPTION
## 概要

#625（#615 T2/T3）で `docker-compose.community-node.yml` に必須 interpolation
（`CN_ARCADEDB_ROOT_PASSWORD` / `COMMUNITY_NODE_CHANNEL_SECRET_KEY`）が加わったが、
docker compose は起動 service の選択に関わらず file 全体を interpolate するため、
xtask の `with_cn_postgres`（cn-postgres / cn-valkey のみ起動）が
`required variable CN_ARCADEDB_ROOT_PASSWORD is missing a value` で失敗するようになった。
linux-cn / linux-community-node job が該当（#627 の CI で顕在化した main の regression）。

## 修正

`cn_compose_envs()` に 2 変数のダミー値を追加（既存の `CN_POSTGRES_PASSWORD` /
`COMMUNITY_NODE_JWT_SECRET` と同じ流儀）。

## 検証

- env なし `docker compose config` → 従来どおり interpolation error（CI の再現）
- 4 変数付き → OK
- `cargo build -p xtask` green

Refs #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)