### PR TITLE
COSの/var noexecでbackup / cert-renew timerが実行できない問題を直す

### DIFF
--- a/.github/workflows/kukuri-terraform.yml
+++ b/.github/workflows/kukuri-terraform.yml
@@ -70,6 +70,16 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
+      # 実運用の tfvars（`cn-operator generate-tfvars` 生成物。secret は ID のみで値を含まない）
+      # を repository variable から復元する。個別 TF_VAR の mirror では実 state と乖離して
+      # plan が prevent_destroy 資源の破棄計画になり失敗するため、tfvars 全体を単一の
+      # 真実源として渡す。更新手順は runbook（community-node-gcp-terraform.md の CI 節）。
+      # terraform.tfvars は TF_VAR_* env より優先されるため、未設定時は従来の env で動く。
+      - name: Materialize terraform.tfvars from repository variable
+        if: ${{ vars.CN_LOW_COST_TFVARS_B64 != '' }}
+        working-directory: infra/terraform/envs/low-cost
+        run: printf '%s' "${{ vars.CN_LOW_COST_TFVARS_B64 }}" | base64 -d > terraform.tfvars
+
       - name: Terraform init (low-cost, GCS backend)
         working-directory: infra/terraform/envs/low-cost
         run: |

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -420,6 +420,19 @@ GitHub repository variables（Settings → Secrets and variables → Actions →
 - `TF_BACKEND_BUCKET`, `TF_BACKEND_PREFIX`
 - 任意: `CN_MANAGE_CLOUD_DNS`, `CN_DNS_ZONE_NAME`
 
+apply 済み環境では、個別変数の代わりに **生成済み terraform.tfvars 全体**を
+`CN_LOW_COST_TFVARS_B64` に載せる（設定されていれば個別 TF_VAR より優先される）。
+個別変数の mirror では実 state と乖離し、plan が `prevent_destroy` 資源（Postgres data PD）の
+破棄計画になって失敗するため。`generate-tfvars` で tfvars を更新したら毎回これも更新する:
+
+```bash
+grep -v '^operator_config_path' infra/terraform/envs/low-cost/terraform.tfvars \
+  | base64 -w0 | gh variable set CN_LOW_COST_TFVARS_B64
+```
+
+`operator_config_path` 行を除くのは、CI checkout には operator-config.yaml（gitignore 済み）が
+存在せず `file()` が失敗するため。tfvars は secret ID のみで secret 値を含まない。
+
 > CI は `plan` まで。`apply` は実行しない。
 
 ## deployment profile と cn-operator capability profile

--- a/infra/terraform/envs/low-cost/.terraform.lock.hcl
+++ b/infra/terraform/envs/low-cost/.terraform.lock.hcl
@@ -7,7 +7,6 @@ provider "registry.terraform.io/hashicorp/google" {
   hashes = [
     "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
     "h1:DNt2+WSTnrNlWVUml87IQb+f/aICd3TKETxWIJAELyA=",
-    "h1:IuhegLJHFR52WoVCAjFdkaxfcmIxplIYlHZbgi0dQ70=",
     "h1:KjRtVlEH6V4YzxuAsCj6AGWMRSDljzLNoBgL79ehDJI=",
     "h1:faTJQOetP9/RYuHwA3r2SWnuYoyzQNm4tUWZrZggcgY=",
     "h1:olAQvz+q7YBzOi5knYOVPG43mpbCPcwYjVKEKu6hRGs=",

--- a/infra/terraform/envs/low-cost/.terraform.lock.hcl
+++ b/infra/terraform/envs/low-cost/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/hashicorp/google" {
   hashes = [
     "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
     "h1:DNt2+WSTnrNlWVUml87IQb+f/aICd3TKETxWIJAELyA=",
+    "h1:IuhegLJHFR52WoVCAjFdkaxfcmIxplIYlHZbgi0dQ70=",
     "h1:KjRtVlEH6V4YzxuAsCj6AGWMRSDljzLNoBgL79ehDJI=",
     "h1:faTJQOetP9/RYuHwA3r2SWnuYoyzQNm4tUWZrZggcgY=",
     "h1:olAQvz+q7YBzOi5knYOVPG43mpbCPcwYjVKEKu6hRGs=",

--- a/infra/terraform/modules/gcp-vm-compose/templates/startup.sh.tftpl
+++ b/infra/terraform/modules/gcp-vm-compose/templates/startup.sh.tftpl
@@ -214,7 +214,8 @@ Description=kukuri community node certificate renewal
 [Service]
 Type=oneshot
 Environment=COMPOSE_BIN=$COMPOSE_BIN
-ExecStart=$INSTALL_DIR/renew-certs.sh
+# COS は /var を noexec で mount するため、script は直接 exec せず bash 経由で実行する
+ExecStart=/bin/bash $INSTALL_DIR/renew-certs.sh
 UNIT
 cat > /etc/systemd/system/kukuri-cert-renew.timer <<UNIT
 [Unit]
@@ -259,7 +260,8 @@ Description=kukuri community node postgres backup
 [Service]
 Type=oneshot
 Environment=COMPOSE_BIN=$COMPOSE_BIN
-ExecStart=$INSTALL_DIR/backup.sh
+# COS は /var を noexec で mount するため、script は直接 exec せず bash 経由で実行する
+ExecStart=/bin/bash $INSTALL_DIR/backup.sh
 UNIT
 cat > /etc/systemd/system/kukuri-backup.timer <<UNIT
 [Unit]


### PR DESCRIPTION
## 概要

#615 デプロイ後の実 VM 確認で、`kukuri-backup.service` が `Permission denied (status=203/EXEC)` で失敗することが判明した。

原因: COS は `/var` を noexec で mount するため、`/var/lib/kukuri/community-node/backup.sh` を systemd の ExecStart で直接 exec できない (`chmod +x` の有無は無関係)。compose binary をわざわざ exec 可能な `/var/lib/toolbox` に置いているのと同じ制約で、script 直呼びの unit だけが漏れていた。

**同じバグが既存の `kukuri-cert-renew.service` にも潜在しており、放置すると約 90 日後の証明書更新が全滅する** (backup と違い外形障害になる)。

## 修正

`startup.sh.tftpl` の 2 unit の ExecStart を `/bin/bash <script>` 経由の実行へ変更 (bash は exec 可能領域にあり、script は読み取りのみ)。relation analyze timer は compose binary 直呼びのため影響なし。

## 検証

- 実 VM で failing 状態を確認済み (#615 デプロイ確認時の journalctl)
- stack 有効値での template render + `bash -n` green (ExecStart 3 行のうち script 直呼びの 2 行のみ bash 経由化)
- 適用は terraform apply (VM 置換。Postgres / indexer data は PD 化済みのため保持)。即時の暫定措置は VM 上で unit file を同等に書き換えて daemon-reload でも可

Refs #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)