### PR TITLE
readinessの走査網羅と全構成の実行時判定を実測で確定させる（#616 T2）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,6 +2961,7 @@ dependencies = [
  "kukuri-cn-safety",
  "kukuri-cn-safety-arachnid",
  "kukuri-cn-safety-vlm",
+ "reqwest 0.13.4",
  "serde_json",
  "sqlx",
  "tokio",

--- a/crates/cn-cli/Cargo.toml
+++ b/crates/cn-cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
+reqwest.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
 tokio.workspace = true

--- a/crates/cn-cli/src/commands/mod.rs
+++ b/crates/cn-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod database;
 mod indexing;
 mod moderation;
 mod readiness;
+mod readiness_runtime;
 mod relation;
 mod reports;
 
@@ -44,6 +45,21 @@ pub(crate) async fn dispatch(pool: &PgPool, command: Command) -> Result<()> {
             profile,
             probe_ttl_secs,
             force_probe,
-        } => readiness::run(pool, &config, &profile, probe_ttl_secs, force_probe).await,
+            indexer_status_url,
+            ingest_max_age_secs,
+            relation_max_age_secs,
+        } => {
+            readiness::run(
+                pool,
+                &config,
+                &profile,
+                probe_ttl_secs,
+                force_probe,
+                &indexer_status_url,
+                ingest_max_age_secs,
+                relation_max_age_secs,
+            )
+            .await
+        }
     }
 }

--- a/crates/cn-cli/src/commands/readiness.rs
+++ b/crates/cn-cli/src/commands/readiness.rs
@@ -144,12 +144,16 @@ fn configured_probe_slots(
         .collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn run(
     pool: &PgPool,
     config_path: &Path,
     profile: &str,
     probe_ttl_secs: u64,
     force_probe: bool,
+    indexer_status_url: &str,
+    ingest_max_age_secs: i64,
+    relation_max_age_secs: i64,
 ) -> Result<()> {
     initialize_database(pool).await?;
 
@@ -272,6 +276,16 @@ pub(super) async fn run(
         }
     };
     apply_runtime_checks(&mut report, vec![credential_check])?;
+
+    // 走査網羅系の実行時判定（#616 T2）。収集の失敗は evaluate 側で不合格へ倒す。
+    let findings = super::readiness_runtime::collect(
+        pool,
+        indexer_status_url,
+        ingest_max_age_secs,
+        relation_max_age_secs,
+    )
+    .await;
+    apply_runtime_checks(&mut report, super::readiness_runtime::evaluate(&findings))?;
 
     println!(
         "readiness profile={} ready={} fail={} unknown={}",

--- a/crates/cn-cli/src/commands/readiness_runtime.rs
+++ b/crates/cn-cli/src/commands/readiness_runtime.rs
@@ -1,0 +1,381 @@
+//! 実行時 readiness の収集と判定（#616 T2）。
+//!
+//! cn-indexer の状態エンドポイント・Postgres の整合検査・ArcadeDB 投影・関係解析の
+//! 実行記録を集め、`RUNTIME_CHECK_IDS` のうち走査網羅系の判定項目を合格/不合格へ
+//! 確定させる。判定は純関数（`evaluate`）に分離し、収集の失敗はすべて不合格へ倒す
+//! （安全側）。出力へ秘匿情報を含めない。
+
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+
+use kukuri_cn_core::{
+    IndexIntegrityFindings, RelationAnalyzeRun, ensure_database_ready, inspect_index_integrity,
+    latest_relation_analyze_run,
+};
+use kukuri_cn_indexer::{ArcadeDbConfig, ArcadeDbProjection, IndexerStateSnapshot};
+use kukuri_cn_operator::{ReadinessCheck, ReadinessStatus};
+
+/// 収集した実行時情報。取得に失敗した要素は Err(要約) を保持し、判定側で不合格へ倒す。
+pub(crate) struct RuntimeFindings {
+    pub snapshot: Result<IndexerStateSnapshot, String>,
+    pub migrations_ready: Result<(), String>,
+    pub integrity: Result<IndexIntegrityFindings, String>,
+    pub projection_count: Result<u64, String>,
+    pub relation_run: Result<Option<RelationAnalyzeRun>, String>,
+    pub now: DateTime<Utc>,
+    pub ingest_max_age_secs: i64,
+    pub relation_max_age_secs: i64,
+}
+
+/// 実行時情報を収集する。個々の失敗はこの関数では握りつぶさず Err 文字列として保持する。
+pub(crate) async fn collect(
+    pool: &PgPool,
+    indexer_status_url: &str,
+    ingest_max_age_secs: i64,
+    relation_max_age_secs: i64,
+) -> RuntimeFindings {
+    let snapshot = fetch_snapshot(indexer_status_url).await;
+    let migrations_ready = ensure_database_ready(pool)
+        .await
+        .map_err(|error| format!("{error:#}"));
+    let integrity = inspect_index_integrity(pool)
+        .await
+        .map_err(|error| format!("{error:#}"));
+    let projection_count = match ArcadeDbProjection::new(ArcadeDbConfig::from_env()) {
+        Ok(projection) => projection
+            .count_all()
+            .await
+            .map_err(|error| format!("{error:#}")),
+        Err(error) => Err(format!("{error:#}")),
+    };
+    let relation_run = latest_relation_analyze_run(pool)
+        .await
+        .map_err(|error| format!("{error:#}"));
+    RuntimeFindings {
+        snapshot,
+        migrations_ready,
+        integrity,
+        projection_count,
+        relation_run,
+        now: Utc::now(),
+        ingest_max_age_secs,
+        relation_max_age_secs,
+    }
+}
+
+async fn fetch_snapshot(indexer_status_url: &str) -> Result<IndexerStateSnapshot, String> {
+    let url = format!("{}/v1/status", indexer_status_url.trim_end_matches('/'));
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|error| error.to_string())?;
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|error| format!("状態エンドポイントへ到達できません: {error}"))?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "状態エンドポイントが HTTP {} を返しました",
+            response.status().as_u16()
+        ));
+    }
+    response
+        .json::<IndexerStateSnapshot>()
+        .await
+        .map_err(|_| "状態エンドポイントの応答を解釈できません".to_string())
+}
+
+/// 収集結果から走査網羅系の判定項目を組み立てる純関数。
+pub(crate) fn evaluate(findings: &RuntimeFindings) -> Vec<ReadinessCheck> {
+    let mut checks = Vec::new();
+
+    // indexer の常駐と取り込みの状態。
+    match &findings.snapshot {
+        Ok(snapshot) => {
+            checks.push(check(
+                "indexer_worker_running",
+                snapshot.worker_running && snapshot.ingest_enabled,
+                format!(
+                    "worker_running={} ingest_enabled={}",
+                    snapshot.worker_running, snapshot.ingest_enabled
+                ),
+            ));
+            checks.push(check(
+                "indexer_scopes_opened",
+                snapshot.opened_scopes >= 1,
+                format!("opened_scopes={}", snapshot.opened_scopes),
+            ));
+            let fresh = snapshot
+                .last_sync_at
+                .is_some_and(|at| findings.now.timestamp() - at <= findings.ingest_max_age_secs);
+            checks.push(check(
+                "indexer_ingest_fresh",
+                fresh,
+                match snapshot.last_sync_at {
+                    Some(at) => format!(
+                        "last_sync_at={} (許容 {} 秒)",
+                        at, findings.ingest_max_age_secs
+                    ),
+                    None => "全件見直しの成功記録がありません".to_string(),
+                },
+            ));
+        }
+        Err(error) => {
+            for id in [
+                "indexer_worker_running",
+                "indexer_scopes_opened",
+                "indexer_ingest_fresh",
+            ] {
+                checks.push(check(id, false, error.clone()));
+            }
+        }
+    }
+
+    // 走査網羅（計数の取得可否 + 安全側不変条件の実測）。
+    match (&findings.snapshot, &findings.integrity) {
+        (Ok(snapshot), Ok(integrity)) => {
+            let invariants_hold = integrity.entries_without_verdict == 0
+                && integrity.non_allow_or_critical_surfaced == 0
+                && integrity.provider_failure_allowed == 0;
+            checks.push(check(
+                "scan_coverage_metrics_available",
+                invariants_hold,
+                format!(
+                    "scanned={} indexed={} skipped_non_allow={} scan_errors={} \
+                     provider_unavailable={} media_fetch(success/unavailable/timeout/oversize)={}/{}/{}/{}; \
+                     判定無し索引={} 非許可・重大の表出={} 失敗→許可={}",
+                    snapshot.scanned,
+                    snapshot.indexed,
+                    snapshot.skipped_non_allow,
+                    snapshot.scan_errors,
+                    snapshot.provider_unavailable,
+                    snapshot.media_fetch_success,
+                    snapshot.media_fetch_unavailable,
+                    snapshot.media_fetch_timeout,
+                    snapshot.media_fetch_oversize,
+                    integrity.entries_without_verdict,
+                    integrity.non_allow_or_critical_surfaced,
+                    integrity.provider_failure_allowed,
+                ),
+            ));
+        }
+        (Err(error), _) | (_, Err(error)) => {
+            checks.push(check(
+                "scan_coverage_metrics_available",
+                false,
+                error.clone(),
+            ));
+        }
+    }
+
+    checks.push(match &findings.migrations_ready {
+        Ok(()) => check(
+            "postgres_migrations_ready",
+            true,
+            "必要な schema / table がすべて存在します".to_string(),
+        ),
+        Err(error) => check("postgres_migrations_ready", false, error.clone()),
+    });
+
+    checks.push(match &findings.projection_count {
+        Ok(count) => check(
+            "arcadedb_projection_ready",
+            true,
+            format!("投影へ到達済み (項目数 {count})"),
+        ),
+        Err(error) => check("arcadedb_projection_ready", false, error.clone()),
+    });
+
+    // 真実源と投影の突合: 投影が真実源より多い（ghost の疑い）を不合格にする。
+    checks.push(match (&findings.projection_count, &findings.integrity) {
+        (Ok(projection), Ok(integrity)) => {
+            let truth = u64::try_from(integrity.index_entries_total).unwrap_or(0);
+            check(
+                "index_truth_projection_consistent",
+                *projection <= truth,
+                format!("truth={truth} projection={projection}"),
+            )
+        }
+        (Err(error), _) | (_, Err(error)) => {
+            check("index_truth_projection_consistent", false, error.clone())
+        }
+    });
+
+    checks.push(match &findings.relation_run {
+        Ok(Some(run)) => {
+            let fresh = findings.now - run.finished_at
+                <= chrono::Duration::seconds(findings.relation_max_age_secs);
+            check(
+                "relation_analysis_recent",
+                run.success && fresh,
+                format!(
+                    "success={} finished_at={} (許容 {} 秒){}",
+                    run.success,
+                    run.finished_at.to_rfc3339(),
+                    findings.relation_max_age_secs,
+                    run.error
+                        .as_deref()
+                        .map(|error| format!(" error={error}"))
+                        .unwrap_or_default(),
+                ),
+            )
+        }
+        Ok(None) => check(
+            "relation_analysis_recent",
+            false,
+            "関係解析の実行記録がありません".to_string(),
+        ),
+        Err(error) => check("relation_analysis_recent", false, error.clone()),
+    });
+
+    checks.push(match &findings.integrity {
+        Ok(integrity) => check(
+            "supported_scopes_public_only",
+            integrity.private_scopes_supported == 0,
+            format!(
+                "プライベートチャンネルの索引対象={}",
+                integrity.private_scopes_supported
+            ),
+        ),
+        Err(error) => check("supported_scopes_public_only", false, error.clone()),
+    });
+
+    checks
+}
+
+fn check(id: &'static str, pass: bool, detail: String) -> ReadinessCheck {
+    ReadinessCheck {
+        id,
+        status: if pass {
+            ReadinessStatus::Pass
+        } else {
+            ReadinessStatus::Fail
+        },
+        detail,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn healthy_findings() -> RuntimeFindings {
+        let now = Utc.timestamp_opt(1_700_010_000, 0).unwrap();
+        RuntimeFindings {
+            snapshot: Ok(IndexerStateSnapshot {
+                worker_running: true,
+                ingest_enabled: true,
+                opened_scopes: 4,
+                last_sync_at: Some(now.timestamp() - 60),
+                ..IndexerStateSnapshot::default()
+            }),
+            migrations_ready: Ok(()),
+            integrity: Ok(IndexIntegrityFindings {
+                index_entries_total: 10,
+                ..IndexIntegrityFindings::default()
+            }),
+            projection_count: Ok(10),
+            relation_run: Ok(Some(RelationAnalyzeRun {
+                started_at: now - chrono::Duration::seconds(120),
+                finished_at: now - chrono::Duration::seconds(60),
+                success: true,
+                edges_upserted: 3,
+                clusters_assigned: 2,
+                error: None,
+            })),
+            now,
+            ingest_max_age_secs: 900,
+            relation_max_age_secs: 7200,
+        }
+    }
+
+    fn status_of<'a>(checks: &'a [ReadinessCheck], id: &str) -> &'a ReadinessCheck {
+        checks
+            .iter()
+            .find(|check| check.id == id)
+            .unwrap_or_else(|| panic!("check {id} not found"))
+    }
+
+    #[test]
+    fn healthy_findings_pass_all_runtime_checks() {
+        let checks = evaluate(&healthy_findings());
+        assert_eq!(checks.len(), 9);
+        for check in &checks {
+            assert_eq!(
+                check.status,
+                ReadinessStatus::Pass,
+                "{}: {}",
+                check.id,
+                check.detail
+            );
+        }
+    }
+
+    #[test]
+    fn stale_ingest_and_old_relation_run_fail() {
+        let mut findings = healthy_findings();
+        if let Ok(snapshot) = &mut findings.snapshot {
+            snapshot.last_sync_at = Some(findings.now.timestamp() - 10_000);
+        }
+        if let Ok(Some(run)) = &mut findings.relation_run {
+            run.finished_at = findings.now - chrono::Duration::seconds(100_000);
+        }
+        let checks = evaluate(&findings);
+        assert_eq!(
+            status_of(&checks, "indexer_ingest_fresh").status,
+            ReadinessStatus::Fail
+        );
+        assert_eq!(
+            status_of(&checks, "relation_analysis_recent").status,
+            ReadinessStatus::Fail
+        );
+    }
+
+    #[test]
+    fn integrity_violations_fail_scan_coverage() {
+        let mut findings = healthy_findings();
+        if let Ok(integrity) = &mut findings.integrity {
+            integrity.provider_failure_allowed = 1;
+        }
+        let checks = evaluate(&findings);
+        assert_eq!(
+            status_of(&checks, "scan_coverage_metrics_available").status,
+            ReadinessStatus::Fail
+        );
+    }
+
+    #[test]
+    fn projection_ghost_and_private_scope_fail() {
+        let mut findings = healthy_findings();
+        findings.projection_count = Ok(11);
+        if let Ok(integrity) = &mut findings.integrity {
+            integrity.private_scopes_supported = 1;
+        }
+        let checks = evaluate(&findings);
+        assert_eq!(
+            status_of(&checks, "index_truth_projection_consistent").status,
+            ReadinessStatus::Fail
+        );
+        assert_eq!(
+            status_of(&checks, "supported_scopes_public_only").status,
+            ReadinessStatus::Fail
+        );
+    }
+
+    #[test]
+    fn unreachable_status_endpoint_fails_indexer_checks() {
+        let mut findings = healthy_findings();
+        findings.snapshot = Err("状態エンドポイントへ到達できません".to_string());
+        let checks = evaluate(&findings);
+        for id in [
+            "indexer_worker_running",
+            "indexer_scopes_opened",
+            "indexer_ingest_fresh",
+            "scan_coverage_metrics_available",
+        ] {
+            assert_eq!(status_of(&checks, id).status, ReadinessStatus::Fail, "{id}");
+        }
+    }
+}

--- a/crates/cn-cli/src/commands/relation.rs
+++ b/crates/cn-cli/src/commands/relation.rs
@@ -1,7 +1,10 @@
 use anyhow::{Context, Result};
+use chrono::Utc;
 use sqlx::PgPool;
 
-use kukuri_cn_core::PgCoParticipationSource;
+use kukuri_cn_core::{
+    PgCoParticipationSource, RelationAnalyzeRun, initialize_database, record_relation_analyze_run,
+};
 use kukuri_cn_indexer::{ArcadeDbConfig, ArcadeDbRelationGraph, analyze_relations};
 
 use crate::RelationAction;
@@ -9,14 +12,35 @@ use crate::RelationAction;
 pub(super) async fn run(pool: &PgPool, action: RelationAction) -> Result<()> {
     match action {
         RelationAction::Analyze { limit } => {
-            let source = PgCoParticipationSource::new(pool.clone());
-            let graph = ArcadeDbRelationGraph::new(ArcadeDbConfig::from_env())
-                .context("failed to build ArcadeDB relation graph client")?;
-            graph
-                .ensure_schema()
-                .await
-                .context("failed to ensure relation graph schema")?;
-            let report = analyze_relations(&source, &graph, limit).await?;
+            // 実行記録の書き込み先（cn_admin.relation_analyze_runs）を先に確保する。
+            initialize_database(pool).await?;
+            let started_at = Utc::now();
+            let outcome = analyze(pool, limit).await;
+            let finished_at = Utc::now();
+
+            // 成否にかかわらず記録する（readiness の relation_analysis_recent が最終成否を
+            // 機械判定するため）。error にはエラー種別の要約のみを入れ、応答本文を含めない。
+            let run = match &outcome {
+                Ok(report) => RelationAnalyzeRun {
+                    started_at,
+                    finished_at,
+                    success: true,
+                    edges_upserted: i64::try_from(report.edges_upserted).unwrap_or(i64::MAX),
+                    clusters_assigned: i64::try_from(report.clusters_assigned).unwrap_or(i64::MAX),
+                    error: None,
+                },
+                Err(error) => RelationAnalyzeRun {
+                    started_at,
+                    finished_at,
+                    success: false,
+                    edges_upserted: 0,
+                    clusters_assigned: 0,
+                    error: Some(format!("{error:#}")),
+                },
+            };
+            record_relation_analyze_run(pool, &run).await?;
+
+            let report = outcome?;
             println!(
                 "relation analysis done: {} edge(s) upserted, {} cluster(s) assigned",
                 report.edges_upserted, report.clusters_assigned
@@ -24,4 +48,15 @@ pub(super) async fn run(pool: &PgPool, action: RelationAction) -> Result<()> {
         }
     }
     Ok(())
+}
+
+async fn analyze(pool: &PgPool, limit: usize) -> Result<kukuri_cn_indexer::RelationAnalysisReport> {
+    let source = PgCoParticipationSource::new(pool.clone());
+    let graph = ArcadeDbRelationGraph::new(ArcadeDbConfig::from_env())
+        .context("failed to build ArcadeDB relation graph client")?;
+    graph
+        .ensure_schema()
+        .await
+        .context("failed to ensure relation graph schema")?;
+    analyze_relations(&source, &graph, limit).await
 }

--- a/crates/cn-cli/src/main.rs
+++ b/crates/cn-cli/src/main.rs
@@ -77,6 +77,15 @@ enum Command {
         /// 保存済みの疎通確認結果を無視して必ず再実行する。
         #[arg(long)]
         force_probe: bool,
+        /// cn-indexer の状態エンドポイント（compose 内から実行する想定の既定値）。
+        #[arg(long, default_value = "http://cn-indexer:8630")]
+        indexer_status_url: String,
+        /// 全件見直しの成功をこの秒数以内に要求する。
+        #[arg(long, default_value_t = 900)]
+        ingest_max_age_secs: i64,
+        /// 関係解析の成功をこの秒数以内に要求する。
+        #[arg(long, default_value_t = 7200)]
+        relation_max_age_secs: i64,
     },
 }
 

--- a/crates/cn-core/migrations/202608050002_relation_analyze_runs.sql
+++ b/crates/cn-core/migrations/202608050002_relation_analyze_runs.sql
@@ -1,0 +1,17 @@
+-- #616: 関係解析（cn-cli relation analyze）の実行記録。
+--
+-- 定期実行の最終成否を readiness（relation_analysis_recent）が機械判定するための記録。
+-- 失敗時の error はエラー種別の要約のみで、秘匿情報・応答本文を含めない（書き込み側の契約）。
+
+CREATE TABLE IF NOT EXISTS cn_admin.relation_analyze_runs (
+    id BIGSERIAL PRIMARY KEY,
+    started_at TIMESTAMPTZ NOT NULL,
+    finished_at TIMESTAMPTZ NOT NULL,
+    success BOOLEAN NOT NULL,
+    edges_upserted BIGINT NOT NULL DEFAULT 0,
+    clusters_assigned BIGINT NOT NULL DEFAULT 0,
+    error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_cn_admin_relation_analyze_runs_finished_at
+    ON cn_admin.relation_analyze_runs (finished_at DESC);

--- a/crates/cn-core/src/lib.rs
+++ b/crates/cn-core/src/lib.rs
@@ -23,6 +23,7 @@ mod errors;
 mod index_entries;
 mod index_scope;
 mod readiness_probe;
+mod readiness_runtime;
 mod relation_optouts;
 mod rendezvous;
 mod reports;
@@ -80,6 +81,10 @@ pub use index_scope::{
     reject_indexing_request, remove_channel_secret, remove_supported_topic, upsert_channel_secret,
 };
 pub use readiness_probe::{ReadinessProbeRecord, list_readiness_probes, upsert_readiness_probe};
+pub use readiness_runtime::{
+    IndexIntegrityFindings, RelationAnalyzeRun, inspect_index_integrity,
+    latest_relation_analyze_run, record_relation_analyze_run,
+};
 pub use relation_optouts::{
     clear_relation_optout, filter_relation_visible, get_relation_optout, is_relation_opted_out,
     set_relation_optout,

--- a/crates/cn-core/src/readiness_runtime.rs
+++ b/crates/cn-core/src/readiness_runtime.rs
@@ -1,0 +1,131 @@
+//! 実行時 readiness のための Postgres 側検査（#616）。
+//!
+//! 索引の安全側不変条件（判定の無い索引項目が無い・許可以外や重大判定が表出しない・
+//! プロバイダ失敗が許可へ落ちていない）と、索引対象が公開トピックのみであることを
+//! 実測で数える。判定そのものは行わず件数を返し、合否の解釈は呼び出し側
+//! （`cn-cli readiness`）が行う。
+//!
+//! あわせて、関係解析（`cn-cli relation analyze`）の実行記録の書き込みと最新取得を持つ。
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+
+/// 索引の整合検査の件数。
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct IndexIntegrityFindings {
+    /// 索引項目の総数（cn_index.index_entries）。
+    pub index_entries_total: i64,
+    /// 対応する判定行が存在しない索引項目の件数（0 であるべき）。
+    pub entries_without_verdict: i64,
+    /// 最新判定が許可以外または重大に変わっているのに索引へ残っている件数（0 であるべき）。
+    pub non_allow_or_critical_surfaced: i64,
+    /// プロバイダ失敗系（scan_failed / provider_unavailable / unscanned）の理由で
+    /// 許可になっている判定の件数（0 であるべき = 失敗が許可へ落ちていない）。
+    pub provider_failure_allowed: i64,
+    /// 索引対象のうちプライベートチャンネルの件数（初期解禁では 0 であるべき）。
+    pub private_scopes_supported: i64,
+}
+
+/// 索引の安全側不変条件を実測で数える。
+pub async fn inspect_index_integrity(pool: &PgPool) -> Result<IndexIntegrityFindings> {
+    let (index_entries_total,): (i64,) =
+        sqlx::query_as("SELECT count(*) FROM cn_index.index_entries")
+            .fetch_one(pool)
+            .await
+            .context("failed to count index entries")?;
+    let (entries_without_verdict,): (i64,) = sqlx::query_as(
+        "SELECT count(*) FROM cn_index.index_entries e \
+         LEFT JOIN cn_safety.scan_verdicts v ON v.id = e.verdict_id \
+         WHERE v.id IS NULL",
+    )
+    .fetch_one(pool)
+    .await
+    .context("failed to count index entries without a verdict")?;
+    let (non_allow_or_critical_surfaced,): (i64,) = sqlx::query_as(
+        "SELECT count(*) FROM cn_index.index_entries e \
+         JOIN cn_safety.scan_verdicts v ON v.id = e.verdict_id \
+         WHERE v.action <> 'allow' OR v.critical",
+    )
+    .fetch_one(pool)
+    .await
+    .context("failed to count surfaced non-allow entries")?;
+    let (provider_failure_allowed,): (i64,) = sqlx::query_as(
+        "SELECT count(*) FROM cn_safety.scan_verdicts \
+         WHERE action = 'allow' \
+           AND reason_code IN ('scan_failed', 'provider_unavailable', 'unscanned')",
+    )
+    .fetch_one(pool)
+    .await
+    .context("failed to count provider failures that fell through to allow")?;
+    let (private_scopes_supported,): (i64,) = sqlx::query_as(
+        "SELECT count(*) FROM cn_index.supported_topics WHERE kind = 'private_channel'",
+    )
+    .fetch_one(pool)
+    .await
+    .context("failed to count supported private channel scopes")?;
+    Ok(IndexIntegrityFindings {
+        index_entries_total,
+        entries_without_verdict,
+        non_allow_or_critical_surfaced,
+        provider_failure_allowed,
+        private_scopes_supported,
+    })
+}
+
+/// 関係解析の実行記録 1 件。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RelationAnalyzeRun {
+    pub started_at: DateTime<Utc>,
+    pub finished_at: DateTime<Utc>,
+    pub success: bool,
+    pub edges_upserted: i64,
+    pub clusters_assigned: i64,
+    /// 失敗時のエラー種別の要約（秘匿情報を含めない契約）。
+    pub error: Option<String>,
+}
+
+/// 関係解析の実行結果を記録する。
+pub async fn record_relation_analyze_run(pool: &PgPool, run: &RelationAnalyzeRun) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO cn_admin.relation_analyze_runs \
+             (started_at, finished_at, success, edges_upserted, clusters_assigned, error) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(run.started_at)
+    .bind(run.finished_at)
+    .bind(run.success)
+    .bind(run.edges_upserted)
+    .bind(run.clusters_assigned)
+    .bind(run.error.as_deref())
+    .execute(pool)
+    .await
+    .context("failed to record the relation analyze run")?;
+    Ok(())
+}
+
+/// 実行記録の行表現（読み戻し用の中間型）。
+type RelationAnalyzeRunRow = (DateTime<Utc>, DateTime<Utc>, bool, i64, i64, Option<String>);
+
+/// 最新の関係解析の実行記録を返す（無ければ None）。
+pub async fn latest_relation_analyze_run(pool: &PgPool) -> Result<Option<RelationAnalyzeRun>> {
+    let row: Option<RelationAnalyzeRunRow> = sqlx::query_as(
+        "SELECT started_at, finished_at, success, edges_upserted, clusters_assigned, error \
+         FROM cn_admin.relation_analyze_runs ORDER BY finished_at DESC, id DESC LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .context("failed to fetch the latest relation analyze run")?;
+    Ok(row.map(
+        |(started_at, finished_at, success, edges_upserted, clusters_assigned, error)| {
+            RelationAnalyzeRun {
+                started_at,
+                finished_at,
+                success,
+                edges_upserted,
+                clusters_assigned,
+                error,
+            }
+        },
+    ))
+}

--- a/crates/cn-core/tests/readiness_probe.rs
+++ b/crates/cn-core/tests/readiness_probe.rs
@@ -7,8 +7,9 @@
 use anyhow::Result;
 use chrono::{TimeZone, Utc};
 use kukuri_cn_core::{
-    ReadinessProbeRecord, TestDatabase, connect_postgres, initialize_database,
-    list_readiness_probes, upsert_readiness_probe,
+    IndexIntegrityFindings, ReadinessProbeRecord, RelationAnalyzeRun, TestDatabase,
+    connect_postgres, initialize_database, inspect_index_integrity, latest_relation_analyze_run,
+    list_readiness_probes, record_relation_analyze_run, upsert_readiness_probe,
 };
 
 const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
@@ -60,5 +61,57 @@ async fn probe_cache_upserts_by_slot_and_round_trips() -> Result<()> {
 
     let records = list_readiness_probes(&pool).await?;
     assert_eq!(records, vec![third, second]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn index_integrity_inspection_runs_against_real_schema() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping index integrity test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_readiness_integrity").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    // 空 DB では全件数 0（SQL が実 schema の列名と一致していることの固定）。
+    let findings = inspect_index_integrity(&pool).await?;
+    assert_eq!(findings, IndexIntegrityFindings::default());
+    Ok(())
+}
+
+#[tokio::test]
+async fn relation_analyze_run_records_round_trip() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping relation run test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_relation_runs").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    initialize_database(&pool).await?;
+
+    assert_eq!(latest_relation_analyze_run(&pool).await?, None);
+
+    let failed = RelationAnalyzeRun {
+        started_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        finished_at: Utc.timestamp_opt(1_700_000_010, 0).unwrap(),
+        success: false,
+        edges_upserted: 0,
+        clusters_assigned: 0,
+        error: Some("ArcadeDB へ到達できません".to_string()),
+    };
+    record_relation_analyze_run(&pool, &failed).await?;
+    let succeeded = RelationAnalyzeRun {
+        started_at: Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        finished_at: Utc.timestamp_opt(1_700_000_110, 0).unwrap(),
+        success: true,
+        edges_upserted: 5,
+        clusters_assigned: 2,
+        error: None,
+    };
+    record_relation_analyze_run(&pool, &succeeded).await?;
+
+    // 最新（finished_at の降順）が返る。
+    assert_eq!(latest_relation_analyze_run(&pool).await?, Some(succeeded));
     Ok(())
 }

--- a/crates/cn-indexer/src/arcadedb.rs
+++ b/crates/cn-indexer/src/arcadedb.rs
@@ -140,6 +140,19 @@ impl ArcadeDbProjection {
         Ok(())
     }
 
+    /// 投影に入っている項目の総数を返す（#616 readiness の真実源との突合用）。
+    ///
+    /// 接続不可・schema 未作成なら Err（呼び出し側が「投影未準備」と判定する）。
+    pub async fn count_all(&self) -> Result<u64> {
+        let value = self
+            .command(
+                "sql",
+                &format!("SELECT count(*) AS total FROM {ENTRY_TYPE}"),
+            )
+            .await?;
+        Ok(u64::try_from(count_from_result(&value)).unwrap_or(0))
+    }
+
     /// ArcadeDB `/api/v1/command/<database>` を叩く（共有 client へ委譲）。
     async fn command(&self, language: &str, command: &str) -> Result<Value> {
         self.client.command(language, command).await

--- a/crates/cn-indexer/src/state.rs
+++ b/crates/cn-indexer/src/state.rs
@@ -8,12 +8,12 @@
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::ingest::IngestSummary;
 
 /// 観測状態の写し。`GET /v1/status` はこの形をそのまま JSON で返す。
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct IndexerStateSnapshot {
     /// ワーカーが動いているか。
     pub worker_running: bool,

--- a/crates/cn-operator/src/lib.rs
+++ b/crates/cn-operator/src/lib.rs
@@ -43,8 +43,8 @@ pub use safety_config::{
     SafetyProvidersConfig, SafetyStorageConfig,
 };
 pub use safety_readiness::{
-    PUBLIC_NODE_PROFILE, READINESS_CHECK_IDS, ReadinessCheck, ReadinessReport, ReadinessStatus,
-    apply_runtime_checks, evaluate_public_node_readiness,
+    PUBLIC_NODE_PROFILE, READINESS_CHECK_IDS, RUNTIME_CHECK_IDS, ReadinessCheck, ReadinessReport,
+    ReadinessStatus, apply_runtime_checks, evaluate_public_node_readiness,
 };
 
 /// `operator init` が出力するサンプル config。

--- a/crates/cn-operator/src/safety_readiness.rs
+++ b/crates/cn-operator/src/safety_readiness.rs
@@ -10,7 +10,7 @@ pub const PUBLIC_NODE_PROFILE: &str = "public-node";
 /// 通常経路（`evaluate_public_node_readiness`）と safety セクション欠落経路
 /// （`missing_safety_report`）の双方が、必ずこの集合を同じ順序で網羅する。ID で機械処理する
 /// 消費側が経路ごとの差異に依存しないことを保証する（テストで固定）。
-pub const READINESS_CHECK_IDS: [&str; 14] = [
+pub const READINESS_CHECK_IDS: [&str; 22] = [
     "safety_config_present",
     "safety_profile_public_node",
     "known_csam_provider_configured",
@@ -25,6 +25,31 @@ pub const READINESS_CHECK_IDS: [&str; 14] = [
     "known_csam_credential_secret_configured",
     "provider_credential_valid",
     "scan_coverage_metrics_available",
+    "indexer_worker_running",
+    "indexer_scopes_opened",
+    "indexer_ingest_fresh",
+    "postgres_migrations_ready",
+    "arcadedb_projection_ready",
+    "index_truth_projection_consistent",
+    "relation_analysis_recent",
+    "supported_scopes_public_only",
+];
+
+/// 実行時（runtime / indexing）接続後にのみ確定できる判定項目の id 集合（#616）。
+///
+/// 静的評価（`evaluate_public_node_readiness`）ではこれらを `Unknown` として返し、
+/// `cn-cli readiness` が実測結果で置換する。
+pub const RUNTIME_CHECK_IDS: [&str; 10] = [
+    "provider_credential_valid",
+    "scan_coverage_metrics_available",
+    "indexer_worker_running",
+    "indexer_scopes_opened",
+    "indexer_ingest_fresh",
+    "postgres_migrations_ready",
+    "arcadedb_projection_ready",
+    "index_truth_projection_consistent",
+    "relation_analysis_recent",
+    "supported_scopes_public_only",
 ];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -141,7 +166,7 @@ pub fn evaluate_public_node_readiness(
         return missing_safety_report(profile);
     };
 
-    ReadinessReport {
+    let mut report = ReadinessReport {
         profile: profile.to_string(),
         checks: vec![
             pass(
@@ -159,19 +184,16 @@ pub fn evaluate_public_node_readiness(
             check_signing_key_secret(safety),
             check_no_permanent_blob_storage(safety),
             check_known_provider_secret(safety),
-            ReadinessCheck {
-                id: "provider_credential_valid",
-                status: ReadinessStatus::Unknown,
-                detail: "credential_secret_id の参照先検証は provider/runtime 接続後に行う"
-                    .to_string(),
-            },
-            ReadinessCheck {
-                id: "scan_coverage_metrics_available",
-                status: ReadinessStatus::Unknown,
-                detail: "scan coverage metrics は runtime/indexing 接続後に検査する".to_string(),
-            },
         ],
-    }
+    };
+    report
+        .checks
+        .extend(RUNTIME_CHECK_IDS.iter().map(|&id| ReadinessCheck {
+            id,
+            status: ReadinessStatus::Unknown,
+            detail: "runtime / indexing 接続後に `cn-cli readiness` が実測で確定する".to_string(),
+        }));
+    report
 }
 
 fn missing_safety_report(profile: &str) -> ReadinessReport {

--- a/crates/cn-operator/tests/safety.rs
+++ b/crates/cn-operator/tests/safety.rs
@@ -2,8 +2,8 @@ use std::fs;
 use std::process::Command;
 
 use kukuri_cn_operator::{
-    READINESS_CHECK_IDS, ReadinessCheck, ReadinessStatus, SafetyErrorAction, apply_runtime_checks,
-    evaluate_public_node_readiness, load_and_validate,
+    READINESS_CHECK_IDS, RUNTIME_CHECK_IDS, ReadinessCheck, ReadinessStatus, SafetyErrorAction,
+    apply_runtime_checks, evaluate_public_node_readiness, load_and_validate,
 };
 
 fn config_with_safety(safety: &str) -> String {
@@ -71,7 +71,7 @@ fn readiness_complete_static_config_has_unknown_runtime_checks() {
     assert!(report.static_checks_pass());
     assert!(!report.has_blocking_failures());
     assert_eq!(report.fail_count(), 0);
-    assert_eq!(report.unknown_count(), 2);
+    assert_eq!(report.unknown_count(), RUNTIME_CHECK_IDS.len());
     assert_check(&report, "safety_config_present", ReadinessStatus::Pass);
     assert_check(
         &report,
@@ -126,22 +126,18 @@ fn readiness_complete_static_config_has_unknown_runtime_checks() {
 fn runtime_checks_resolve_unknowns_and_gate_readiness() {
     let resolved = load_and_validate(&config_with_safety(complete_safety())).unwrap();
 
-    // 実行時判定が両方合格なら unknown が消えて is_ready が真になる。
+    // 実行時判定がすべて合格なら unknown が消えて is_ready が真になる。
     let mut report = evaluate_public_node_readiness(&resolved, "public-node");
     apply_runtime_checks(
         &mut report,
-        vec![
-            ReadinessCheck {
-                id: "provider_credential_valid",
+        RUNTIME_CHECK_IDS
+            .iter()
+            .map(|&id| ReadinessCheck {
+                id,
                 status: ReadinessStatus::Pass,
-                detail: "probe ok".to_string(),
-            },
-            ReadinessCheck {
-                id: "scan_coverage_metrics_available",
-                status: ReadinessStatus::Pass,
-                detail: "coverage ok".to_string(),
-            },
-        ],
+                detail: "runtime ok".to_string(),
+            })
+            .collect(),
     )
     .unwrap();
     assert_eq!(report.unknown_count(), 0);
@@ -307,7 +303,10 @@ fn safety_readiness_cli_fails_on_static_failure() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(!output.status.success(), "stdout:\n{stdout}");
     assert!(stdout.contains("static_ok=false"), "stdout:\n{stdout}");
-    assert!(stdout.contains("fail=14"), "stdout:\n{stdout}");
+    assert!(
+        stdout.contains(&format!("fail={}", READINESS_CHECK_IDS.len())),
+        "stdout:\n{stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 概要

#616 の T2。準備完了判定に残っていた「不明」を、実測に基づく合格/不合格で確定できるようにする。T1（プロバイダ疎通確認）と合わせて、`cn-cli readiness` が全 22 項目を機械判定する。

## 変更内容

- **判定項目の拡張**（`READINESS_CHECK_IDS` は単一の真実源のまま 14 → 22 項目）
  - 常駐が稼働中 / 対象範囲が開いている / 取り込みが新しい（`/v1/status`）
  - migration 適用済み（既存 `ensure_database_ready` を判定に転用）
  - ArcadeDB 投影へ到達済み（新設 `ArcadeDbProjection::count_all`）
  - 真実源と投影の突合（投影が真実源より多い = 幽霊項目の疑いを不合格）
  - 関係解析の最終実行が成功かつ新しい
  - 索引対象が公開トピックのみ
- **`scan_coverage_metrics_available` の実判定**: 計数の取得可否だけでなく、安全側不変条件（判定の無い索引項目 0・許可以外や重大判定の表出 0・プロバイダ失敗が許可へ落ちた判定 0）の実測を合格条件にする
- **関係解析の実行記録**: `cn-cli relation analyze` が成否を `cn_admin.relation_analyze_runs` へ記録する（失敗も記録。エラーは種別の要約のみで秘匿情報を含めない）
- 収集の失敗（状態エンドポイント不達・DB 不達など）はすべて不合格へ倒す（安全側）。判定は純関数に分離し単体テストで固定

## 検証

- `cargo xtask cn-check`（clippy、警告拒否）緑
- 判定の純関数テスト 5 件（健全時全合格 / 鮮度切れ / 不変条件違反 / 幽霊項目・プライベート対象 / 状態エンドポイント不達）
- 実 Postgres の統合テスト 3 件（保存の往復・整合検査 SQL が実 schema で走ること・実行記録の最新取得）
- cn-operator の判定項目集合テスト更新（22 項目、実行時 10 項目の Unknown 生成）

Refs #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)