### PR TITLE
cn-cli readinessでプロバイダ疎通確認を実行しprovider_credential_validを確定させる（#616 T1）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,10 +2957,14 @@ dependencies = [
  "clap",
  "kukuri-cn-core",
  "kukuri-cn-indexer",
+ "kukuri-cn-operator",
  "kukuri-cn-safety",
+ "kukuri-cn-safety-arachnid",
+ "kukuri-cn-safety-vlm",
  "serde_json",
  "sqlx",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/cn-cli/Cargo.toml
+++ b/crates/cn-cli/Cargo.toml
@@ -20,7 +20,13 @@ sqlx.workspace = true
 tokio.workspace = true
 kukuri-cn-core = { path = "../cn-core" }
 kukuri-cn-indexer = { path = "../cn-indexer" }
+kukuri-cn-operator = { path = "../cn-operator" }
 kukuri-cn-safety = { path = "../cn-safety" }
+kukuri-cn-safety-arachnid = { path = "../cn-safety-arachnid" }
+kukuri-cn-safety-vlm = { path = "../cn-safety-vlm" }
+
+[dev-dependencies]
+wiremock.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cn-cli/src/commands/mod.rs
+++ b/crates/cn-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod admission;
 mod database;
 mod indexing;
 mod moderation;
+mod readiness;
 mod relation;
 mod reports;
 
@@ -38,5 +39,11 @@ pub(crate) async fn dispatch(pool: &PgPool, command: Command) -> Result<()> {
         Command::IndexingRequest { action } => indexing::run_indexing_request(pool, action).await,
         Command::Relation { action } => relation::run(pool, action).await,
         Command::Moderation { action } => moderation::run(pool, action).await,
+        Command::Readiness {
+            config,
+            profile,
+            probe_ttl_secs,
+            force_probe,
+        } => readiness::run(pool, &config, &profile, probe_ttl_secs, force_probe).await,
     }
 }

--- a/crates/cn-cli/src/commands/readiness.rs
+++ b/crates/cn-cli/src/commands/readiness.rs
@@ -1,0 +1,454 @@
+//! 公開ノードの準備完了判定（実行時情報込み。#616）。
+//!
+//! `cn-operator safety readiness` の静的判定に、実際の外部プロバイダへの疎通確認を合成して
+//! `provider_credential_valid` を確定させる。疎通確認は合成データのみを送り、資格情報の値・
+//! 応答本文・Match Data を出力にも保存にも含めない。結果は期限付きで Postgres に保存し、
+//! 期限内の再実行では外部プロバイダを叩かない（外部負荷と発報回数の抑制）。
+
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use chrono::{Duration, Utc};
+use sqlx::PgPool;
+
+use kukuri_cn_core::{
+    ReadinessProbeRecord, initialize_database, list_readiness_probes, upsert_readiness_probe,
+};
+use kukuri_cn_operator::{
+    ReadinessCheck, ReadinessStatus, apply_runtime_checks, evaluate_public_node_readiness,
+    load_and_validate,
+};
+use kukuri_cn_safety_arachnid::{
+    SYNTHETIC_PROBE_PDQ_HASH, ShieldClient, ShieldError, ShieldProviderConfig,
+};
+use kukuri_cn_safety_vlm::{VlmClient, VlmError, VlmProviderConfig, VlmScanInput};
+
+/// 疎通確認で送る無害な合成文（判定結果そのものは使わない）。
+const VLM_PROBE_TEXT: &str = "kukuri readiness probe: benign connectivity check";
+
+/// 疎通確認 1 回の結果。detail に秘匿情報を含めない契約。
+#[derive(Clone, Debug)]
+struct ProbeOutcome {
+    pass: bool,
+    detail: String,
+}
+
+/// Project Arachnid Shield への疎通確認（合成 PDQ hash の送信）。
+///
+/// 認証・接続・応答解釈の成否だけを判定し、分類結果は使わない。エラーは HTTP 状態の
+/// 区分（認証拒否 / 頻度制限 / プロバイダ側エラー / 時間切れ / 接続失敗 / 解釈失敗）へ
+/// 写像し、応答本文を含めない（`ShieldError` 自体が本文を持たない）。
+async fn probe_arachnid(client: &ShieldClient) -> ProbeOutcome {
+    match client
+        .scan_pdq(&[SYNTHETIC_PROBE_PDQ_HASH.to_string()])
+        .await
+    {
+        Ok(_) => ProbeOutcome {
+            pass: true,
+            detail: "認証と応答受信に成功".to_string(),
+        },
+        Err(ShieldError::Unauthorized { status }) => ProbeOutcome {
+            pass: false,
+            detail: format!("認証拒否 (HTTP {status})"),
+        },
+        Err(ShieldError::Http { status: 429 }) => ProbeOutcome {
+            pass: false,
+            detail: "頻度制限 (HTTP 429)".to_string(),
+        },
+        Err(ShieldError::Http { status }) if status >= 500 => ProbeOutcome {
+            pass: false,
+            detail: format!("プロバイダ側エラー (HTTP {status})"),
+        },
+        Err(ShieldError::Http { status }) => ProbeOutcome {
+            pass: false,
+            detail: format!("予期しない応答 (HTTP {status})"),
+        },
+        Err(ShieldError::Timeout) => ProbeOutcome {
+            pass: false,
+            detail: "時間切れ".to_string(),
+        },
+        Err(ShieldError::Network { detail }) => ProbeOutcome {
+            pass: false,
+            detail: format!("接続失敗: {detail}"),
+        },
+        Err(ShieldError::Protocol { .. }) => ProbeOutcome {
+            pass: false,
+            detail: "応答の解釈に失敗".to_string(),
+        },
+    }
+}
+
+/// OpenAI-compatible な視覚言語モデルへの疎通確認（無害な合成文の送信）。
+///
+/// 接続先・モデルへの到達と、設定した応答形式の解析成功までを判定する。
+async fn probe_vlm(client: &VlmClient) -> ProbeOutcome {
+    let input = VlmScanInput {
+        text: Some(VLM_PROBE_TEXT),
+        media: None,
+    };
+    match client.moderate(&input).await {
+        Ok(_) => ProbeOutcome {
+            pass: true,
+            detail: "接続と応答形式の解析に成功".to_string(),
+        },
+        Err(VlmError::Unauthorized { status }) => ProbeOutcome {
+            pass: false,
+            detail: format!("認証拒否 (HTTP {status})"),
+        },
+        Err(VlmError::Http { status: 429 }) => ProbeOutcome {
+            pass: false,
+            detail: "頻度制限 (HTTP 429)".to_string(),
+        },
+        Err(VlmError::Http { status }) if status >= 500 => ProbeOutcome {
+            pass: false,
+            detail: format!("プロバイダ側エラー (HTTP {status})"),
+        },
+        Err(VlmError::Http { status }) => ProbeOutcome {
+            pass: false,
+            detail: format!("予期しない応答 (HTTP {status})"),
+        },
+        Err(VlmError::Timeout) => ProbeOutcome {
+            pass: false,
+            detail: "時間切れ".to_string(),
+        },
+        Err(VlmError::Network { detail }) => ProbeOutcome {
+            pass: false,
+            detail: format!("接続失敗: {detail}"),
+        },
+        Err(VlmError::Protocol { .. }) => ProbeOutcome {
+            pass: false,
+            detail: "応答形式の解析に失敗".to_string(),
+        },
+    }
+}
+
+/// operator-config の providers 節から疎通確認の対象 (slot, 実装名) を集める。
+fn configured_probe_slots(
+    safety: &kukuri_cn_operator::SafetyConfig,
+) -> Vec<(&'static str, String)> {
+    let slots = [
+        ("known_csam", safety.providers.known_csam.as_ref()),
+        ("general", safety.providers.general.as_ref()),
+        ("unknown_csam", safety.providers.unknown_csam.as_ref()),
+    ];
+    slots
+        .into_iter()
+        .filter_map(|(slot, entry)| {
+            let entry = entry?;
+            let normalized = entry.provider.trim().replace('_', "-");
+            if normalized.is_empty() {
+                return None;
+            }
+            Some((slot, normalized))
+        })
+        .collect()
+}
+
+pub(super) async fn run(
+    pool: &PgPool,
+    config_path: &Path,
+    profile: &str,
+    probe_ttl_secs: u64,
+    force_probe: bool,
+) -> Result<()> {
+    initialize_database(pool).await?;
+
+    let yaml = std::fs::read_to_string(config_path)
+        .with_context(|| format!("{} を読み込めません", config_path.display()))?;
+    let resolved = load_and_validate(&yaml)?;
+    let mut report = evaluate_public_node_readiness(&resolved, profile);
+
+    let safety = resolved.raw.safety.clone().unwrap_or_default();
+    let slots = configured_probe_slots(&safety);
+
+    let cached = if force_probe {
+        Vec::new()
+    } else {
+        list_readiness_probes(pool).await?
+    };
+    let now = Utc::now();
+    let ttl = Duration::seconds(i64::try_from(probe_ttl_secs).unwrap_or(i64::MAX));
+
+    // 同一の実装名は接続先も同一のため、疎通確認は実装名ごとに 1 回だけ行い
+    // 該当する全 slot へ結果を写す（視覚言語モデルが general / unknown_csam の両方に
+    // 構成される標準構成で、外部への発報を 1 回に抑える）。
+    let mut fresh_by_provider: std::collections::BTreeMap<String, ProbeOutcome> =
+        std::collections::BTreeMap::new();
+    let mut slot_results: Vec<(String, String, ProbeOutcome)> = Vec::new();
+
+    for (slot, provider) in &slots {
+        // 期限内の保存結果があれば再利用する。
+        if let Some(record) = cached.iter().find(|record| {
+            record.provider_slot == *slot
+                && record.provider == *provider
+                && now - record.checked_at <= ttl
+        }) {
+            slot_results.push((
+                (*slot).to_string(),
+                provider.clone(),
+                ProbeOutcome {
+                    pass: record.pass,
+                    detail: format!(
+                        "{} (前回 {} の結果を再利用)",
+                        record.detail,
+                        record.checked_at.to_rfc3339()
+                    ),
+                },
+            ));
+            continue;
+        }
+
+        let outcome = if let Some(outcome) = fresh_by_provider.get(provider) {
+            outcome.clone()
+        } else {
+            let outcome = match provider.as_str() {
+                "project-arachnid-shield" => {
+                    match ShieldProviderConfig::from_env()
+                        .map_err(anyhow::Error::from)
+                        .and_then(|config| ShieldClient::from_config(&config).map_err(Into::into))
+                    {
+                        Ok(client) => probe_arachnid(&client).await,
+                        // 設定エラーの表示は env の名前のみ（値を含まない契約は provider 側）。
+                        Err(error) => ProbeOutcome {
+                            pass: false,
+                            detail: format!("設定不備: {error}"),
+                        },
+                    }
+                }
+                "openai-compatible-vlm" => {
+                    match VlmProviderConfig::from_env()
+                        .map_err(anyhow::Error::from)
+                        .and_then(|config| VlmClient::from_config(&config).map_err(Into::into))
+                    {
+                        Ok(client) => probe_vlm(&client).await,
+                        Err(error) => ProbeOutcome {
+                            pass: false,
+                            detail: format!("設定不備: {error}"),
+                        },
+                    }
+                }
+                other => ProbeOutcome {
+                    pass: false,
+                    detail: format!("疎通確認の方法が未定義の実装名です: {other}"),
+                },
+            };
+            fresh_by_provider.insert(provider.clone(), outcome.clone());
+            outcome
+        };
+
+        upsert_readiness_probe(
+            pool,
+            &ReadinessProbeRecord {
+                provider_slot: (*slot).to_string(),
+                provider: provider.clone(),
+                pass: outcome.pass,
+                detail: outcome.detail.clone(),
+                checked_at: now,
+            },
+        )
+        .await?;
+        slot_results.push(((*slot).to_string(), provider.clone(), outcome));
+    }
+
+    // provider_credential_valid の合成。対象が無い構成は fail-closed（公開ノードでは
+    // known_csam が必須であり、静的判定側も fail になっているはず）。
+    let credential_check = if slot_results.is_empty() {
+        ReadinessCheck {
+            id: "provider_credential_valid",
+            status: ReadinessStatus::Fail,
+            detail: "疎通確認の対象プロバイダが構成されていません".to_string(),
+        }
+    } else if slot_results.iter().all(|(_, _, outcome)| outcome.pass) {
+        ReadinessCheck {
+            id: "provider_credential_valid",
+            status: ReadinessStatus::Pass,
+            detail: summarize(&slot_results),
+        }
+    } else {
+        ReadinessCheck {
+            id: "provider_credential_valid",
+            status: ReadinessStatus::Fail,
+            detail: summarize(&slot_results),
+        }
+    };
+    apply_runtime_checks(&mut report, vec![credential_check])?;
+
+    println!(
+        "readiness profile={} ready={} fail={} unknown={}",
+        report.profile,
+        report.is_ready(),
+        report.fail_count(),
+        report.unknown_count()
+    );
+    for check in &report.checks {
+        println!("{}  {}  {}", check.status.key(), check.id, check.detail);
+    }
+
+    if report.has_blocking_failures() {
+        bail!(
+            "readiness に不合格の項目があります (fail={})",
+            report.fail_count()
+        );
+    }
+    if report.is_ready() {
+        println!("OK: すべての readiness check を満たしています。");
+    } else {
+        println!(
+            "NOTE: 残り {} 項目は runtime 接続後に確定します。",
+            report.unknown_count()
+        );
+    }
+    Ok(())
+}
+
+fn summarize(results: &[(String, String, ProbeOutcome)]) -> String {
+    results
+        .iter()
+        .map(|(slot, provider, outcome)| {
+            format!(
+                "{slot}={} ({provider}: {})",
+                if outcome.pass { "pass" } else { "fail" },
+                outcome.detail
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kukuri_cn_safety_arachnid::ShieldCredentials;
+    use kukuri_cn_safety_vlm::{VlmCredentials, VlmResponseFormat};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn shield_client(base_url: &str, timeout_secs: u64) -> ShieldClient {
+        let config = ShieldProviderConfig {
+            api_base_url: base_url.to_string(),
+            timeout: std::time::Duration::from_secs(timeout_secs),
+            ..ShieldProviderConfig::default()
+        };
+        ShieldClient::new(&config, ShieldCredentials::new("probe-user", "probe-pass"))
+            .expect("shield client")
+    }
+
+    fn vlm_client(base_url: &str, timeout_secs: u64) -> VlmClient {
+        let config = VlmProviderConfig {
+            api_base_url: base_url.to_string(),
+            api_key_env: "UNUSED_TEST_VLM_KEY".to_string(),
+            model: "test-org/test-guard".to_string(),
+            response_format: VlmResponseFormat::Guard,
+            timeout: std::time::Duration::from_secs(timeout_secs),
+        };
+        VlmClient::new(&config, VlmCredentials::anonymous()).expect("vlm client")
+    }
+
+    #[tokio::test]
+    async fn arachnid_probe_distinguishes_success_auth_and_rate_limit() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/pdq"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "scanned_hashes": {
+                    SYNTHETIC_PROBE_PDQ_HASH: {
+                        "classification": "no-known-match"
+                    }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let outcome = probe_arachnid(&shield_client(&server.uri(), 5)).await;
+        assert!(outcome.pass, "detail: {}", outcome.detail);
+        server.reset().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/pdq"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+        let outcome = probe_arachnid(&shield_client(&server.uri(), 5)).await;
+        assert!(!outcome.pass);
+        assert!(outcome.detail.contains("認証拒否"), "{}", outcome.detail);
+        server.reset().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/pdq"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+        let outcome = probe_arachnid(&shield_client(&server.uri(), 5)).await;
+        assert!(!outcome.pass);
+        assert!(outcome.detail.contains("頻度制限"), "{}", outcome.detail);
+    }
+
+    #[tokio::test]
+    async fn arachnid_probe_reports_timeout_and_server_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/pdq"))
+            .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(5)))
+            .mount(&server)
+            .await;
+        let outcome = probe_arachnid(&shield_client(&server.uri(), 1)).await;
+        assert!(!outcome.pass);
+        assert!(outcome.detail.contains("時間切れ"), "{}", outcome.detail);
+        server.reset().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/pdq"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        let outcome = probe_arachnid(&shield_client(&server.uri(), 5)).await;
+        assert!(!outcome.pass);
+        assert!(
+            outcome.detail.contains("プロバイダ側エラー"),
+            "{}",
+            outcome.detail
+        );
+    }
+
+    #[tokio::test]
+    async fn vlm_probe_passes_on_guard_response_and_fails_on_unparseable_body() {
+        let server = MockServer::start().await;
+        // guard 形式: 1 行目 safe/unsafe。解析成功 = 疎通確認の合格。
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{
+                    "message": { "role": "assistant", "content": "safe" },
+                    "logprobs": { "content": [{
+                        "token": "safe",
+                        "logprob": -0.01,
+                        "top_logprobs": [
+                            { "token": "safe", "logprob": -0.01 },
+                            { "token": "unsafe", "logprob": -4.5 }
+                        ]
+                    }]}
+                }]
+            })))
+            .mount(&server)
+            .await;
+        let outcome = probe_vlm(&vlm_client(&server.uri(), 5)).await;
+        assert!(outcome.pass, "detail: {}", outcome.detail);
+        server.reset().await;
+
+        // 解釈できない本文は不合格（安全側）。detail に本文を含めない。
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("secret-body-must-not-leak not json"),
+            )
+            .mount(&server)
+            .await;
+        let outcome = probe_vlm(&vlm_client(&server.uri(), 5)).await;
+        assert!(!outcome.pass);
+        assert!(
+            !outcome.detail.contains("secret-body-must-not-leak"),
+            "応答本文が detail に漏れています: {}",
+            outcome.detail
+        );
+    }
+}

--- a/crates/cn-cli/src/main.rs
+++ b/crates/cn-cli/src/main.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
 use kukuri_cn_core::{
@@ -61,6 +63,20 @@ enum Command {
     Moderation {
         #[command(subcommand)]
         action: ModerationCliAction,
+    },
+    /// 公開ノードの準備完了判定を実行時情報込みで検査する（#616）。
+    Readiness {
+        /// operator-config.yaml のパス。
+        #[arg(long, default_value = "operator-config.yaml")]
+        config: PathBuf,
+        #[arg(long, default_value = "public-node")]
+        profile: String,
+        /// 疎通確認結果の再利用期限（秒）。期限内は外部プロバイダを叩かない。
+        #[arg(long, default_value_t = 900)]
+        probe_ttl_secs: u64,
+        /// 保存済みの疎通確認結果を無視して必ず再実行する。
+        #[arg(long)]
+        force_probe: bool,
     },
 }
 

--- a/crates/cn-core/migrations/202608050001_readiness_probe.sql
+++ b/crates/cn-core/migrations/202608050001_readiness_probe.sql
@@ -1,0 +1,19 @@
+-- #616: プロバイダ疎通確認の期限付き保存。
+--
+-- `cn-cli readiness` が外部プロバイダへの疎通確認（合成データのみ）の結果を保存し、
+-- 有効期限内の再実行では外部プロバイダを叩かずにこの結果を使い回す（外部負荷と
+-- 発報回数の抑制）。保存するのは判定と区分の要約のみで、資格情報の値・応答本文・
+-- Match Data は構造的に持たない。
+
+CREATE TABLE IF NOT EXISTS cn_admin.readiness_probe_cache (
+    -- 疎通確認の対象 slot（known_csam / general / unknown_csam）。
+    provider_slot TEXT PRIMARY KEY,
+    -- slot に構成されたプロバイダ実装名（例: project-arachnid-shield）。
+    provider TEXT NOT NULL,
+    -- 判定（pass / fail）。
+    status TEXT NOT NULL CHECK (status IN ('pass', 'fail')),
+    -- 人間向けの要約（HTTP 状態の区分・時間切れ等。秘匿情報を含めない）。
+    detail TEXT NOT NULL,
+    -- 疎通確認を実行した時刻。
+    checked_at TIMESTAMPTZ NOT NULL
+);

--- a/crates/cn-core/src/lib.rs
+++ b/crates/cn-core/src/lib.rs
@@ -22,6 +22,7 @@ mod env;
 mod errors;
 mod index_entries;
 mod index_scope;
+mod readiness_probe;
 mod relation_optouts;
 mod rendezvous;
 mod reports;
@@ -78,6 +79,7 @@ pub use index_scope::{
     list_indexing_requests, list_supported_topics, register_channel_secret,
     reject_indexing_request, remove_channel_secret, remove_supported_topic, upsert_channel_secret,
 };
+pub use readiness_probe::{ReadinessProbeRecord, list_readiness_probes, upsert_readiness_probe};
 pub use relation_optouts::{
     clear_relation_optout, filter_relation_visible, get_relation_optout, is_relation_opted_out,
     set_relation_optout,

--- a/crates/cn-core/src/readiness_probe.rs
+++ b/crates/cn-core/src/readiness_probe.rs
@@ -1,0 +1,70 @@
+//! プロバイダ疎通確認の期限付き保存（#616）。
+//!
+//! `cn-cli readiness` が外部プロバイダへの疎通確認結果を保存し、有効期限内の再実行では
+//! 外部プロバイダを叩かずに使い回すための最小の保存層。判定と要約のみを持ち、
+//! 資格情報の値・応答本文は保存しない（呼び出し側もそれらを渡さない契約）。
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+
+/// 保存された疎通確認の結果 1 件。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadinessProbeRecord {
+    /// 疎通確認の対象 slot（known_csam / general / unknown_csam）。
+    pub provider_slot: String,
+    /// slot に構成されたプロバイダ実装名。
+    pub provider: String,
+    /// 判定（true = pass）。
+    pub pass: bool,
+    /// 人間向けの要約（秘匿情報を含めない）。
+    pub detail: String,
+    /// 疎通確認を実行した時刻。
+    pub checked_at: DateTime<Utc>,
+}
+
+/// 疎通確認の結果を slot 単位で upsert する。
+pub async fn upsert_readiness_probe(pool: &PgPool, record: &ReadinessProbeRecord) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO cn_admin.readiness_probe_cache \
+             (provider_slot, provider, status, detail, checked_at) \
+         VALUES ($1, $2, $3, $4, $5) \
+         ON CONFLICT (provider_slot) DO UPDATE SET \
+             provider = EXCLUDED.provider, \
+             status = EXCLUDED.status, \
+             detail = EXCLUDED.detail, \
+             checked_at = EXCLUDED.checked_at",
+    )
+    .bind(record.provider_slot.as_str())
+    .bind(record.provider.as_str())
+    .bind(if record.pass { "pass" } else { "fail" })
+    .bind(record.detail.as_str())
+    .bind(record.checked_at)
+    .execute(pool)
+    .await
+    .context("failed to upsert the readiness probe cache")?;
+    Ok(())
+}
+
+/// 保存済みの疎通確認結果を slot 順で返す。
+pub async fn list_readiness_probes(pool: &PgPool) -> Result<Vec<ReadinessProbeRecord>> {
+    let rows: Vec<(String, String, String, String, DateTime<Utc>)> = sqlx::query_as(
+        "SELECT provider_slot, provider, status, detail, checked_at \
+         FROM cn_admin.readiness_probe_cache ORDER BY provider_slot",
+    )
+    .fetch_all(pool)
+    .await
+    .context("failed to list the readiness probe cache")?;
+    Ok(rows
+        .into_iter()
+        .map(
+            |(provider_slot, provider, status, detail, checked_at)| ReadinessProbeRecord {
+                provider_slot,
+                provider,
+                pass: status == "pass",
+                detail,
+                checked_at,
+            },
+        )
+        .collect())
+}

--- a/crates/cn-core/tests/readiness_probe.rs
+++ b/crates/cn-core/tests/readiness_probe.rs
@@ -1,0 +1,64 @@
+//! #616 プロバイダ疎通確認の期限付き保存の Postgres integration テスト。
+//!
+//! `KUKURI_CN_RUN_INTEGRATION_TESTS=1` のときだけ実 DB に接続して実行する。
+//! - slot 単位の upsert（同一 slot は上書き）。
+//! - 保存されるのは判定と要約のみ（読み戻しで往復が安定する）。
+
+use anyhow::Result;
+use chrono::{TimeZone, Utc};
+use kukuri_cn_core::{
+    ReadinessProbeRecord, TestDatabase, connect_postgres, initialize_database,
+    list_readiness_probes, upsert_readiness_probe,
+};
+
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+
+fn integration_test_admin_database_url() -> Option<String> {
+    kukuri_test_support::gated_env_url(
+        "KUKURI_CN_RUN_INTEGRATION_TESTS",
+        "COMMUNITY_NODE_DATABASE_URL",
+        DEFAULT_ADMIN_DATABASE_URL,
+    )
+}
+
+#[tokio::test]
+async fn probe_cache_upserts_by_slot_and_round_trips() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping readiness probe test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_readiness_probe").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    let first = ReadinessProbeRecord {
+        provider_slot: "known_csam".to_string(),
+        provider: "project-arachnid-shield".to_string(),
+        pass: false,
+        detail: "認証拒否 (HTTP 401)".to_string(),
+        checked_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+    };
+    upsert_readiness_probe(&pool, &first).await?;
+
+    // 同一 slot は上書きされ、行が増えない。
+    let second = ReadinessProbeRecord {
+        pass: true,
+        detail: "認証と応答受信に成功".to_string(),
+        checked_at: Utc.timestamp_opt(1_700_000_600, 0).unwrap(),
+        ..first.clone()
+    };
+    upsert_readiness_probe(&pool, &second).await?;
+
+    let third = ReadinessProbeRecord {
+        provider_slot: "general".to_string(),
+        provider: "openai-compatible-vlm".to_string(),
+        pass: true,
+        detail: "接続と応答形式の解析に成功".to_string(),
+        checked_at: Utc.timestamp_opt(1_700_000_700, 0).unwrap(),
+    };
+    upsert_readiness_probe(&pool, &third).await?;
+
+    let records = list_readiness_probes(&pool).await?;
+    assert_eq!(records, vec![third, second]);
+    Ok(())
+}

--- a/crates/cn-operator/src/lib.rs
+++ b/crates/cn-operator/src/lib.rs
@@ -44,7 +44,7 @@ pub use safety_config::{
 };
 pub use safety_readiness::{
     PUBLIC_NODE_PROFILE, READINESS_CHECK_IDS, ReadinessCheck, ReadinessReport, ReadinessStatus,
-    evaluate_public_node_readiness,
+    apply_runtime_checks, evaluate_public_node_readiness,
 };
 
 /// `operator init` が出力するサンプル config。

--- a/crates/cn-operator/src/main.rs
+++ b/crates/cn-operator/src/main.rs
@@ -238,11 +238,9 @@ fn run_safety(action: SafetyCommand) -> Result<ExitCode> {
 /// 表示しない。
 #[cfg(feature = "safety-arachnid")]
 fn run_safety_test_arachnid_shield() -> Result<ExitCode> {
-    use kukuri_cn_safety_arachnid::{ShieldClient, ShieldError, ShieldProviderConfig};
-
-    // 合成 PDQ hash（Shield API の期待形式 = 32 bytes の base64。実画像から計算したものではない。
-    // 2026-07-02 に実 API で形式を確認済み）。
-    const PROBE_PDQ_HASH: &str = "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=";
+    use kukuri_cn_safety_arachnid::{
+        SYNTHETIC_PROBE_PDQ_HASH as PROBE_PDQ_HASH, ShieldClient, ShieldError, ShieldProviderConfig,
+    };
 
     let config = ShieldProviderConfig::from_env()?;
     println!("provider: project-arachnid-shield");

--- a/crates/cn-operator/src/safety_readiness.rs
+++ b/crates/cn-operator/src/safety_readiness.rs
@@ -100,6 +100,33 @@ impl ReadinessReport {
     }
 }
 
+/// 実行時判定の結果を静的報告へ合成する（#616）。
+///
+/// `runtime` の各項目は、id が一致する既存項目を置換する。静的評価で `Unknown` のまま残る
+/// 項目（`provider_credential_valid` / `scan_coverage_metrics_available` 等）を、実際の
+/// 疎通確認・実測に基づく合格/不合格で確定させるための単一の合成点。既存 id に無い項目を
+/// 渡された場合は末尾へ追加せずエラーにする（判定項目の集合は `READINESS_CHECK_IDS` が
+/// 単一の真実源であり、勝手に増やさない）。
+pub fn apply_runtime_checks(
+    report: &mut ReadinessReport,
+    runtime: Vec<ReadinessCheck>,
+) -> anyhow::Result<()> {
+    for incoming in runtime {
+        let Some(existing) = report
+            .checks
+            .iter_mut()
+            .find(|check| check.id == incoming.id)
+        else {
+            anyhow::bail!(
+                "実行時判定の id `{}` は readiness の判定項目集合に存在しません",
+                incoming.id
+            );
+        };
+        *existing = incoming;
+    }
+    Ok(())
+}
+
 pub fn evaluate_public_node_readiness(
     config: &ResolvedConfig,
     requested_profile: &str,

--- a/crates/cn-operator/tests/safety.rs
+++ b/crates/cn-operator/tests/safety.rs
@@ -2,8 +2,8 @@ use std::fs;
 use std::process::Command;
 
 use kukuri_cn_operator::{
-    READINESS_CHECK_IDS, ReadinessStatus, SafetyErrorAction, evaluate_public_node_readiness,
-    load_and_validate,
+    READINESS_CHECK_IDS, ReadinessCheck, ReadinessStatus, SafetyErrorAction, apply_runtime_checks,
+    evaluate_public_node_readiness, load_and_validate,
 };
 
 fn config_with_safety(safety: &str) -> String {
@@ -120,6 +120,59 @@ fn readiness_complete_static_config_has_unknown_runtime_checks() {
         "scan_coverage_metrics_available",
         ReadinessStatus::Unknown,
     );
+}
+
+#[test]
+fn runtime_checks_resolve_unknowns_and_gate_readiness() {
+    let resolved = load_and_validate(&config_with_safety(complete_safety())).unwrap();
+
+    // 実行時判定が両方合格なら unknown が消えて is_ready が真になる。
+    let mut report = evaluate_public_node_readiness(&resolved, "public-node");
+    apply_runtime_checks(
+        &mut report,
+        vec![
+            ReadinessCheck {
+                id: "provider_credential_valid",
+                status: ReadinessStatus::Pass,
+                detail: "probe ok".to_string(),
+            },
+            ReadinessCheck {
+                id: "scan_coverage_metrics_available",
+                status: ReadinessStatus::Pass,
+                detail: "coverage ok".to_string(),
+            },
+        ],
+    )
+    .unwrap();
+    assert_eq!(report.unknown_count(), 0);
+    assert!(report.is_ready());
+
+    // 実行時判定の不合格は is_ready を偽へ倒す。
+    let mut report = evaluate_public_node_readiness(&resolved, "public-node");
+    apply_runtime_checks(
+        &mut report,
+        vec![ReadinessCheck {
+            id: "provider_credential_valid",
+            status: ReadinessStatus::Fail,
+            detail: "401".to_string(),
+        }],
+    )
+    .unwrap();
+    assert!(!report.is_ready());
+    assert!(report.has_blocking_failures());
+
+    // 判定項目集合に無い id はエラー（集合の単一の真実源を守る）。
+    let mut report = evaluate_public_node_readiness(&resolved, "public-node");
+    let error = apply_runtime_checks(
+        &mut report,
+        vec![ReadinessCheck {
+            id: "no_such_check",
+            status: ReadinessStatus::Pass,
+            detail: String::new(),
+        }],
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("no_such_check"));
 }
 
 #[test]

--- a/crates/cn-safety-arachnid/src/lib.rs
+++ b/crates/cn-safety-arachnid/src/lib.rs
@@ -33,3 +33,9 @@ pub use config::{
     DEFAULT_API_USERNAME_ENV, ShieldConfigError, ShieldCredentials, ShieldProviderConfig,
 };
 pub use provider::{PROVIDER_NAME, ProjectArachnidShieldProvider};
+
+/// 疎通確認に使う合成 PDQ hash（Shield API の期待形式 = 32 bytes の base64）。
+///
+/// 実画像から計算したものではない固定値（2026-07-02 に実 API で形式を確認済み）。
+/// `cn-operator safety test-provider` と `cn-cli readiness` の疎通確認が共有する。
+pub const SYNTHETIC_PROBE_PDQ_HASH: &str = "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=";


### PR DESCRIPTION
## 概要

#616 の T1。準備完了判定のうち恒久的に「不明」だった `provider_credential_valid` を、実際の外部プロバイダへの疎通確認で合格/不合格へ確定させる。

## 変更内容

- **cn-operator**: `apply_runtime_checks` を追加。実行時判定の結果を静的報告へ合成する単一の合成点で、判定項目の集合は `READINESS_CHECK_IDS` を単一の真実源のまま維持する（集合に無い id はエラー）
- **cn-safety-arachnid**: 疎通確認用の合成 PDQ hash（実画像由来ではない固定値）を `SYNTHETIC_PROBE_PDQ_HASH` として公開し、既存の `cn-operator safety test-provider` と共有する
- **cn-cli**: `readiness` サブコマンドを追加
  - operator-config の providers 節に構成された実装ごとに疎通確認を行う（Arachnid = 合成 hash の `POST /v1/pdq`、視覚言語モデル = 無害な合成文の 1 リクエスト + 応答形式の解析確認）
  - 認証拒否 / 頻度制限 / プロバイダ側エラー / 時間切れ / 接続失敗 / 解釈失敗を区別して報告する
  - 資格情報の値・応答本文・Match Data は出力にも保存にも含めない（プロバイダ側のエラー型が本文を持たない設計をそのまま利用）
  - 同一実装名の疎通確認は 1 回にまとめ、該当する全 slot へ結果を写す（外部への発報を抑制）
- **cn-core**: `cn_admin.readiness_probe_cache` を追加（migration）。結果を期限付き（`--probe-ttl-secs`、既定 900 秒）で保存し、期限内の再実行では外部プロバイダを叩かない。`--force-probe` で強制再実行

`scan_coverage_metrics_available` は次の T2 で確定させる（本 PR の時点では従来どおり「不明」のまま残り、終了コードの扱いも従来と同じ）。

## 検証

- `cargo xtask cn-check`（clippy、警告拒否）緑
- cn-cli の wiremock による単体テスト 3 件（成功 / 401 / 429 / 5xx / 時間切れ / 解析不能本文の非漏出）
- cn-operator の合成 API テスト（不明の解消・不合格の伝播・未知 id の拒否）
- cn-core の保存層の統合テスト（実 Postgres。slot 単位の上書きと読み戻し）

Refs #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)