### PR TITLE
readiness 全項目合格の記録を関門にして読み取り面を有効化する (#616 T3)

### DIFF
--- a/crates/cn-cli/src/commands/readiness.rs
+++ b/crates/cn-cli/src/commands/readiness.rs
@@ -12,7 +12,8 @@ use chrono::{Duration, Utc};
 use sqlx::PgPool;
 
 use kukuri_cn_core::{
-    ReadinessProbeRecord, initialize_database, list_readiness_probes, upsert_readiness_probe,
+    ReadinessProbeRecord, initialize_database, list_readiness_probes, record_readiness_activation,
+    upsert_readiness_probe,
 };
 use kukuri_cn_operator::{
     ReadinessCheck, ReadinessStatus, apply_runtime_checks, evaluate_public_node_readiness,
@@ -305,7 +306,23 @@ pub(super) async fn run(
         );
     }
     if report.is_ready() {
-        println!("OK: すべての readiness check を満たしています。");
+        // 全項目合格のときにのみ有効化記録を書く（cn-user-api の読み取り面の関門）。
+        let check_ids: Vec<&str> = report.checks.iter().map(|check| check.id).collect();
+        let report_json = serde_json::json!(
+            report
+                .checks
+                .iter()
+                .map(|check| {
+                    serde_json::json!({
+                        "id": check.id,
+                        "status": check.status.key(),
+                        "detail": check.detail,
+                    })
+                })
+                .collect::<Vec<_>>()
+        );
+        record_readiness_activation(pool, now, &report.profile, &check_ids, &report_json).await?;
+        println!("OK: すべての readiness check を満たしています。有効化記録を書き込みました。");
     } else {
         println!(
             "NOTE: 残り {} 項目は runtime 接続後に確定します。",

--- a/crates/cn-core/migrations/202608060001_readiness_activation.sql
+++ b/crates/cn-core/migrations/202608060001_readiness_activation.sql
@@ -1,0 +1,20 @@
+-- #616: 読み取り面の有効化記録。
+--
+-- `cn-cli readiness` が全項目合格を確認したときにのみ行を追加する。cn-user-api は
+-- 環境変数（COMMUNITY_NODE_INDEX_QUERY_ENABLED / COMMUNITY_NODE_TRUST_READ_ENABLED）が
+-- 真でも、有効な記録が無ければ該当の読み取り面を公開しない（有効化の関門）。
+-- report は判定の id / 状態 / 要約のみで、資格情報・応答本文を含めない（書き込み側の契約）。
+
+CREATE TABLE IF NOT EXISTS cn_admin.readiness_activations (
+    id BIGSERIAL PRIMARY KEY,
+    activated_at TIMESTAMPTZ NOT NULL,
+    profile TEXT NOT NULL,
+    -- 評価時点の判定項目 id の配列。cn-user-api は現行の判定項目集合との一致を検証し、
+    -- 集合が変わった（= 判定基準が変わった）記録を無効として扱う。
+    check_ids JSONB NOT NULL,
+    -- 全合格の報告本文（id / status / detail の配列）。監査用。
+    report JSONB NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_cn_admin_readiness_activations_activated_at
+    ON cn_admin.readiness_activations (activated_at DESC);

--- a/crates/cn-core/src/lib.rs
+++ b/crates/cn-core/src/lib.rs
@@ -22,6 +22,7 @@ mod env;
 mod errors;
 mod index_entries;
 mod index_scope;
+mod readiness_activation;
 mod readiness_probe;
 mod readiness_runtime;
 mod relation_optouts;
@@ -79,6 +80,9 @@ pub use index_scope::{
     get_channel_secret, insert_indexing_request, is_topic_supported, list_channel_secrets,
     list_indexing_requests, list_supported_topics, register_channel_secret,
     reject_indexing_request, remove_channel_secret, remove_supported_topic, upsert_channel_secret,
+};
+pub use readiness_activation::{
+    ReadinessActivation, latest_readiness_activation, record_readiness_activation,
 };
 pub use readiness_probe::{ReadinessProbeRecord, list_readiness_probes, upsert_readiness_probe};
 pub use readiness_runtime::{

--- a/crates/cn-core/src/readiness_activation.rs
+++ b/crates/cn-core/src/readiness_activation.rs
@@ -1,0 +1,106 @@
+//! 読み取り面の有効化記録（#616 T3）。
+//!
+//! `cn-cli readiness` が全項目合格を確認したときにのみ記録を追加し、cn-user-api は
+//! 環境変数が真でも有効な記録が無ければ索引・信頼の読み取り面を公開しない。
+//! 記録には評価時点の判定項目 id 集合を含め、判定基準が変わった後の古い記録は
+//! 集合の不一致として無効に倒す（安全側）。
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+
+/// 有効化記録 1 件。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadinessActivation {
+    pub activated_at: DateTime<Utc>,
+    pub profile: String,
+    /// 評価時点の判定項目 id の配列。
+    pub check_ids: Vec<String>,
+}
+
+impl ReadinessActivation {
+    /// 現行の判定項目集合と一致するか（順序は問わない集合一致）。
+    ///
+    /// 判定基準が変わった（項目が増減・改名した）後は、旧基準での合格記録を
+    /// 有効化の根拠にしない。
+    pub fn matches_check_ids(&self, expected: &[&str]) -> bool {
+        let mut recorded: Vec<&str> = self.check_ids.iter().map(String::as_str).collect();
+        let mut expected: Vec<&str> = expected.to_vec();
+        recorded.sort_unstable();
+        expected.sort_unstable();
+        recorded == expected
+    }
+}
+
+/// 全項目合格の有効化記録を追加する。
+pub async fn record_readiness_activation(
+    pool: &PgPool,
+    activated_at: DateTime<Utc>,
+    profile: &str,
+    check_ids: &[&str],
+    report: &serde_json::Value,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO cn_admin.readiness_activations (activated_at, profile, check_ids, report) \
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(activated_at)
+    .bind(profile)
+    .bind(serde_json::json!(check_ids))
+    .bind(report)
+    .execute(pool)
+    .await
+    .context("failed to record the readiness activation")?;
+    Ok(())
+}
+
+/// 最新の有効化記録を返す（無ければ None）。
+pub async fn latest_readiness_activation(pool: &PgPool) -> Result<Option<ReadinessActivation>> {
+    let row: Option<(DateTime<Utc>, String, serde_json::Value)> = sqlx::query_as(
+        "SELECT activated_at, profile, check_ids FROM cn_admin.readiness_activations \
+         ORDER BY activated_at DESC, id DESC LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await
+    .context("failed to fetch the latest readiness activation")?;
+    Ok(
+        row.map(|(activated_at, profile, check_ids)| ReadinessActivation {
+            activated_at,
+            profile,
+            check_ids: check_ids
+                .as_array()
+                .map(|values| {
+                    values
+                        .iter()
+                        .filter_map(|value| value.as_str().map(str::to_string))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn activation(check_ids: &[&str]) -> ReadinessActivation {
+        ReadinessActivation {
+            activated_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            profile: "public-node".to_string(),
+            check_ids: check_ids.iter().map(|id| id.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn matches_check_ids_is_order_insensitive_set_equality() {
+        let recorded = activation(&["b", "a", "c"]);
+        assert!(recorded.matches_check_ids(&["a", "b", "c"]));
+        assert!(recorded.matches_check_ids(&["c", "b", "a"]));
+        // 欠落・過剰・改名はいずれも不一致（旧基準の合格を有効化の根拠にしない）。
+        assert!(!recorded.matches_check_ids(&["a", "b"]));
+        assert!(!recorded.matches_check_ids(&["a", "b", "c", "d"]));
+        assert!(!recorded.matches_check_ids(&["a", "b", "x"]));
+    }
+}

--- a/crates/cn-user-api/src/state.rs
+++ b/crates/cn-user-api/src/state.rs
@@ -10,7 +10,9 @@ use kukuri_cn_core::{
 use kukuri_cn_indexer::{
     ArcadeDbConfig, ArcadeDbProjection, ArcadeDbRelationGraph, FailClosedIndexQuery, IndexQuery,
 };
-use kukuri_cn_operator::{CommunityNodeManifest, build_manifest, load_and_validate};
+use kukuri_cn_operator::{
+    CommunityNodeManifest, READINESS_CHECK_IDS, build_manifest, load_and_validate,
+};
 use kukuri_cn_protocol::{CommunityNodeBootstrapNode, CommunityNodeResolvedUrls};
 use kukuri_cn_trust::{RelationStore, TrustParams};
 use sqlx::postgres::PgPool;
@@ -100,22 +102,55 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
         .transpose()
         .context("invalid COMMUNITY_NODE_CHANNEL_SECRET_KEY")?
         .map(Arc::new);
+    // 有効化の関門（#616）。環境変数が真でも、`cn-cli readiness` の全項目合格記録が
+    // 無ければ索引・信頼の読み取り面を公開しない（該当 surface は 404 のまま）。
+    // 記録の判定項目集合が現行と不一致（判定基準の変更後）も無効に倒す（安全側）。
+    let readiness_activated = if config.index_query_enabled || config.trust_read_enabled {
+        match kukuri_cn_core::latest_readiness_activation(&pool).await? {
+            Some(activation) if activation.matches_check_ids(&READINESS_CHECK_IDS) => {
+                tracing::info!(
+                    activated_at = %activation.activated_at.to_rfc3339(),
+                    "readiness の有効化記録を確認しました"
+                );
+                true
+            }
+            Some(activation) => {
+                tracing::warn!(
+                    activated_at = %activation.activated_at.to_rfc3339(),
+                    "readiness の有効化記録の判定項目集合が現行と一致しないため、                     index / trust の読み取り面を公開しません（`cn-cli readiness` を再実行してください）"
+                );
+                false
+            }
+            None => {
+                tracing::warn!(
+                    "readiness の有効化記録が無いため、index / trust の読み取り面を公開しません                     （`cn-cli readiness` の全項目合格が必要です）"
+                );
+                false
+            }
+        }
+    } else {
+        false
+    };
+
     // ユーザー向け index query(#404)。有効時のみ ArcadeDB(投影)+ Postgres(真実源)を
     // fail-closed gate(`FailClosedIndexQuery`)で束ねる。読み口はこの gate 以外に作らない。
-    let index_query: Option<Arc<dyn IndexQuery>> = if config.index_query_enabled {
-        let projection = ArcadeDbProjection::new(ArcadeDbConfig::from_env())
-            .context("failed to build ArcadeDB client for index query")?;
-        let entries = PgIndexEntryStore::new(pool.clone());
-        Some(Arc::new(FailClosedIndexQuery::new(
-            Arc::new(projection),
-            Arc::new(entries),
-        )))
-    } else {
-        None
-    };
+    let index_query: Option<Arc<dyn IndexQuery>> =
+        if config.index_query_enabled && readiness_activated {
+            let projection = ArcadeDbProjection::new(ArcadeDbConfig::from_env())
+                .context("failed to build ArcadeDB client for index query")?;
+            let entries = PgIndexEntryStore::new(pool.clone());
+            Some(Arc::new(FailClosedIndexQuery::new(
+                Arc::new(projection),
+                Arc::new(entries),
+            )))
+        } else {
+            None
+        };
     // trust / relation read surface(#415)。有効時のみ trust パラメータ(operator 可変)を
     // 検証つきで読み、relation graph(ArcadeDB。`cn-cli relation analyze` が構築する)へ接続する。
-    let trust_read: Option<Arc<TrustReadState>> = if config.trust_read_enabled {
+    let trust_read: Option<Arc<TrustReadState>> = if config.trust_read_enabled
+        && readiness_activated
+    {
         let params = TrustParams::from_env().context("invalid COMMUNITY_NODE_TRUST_* params")?;
         let relation = ArcadeDbRelationGraph::new(ArcadeDbConfig::from_env())
             .context("failed to build ArcadeDB client for relation graph")?;

--- a/crates/cn-user-api/tests/activation_gate.rs
+++ b/crates/cn-user-api/tests/activation_gate.rs
@@ -1,0 +1,152 @@
+//! #616 有効化の関門の contract test。
+//!
+//! 環境変数（COMMUNITY_NODE_INDEX_QUERY_ENABLED / COMMUNITY_NODE_TRUST_READ_ENABLED）を
+//! 真にしただけでは索引・信頼の読み取り面は公開されず、`cn-cli readiness` の全項目合格
+//! 記録（cn_admin.readiness_activations）が存在するときにのみ有効化される。
+//! 判定項目集合が現行と一致しない古い記録は無効（安全側）。
+//!
+//! Postgres + Redis を要するため `KUKURI_CN_RUN_INTEGRATION_TESTS=1` で gate する。
+//! ArcadeDB へは接続しない（有効時の確認は「404 でない」ことに留める。実際の応答内容は
+//! 全構成 E2E が担う）。
+
+use std::net::SocketAddr;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use kukuri_cn_core::{JwtConfig, TestDatabase, connect_postgres, record_readiness_activation};
+use kukuri_cn_operator::READINESS_CHECK_IDS;
+use kukuri_cn_user_api::{UserApiConfig, app_router, build_state};
+use reqwest::{Client, StatusCode};
+
+mod support;
+use support::{integration_test_admin_database_url, integration_test_rendezvous_redis_url};
+
+const SURFACES: [&str; 3] = [
+    "/v1/index/search?q=test",
+    "/v1/trust/users/0000000000000000000000000000000000000000000000000000000000000001",
+    "/v1/relation/users/0000000000000000000000000000000000000000000000000000000000000001",
+];
+
+async fn spawn_api(
+    database_url: &str,
+    prefix: &str,
+) -> Result<(String, tokio::task::JoinHandle<()>)> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("failed to bind test listener")?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://{addr}");
+    let state = build_state(&UserApiConfig {
+        bind_addr: addr,
+        database_url: database_url.to_string(),
+        rendezvous_redis_url: integration_test_rendezvous_redis_url(),
+        rendezvous_key_prefix: format!("cn:test:{prefix}"),
+        base_url: base_url.clone(),
+        public_base_url: base_url.clone(),
+        connectivity_urls: vec!["http://127.0.0.1:13340".to_string()],
+        jwt_config: JwtConfig::new("kukuri-cn-tests", "test-secret", 3600),
+        operator_config_path: None,
+        channel_secret_key: None,
+        index_query_enabled: true,
+        trust_read_enabled: true,
+    })
+    .await?;
+    let app = app_router(state);
+    let task = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .expect("test user-api server");
+    });
+    Ok((base_url, task))
+}
+
+async fn surface_statuses(base_url: &str) -> Result<Vec<(String, StatusCode, String)>> {
+    let client = Client::new();
+    let mut statuses = Vec::new();
+    for path in SURFACES {
+        let response = client.get(format!("{base_url}{path}")).send().await?;
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        statuses.push((path.to_string(), status, body));
+    }
+    Ok(statuses)
+}
+
+#[tokio::test]
+async fn flags_without_activation_record_keep_surfaces_hidden() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping activation gate test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_activation_none").await?;
+
+    // 記録なし + 環境変数真 → 全 surface が 404 のまま。
+    let (base_url, task) = spawn_api(database.database_url.as_str(), "act-none").await?;
+    for (path, status, body) in surface_statuses(&base_url).await? {
+        assert_eq!(status, StatusCode::NOT_FOUND, "{path}: {body}");
+    }
+    task.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn stale_check_id_set_keeps_surfaces_hidden() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping activation gate test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_activation_stale").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    kukuri_cn_core::initialize_database(&pool).await?;
+
+    // 判定項目集合が現行と一致しない記録（判定基準の変更前の合格）は無効。
+    record_readiness_activation(
+        &pool,
+        Utc::now(),
+        "public-node",
+        &["old_check_only"],
+        &serde_json::json!([]),
+    )
+    .await?;
+    let (base_url, task) = spawn_api(database.database_url.as_str(), "act-stale").await?;
+    for (path, status, body) in surface_statuses(&base_url).await? {
+        assert_eq!(status, StatusCode::NOT_FOUND, "{path}: {body}");
+    }
+    task.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn valid_activation_record_enables_surfaces() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping activation gate test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_activation_ok").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    kukuri_cn_core::initialize_database(&pool).await?;
+
+    record_readiness_activation(
+        &pool,
+        Utc::now(),
+        "public-node",
+        &READINESS_CHECK_IDS,
+        &serde_json::json!([]),
+    )
+    .await?;
+    let (base_url, task) = spawn_api(database.database_url.as_str(), "act-ok").await?;
+    // 有効化済みなら 404 ではなくなる（実際の応答内容は認証・ArcadeDB を要するため
+    // 全構成 E2E が担う。ここでは「隠されていない」ことだけを固定する）。
+    for (path, status, body) in surface_statuses(&base_url).await? {
+        assert_ne!(
+            status,
+            StatusCode::NOT_FOUND,
+            "surface が 404 のまま: {path}: {body}"
+        );
+    }
+    task.abort();
+    Ok(())
+}


### PR DESCRIPTION
## 概要

#616 の T3（有効化の関門）。環境変数を真にしただけでは索引・信頼の読み取り面が公開されないようにし、`cn-cli readiness` の全項目合格記録を有効化の必要条件にする。

## 変更点

- `cn_admin.readiness_activations` を新設（migration 202608060001）。`cn-cli readiness` が全項目合格（is_ready）のときにのみ、時刻・profile・判定項目 id 集合・報告本文を記録する
- cn-user-api の state 構築に関門を追加。`COMMUNITY_NODE_INDEX_QUERY_ENABLED` / `COMMUNITY_NODE_TRUST_READ_ENABLED` が真でも、有効な記録が無ければ `/v1/index/*` `/v1/trust/*` `/v1/relation/*` は 404 のまま
- 記録の判定項目 id 集合が現行の `READINESS_CHECK_IDS` と一致しない場合（判定基準の変更後の古い合格）は無効に倒す（安全側）
- 契約テスト 3 本を追加（記録なし → 404 / 集合不一致 → 404 / 有効な記録 → 404 でない）

## 検証

- `cargo test -p kukuri-cn-user-api --test activation_gate`（統合、Postgres + Redis）3 本合格
- `cargo test -p kukuri-cn-core --lib readiness_activation` 合格
- `cargo xtask cn-check` 合格

Refs #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)