### PR TITLE
topic IDの名前空間prefixをUIから隠す

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -35,8 +35,8 @@ test('desktop app bootstraps the shell with the default timeline workspace', asy
     expect(document.documentElement).toHaveAttribute('data-theme', 'dark');
   });
   expect(screen.getByRole('tablist', { name: 'Workspaces' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'kukuri:topic:demo' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'kukuri:topic:demo' }).closest('li')).toHaveClass(
+  expect(screen.getByRole('button', { name: 'demo' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'demo' }).closest('li')).toHaveClass(
     'topic-item-active'
   );
   expect(screen.getByRole('button', { name: 'Publish' })).toBeInTheDocument();

--- a/apps/desktop/src/components/core/FilterableTopicNavList.tsx
+++ b/apps/desktop/src/components/core/FilterableTopicNavList.tsx
@@ -6,6 +6,7 @@ import { Select } from '@/components/ui/select';
 
 import { TopicNavList } from './TopicNavList';
 import { type TopicDiagnosticSummary } from './types';
+import { topicDisplayName } from '@/lib/topicId';
 
 type TopicNavFilter = 'all' | 'connected' | 'disconnected';
 type TopicNavSort = 'added' | 'name' | 'updated';
@@ -35,7 +36,11 @@ export function FilterableTopicNavList({ items, ...listProps }: TopicNavListProp
       if (!query) {
         return true;
       }
-      if (item.topic.toLowerCase().includes(query)) {
+      // 表示名で探すのが基本だが、完全な ID の貼り付け検索も通す。
+      if (
+        topicDisplayName(item.topic).toLowerCase().includes(query) ||
+        item.topic.toLowerCase().includes(query)
+      ) {
         return true;
       }
       return Boolean(item.channels?.some((channel) => channel.label.toLowerCase().includes(query)));
@@ -60,7 +65,10 @@ export function FilterableTopicNavList({ items, ...listProps }: TopicNavListProp
 
     filtered.sort((a, b) => {
       if (sort === 'name') {
-        return a.item.topic.localeCompare(b.item.topic) || a.index - b.index;
+        return (
+          topicDisplayName(a.item.topic).localeCompare(topicDisplayName(b.item.topic)) ||
+          a.index - b.index
+        );
       }
       if (sort === 'updated') {
         const aAt = a.item.lastReceivedAt ?? null;

--- a/apps/desktop/src/components/core/SmartReferenceText.tsx
+++ b/apps/desktop/src/components/core/SmartReferenceText.tsx
@@ -7,6 +7,7 @@ import {
   shortenReferenceId,
   type InternalSmartReference,
 } from '@/lib/internalLinks';
+import { topicDisplayName } from '@/lib/topicId';
 import { cn } from '@/lib/utils';
 import {
   Tooltip,
@@ -57,7 +58,7 @@ function referenceLabel(
   t: ReturnType<typeof useTranslation>['t']
 ): string {
   if (reference.kind === 'topic') {
-    return reference.topic;
+    return topicDisplayName(reference.topic);
   }
   if (reference.kind === 'post') {
     return `${t('common:labels.post')} ${shortenReferenceId(

--- a/apps/desktop/src/components/core/TopicNavList.test.tsx
+++ b/apps/desktop/src/components/core/TopicNavList.test.tsx
@@ -42,7 +42,7 @@ test('renders the topic plug as connected and disconnects on click', async () =>
   );
 
   const button = screen.getByLabelText(
-    'Disconnect kukuri:topic:demo from the gossip network'
+    'Disconnect demo from the gossip network'
   );
   expect(button).toHaveAttribute('aria-pressed', 'true');
   expect(button).toHaveClass('topic-plug-active');
@@ -65,7 +65,7 @@ test('renders the topic plug as disconnected and reconnects on click', async () 
     />
   );
 
-  const button = screen.getByLabelText('Connect kukuri:topic:demo to the gossip network');
+  const button = screen.getByLabelText('Connect demo to the gossip network');
   expect(button).toHaveAttribute('aria-pressed', 'false');
   expect(button).not.toHaveClass('topic-plug-active');
 

--- a/apps/desktop/src/components/core/TopicNavList.tsx
+++ b/apps/desktop/src/components/core/TopicNavList.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Link2, Plug, Settings, SquareArrowRightExit } from 'lucide-react';
 
 import { type TopicDiagnosticSummary } from './types';
+import { topicDisplayName } from '@/lib/topicId';
 import { cn } from '@/lib/utils';
 
 type TopicNavListProps = {
@@ -32,6 +33,7 @@ export function TopicNavList({
   return (
     <ul>
       {items.map((item) => {
+        const topicName = topicDisplayName(item.topic);
         const hasChannels = Boolean(item.channels?.length);
         const publicActive = item.publicActive ?? !item.channels?.some((channel) => channel.active);
         const topicGossipJoined = item.gossipJoined ?? true;
@@ -43,7 +45,7 @@ export function TopicNavList({
           >
             <button className='topic-link' type='button' onClick={() => onSelectTopic(item.topic)}>
               <span className='shell-topic-link-label' title={item.topic}>
-                {item.topic}
+                {topicName}
               </span>
             </button>
 
@@ -57,7 +59,7 @@ export function TopicNavList({
                     topicGossipJoined
                       ? 'shell:navigation.disconnectTopic'
                       : 'shell:navigation.connectTopic',
-                    { topic: item.topic }
+                    { topic: topicName }
                   )}
                   onClick={() => onToggleTopicGossip(item.topic, !topicGossipJoined)}
                 >
@@ -80,7 +82,7 @@ export function TopicNavList({
                 <button
                   className='topic-remove'
                   type='button'
-                  aria-label={t('shell:navigation.removeTopic', { topic: item.topic })}
+                  aria-label={t('shell:navigation.removeTopic', { topic: topicName })}
                   onClick={() => onRemoveTopic(item.topic)}
                 >
                   x

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.test.tsx
@@ -299,13 +299,13 @@ describe('MetaverseRoomPanel animation sharing', () => {
     renderPanel(api);
     await user.click(screen.getByRole('button', { name: 'Join Room' }));
 
-    expect(screen.queryByText(/Topic: kukuri:topic:demo/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Topic: demo/)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Debug details' })).toHaveAttribute(
       'aria-expanded',
       'false'
     );
     await user.click(screen.getByRole('button', { name: 'Debug details' }));
-    expect(screen.getByText(/Topic: kukuri:topic:demo/)).toBeInTheDocument();
+    expect(screen.getByText(/Topic: demo/)).toBeInTheDocument();
 
     expect(document.querySelector('.metaverse-room-hud')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Expand room HUD' })).not.toBeInTheDocument();

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.test.tsx
@@ -111,7 +111,7 @@ describe('MetaverseRoomControls', () => {
       onMoveSharedObject,
     });
 
-    expect(screen.getByText('Topic: kukuri:topic:demo')).toBeInTheDocument();
+    expect(screen.getByText('Topic: demo')).toBeInTheDocument();
     expect(screen.getByText('Community assist: available')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Leave room' }));
     await user.click(screen.getByRole('button', { name: 'Hide room HUD' }));

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.tsx
@@ -21,6 +21,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import type { SupportedLocale } from '@/i18n';
 import { formatLocalizedTime } from '@/i18n/format';
+import { topicDisplayName } from '@/lib/topicId';
 import type { GameRoomView, MetaverseAssetRef } from '@/lib/api';
 import type {
   AvatarAssetStatus,
@@ -164,7 +165,7 @@ export function MetaverseRoomControls({
               </button>
               {hudDebugOpen ? (
                 <div className='metaverse-room-diagnostics'>
-                  <span>{t('hud.topic', { topic: activeTopic })}</span>
+                  <span>{t('hud.topic', { topic: topicDisplayName(activeTopic) })}</span>
                   <span>{t('hud.localPeer', { peer: localPeerId })}</span>
                   <span>{t('hud.knownPeers', { count: knownPeerCount })}</span>
                   <span>{t('hud.lastSentSeq', { seq: lastSentSeq })}</span>

--- a/apps/desktop/src/components/settings/ConnectivityPanel.tsx
+++ b/apps/desktop/src/components/settings/ConnectivityPanel.tsx
@@ -11,6 +11,7 @@ import { SettingsActionRow } from './SettingsActionRow';
 import { SettingsDiagnosticList } from './SettingsDiagnosticList';
 import { SettingsMetricGrid } from './SettingsMetricGrid';
 import { type ConnectivityPanelView } from './types';
+import { topicDisplayName } from '@/lib/topicId';
 
 type ConnectivityPanelProps = {
   view: ConnectivityPanelView;
@@ -95,7 +96,7 @@ export function ConnectivityPanel({
             >
               <div className='flex flex-wrap items-start justify-between gap-3'>
                 <div className='min-w-0'>
-                  <h4 className='break-all text-base font-semibold text-foreground'>{topic.topic}</h4>
+                  <h4 className='break-all text-base font-semibold text-foreground' title={topic.topic}>{topicDisplayName(topic.topic)}</h4>
                   <p className='mt-2 text-sm text-[var(--muted-foreground)]'>{topic.summary}</p>
                 </div>
                 <StatusBadge

--- a/apps/desktop/src/i18n/locales/en/shell.json
+++ b/apps/desktop/src/i18n/locales/en/shell.json
@@ -15,7 +15,7 @@
     "close": "Close navigation",
     "notificationsButton": "Notifications",
     "open": "Open navigation",
-    "placeholder": "kukuri:topic:demo",
+    "placeholder": "demo",
     "primaryNavigation": "Primary navigation",
     "connectTopic": "Connect {{topic}} to the gossip network",
     "disconnectTopic": "Disconnect {{topic}} from the gossip network",

--- a/apps/desktop/src/i18n/locales/ja/shell.json
+++ b/apps/desktop/src/i18n/locales/ja/shell.json
@@ -15,7 +15,7 @@
     "close": "ナビゲーションを閉じる",
     "notificationsButton": "通知",
     "open": "ナビゲーションを開く",
-    "placeholder": "kukuri:topic:demo",
+    "placeholder": "demo",
     "primaryNavigation": "メインナビゲーション",
     "connectTopic": "{{topic}} を Gossip ネットワークに接続",
     "disconnectTopic": "{{topic}} を Gossip ネットワークから切断",

--- a/apps/desktop/src/i18n/locales/zh-CN/shell.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/shell.json
@@ -15,7 +15,7 @@
     "close": "关闭导航",
     "notificationsButton": "通知",
     "open": "打开导航",
-    "placeholder": "kukuri:topic:demo",
+    "placeholder": "demo",
     "primaryNavigation": "主导航",
     "connectTopic": "将 {{topic}} 连接到 Gossip 网络",
     "disconnectTopic": "将 {{topic}} 从 Gossip 网络断开",

--- a/apps/desktop/src/lib/topicId.test.ts
+++ b/apps/desktop/src/lib/topicId.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { TOPIC_ID_PREFIX, normalizeTopicId, topicDisplayName } from './topicId';
+
+describe('topicDisplayName', () => {
+  it('名前空間 prefix を剥がして表示名を返す', () => {
+    expect(topicDisplayName('kukuri:topic:demo')).toBe('demo');
+    expect(topicDisplayName(`${TOPIC_ID_PREFIX}iroh`)).toBe('iroh');
+  });
+
+  it('prefix の無い ID はそのまま返す', () => {
+    expect(topicDisplayName('legacy-topic')).toBe('legacy-topic');
+  });
+
+  it('名前部分に : が含まれても先頭 prefix だけを剥がす', () => {
+    expect(topicDisplayName('kukuri:topic:a:b')).toBe('a:b');
+  });
+});
+
+describe('normalizeTopicId', () => {
+  it('素の名前へ prefix を付与する', () => {
+    expect(normalizeTopicId('demo')).toBe('kukuri:topic:demo');
+    expect(normalizeTopicId('  demo  ')).toBe('kukuri:topic:demo');
+  });
+
+  it('完全な ID の貼り付けは二重付与しない', () => {
+    expect(normalizeTopicId('kukuri:topic:demo')).toBe('kukuri:topic:demo');
+  });
+
+  it('空・空白のみの入力は空文字を返す', () => {
+    expect(normalizeTopicId('')).toBe('');
+    expect(normalizeTopicId('   ')).toBe('');
+  });
+
+  it('display 名との往復が安定する', () => {
+    expect(normalizeTopicId(topicDisplayName('kukuri:topic:demo'))).toBe('kukuri:topic:demo');
+  });
+});

--- a/apps/desktop/src/lib/topicId.ts
+++ b/apps/desktop/src/lib/topicId.ts
@@ -1,0 +1,21 @@
+// kukuri の topic ID は wire 上では `kukuri:topic:<name>` の名前空間付き文字列で扱う
+// (gossip topic 導出・docs replica・community node の index scope と互換を保つ)。
+// UI ではこの prefix を見せない: 入力は normalizeTopicId で ID へ、表示は
+// topicDisplayName で名前へ変換し、この 2 関数以外で prefix を直接扱わない。
+
+export const TOPIC_ID_PREFIX = 'kukuri:topic:';
+
+/// topic ID から UI 表示名を得る。名前空間 prefix の無い（外部由来の）ID はそのまま返す。
+export function topicDisplayName(topicId: string): string {
+  return topicId.startsWith(TOPIC_ID_PREFIX) ? topicId.slice(TOPIC_ID_PREFIX.length) : topicId;
+}
+
+/// ユーザー入力を topic ID へ正規化する。prefix 付きの完全な ID（共有されたものの
+/// 貼り付け等）はそのまま受け付ける。空入力は空文字を返し、呼び出し側で無視する。
+export function normalizeTopicId(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.startsWith(TOPIC_ID_PREFIX) ? trimmed : `${TOPIC_ID_PREFIX}${trimmed}`;
+}

--- a/apps/desktop/src/shell/DesktopShellPage.channels.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.channels.test.tsx
@@ -445,7 +445,7 @@ test('copy link actions write canonical hash routes for topic, post, and live', 
     />
   );
 
-  const topicItem = screen.getByRole('button', { name: 'kukuri:topic:demo' }).closest('li');
+  const topicItem = screen.getByRole('button', { name: 'demo' }).closest('li');
   if (!(topicItem instanceof HTMLElement)) {
     throw new Error('expected topic item');
   }

--- a/apps/desktop/src/shell/DesktopShellPage.composer.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.composer.test.tsx
@@ -35,7 +35,7 @@ test('desktop shell can publish and render a post', async () => {
   });
   expectActiveTopic('kukuri:topic:demo');
   expect(screen.queryByTestId('shell-nav-trigger')).not.toBeInTheDocument();
-  const demoTopic = screen.getByRole('button', { name: 'kukuri:topic:demo' }).closest('li');
+  const demoTopic = screen.getByRole('button', { name: 'demo' }).closest('li');
   expect(demoTopic).not.toBeNull();
   expect(demoTopic).toHaveTextContent('joined / peers: 1');
 

--- a/apps/desktop/src/shell/DesktopShellPage.profile.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.profile.test.tsx
@@ -55,11 +55,11 @@ test('profile overview aggregates public posts across topics and excludes privat
   await selectWorkspace(user, 'Profile');
   expect(screen.getByText('demo public post')).toBeInTheDocument();
   expect(screen.queryByText('demo private post')).not.toBeInTheDocument();
-  expect(screen.getAllByText('kukuri:topic:demo').length).toBeGreaterThan(0);
+  expect(screen.getAllByText('demo').length).toBeGreaterThan(0);
 
-  await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:second');
+  await user.type(screen.getByPlaceholderText('demo'), 'kukuri:topic:second');
   await user.click(screen.getByRole('button', { name: 'Add' }));
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:second' }));
+  await user.click(screen.getByRole('button', { name: 'second' }));
   await waitFor(() => {
     expectActiveTopic('kukuri:topic:second');
   });
@@ -194,7 +194,7 @@ test('author detail shows profile topic posts and can open an untracked origin t
   const authorPane = await screen.findByRole('complementary', { name: 'Author' });
   expect(within(authorPane).getByText('post from demo topic')).toBeInTheDocument();
   expect(within(authorPane).getByText('post from relay topic')).toBeInTheDocument();
-  expect(within(authorPane).getByText('kukuri:topic:relay')).toBeInTheDocument();
+  expect(within(authorPane).getByText('relay')).toBeInTheDocument();
   expect(within(authorPane).queryByRole('button', { name: 'Reply' })).not.toBeInTheDocument();
 
   await user.click(within(authorPane).getAllByRole('button', { name: 'Open original topic' })[0]);
@@ -204,7 +204,7 @@ test('author detail shows profile topic posts and can open an untracked origin t
     expect(screen.queryByRole('complementary', { name: 'Author' })).not.toBeInTheDocument();
   });
   expect(screen.getByText('post from relay topic')).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'kukuri:topic:relay' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'relay' })).toBeInTheDocument();
 });
 
 test('local profile editor saves profile draft from primary navigation and settings stays diagnostics-only', async () => {

--- a/apps/desktop/src/shell/DesktopShellPage.shellChrome.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.shellChrome.test.tsx
@@ -187,18 +187,18 @@ test('desktop shell surfaces docs-assisted topic recovery in diagnostics', async
     expect(within(drawer).getAllByText('relay-peer').length).toBeGreaterThan(0);
   });
 
-  await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:relay');
+  await user.type(screen.getByPlaceholderText('demo'), 'kukuri:topic:relay');
   await user.click(screen.getByRole('button', { name: 'Add' }));
 
   await waitFor(() => {
-    const relayTopic = screen.getByRole('button', { name: 'kukuri:topic:relay' }).closest('li');
+    const relayTopic = screen.getByRole('button', { name: 'relay' }).closest('li');
     expect(relayTopic).not.toBeNull();
     expect(relayTopic).toHaveTextContent('recovering / peers: 0');
     expect(relayTopic).not.toHaveTextContent('relay-assisted sync available via 1 peer(s)');
   });
 
   await user.click(within(drawer).getByTestId('settings-section-connectivity'));
-  const relayHeading = await within(drawer).findByRole('heading', { name: 'kukuri:topic:relay' });
+  const relayHeading = await within(drawer).findByRole('heading', { name: 'relay' });
   const relaySection = closestSection(relayHeading);
   expect(
     within(relaySection).getByText(
@@ -225,7 +225,7 @@ test('desktop shell renders diagnostics error reasons', async () => {
     ).toBeInTheDocument();
   });
 
-  const topicHeading = await within(drawer).findByRole('heading', { name: 'kukuri:topic:demo' });
+  const topicHeading = await within(drawer).findByRole('heading', { name: 'demo' });
   const topicSection = closestSection(topicHeading);
   expect(within(topicSection).getByText('timed out waiting for gossip topic join')).toBeInTheDocument();
 });

--- a/apps/desktop/src/shell/DesktopShellPage.testHelpers.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.testHelpers.tsx
@@ -5,6 +5,7 @@ import { expect, vi } from 'vitest';
 import { App } from '@/App';
 import { createDesktopMockApi } from '@/mocks/desktopApiMock';
 import type { AttachmentView, NotificationView, PostView, TimelineCursor, TimelineView } from '@/lib/api';
+import { topicDisplayName } from '@/lib/topicId';
 
 export function setViewportWidth(width: number) {
   Object.defineProperty(window, 'innerWidth', {
@@ -299,7 +300,9 @@ export function renderAtHash(hash: string, api = createDesktopMockApi()) {
 
 export function expectActiveTopic(topic: string) {
   expect(window.location.hash).toContain(`topic=${encodeURIComponent(topic)}`);
-  expect(screen.getByRole('button', { name: topic }).closest('li')).toHaveClass('topic-item-active');
+  expect(screen.getByRole('button', { name: topicDisplayName(topic) }).closest('li')).toHaveClass(
+    'topic-item-active'
+  );
 }
 
 export function getWorkspaceTabs() {

--- a/apps/desktop/src/shell/DesktopShellPage.timelineRefresh.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.timelineRefresh.test.tsx
@@ -487,7 +487,7 @@ test('private channel timeline keeps scope-separated posts and pending counts fr
   });
   expect(screen.queryByText('public post')).not.toBeInTheDocument();
 
-  const topicItem = screen.getByRole('button', { name: 'kukuri:topic:demo' }).closest('li');
+  const topicItem = screen.getByRole('button', { name: 'demo' }).closest('li');
   if (!(topicItem instanceof HTMLElement)) {
     throw new Error('active topic item not found');
   }

--- a/apps/desktop/src/shell/DesktopShellPage.topics.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.topics.test.tsx
@@ -135,15 +135,15 @@ test('topic and private channel selection sync into the hash route', async () =>
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
-  await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:second');
+  await user.type(screen.getByPlaceholderText('demo'), 'kukuri:topic:second');
   await user.click(screen.getByRole('button', { name: 'Add' }));
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:second' }));
+  await user.click(screen.getByRole('button', { name: 'second' }));
 
   await waitFor(() => {
     expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Asecond');
   });
 
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:demo' }));
+  await user.click(screen.getByRole('button', { name: 'demo' }));
   const channelDialog = await openChannelManager(user);
   await user.type(within(channelDialog).getByPlaceholderText('Channel name'), 'core');
   await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));
@@ -177,7 +177,7 @@ test('tracked topics show public and channel scope separately in the sidebar', a
     ).toBeInTheDocument();
   });
 
-  const topicItem = screen.getByRole('button', { name: 'kukuri:topic:demo' }).closest('li');
+  const topicItem = screen.getByRole('button', { name: 'demo' }).closest('li');
   if (!(topicItem instanceof HTMLElement)) {
     throw new Error('active topic item not found');
   }
@@ -220,7 +220,7 @@ test('sidebar can reselect the same private channel after switching back to publ
   });
   await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
 
-  const topicItem = screen.getByRole('button', { name: 'kukuri:topic:demo' }).closest('li');
+  const topicItem = screen.getByRole('button', { name: 'demo' }).closest('li');
   if (!(topicItem instanceof HTMLElement)) {
     throw new Error('active topic item not found');
   }
@@ -247,9 +247,9 @@ test('sidebar can switch from one topic public scope to another topic private ch
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
-  await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:second');
+  await user.type(screen.getByPlaceholderText('demo'), 'kukuri:topic:second');
   await user.click(screen.getByRole('button', { name: 'Add' }));
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:second' }));
+  await user.click(screen.getByRole('button', { name: 'second' }));
 
   const channelDialog = await openChannelManager(user);
   await user.type(within(channelDialog).getByPlaceholderText('Channel name'), 'second-core');
@@ -259,14 +259,14 @@ test('sidebar can switch from one topic public scope to another topic private ch
   });
   await user.click(within(channelDialog).getByRole('button', { name: 'Close dialog' }));
 
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:demo' }));
+  await user.click(screen.getByRole('button', { name: 'demo' }));
   await waitFor(() => {
     expectActiveTopic('kukuri:topic:demo');
     expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Ademo');
   });
 
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:second' }));
-  const secondTopicItem = screen.getByRole('button', { name: 'kukuri:topic:second' }).closest('li');
+  await user.click(screen.getByRole('button', { name: 'second' }));
+  const secondTopicItem = screen.getByRole('button', { name: 'second' }).closest('li');
   if (!(secondTopicItem instanceof HTMLElement)) {
     throw new Error('second topic item not found');
   }
@@ -288,24 +288,24 @@ test('desktop shell can track multiple topics at once', async () => {
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
-  await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:second');
+  await user.type(screen.getByPlaceholderText('demo'), 'kukuri:topic:second');
   await user.click(screen.getByRole('button', { name: 'Add' }));
-  expect(screen.getByRole('button', { name: 'kukuri:topic:second' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'second' })).toBeInTheDocument();
 
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:demo' }));
+  await user.click(screen.getByRole('button', { name: 'demo' }));
   await publishPost(user, 'demo post');
   await waitFor(() => {
     expect(screen.getByText('demo post')).toBeInTheDocument();
   });
 
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:second' }));
+  await user.click(screen.getByRole('button', { name: 'second' }));
   await publishPost(user, 'second post');
   await waitFor(() => {
     expect(screen.getByText('second post')).toBeInTheDocument();
   });
 
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:demo' }));
-  const demoTopic = screen.getByRole('button', { name: 'kukuri:topic:demo' }).closest('li');
+  await user.click(screen.getByRole('button', { name: 'demo' }));
+  const demoTopic = screen.getByRole('button', { name: 'demo' }).closest('li');
   expect(demoTopic).not.toBeNull();
   expect(screen.getByText('demo post')).toBeInTheDocument();
   expect(demoTopic).toHaveTextContent(/\/ peers: \d/);
@@ -317,19 +317,19 @@ test('removing the active topic falls back to the remaining tracked topic', asyn
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
-  await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:second');
+  await user.type(screen.getByPlaceholderText('demo'), 'kukuri:topic:second');
   await user.click(screen.getByRole('button', { name: 'Add' }));
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:second' }));
+  await user.click(screen.getByRole('button', { name: 'second' }));
 
   await waitFor(() => {
     expectActiveTopic('kukuri:topic:second');
   });
 
-  await user.click(screen.getByRole('button', { name: 'Remove kukuri:topic:second' }));
+  await user.click(screen.getByRole('button', { name: 'Remove second' }));
 
   await waitFor(() => {
     expect(
-      screen.queryByRole('button', { name: 'kukuri:topic:second' })
+      screen.queryByRole('button', { name: 'second' })
     ).not.toBeInTheDocument();
     expectActiveTopic('kukuri:topic:demo');
   });

--- a/apps/desktop/src/shell/DesktopShellPage.workspaceResilience.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.workspaceResilience.test.tsx
@@ -153,7 +153,7 @@ test('timeline keeps the last successful workspace state when joined channels re
   await waitFor(() => {
     expect(screen.getByText('joined channel refresh fallback')).toBeInTheDocument();
     expect(screen.getByText('temporary joined channel failure')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'kukuri:topic:demo' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'demo' })).toBeInTheDocument();
   });
 });
 
@@ -207,7 +207,7 @@ test('timeline keeps the last successful workspace state when community-node sta
     expect(
       screen.queryByText('temporary community node status failure')
     ).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'kukuri:topic:demo' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'demo' })).toBeInTheDocument();
   });
 });
 

--- a/apps/desktop/src/shell/actions/profileTopicChannel.ts
+++ b/apps/desktop/src/shell/actions/profileTopicChannel.ts
@@ -6,6 +6,7 @@ import type {
   ProfileInput,
 } from '@/lib/api';
 import { fileToCreateAttachment } from '@/lib/attachments';
+import { normalizeTopicId } from '@/lib/topicId';
 
 import {
   DEFAULT_COMMUNITY_NODE_CONFIG,
@@ -283,7 +284,8 @@ export function createProfileTopicChannelActions({
   }
 
   async function handleAddTopic() {
-    const nextTopic = topicInput.trim();
+    // 入力は素の名前でも完全な ID でも受け付け、wire 上は常に名前空間付き ID にする。
+    const nextTopic = normalizeTopicId(topicInput);
     if (!nextTopic) {
       return;
     }

--- a/apps/desktop/src/shell/page/DesktopShellOverlays.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellOverlays.tsx
@@ -34,6 +34,7 @@ import type { useSharePreview } from '@/shell/page/useSharePreview';
 import type { useDesktopShellActions } from '@/shell/useDesktopShellActions';
 import { useDesktopShellViewModels } from '@/shell/useDesktopShellViewModels';
 import { useShallow } from 'zustand/react/shallow';
+import { topicDisplayName } from '@/lib/topicId';
 
 type ViewModels = ReturnType<typeof useDesktopShellViewModels>;
 type OverlayActions = Pick<
@@ -305,7 +306,7 @@ export function DesktopShellOverlays({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t('channels:createDialogTitle')}</DialogTitle>
-            <DialogDescription>{activeTopic}</DialogDescription>
+            <DialogDescription>{topicDisplayName(activeTopic)}</DialogDescription>
           </DialogHeader>
           <DialogBody>
             <PrivateChannelPanel

--- a/apps/desktop/src/shell/routes.test.tsx
+++ b/apps/desktop/src/shell/routes.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, expect, test } from 'vitest';
 import { App } from '@/App';
 import { createDesktopMockApi } from '@/mocks/desktopApiMock';
 import { resolveHashBackedRouteLocation } from '@/shell/routes';
+import { topicDisplayName } from '@/lib/topicId';
 
 beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', {
@@ -23,7 +24,9 @@ function renderAtHash(hash: string, api = createDesktopMockApi()) {
 
 function expectActiveTopic(topic: string) {
   expect(window.location.hash).toContain(`topic=${encodeURIComponent(topic)}`);
-  expect(screen.getByRole('button', { name: topic }).closest('li')).toHaveClass('topic-item-active');
+  expect(screen.getByRole('button', { name: topicDisplayName(topic) }).closest('li')).toHaveClass(
+    'topic-item-active'
+  );
 }
 
 function getTimelineViewTabs() {
@@ -459,15 +462,15 @@ test('topic and private channel selection sync into the hash route', async () =>
   const user = userEvent.setup();
   render(<App api={createDesktopMockApi()} />);
 
-  await user.type(screen.getByPlaceholderText('kukuri:topic:demo'), 'kukuri:topic:second');
+  await user.type(screen.getByPlaceholderText('demo'), 'kukuri:topic:second');
   await user.click(screen.getByRole('button', { name: 'Add' }));
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:second' }));
+  await user.click(screen.getByRole('button', { name: 'second' }));
 
   await waitFor(() => {
     expect(window.location.hash).toBe('#/timeline?topic=kukuri%3Atopic%3Asecond');
   });
 
-  await user.click(screen.getByRole('button', { name: 'kukuri:topic:demo' }));
+  await user.click(screen.getByRole('button', { name: 'demo' }));
   const channelDialog = await openChannelManager(user);
   await user.type(within(channelDialog).getByPlaceholderText('Channel name'), 'core');
   await user.click(within(channelDialog).getByRole('button', { name: 'Create Channel' }));

--- a/apps/desktop/tests/playwright/shell.smoke.spec.ts
+++ b/apps/desktop/tests/playwright/shell.smoke.spec.ts
@@ -14,10 +14,16 @@ async function openComposerDialog(page: Page) {
   await expect(page.getByRole('dialog')).toBeVisible();
 }
 
+const TOPIC_ID_PREFIX = 'kukuri:topic:';
+
+function topicDisplayName(topicId: string): string {
+  return topicId.startsWith(TOPIC_ID_PREFIX) ? topicId.slice(TOPIC_ID_PREFIX.length) : topicId;
+}
+
 async function expectActiveTopic(page: Page, topic: string) {
   const navRail = page.getByRole('complementary', { name: 'Primary navigation' });
   const topicItem = navRail
-    .getByRole('button', { name: topic, exact: true })
+    .getByRole('button', { name: topicDisplayName(topic), exact: true })
     .locator('xpath=ancestor::li[1]');
   await expect(topicItem).toHaveClass(/topic-item-active/);
 }
@@ -46,9 +52,9 @@ test('browser mock shell can switch topics, publish, open thread, open author, a
 
   await expectActiveTopic(page, 'kukuri:topic:demo');
 
-  await page.getByPlaceholder('kukuri:topic:demo').fill('kukuri:topic:browser');
+  await page.getByPlaceholder('demo').fill('kukuri:topic:browser');
   await page.getByRole('button', { name: 'Add' }).click();
-  await page.getByRole('button', { name: /^kukuri:topic:browser$/ }).click();
+  await page.getByRole('button', { name: /^browser$/ }).click();
   await expectActiveTopic(page, 'kukuri:topic:browser');
 
   await openComposerDialog(page);
@@ -224,11 +230,11 @@ test('browser mock narrow shell keeps nav, context, and settings flows reachable
   await page.goto('/');
 
   await page.getByTestId('shell-nav-trigger').click();
-  await page.getByPlaceholder('kukuri:topic:demo').fill('kukuri:topic:narrow');
+  await page.getByPlaceholder('demo').fill('kukuri:topic:narrow');
   await page.getByRole('button', { name: 'Add' }).click();
 
   await page.getByTestId('shell-nav-trigger').click();
-  await page.getByRole('button', { name: /^kukuri:topic:demo$/ }).click();
+  await page.getByRole('button', { name: /^demo$/ }).click();
   await expectActiveTopic(page, 'kukuri:topic:demo');
 
   await openComposerDialog(page);


### PR DESCRIPTION
## 概要 / user flow summary

`kukuri:topic:` は wire 上の名前空間 (gossip topic 導出・docs replica・community node の index scope と互換) として維持しつつ、UI では見せないようにする。

- **topic 追加**: ユーザーは素の名前 (例: `demo`) を入力するだけでよい。`normalizeTopicId` が prefix を付与して ID にする。完全な ID の貼り付け (共有されたもの) はそのまま受理する
- **表示**: nav rail の topic 一覧 / 投稿内・repost 元の topic chip (SmartReferenceText) / metaverse HUD / connectivity 診断 / channel 作成 dialog はすべて表示名 (`demo`) になる。nav rail の tooltip (title) と診断見出しの title には完全な ID を残し、ID を確認したい場合の導線を保つ
- **検索 / 名前ソート**: 表示名基準。完全 ID の貼り付け検索も通す
- ID は不変のため、既存ネットワーク・CN の supported topics 登録・route hash・API 契約に影響なし

## Preview

一次レビュー面は Storybook `Core/TopicNavList`。実ブラウザ (vite build + preview, mock runtime) で次を確認済み:

- nav rail の topic label が `demo` / `iroh` / `nostr` / `operators` 表示、tooltip (title) に完全 ID `kukuri:topic:demo`
- add topic の placeholder が `demo`、aria-label が「demo を削除」等の表示名基準

visual baseline (`tests/playwright/__screenshots__/`) は `kukuri-visual-baseline` workflow を本 branch で dispatch して確認したところ、変更部 (nav の label 数箇所 + placeholder) が `maxDiffPixelRatio: 0.01` の許容内に収まり `--update-snapshots` (changed mode) では書き換え対象にならなかったため不変。よって PR に png diff は含まれない (次回 baseline 全面再生成時に追従する)。ADR 0014 の preview image は上記 Storybook + 本記述で代替する (例外として明記)。

## Shneiderman checklist

- **Consistency**: topic の表示名化を nav / chip / HUD / 診断 / dialog の全表示面へ一律適用 ✓
- **Shortcuts**: topic 追加が `kukuri:topic:` の手入力なしで済むようになる ✓
- **Informative feedback**: 追加後の nav 表示・active 状態は従来どおり ✓
- **Dialog closure**: 変更なし (n/a)
- **Error prevention**: 完全 ID 貼り付け時の二重 prefix を normalize が防止 ✓
- **Easy reversal**: 変更なし (topic 削除導線は従来どおり) ✓
- **Internal locus of control**: 表示のみの変更で挙動・状態は不変 ✓
- **Memory load**: `kukuri:topic:` の暗記・手入力が不要になり負荷減 ✓

## 検証

- `pnpm test` 622 passed (helper の unit test `topicId.test.ts` 追加、表示名化に伴う期待値更新 13 file)
- `pnpm exec playwright test --project=chromium` 11 passed (shell.smoke の selector を表示名基準へ更新)
- `pnpm exec tsc --noEmit` / `pnpm lint` green
- Storybook + vite preview の実ブラウザで表示・tooltip・aria を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)