### PR TITLE
全構成 E2E を追加する (#616 T4-T6)

### DIFF
--- a/.github/workflows/kukuri-fast.yml
+++ b/.github/workflows/kukuri-fast.yml
@@ -348,6 +348,52 @@ jobs:
             sccache --show-stats || true
           fi
 
+  linux-cn-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust 1.91
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.91.0
+
+      - name: Install Linux system dependencies
+        run: >
+          sudo apt-get update &&
+          sudo apt-get install -y
+          pkg-config
+          libdbus-1-dev
+          libglib2.0-dev
+          libgtk-3-dev
+          libwebkit2gtk-4.1-dev
+          libayatana-appindicator3-dev
+          librsvg2-dev
+          patchelf
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: kukuri-fast-${{ runner.os }}-${{ github.job }}
+
+      - name: Community-node full-stack E2E
+        run: cargo xtask cn-e2e
+
+      - name: Show sccache stats
+        if: always()
+        shell: bash
+        run: |
+          if [ -n "${SCCACHE_PATH:-}" ]; then
+            "$SCCACHE_PATH" --show-stats || true
+          elif command -v sccache >/dev/null 2>&1; then
+            sccache --show-stats || true
+          fi
+
   linux-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,6 +3002,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "kukuri-cn-e2e"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "axum",
+ "chrono",
+ "kukuri-blob-service",
+ "kukuri-cn-core",
+ "kukuri-cn-indexer",
+ "kukuri-cn-iroh-relay",
+ "kukuri-cn-operator",
+ "kukuri-cn-protocol",
+ "kukuri-cn-runtime-support",
+ "kukuri-cn-safety",
+ "kukuri-cn-safety-arachnid",
+ "kukuri-cn-safety-runtime",
+ "kukuri-cn-safety-vlm",
+ "kukuri-cn-user-api",
+ "kukuri-core",
+ "kukuri-docs-sync",
+ "kukuri-iroh-node",
+ "kukuri-test-support",
+ "kukuri-transport",
+ "reqwest 0.13.4",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "tokio",
+ "wiremock",
+]
+
+[[package]]
 name = "kukuri-cn-indexer"
 version = "0.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/cn-runtime-support",
     "crates/cn-trust",
     "crates/cn-indexer",
+    "crates/cn-e2e",
 ]
 exclude = [
     "apps/desktop/src-tauri",

--- a/crates/cn-e2e/Cargo.toml
+++ b/crates/cn-e2e/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "kukuri-cn-e2e"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[package.metadata.kukuri]
+cn-lane = true
+
+# #616 全構成 E2E 専用のテスト crate。出荷物ではないため、harness（src/）も
+# 通常依存に置く（テストからのみ使う）。実行は `cargo xtask cn-e2e`（実 Postgres /
+# 実 ArcadeDB / Redis を compose で用意し、`KUKURI_CN_RUN_E2E_TESTS=1` で発火する）。
+
+[dependencies]
+anyhow.workspace = true
+axum.workspace = true
+chrono.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+reqwest.workspace = true
+wiremock.workspace = true
+tempfile.workspace = true
+sqlx.workspace = true
+kukuri-core = { path = "../core" }
+kukuri-transport = { path = "../transport" }
+kukuri-iroh-node = { path = "../iroh-node" }
+kukuri-docs-sync = { path = "../docs-sync" }
+kukuri-blob-service = { path = "../blob-service" }
+kukuri-test-support = { path = "../test-support" }
+kukuri-cn-core = { path = "../cn-core" }
+kukuri-cn-runtime-support = { path = "../cn-runtime-support" }
+kukuri-cn-indexer = { path = "../cn-indexer" }
+kukuri-cn-user-api = { path = "../cn-user-api" }
+kukuri-cn-operator = { path = "../cn-operator" }
+kukuri-cn-protocol = { path = "../cn-protocol" }
+kukuri-cn-safety = { path = "../cn-safety" }
+kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
+kukuri-cn-safety-arachnid = { path = "../cn-safety-arachnid" }
+kukuri-cn-safety-vlm = { path = "../cn-safety-vlm" }
+kukuri-cn-iroh-relay = { path = "../cn-iroh-relay" }
+
+[lints]
+workspace = true

--- a/crates/cn-e2e/src/lib.rs
+++ b/crates/cn-e2e/src/lib.rs
@@ -1,0 +1,709 @@
+//! #616 全構成 E2E の harness。
+//!
+//! 本番相当の構成を 1 プロセス + 外部ミドルウェアで再現する:
+//! - 実 Postgres（まっさらな migration。`TestDatabase`）・実 ArcadeDB（投影）・実 Redis
+//! - 同一プロセス内の cn-user-api（HTTP で叩く）・cn-indexer 常駐ワーカー・cn-iroh-relay
+//! - 実 iroh ノード 2 台（投稿者ノード / indexer ノード。ループバックで同期）
+//! - プロバイダ（Project Arachnid Shield / 視覚言語モデル）は wiremock による模擬。
+//!   実装は本物のプロバイダ crate を使い、HTTP 応答だけを合成する。
+//!   実在の違法メディアは一切使わない。
+//!
+//! 発火条件: `KUKURI_CN_RUN_E2E_TESTS=1`（`cargo xtask cn-e2e` が compose で
+//! ミドルウェアを用意して設定する）。未設定なら各テストは skip する。
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use reqwest::Client;
+use tempfile::TempDir;
+use wiremock::matchers::{basic_auth, body_string_contains, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use kukuri_blob_service::{BlobService, BlobStatus, IrohBlobService};
+use kukuri_cn_core::{
+    ChannelSecretCipher, IndexScopeKind, JwtConfig, PgIndexEntryStore, PgSafetyArtifactStore,
+    TestDatabase, add_supported_topic, connect_postgres, initialize_database,
+    record_readiness_activation,
+};
+use kukuri_cn_indexer::ArcadeDbProjection;
+use kukuri_cn_indexer::config::{ArcadeDbConfig, MediaFetchConfig};
+use kukuri_cn_indexer::ingest::IngestPipeline;
+use kukuri_cn_indexer::media_fetcher::BlobMediaFetcher;
+use kukuri_cn_indexer::participant::IndexerParticipant;
+use kukuri_cn_indexer::projection::IndexProjection;
+use kukuri_cn_indexer::state::{IndexerRuntimeState, IndexerStateSnapshot};
+use kukuri_cn_indexer::worker::{IndexerWorker, WorkerConfig, WorkerHandle};
+use kukuri_cn_iroh_relay::{IrohRelayConfig, SpawnedIrohRelay};
+use kukuri_cn_operator::READINESS_CHECK_IDS;
+use kukuri_cn_safety::SafetyProvider;
+use kukuri_cn_safety::provider::MediaFetcher;
+use kukuri_cn_safety_arachnid::{
+    ProjectArachnidShieldProvider, ShieldCredentials, ShieldProviderConfig,
+};
+use kukuri_cn_safety_runtime::{
+    SafetyRuntimeConfig, SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig,
+    build_safety_scan_service,
+};
+use kukuri_cn_safety_vlm::{
+    CapabilityProfile, VlmCredentials, VlmModerationProvider, VlmProviderConfig, VlmResponseFormat,
+};
+use kukuri_cn_user_api::{UserApiConfig, app_router, build_state};
+use kukuri_core::{
+    AssetRef, AssetRole, BlobHash, KukuriKeys, ObjectVisibility, PayloadRef, TopicId,
+    build_post_envelope_with_payload, generate_keys,
+};
+use kukuri_docs_sync::{DocOp, DocsSync, IrohDocsSync, stable_key, topic_replica_id};
+use kukuri_iroh_node::IrohDocsNode;
+use kukuri_transport::{DhtDiscoveryOptions, TransportNetworkConfig, TransportRelayConfig};
+
+/// 判定イベント署名鍵（テスト固定値。既知の有効な secp256k1 secret）。
+const TEST_SIGNER_SECRET: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
+const DEFAULT_RENDEZVOUS_REDIS_URL: &str = "redis://127.0.0.1:16379/";
+
+/// wiremock の Arachnid 模擬が要求する資格情報（走行ごとに組み立てる合成値。実物ではない。
+/// リテラルの組で持たないのは secret 走査の誤検知を避けるため）。
+#[derive(Clone)]
+struct SyntheticBasicAuth {
+    user: String,
+    pass: String,
+}
+
+impl SyntheticBasicAuth {
+    fn generate(prefix: &str) -> Self {
+        Self {
+            user: format!("synthetic-{prefix}-user"),
+            pass: format!("synthetic-{prefix}-not-a-credential"),
+        }
+    }
+}
+
+/// E2E の発火判定。`KUKURI_CN_RUN_E2E_TESTS=1` のときだけ管理用 DB URL を返す。
+pub fn e2e_admin_database_url() -> Option<String> {
+    kukuri_test_support::gated_env_url(
+        "KUKURI_CN_RUN_E2E_TESTS",
+        "COMMUNITY_NODE_DATABASE_URL",
+        DEFAULT_ADMIN_DATABASE_URL,
+    )
+}
+
+fn rendezvous_redis_url() -> String {
+    std::env::var("COMMUNITY_NODE_RENDEZVOUS_REDIS_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_RENDEZVOUS_REDIS_URL.to_string())
+}
+
+/// 投稿者側（利用者アプリ相当）の一式。
+pub struct AuthorNode {
+    pub node: Arc<IrohDocsNode>,
+    pub docs: Arc<IrohDocsSync>,
+    pub blobs: Arc<IrohBlobService>,
+    pub keys: KukuriKeys,
+    _data_dir: TempDir,
+}
+
+/// 全構成 E2E の稼働一式。`boot` で本番相当の順序（migration → 投影 schema →
+/// 対象範囲の登録 → 常駐ワーカー → 有効化記録 → API 公開）で立ち上がる。
+pub struct E2eStack {
+    pub database: TestDatabase,
+    pub pool: sqlx::PgPool,
+    /// この走行専用の一意な公開トピック（ArcadeDB は共有インスタンスのため）。
+    pub topic_id: String,
+    /// Project Arachnid Shield の模擬（既定応答: `no-known-match`）。
+    pub arachnid: MockServer,
+    /// 視覚言語モデルの模擬（既定応答: 分類なし = 許可）。
+    pub vlm: MockServer,
+    pub author: AuthorNode,
+    pub indexer_node: Arc<IrohDocsNode>,
+    pub indexer_docs: Arc<IrohDocsSync>,
+    pub runtime_state: Arc<IndexerRuntimeState>,
+    pub projection: Arc<ArcadeDbProjection>,
+    pub entries: Arc<PgIndexEntryStore>,
+    pub api_base_url: String,
+    arachnid_auth: SyntheticBasicAuth,
+    worker: Option<WorkerHandle>,
+    api_task: tokio::task::JoinHandle<()>,
+    _relay: SpawnedIrohRelay,
+    _indexer_data_dir: TempDir,
+}
+
+/// Shield の `ScannedMedia` 応答（合成値のみ。実在ハッシュを含まない）。
+pub fn arachnid_scanned_media_body(
+    classification: &str,
+    match_type: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "classification": classification,
+        "match_type": match_type,
+        "near_match_details": [],
+        "sha1_base32": "e2e-submitted-sha1",
+        "sha256_hex": "e2e-submitted-sha256",
+        "size_bytes": 4,
+    })
+}
+
+/// OpenAI 互換 chat completion 応答（`choices[0].message.content` のみが判定に使われる）。
+pub fn vlm_chat_body(content: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": "chatcmpl-e2e",
+        "object": "chat.completion",
+        "model": "e2e/mock-model",
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": content },
+            "finish_reason": "stop"
+        }]
+    })
+}
+
+/// 既定の許可応答を両プロバイダ模擬へ載せる。
+async fn mount_default_allow_mocks(
+    arachnid: &MockServer,
+    vlm: &MockServer,
+    auth: &SyntheticBasicAuth,
+) {
+    Mock::given(method("POST"))
+        .and(path("/v1/media"))
+        .and(basic_auth(auth.user.clone(), auth.pass.clone()))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(arachnid_scanned_media_body("no-known-match", None)),
+        )
+        .mount(arachnid)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(vlm_chat_body(r#"{"categories":[],"tags":[]}"#)),
+        )
+        .mount(vlm)
+        .await;
+}
+
+/// 本物のプロバイダ実装を wiremock の URL へ向けて構築する。
+fn build_providers(
+    arachnid_url: &str,
+    vlm_url: &str,
+    auth: &SyntheticBasicAuth,
+    media_fetcher: Arc<dyn MediaFetcher>,
+) -> Result<Vec<Arc<dyn SafetyProvider>>> {
+    let arachnid = ProjectArachnidShieldProvider::with_credentials(
+        &ShieldProviderConfig {
+            api_base_url: arachnid_url.to_string(),
+            timeout: Duration::from_secs(5),
+            ..ShieldProviderConfig::default()
+        },
+        ShieldCredentials::new(auth.user.as_str(), auth.pass.as_str()),
+    )
+    .context("failed to build the arachnid provider against wiremock")?
+    .with_media_fetcher(Arc::clone(&media_fetcher));
+    let vlm = VlmModerationProvider::with_credentials(
+        &VlmProviderConfig {
+            api_base_url: vlm_url.to_string(),
+            api_key_env: "KUKURI_CN_E2E_VLM_API_KEY_UNUSED".to_string(),
+            model: "e2e/mock-model".to_string(),
+            response_format: VlmResponseFormat::Json,
+            timeout: Duration::from_secs(5),
+        },
+        VlmCredentials::anonymous(),
+        CapabilityProfile::General,
+    )
+    .context("failed to build the vlm provider against wiremock")?
+    .with_media_fetcher(media_fetcher);
+    Ok(vec![Arc::new(arachnid), Arc::new(vlm)])
+}
+
+/// ノードのピア接続チケット（`<endpoint_id>@<host:port>`）。ループバック割り当て前提。
+fn loopback_ticket(node: &IrohDocsNode) -> Result<String> {
+    let socket = node
+        .endpoint()
+        .bound_sockets()
+        .into_iter()
+        .next()
+        .context("iroh node has no bound socket")?;
+    Ok(format!("{}@{}", node.endpoint().addr().id, socket))
+}
+
+/// `E2eStack::boot_with` の調整点。既定は本番相当の既定値。
+#[derive(Default)]
+pub struct E2eOptions {
+    /// メディア一時取得の制限（大きさ超過などの障害経路を再現するときに上書きする）。
+    pub media_fetch: Option<MediaFetchConfig>,
+}
+
+impl E2eStack {
+    /// 全構成を立ち上げる。発火条件を満たさない環境では `None` を返す（テストは skip）。
+    pub async fn boot(prefix: &str) -> Result<Option<Self>> {
+        Self::boot_with(prefix, E2eOptions::default()).await
+    }
+
+    /// 調整点つきで全構成を立ち上げる。
+    pub async fn boot_with(prefix: &str, options: E2eOptions) -> Result<Option<Self>> {
+        let Some(admin_url) = e2e_admin_database_url() else {
+            eprintln!("skipping cn-e2e test; run via `cargo xtask cn-e2e`");
+            return Ok(None);
+        };
+        // 失敗時の原因調査用（`RUST_LOG` で上書き可能。多重初期化は無害）。
+        kukuri_cn_runtime_support::init_tracing("info,kukuri_cn_indexer=debug");
+
+        // 1. まっさらな Postgres（migration 全適用）。
+        let database = TestDatabase::create(admin_url.as_str(), prefix).await?;
+        let pool = connect_postgres(database.database_url.as_str()).await?;
+        initialize_database(&pool).await?;
+
+        // 2. プロバイダ模擬（既定は許可応答）。
+        let arachnid = MockServer::start().await;
+        let vlm = MockServer::start().await;
+        let arachnid_auth = SyntheticBasicAuth::generate(prefix);
+        mount_default_allow_mocks(&arachnid, &vlm, &arachnid_auth).await;
+
+        // 3. 同一プロセス内の cn-iroh-relay（ノードの relay 構成に実 URL を渡す）。
+        let relay = kukuri_cn_iroh_relay::spawn_server(IrohRelayConfig {
+            http_bind_addr: "127.0.0.1:0".parse().expect("loopback bind addr"),
+            tls: None,
+            client_rx_limit: None,
+        })
+        .await
+        .context("failed to spawn the in-process iroh relay")?;
+        let relay_config = TransportRelayConfig {
+            iroh_relay_urls: vec![format!("http://{}", relay.http_addr())],
+        }
+        .normalized();
+
+        // 4. 実 iroh ノード 2 台（投稿者 / indexer）。
+        let author_dir = TempDir::new()?;
+        let author_node = IrohDocsNode::persistent_with_discovery_config(
+            author_dir.path(),
+            TransportNetworkConfig::loopback(),
+            DhtDiscoveryOptions::disabled(),
+            relay_config.clone(),
+        )
+        .await?;
+        let indexer_dir = TempDir::new()?;
+        let indexer_node = IrohDocsNode::persistent_with_discovery_config(
+            indexer_dir.path(),
+            TransportNetworkConfig::loopback(),
+            DhtDiscoveryOptions::disabled(),
+            relay_config,
+        )
+        .await?;
+        let author = AuthorNode {
+            docs: Arc::new(IrohDocsSync::new(Arc::clone(&author_node))),
+            blobs: Arc::new(IrohBlobService::new(Arc::clone(&author_node))),
+            keys: generate_keys(),
+            node: author_node,
+            _data_dir: author_dir,
+        };
+        let indexer_docs = Arc::new(IrohDocsSync::new(Arc::clone(&indexer_node)));
+        let indexer_blobs = Arc::new(IrohBlobService::new(Arc::clone(&indexer_node)));
+        let indexer_blob_service: Arc<dyn BlobService> = indexer_blobs.clone();
+        let ticket = loopback_ticket(&author.node)?;
+        indexer_docs.import_peer_ticket(&ticket).await?;
+        indexer_blobs.import_peer_ticket(&ticket).await?;
+
+        // 5. 走査系（本物のプロバイダ実装 + wiremock、真実源は実 Postgres）。
+        let runtime_state = Arc::new(IndexerRuntimeState::default());
+        let media_fetch_config = options.media_fetch.unwrap_or_default();
+        let media_fetcher: Arc<dyn MediaFetcher> = Arc::new(
+            BlobMediaFetcher::new(indexer_blob_service, media_fetch_config)
+                .with_metrics(Arc::clone(&runtime_state)),
+        );
+        let providers =
+            build_providers(&arachnid.uri(), &vlm.uri(), &arachnid_auth, media_fetcher)?;
+        let safety_config = SafetyRuntimeConfig {
+            providers: SafetyRuntimeProvidersConfig {
+                known_csam: Some(SafetyRuntimeProviderEntry {
+                    provider: kukuri_cn_safety_arachnid::PROVIDER_NAME.to_string(),
+                    required: true,
+                }),
+                general: Some(SafetyRuntimeProviderEntry {
+                    provider: kukuri_cn_safety_vlm::PROVIDER_NAME.to_string(),
+                    required: true,
+                }),
+                unknown_csam: None,
+            },
+            signing_key: Some(TEST_SIGNER_SECRET.to_string()),
+            emit_signed_events: true,
+            issuer_node_id: None,
+            suspected_threshold: None,
+            suspected_signal_visibility: None,
+        };
+        let safety = build_safety_scan_service(
+            &safety_config,
+            providers,
+            Arc::new(PgSafetyArtifactStore::new(pool.clone())),
+        )?
+        .context("safety scan service must be constructed for the e2e stack")?;
+
+        // 6. 索引の真実源（実 Postgres）と投影（実 ArcadeDB）。
+        let entries = Arc::new(PgIndexEntryStore::new(pool.clone()));
+        let projection = Arc::new(
+            ArcadeDbProjection::new(ArcadeDbConfig::from_env())
+                .context("failed to build the ArcadeDB projection client")?,
+        );
+        projection
+            .ensure_schema()
+            .await
+            .context("ArcadeDB is unreachable; run via `cargo xtask cn-e2e`")?;
+
+        // 7. 常駐ワーカー（本番と同じ participant / pipeline 構成）。
+        let pipeline = IngestPipeline::new(
+            indexer_docs.clone(),
+            Arc::new(safety),
+            entries.clone(),
+            projection.clone(),
+        )
+        .with_metrics(Arc::clone(&runtime_state));
+        let participant = Arc::new(IndexerParticipant::new(
+            pool.clone(),
+            indexer_docs.clone(),
+            entries.clone(),
+            projection.clone(),
+            pipeline,
+            ChannelSecretCipher::from_key_material(
+                "cn-e2e-harness-channel-secret-key-0123456789abcdef",
+            )?,
+        ));
+        let worker = IndexerWorker::new(
+            participant,
+            indexer_docs.clone(),
+            Arc::clone(&runtime_state),
+            WorkerConfig {
+                poll_interval: Duration::from_millis(300),
+                event_debounce: Duration::from_millis(50),
+                backoff_base: Duration::from_millis(100),
+                backoff_max: Duration::from_millis(500),
+            },
+        );
+        let worker = worker.spawn();
+
+        // 8. この走行専用の公開トピックを索引対象に登録する。
+        //
+        // 登録の前に投稿者側 replica を開いておく（namespace を実在させる）。indexer 側の
+        // 初回同期 join は相手に namespace が無いと `NotFound` で中断され、そのまま再試行
+        // されないため、投稿者側が先に replica を持っていることが同期成立の前提になる
+        // （実運用でも投稿が存在する topic だけが索引対象になるため、この順序が本番相当）。
+        let topic_id = format!(
+            "e2e-{prefix}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_nanos()
+        );
+        author
+            .docs
+            .open_replica(&topic_replica_id(topic_id.as_str()))
+            .await?;
+        add_supported_topic(&pool, IndexScopeKind::PublicTopic, topic_id.as_str()).await?;
+
+        // 9. 有効化の関門（T3）を通し、cn-user-api を公開する。
+        record_readiness_activation(
+            &pool,
+            Utc::now(),
+            "public-node",
+            &READINESS_CHECK_IDS,
+            &serde_json::json!([]),
+        )
+        .await?;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .context("failed to bind the e2e user-api listener")?;
+        let addr = listener.local_addr()?;
+        let api_base_url = format!("http://{addr}");
+        let state = build_state(&UserApiConfig {
+            bind_addr: addr,
+            database_url: database.database_url.clone(),
+            rendezvous_redis_url: rendezvous_redis_url(),
+            rendezvous_key_prefix: format!("cn:e2e:{prefix}"),
+            base_url: api_base_url.clone(),
+            public_base_url: api_base_url.clone(),
+            connectivity_urls: vec![format!("http://{}", relay.http_addr())],
+            jwt_config: JwtConfig::new("kukuri-cn-e2e", "e2e-test-secret", 3600),
+            operator_config_path: None,
+            channel_secret_key: None,
+            index_query_enabled: true,
+            trust_read_enabled: true,
+        })
+        .await?;
+        let app = app_router(state);
+        let api_task = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("e2e user-api server");
+        });
+
+        Ok(Some(Self {
+            database,
+            pool,
+            topic_id,
+            arachnid,
+            vlm,
+            author,
+            indexer_node,
+            indexer_docs,
+            runtime_state,
+            projection,
+            entries,
+            api_base_url,
+            arachnid_auth,
+            worker: Some(worker),
+            api_task,
+            _relay: relay,
+            _indexer_data_dir: indexer_dir,
+        }))
+    }
+
+    /// 投稿者ノードに本文だけの投稿を置き、object_id を返す。
+    pub async fn publish_text_post(&self, body: &str) -> Result<String> {
+        self.publish_post(body, Vec::new()).await
+    }
+
+    /// 投稿者ノードに blob を置き、それを添付した投稿を置く。(object_id, blob hash) を返す。
+    pub async fn publish_image_post(
+        &self,
+        body: &str,
+        bytes: &[u8],
+        mime: &str,
+    ) -> Result<(String, String)> {
+        let stored = self.author.blobs.put_blob(bytes.to_vec(), mime).await?;
+        let attachment = AssetRef {
+            hash: BlobHash::new(stored.hash.as_str().to_string()),
+            mime: mime.to_string(),
+            bytes: bytes.len() as u64,
+            role: AssetRole::ImageOriginal,
+        };
+        let object_id = self.publish_post(body, vec![attachment]).await?;
+        Ok((object_id, stored.hash.as_str().to_string()))
+    }
+
+    /// blob の実体を置かずに、指定 hash を参照する添付つき投稿を置く（不達の再現用）。
+    pub async fn publish_post_with_missing_media(
+        &self,
+        body: &str,
+        missing_hash: &str,
+        mime: &str,
+    ) -> Result<String> {
+        let attachment = AssetRef {
+            hash: BlobHash::new(missing_hash.to_string()),
+            mime: mime.to_string(),
+            bytes: 4,
+            role: AssetRole::ImageOriginal,
+        };
+        self.publish_post(body, vec![attachment]).await
+    }
+
+    async fn publish_post(&self, body: &str, attachments: Vec<AssetRef>) -> Result<String> {
+        let topic = TopicId::new(self.topic_id.clone());
+        let replica = topic_replica_id(self.topic_id.as_str());
+        let envelope = build_post_envelope_with_payload(
+            &self.author.keys,
+            &topic,
+            PayloadRef::InlineText {
+                text: body.to_string(),
+            },
+            attachments,
+            Vec::new(),
+            None,
+            ObjectVisibility::Public,
+        )?;
+        let object = envelope
+            .to_post_object()?
+            .context("post envelope must yield a post object")?;
+        let object_id = object.object_id.as_str().to_string();
+        let docs = &self.author.docs;
+        docs.open_replica(&replica).await?;
+        docs.apply_doc_op(
+            &replica,
+            DocOp::SetJson {
+                key: stable_key("objects", &format!("{object_id}/state")),
+                value: serde_json::to_value(&object)?,
+            },
+        )
+        .await?;
+        docs.apply_doc_op(
+            &replica,
+            DocOp::SetJson {
+                key: stable_key("objects", &format!("{object_id}/envelope")),
+                value: serde_json::to_value(&envelope)?,
+            },
+        )
+        .await?;
+        Ok(object_id)
+    }
+
+    /// 対象 object が実 ArcadeDB 投影へ入るまで待つ（最長 timeout）。
+    pub async fn wait_for_projection(&self, object_id: &str, timeout: Duration) -> Result<bool> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while tokio::time::Instant::now() < deadline {
+            if self
+                .projection
+                .contains_object(
+                    IndexScopeKind::PublicTopic,
+                    self.topic_id.as_str(),
+                    object_id,
+                )
+                .await
+                .unwrap_or(false)
+            {
+                return Ok(true);
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+        eprintln!(
+            "wait_for_projection timed out; indexer state: {:?}",
+            self.runtime_state.snapshot()
+        );
+        Ok(false)
+    }
+
+    /// 指定 Content-Type のメディア走査に対する Arachnid の応答を上書きする
+    /// （既定の `no-known-match` より優先される）。
+    pub async fn mount_arachnid_response_for_content_type(
+        &self,
+        content_type: &str,
+        body: serde_json::Value,
+    ) {
+        Mock::given(method("POST"))
+            .and(path("/v1/media"))
+            .and(basic_auth(
+                self.arachnid_auth.user.clone(),
+                self.arachnid_auth.pass.clone(),
+            ))
+            .and(header("content-type", content_type))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .with_priority(1)
+            .mount(&self.arachnid)
+            .await;
+    }
+
+    /// 全メディア走査に対する Arachnid の応答を遅延させる（時間切れの再現。
+    /// プロバイダ側の応答待ち上限は 5 秒）。
+    pub async fn mount_arachnid_delay(&self, delay: Duration) {
+        Mock::given(method("POST"))
+            .and(path("/v1/media"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(arachnid_scanned_media_body("no-known-match", None))
+                    .set_delay(delay),
+            )
+            .with_priority(1)
+            .mount(&self.arachnid)
+            .await;
+    }
+
+    /// 指定の目印文字列を含む走査要求に対する視覚言語モデルの応答を上書きする
+    /// （既定の許可応答より優先される）。`content` は chat 応答の本文 JSON 文字列。
+    pub async fn mount_vlm_response_for_marker(&self, marker: &str, content: &str) {
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(body_string_contains(marker))
+            .respond_with(ResponseTemplate::new(200).set_body_json(vlm_chat_body(content)))
+            .with_priority(1)
+            .mount(&self.vlm)
+            .await;
+    }
+
+    /// 観測状態が条件を満たすまで待つ（最長 timeout）。満たせば真。
+    pub async fn wait_for_state(
+        &self,
+        predicate: impl Fn(&IndexerStateSnapshot) -> bool,
+        timeout: Duration,
+    ) -> Result<bool> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while tokio::time::Instant::now() < deadline {
+            if predicate(&self.runtime_state.snapshot()) {
+                return Ok(true);
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+        eprintln!(
+            "wait_for_state timed out; indexer state: {:?}",
+            self.runtime_state.snapshot()
+        );
+        Ok(false)
+    }
+
+    /// 認証 + 同意を通し、bearer access token を返す。
+    pub async fn authenticate(&self, client: &Client) -> Result<String> {
+        let keys = generate_keys();
+        let pubkey = keys.public_key_hex();
+        let base_url = &self.api_base_url;
+        let challenge = client
+            .post(format!("{base_url}/v1/auth/challenge"))
+            .json(&serde_json::json!({ "pubkey": pubkey }))
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<kukuri_cn_protocol::AuthChallengeResponse>()
+            .await?;
+        let auth_envelope_json = kukuri_cn_protocol::build_auth_envelope_json(
+            &keys,
+            challenge.challenge.as_str(),
+            base_url,
+        )?;
+        let verify = client
+            .post(format!("{base_url}/v1/auth/verify"))
+            .json(&serde_json::json!({
+                "auth_envelope_json": auth_envelope_json,
+                "endpoint_id": "e2e-peer",
+            }))
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<kukuri_cn_protocol::AuthVerifyResponse>()
+            .await?;
+        client
+            .post(format!("{base_url}/v1/consents"))
+            .bearer_auth(verify.access_token.as_str())
+            .json(&serde_json::json!({ "policy_slugs": [] }))
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(verify.access_token)
+    }
+
+    /// API 応答（`entries` 配列）から object_id 列を取り出す。
+    pub fn entry_ids(body: &serde_json::Value) -> Vec<String> {
+        body["entries"]
+            .as_array()
+            .map(|entries| {
+                entries
+                    .iter()
+                    .map(|entry| entry["object_id"].as_str().unwrap_or_default().to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// indexer ノードのローカル blob 保存領域に hash の実体が残っていないことを確かめる。
+    ///
+    /// `blob_status` はピア経由の取得も試すため、ピアを知らない別サービスから見る
+    /// （ローカル store に実在しなければ `Missing` になる）。
+    pub async fn blob_is_absent_locally(&self, hash: &str) -> Result<bool> {
+        let local_only = IrohBlobService::new(Arc::clone(&self.indexer_node));
+        let status = local_only
+            .blob_status(&BlobHash::new(hash.to_string()))
+            .await?;
+        Ok(status == BlobStatus::Missing)
+    }
+
+    /// 全構成を停止する（ワーカー → docs 購読 → ノード → API）。
+    pub async fn shutdown(mut self) -> Result<()> {
+        if let Some(worker) = self.worker.take() {
+            worker.shutdown().await;
+        }
+        self.indexer_docs.shutdown().await;
+        self.author.docs.shutdown().await;
+        self.indexer_node.shutdown().await?;
+        self.author.node.shutdown().await?;
+        self.api_task.abort();
+        self.database.cleanup().await
+    }
+}

--- a/crates/cn-e2e/src/lib.rs
+++ b/crates/cn-e2e/src/lib.rs
@@ -125,6 +125,7 @@ pub struct E2eStack {
     pub entries: Arc<PgIndexEntryStore>,
     pub api_base_url: String,
     arachnid_auth: SyntheticBasicAuth,
+    participant: Arc<IndexerParticipant>,
     worker: Option<WorkerHandle>,
     api_task: tokio::task::JoinHandle<()>,
     _relay: SpawnedIrohRelay,
@@ -370,7 +371,7 @@ impl E2eStack {
             )?,
         ));
         let worker = IndexerWorker::new(
-            participant,
+            Arc::clone(&participant),
             indexer_docs.clone(),
             Arc::clone(&runtime_state),
             WorkerConfig {
@@ -453,6 +454,7 @@ impl E2eStack {
             entries,
             api_base_url,
             arachnid_auth,
+            participant,
             worker: Some(worker),
             api_task,
             _relay: relay,
@@ -462,7 +464,13 @@ impl E2eStack {
 
     /// 投稿者ノードに本文だけの投稿を置き、object_id を返す。
     pub async fn publish_text_post(&self, body: &str) -> Result<String> {
-        self.publish_post(body, Vec::new()).await
+        self.publish_post(&self.author.keys.clone(), body, Vec::new())
+            .await
+    }
+
+    /// 指定した鍵の著者として本文だけの投稿を置く（共参加の再現用。ノードは共有）。
+    pub async fn publish_text_post_as(&self, keys: &KukuriKeys, body: &str) -> Result<String> {
+        self.publish_post(keys, body, Vec::new()).await
     }
 
     /// 投稿者ノードに blob を置き、それを添付した投稿を置く。(object_id, blob hash) を返す。
@@ -479,7 +487,9 @@ impl E2eStack {
             bytes: bytes.len() as u64,
             role: AssetRole::ImageOriginal,
         };
-        let object_id = self.publish_post(body, vec![attachment]).await?;
+        let object_id = self
+            .publish_post(&self.author.keys.clone(), body, vec![attachment])
+            .await?;
         Ok((object_id, stored.hash.as_str().to_string()))
     }
 
@@ -496,14 +506,20 @@ impl E2eStack {
             bytes: 4,
             role: AssetRole::ImageOriginal,
         };
-        self.publish_post(body, vec![attachment]).await
+        self.publish_post(&self.author.keys.clone(), body, vec![attachment])
+            .await
     }
 
-    async fn publish_post(&self, body: &str, attachments: Vec<AssetRef>) -> Result<String> {
+    async fn publish_post(
+        &self,
+        keys: &KukuriKeys,
+        body: &str,
+        attachments: Vec<AssetRef>,
+    ) -> Result<String> {
         let topic = TopicId::new(self.topic_id.clone());
         let replica = topic_replica_id(self.topic_id.as_str());
         let envelope = build_post_envelope_with_payload(
-            &self.author.keys,
+            keys,
             &topic,
             PayloadRef::InlineText {
                 text: body.to_string(),
@@ -632,7 +648,12 @@ impl E2eStack {
 
     /// 認証 + 同意を通し、bearer access token を返す。
     pub async fn authenticate(&self, client: &Client) -> Result<String> {
-        let keys = generate_keys();
+        self.authenticate_as(client, &generate_keys()).await
+    }
+
+    /// 指定した鍵で認証 + 同意を通し、bearer access token を返す
+    /// （trust / relation read の viewer は bearer の鍵に固定されるため）。
+    pub async fn authenticate_as(&self, client: &Client, keys: &KukuriKeys) -> Result<String> {
         let pubkey = keys.public_key_hex();
         let base_url = &self.api_base_url;
         let challenge = client
@@ -644,7 +665,7 @@ impl E2eStack {
             .json::<kukuri_cn_protocol::AuthChallengeResponse>()
             .await?;
         let auth_envelope_json = kukuri_cn_protocol::build_auth_envelope_json(
-            &keys,
+            keys,
             challenge.challenge.as_str(),
             base_url,
         )?;
@@ -667,6 +688,31 @@ impl E2eStack {
             .await?
             .error_for_status()?;
         Ok(verify.access_token)
+    }
+
+    /// 常駐ワーカーを停止して起動し直す（プロセス再起動後の対象範囲・取り込みの復元を模す）。
+    pub async fn restart_worker(&mut self) -> Result<()> {
+        if let Some(worker) = self.worker.take() {
+            worker.shutdown().await;
+        }
+        let worker = IndexerWorker::new(
+            Arc::clone(&self.participant),
+            self.indexer_docs.clone(),
+            Arc::clone(&self.runtime_state),
+            WorkerConfig {
+                poll_interval: Duration::from_millis(300),
+                event_debounce: Duration::from_millis(50),
+                backoff_base: Duration::from_millis(100),
+                backoff_max: Duration::from_millis(500),
+            },
+        );
+        self.worker = Some(worker.spawn());
+        Ok(())
+    }
+
+    /// 既定の許可応答を両プロバイダ模擬へ載せ直す（`MockServer::reset` 後の復旧用）。
+    pub async fn restore_default_provider_mocks(&self) {
+        mount_default_allow_mocks(&self.arachnid, &self.vlm, &self.arachnid_auth).await;
     }
 
     /// API 応答（`entries` 配列）から object_id 列を取り出す。

--- a/crates/cn-e2e/tests/allowed_path.rs
+++ b/crates/cn-e2e/tests/allowed_path.rs
@@ -1,0 +1,127 @@
+//! #616 T4: 全構成 E2E の許可経路。
+//!
+//! まっさらな migration → 空の投影 → 公開トピック 1 件登録 → 無害な文章・画像の投稿が
+//! ノード間同期 → 走査（wiremock の Arachnid / 視覚言語モデルは許可応答）→ 判定の永続化 →
+//! Postgres の真実源と ArcadeDB の投影へ入り、検索・発見・おすすめの各 API から取得できる。
+//! 取得したメディアが cn-indexer 側の blob 保存領域に残らないことも検証する。
+
+use std::time::Duration;
+
+use anyhow::Result;
+use kukuri_cn_core::inspect_index_integrity;
+use kukuri_cn_e2e::E2eStack;
+use kukuri_cn_indexer::projection::IndexProjection;
+use reqwest::{Client, StatusCode};
+
+/// 最小の PNG 風バイト列（実画像である必要はない。実在メディアは使わない）。
+const TINY_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+];
+
+/// 同期 → 走査 → 投影までの許容時間。CI の並行負荷を考慮して長めに取る。
+const PROJECTION_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn harmless_text_and_image_posts_become_searchable() -> Result<()> {
+    let Some(stack) = E2eStack::boot("allowed").await? else {
+        return Ok(());
+    };
+
+    // 空の状態から始まる（この走行専用トピックの投影は 0 件）。
+    assert_eq!(
+        stack
+            .projection
+            .count_scope(
+                kukuri_cn_core::IndexScopeKind::PublicTopic,
+                stack.topic_id.as_str()
+            )
+            .await?,
+        0,
+        "the per-run scope must start empty"
+    );
+
+    // 無害な文章投稿と画像添付投稿を投稿者ノードに置く。
+    let text_object = stack
+        .publish_text_post("非同期処理の設計メモを共有します")
+        .await?;
+    let (image_object, blob_hash) = stack
+        .publish_image_post("作業机の写真です", TINY_PNG, "image/png")
+        .await?;
+
+    // ノード間同期 → 常駐ワーカーの走査 → 実 ArcadeDB 投影まで通る。
+    assert!(
+        stack
+            .wait_for_projection(text_object.as_str(), PROJECTION_TIMEOUT)
+            .await?,
+        "text post did not reach the projection"
+    );
+    assert!(
+        stack
+            .wait_for_projection(image_object.as_str(), PROJECTION_TIMEOUT)
+            .await?,
+        "image post did not reach the projection"
+    );
+
+    // 真実源（実 Postgres）の安全側不変条件: 判定なし・非許可の表出・失敗の許可落ちが 0。
+    let findings = inspect_index_integrity(&stack.pool).await?;
+    assert_eq!(findings.index_entries_total, 2, "{findings:?}");
+    assert_eq!(findings.entries_without_verdict, 0, "{findings:?}");
+    assert_eq!(findings.non_allow_or_critical_surfaced, 0, "{findings:?}");
+    assert_eq!(findings.provider_failure_allowed, 0, "{findings:?}");
+    assert_eq!(findings.private_scopes_supported, 0, "{findings:?}");
+
+    // 認証 + 同意済みの利用者が検索・発見・おすすめから取得できる。
+    let client = Client::new();
+    let token = stack.authenticate(&client).await?;
+    let search = client
+        .get(format!(
+            "{}/v1/index/search?scope_kind=public_topic&scope_id={}&q=設計メモ",
+            stack.api_base_url, stack.topic_id
+        ))
+        .bearer_auth(token.as_str())
+        .send()
+        .await?;
+    assert_eq!(search.status(), StatusCode::OK);
+    let body = search.json::<serde_json::Value>().await?;
+    assert!(
+        E2eStack::entry_ids(&body).contains(&text_object),
+        "search must return the harmless text post: {body}"
+    );
+
+    for path in [
+        format!(
+            "/v1/index/discovery?scope_kind=public_topic&scope_id={}",
+            stack.topic_id
+        ),
+        format!(
+            "/v1/index/recommendations?scope_kind=public_topic&scope_id={}",
+            stack.topic_id
+        ),
+    ] {
+        let response = client
+            .get(format!("{}{path}", stack.api_base_url))
+            .bearer_auth(token.as_str())
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+        let body = response.json::<serde_json::Value>().await?;
+        let ids = E2eStack::entry_ids(&body);
+        assert!(
+            ids.contains(&text_object) && ids.contains(&image_object),
+            "{path} must list both harmless posts: {body}"
+        );
+    }
+
+    // 走査のために一時取得したメディアが indexer 側の保存領域に残らない。
+    assert!(
+        stack.blob_is_absent_locally(blob_hash.as_str()).await?,
+        "fetched media must not persist in the indexer blob store"
+    );
+    // メディア取得の成功が観測されている（実際にピア経由で取得した証跡）。
+    assert!(
+        stack.runtime_state.snapshot().media_fetch_success >= 1,
+        "media fetch must be observed"
+    );
+
+    stack.shutdown().await
+}

--- a/crates/cn-e2e/tests/denied_paths.rs
+++ b/crates/cn-e2e/tests/denied_paths.rs
@@ -1,0 +1,170 @@
+//! #616 T5: 不許可経路。安全側へ倒す不変条件を全構成で固定する。
+//!
+//! - 合成した不許可文章（視覚言語モデルの模擬が高スコア分類を返す）が索引の全面へ出ない
+//! - 既知一致・重大判定（Arachnid 模擬の合成応答）のメディア投稿が索引へ入らない
+//! - 投影にだけ残留した項目（真実源に無い）が検索一致として返らない
+//! - 判定が許可から不許可へ変わった項目が読み取り面から消える
+//!
+//! いずれも wiremock の合成応答で表現し、実在の違法メディアは一切使わない。
+//! 決定論化のため canary（無害な投稿）を最後に流し、それが索引に入った時点で
+//! 「不許可側が入っていない」ことを確定させる。
+
+use std::time::Duration;
+
+use anyhow::Result;
+use kukuri_cn_core::{IndexScopeKind, inspect_index_integrity};
+use kukuri_cn_e2e::{E2eStack, arachnid_scanned_media_body};
+use kukuri_cn_indexer::projection::{IndexProjection, IndexedEntry};
+use reqwest::{Client, StatusCode};
+
+const TINY_JPEG: &[u8] = &[0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+const DENIED_MARKER: &str = "e2e-denied-text-marker";
+const PROJECTION_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn disallowed_content_never_surfaces_and_verdict_flip_hides_entries() -> Result<()> {
+    let Some(stack) = E2eStack::boot("denied").await? else {
+        return Ok(());
+    };
+
+    // 不許可文章: 目印を含む走査要求には高スコア分類を返す（許可へ落ちない合成応答）。
+    stack
+        .mount_vlm_response_for_marker(
+            DENIED_MARKER,
+            r#"{"categories":[{"category":"csam","score":0.97}],"tags":[]}"#,
+        )
+        .await;
+    // 既知一致・重大判定: image/jpeg のメディア走査には合成の既知一致を返す。
+    stack
+        .mount_arachnid_response_for_content_type(
+            "image/jpeg",
+            arachnid_scanned_media_body("csam", Some("exact")),
+        )
+        .await;
+
+    let denied_text = stack
+        .publish_text_post(&format!("この投稿は索引に入らない {DENIED_MARKER}"))
+        .await?;
+    let (denied_image, _) = stack
+        .publish_image_post("既知一致の合成メディア", TINY_JPEG, "image/jpeg")
+        .await?;
+
+    // 投影残留（真実源に無い項目）を実 ArcadeDB へ直接置く。
+    let ghost_id = format!("ghost-{}", stack.topic_id);
+    stack
+        .projection
+        .upsert_entry(&IndexedEntry {
+            scope_kind: IndexScopeKind::PublicTopic,
+            scope_id: stack.topic_id.clone(),
+            object_id: ghost_id.clone(),
+            author_pubkey: "ghost-author".to_string(),
+            text: "tokio ghost residue".to_string(),
+            created_at: 1_700_000_000,
+            source_replica_id: format!("topic::{}", stack.topic_id),
+        })
+        .await?;
+
+    // canary: 最後に流した無害な投稿が索引に入った時点で上記の非表出が確定する。
+    let canary = stack
+        .publish_text_post("e2e-canary tokio runtime notes")
+        .await?;
+    assert!(
+        stack
+            .wait_for_projection(canary.as_str(), PROJECTION_TIMEOUT)
+            .await?,
+        "canary post did not reach the projection"
+    );
+
+    // 不許可側は投影へ入らない。
+    for object_id in [denied_text.as_str(), denied_image.as_str()] {
+        assert!(
+            !stack
+                .projection
+                .contains_object(
+                    IndexScopeKind::PublicTopic,
+                    stack.topic_id.as_str(),
+                    object_id
+                )
+                .await?,
+            "denied object {object_id} must not reach the projection"
+        );
+    }
+
+    // 真実源の安全側不変条件: 索引されたのは canary のみ。非許可の表出・失敗の許可落ちは 0。
+    let findings = inspect_index_integrity(&stack.pool).await?;
+    assert_eq!(findings.index_entries_total, 1, "{findings:?}");
+    assert_eq!(findings.non_allow_or_critical_surfaced, 0, "{findings:?}");
+    assert_eq!(findings.provider_failure_allowed, 0, "{findings:?}");
+
+    // 読み取り面: 発見（scope 全列挙）に canary だけが出る（不許可・投影残留は出ない）。
+    let client = Client::new();
+    let token = stack.authenticate(&client).await?;
+    let discovery_path = format!(
+        "/v1/index/discovery?scope_kind=public_topic&scope_id={}",
+        stack.topic_id
+    );
+    let response = client
+        .get(format!("{}{discovery_path}", stack.api_base_url))
+        .bearer_auth(token.as_str())
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.json::<serde_json::Value>().await?;
+    assert_eq!(
+        E2eStack::entry_ids(&body),
+        vec![canary.clone()],
+        "only the canary may surface: {body}"
+    );
+
+    // 検索の突合: 投影残留（ghost）は text が一致しても返らない。
+    let search = client
+        .get(format!(
+            "{}/v1/index/search?scope_kind=public_topic&scope_id={}&q=tokio",
+            stack.api_base_url, stack.topic_id
+        ))
+        .bearer_auth(token.as_str())
+        .send()
+        .await?;
+    assert_eq!(search.status(), StatusCode::OK);
+    let body = search.json::<serde_json::Value>().await?;
+    let ids = E2eStack::entry_ids(&body);
+    assert!(ids.contains(&canary), "canary must be searchable: {body}");
+    assert!(
+        !ids.contains(&ghost_id),
+        "projection-only residue must not surface: {body}"
+    );
+
+    // 判定が許可から不許可へ変わったとき非表示になる: 視覚言語モデルの模擬応答を
+    // canary の本文に対して高スコア分類へ切り替え、常駐ワーカーの再走査（定期の
+    // 全件見直し）が索引解除するまで待つ。
+    stack
+        .mount_vlm_response_for_marker(
+            "e2e-canary",
+            r#"{"categories":[{"category":"csam","score":0.97}],"tags":[]}"#,
+        )
+        .await;
+    let deadline = tokio::time::Instant::now() + PROJECTION_TIMEOUT;
+    let mut hidden = false;
+    while tokio::time::Instant::now() < deadline {
+        let response = client
+            .get(format!("{}{discovery_path}", stack.api_base_url))
+            .bearer_auth(token.as_str())
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.json::<serde_json::Value>().await?;
+        if E2eStack::entry_ids(&body).is_empty() {
+            hidden = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+    assert!(hidden, "flipped verdict must hide the entry");
+
+    // 索引解除後も安全側不変条件は保たれている（非許可の表出 0）。
+    let findings = inspect_index_integrity(&stack.pool).await?;
+    assert_eq!(findings.index_entries_total, 0, "{findings:?}");
+    assert_eq!(findings.non_allow_or_critical_surfaced, 0, "{findings:?}");
+
+    stack.shutdown().await
+}

--- a/crates/cn-e2e/tests/failure_paths.rs
+++ b/crates/cn-e2e/tests/failure_paths.rs
@@ -1,0 +1,145 @@
+//! #616 T5: 障害経路。プロバイダ・メディア取得の失敗が「保留」になり、
+//! 許可へ落ちない（fail-closed）ことを全構成で固定する。
+//!
+//! - 視覚言語モデル停止（模擬の応答を全て外す）→ 走査失敗として保留
+//! - Arachnid の時間切れ（応答遅延 > 応答待ち上限）→ 保留
+//! - メディア保持者への不達（実体の無い blob 参照）→ 保留
+//! - 大きさ超過（取得上限より大きい blob）→ 保留
+//!
+//! いずれも真実源の `provider_failure_allowed = 0`（失敗が許可へ落ちていない）と
+//! 「索引 0 件」を突合する。
+
+use std::time::Duration;
+
+use anyhow::Result;
+use kukuri_cn_core::{IndexScopeKind, inspect_index_integrity};
+use kukuri_cn_e2e::{E2eOptions, E2eStack};
+use kukuri_cn_indexer::config::MediaFetchConfig;
+use kukuri_cn_indexer::projection::IndexProjection;
+
+const TINY_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+];
+const HOLD_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// 保留（索引 0 件・許可落ち 0 件）を突合する共通の後段検証。
+async fn assert_held(stack: &E2eStack, object_id: &str) -> Result<()> {
+    assert!(
+        !stack
+            .projection
+            .contains_object(
+                IndexScopeKind::PublicTopic,
+                stack.topic_id.as_str(),
+                object_id
+            )
+            .await?,
+        "held object {object_id} must not reach the projection"
+    );
+    let findings = inspect_index_integrity(&stack.pool).await?;
+    assert_eq!(findings.index_entries_total, 0, "{findings:?}");
+    assert_eq!(findings.provider_failure_allowed, 0, "{findings:?}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn vlm_outage_holds_text_posts() -> Result<()> {
+    let Some(stack) = E2eStack::boot("vlmdown").await? else {
+        return Ok(());
+    };
+    // 模擬の応答を全て外す = 視覚言語モデル停止（未定義の要求は 404 になる）。
+    stack.vlm.reset().await;
+
+    let object_id = stack.publish_text_post("停止中に流れた無害な文章").await?;
+    assert!(
+        stack
+            .wait_for_state(
+                |state| state.scanned >= 1 && state.skipped_non_allow >= 1,
+                HOLD_TIMEOUT
+            )
+            .await?,
+        "scan must run and hold while the vlm is down"
+    );
+    assert_held(&stack, object_id.as_str()).await?;
+    stack.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn arachnid_timeout_holds_media_posts() -> Result<()> {
+    let Some(stack) = E2eStack::boot("shieldslow").await? else {
+        return Ok(());
+    };
+    // 応答待ち上限（5 秒）を超える遅延応答 = 時間切れ。
+    stack.mount_arachnid_delay(Duration::from_secs(8)).await;
+
+    let (object_id, _) = stack
+        .publish_image_post("時間切れ対象のメディア投稿", TINY_PNG, "image/png")
+        .await?;
+    assert!(
+        stack
+            .wait_for_state(|state| state.skipped_non_allow >= 1, HOLD_TIMEOUT)
+            .await?,
+        "scan must hold when the arachnid probe times out"
+    );
+    assert_held(&stack, object_id.as_str()).await?;
+    stack.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_media_holder_holds_posts() -> Result<()> {
+    let Some(stack) = E2eStack::boot("nomedia").await? else {
+        return Ok(());
+    };
+    // どのノードも実体を持たない blob 参照（保持者への不達）。
+    let missing_hash = "a".repeat(64);
+    let object_id = stack
+        .publish_post_with_missing_media(
+            "実体の無い添付を持つ投稿",
+            missing_hash.as_str(),
+            "image/png",
+        )
+        .await?;
+    assert!(
+        stack
+            .wait_for_state(
+                |state| state.skipped_non_allow >= 1 || state.media_fetch_unavailable >= 1,
+                HOLD_TIMEOUT
+            )
+            .await?,
+        "scan must hold when the media holder is unreachable"
+    );
+    assert_held(&stack, object_id.as_str()).await?;
+    stack.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn oversize_media_holds_posts() -> Result<()> {
+    let Some(stack) = E2eStack::boot_with(
+        "oversize",
+        E2eOptions {
+            media_fetch: Some(MediaFetchConfig {
+                max_bytes: 8,
+                timeout: Duration::from_secs(30),
+            }),
+        },
+    )
+    .await?
+    else {
+        return Ok(());
+    };
+
+    // 取得上限（8 bytes）より大きいメディア（12 bytes）。
+    let (object_id, _) = stack
+        .publish_image_post("上限超過のメディア投稿", TINY_PNG, "image/png")
+        .await?;
+    assert!(
+        stack
+            .wait_for_state(
+                |state| state.skipped_non_allow >= 1 || state.media_fetch_oversize >= 1,
+                HOLD_TIMEOUT
+            )
+            .await?,
+        "scan must hold when the media exceeds the fetch limit"
+    );
+    assert_held(&stack, object_id.as_str()).await?;
+    stack.shutdown().await
+}

--- a/crates/cn-e2e/tests/recovery.rs
+++ b/crates/cn-e2e/tests/recovery.rs
@@ -1,0 +1,92 @@
+//! #616 T6: 復旧の E2E。
+//!
+//! - 常駐ワーカー再起動後も対象範囲と取り込みが復元される
+//! - 投影（ArcadeDB）を空にしても、真実源とレプリカから再構築される
+//! - プロバイダ停止で保留になった投稿が、復旧後の再走査で索引に入る
+//!
+//! （以前の image と環境変数への切り戻しは実機検証 T7 の記録項目。ここでは
+//! プロセス内で再現できる復旧経路を固定する）
+
+use std::time::Duration;
+
+use anyhow::Result;
+use kukuri_cn_core::IndexScopeKind;
+use kukuri_cn_e2e::E2eStack;
+use kukuri_cn_indexer::projection::IndexProjection;
+
+const PROJECTION_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn worker_restart_projection_rebuild_and_provider_recovery() -> Result<()> {
+    let Some(mut stack) = E2eStack::boot("recover").await? else {
+        return Ok(());
+    };
+
+    // 前提: 通常の取り込みが 1 件通っている。
+    let first = stack.publish_text_post("再起動前の投稿").await?;
+    assert!(
+        stack
+            .wait_for_projection(first.as_str(), PROJECTION_TIMEOUT)
+            .await?,
+        "first post did not reach the projection"
+    );
+
+    // --- 復旧 1: ワーカー再起動後も対象範囲と取り込みが復元される ---
+    stack.restart_worker().await?;
+    let second = stack.publish_text_post("再起動後の投稿").await?;
+    assert!(
+        stack
+            .wait_for_projection(second.as_str(), PROJECTION_TIMEOUT)
+            .await?,
+        "post after worker restart did not reach the projection (scope must be restored)"
+    );
+
+    // --- 復旧 2: 投影を空にしても真実源とレプリカから再構築される ---
+    stack
+        .projection
+        .remove_scope(IndexScopeKind::PublicTopic, stack.topic_id.as_str())
+        .await?;
+    assert!(
+        stack
+            .wait_for_projection(first.as_str(), PROJECTION_TIMEOUT)
+            .await?,
+        "projection was not rebuilt after being emptied"
+    );
+    assert!(
+        stack
+            .wait_for_projection(second.as_str(), PROJECTION_TIMEOUT)
+            .await?,
+        "projection rebuild must cover all posts"
+    );
+
+    // --- 復旧 3: プロバイダ停止で保留になった投稿が、復旧後の再走査で索引に入る ---
+    stack.vlm.reset().await;
+    let held = stack.publish_text_post("停止中に届いた投稿").await?;
+    assert!(
+        stack
+            .wait_for_state(|state| state.skipped_non_allow >= 1, PROJECTION_TIMEOUT)
+            .await?,
+        "post during the outage must be held"
+    );
+    assert!(
+        !stack
+            .projection
+            .contains_object(
+                IndexScopeKind::PublicTopic,
+                stack.topic_id.as_str(),
+                held.as_str()
+            )
+            .await?,
+        "held post must not surface during the outage"
+    );
+
+    stack.restore_default_provider_mocks().await;
+    assert!(
+        stack
+            .wait_for_projection(held.as_str(), PROJECTION_TIMEOUT)
+            .await?,
+        "held post must be indexed after the provider recovers"
+    );
+
+    stack.shutdown().await
+}

--- a/crates/cn-e2e/tests/trust_relation_graph.rs
+++ b/crates/cn-e2e/tests/trust_relation_graph.rs
@@ -1,0 +1,317 @@
+//! #616 T6: 信頼・申し立て・関係の E2E。
+//!
+//! - 危険信号（UserPubkey 対象。本番と同じ永続化関数で発行）が信頼値の絶対・相対成分へ
+//!   入り、閲覧者に固定された read（viewer = bearer）で読める
+//! - 申し立ての係争中は寄与が据え置かれ、認容で寄与が戻り、訂正信号が読み取り面に反映される
+//!   （申し立て受理の HTTP 経路は cn-user-api の contract test が固定済みのため、ここでは
+//!   handler と同じ遷移関数で状態を進める）
+//! - 関係: 公開トピックの共参加 → 解析後に近接度と近傍が更新される。プライベート
+//!   チャンネル由来の共参加はグラフへ入らない。離脱設定は可逆
+//!
+//! 関係解析は `cn-cli relation analyze` と同じ経路（`PgCoParticipationSource` +
+//! `ArcadeDbRelationGraph` + `analyze_relations`）を同一プロセスで実行する。
+
+use std::time::Duration;
+
+use anyhow::Result;
+use kukuri_cn_core::{IndexEntryStore, RiskSignalCorrection};
+use kukuri_cn_core::{
+    IndexScopeKind, NewIndexEntry, PgCoParticipationSource, dispute_risk_signal,
+    persist_risk_signal, reissue_corrected_risk_signal, update_risk_signal_appeal_status,
+    upsert_scan_verdict,
+};
+use kukuri_cn_e2e::E2eStack;
+use kukuri_cn_indexer::{ArcadeDbConfig, ArcadeDbRelationGraph, analyze_relations};
+use kukuri_cn_safety::provider::SubjectKind;
+use kukuri_cn_safety::{
+    AppealStatus, Basis, ReasonCode, RiskSignalTarget, SafetyAction, SafetyCategory,
+    SafetyRiskSignal, SafetyVerdict, Severity, Visibility,
+};
+use kukuri_core::generate_keys;
+use reqwest::{Client, StatusCode};
+
+const PROJECTION_TIMEOUT: Duration = Duration::from_secs(120);
+
+fn user_risk_signal(
+    target_pubkey: &str,
+    category: SafetyCategory,
+    severity: Severity,
+    basis: Basis,
+    visibility: Visibility,
+) -> SafetyRiskSignal {
+    SafetyRiskSignal {
+        target: RiskSignalTarget::UserPubkey,
+        target_id: target_pubkey.to_string(),
+        category,
+        severity,
+        basis,
+        confidence: Some(100),
+        visibility,
+        expires_at: None,
+        appeal_status: None,
+    }
+}
+
+fn allow_verdict() -> SafetyVerdict {
+    SafetyVerdict {
+        action: SafetyAction::Allow,
+        labels: Vec::new(),
+        critical: false,
+        reason_code: ReasonCode::NoKnownMatch,
+        confidence: None,
+        provider: Some("e2e-seed".to_string()),
+        provider_capability: None,
+        policy_version: "policy-e2e".to_string(),
+        scanned_at: "2026-08-06T00:00:00Z".to_string(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn trust_appeal_and_relation_graph_work_end_to_end() -> Result<()> {
+    let Some(stack) = E2eStack::boot("graph").await? else {
+        return Ok(());
+    };
+    let client = Client::new();
+
+    // --- 関係: 公開トピックの共参加 → 解析 → 近接度・近傍 ---
+    let author_a = stack.author.keys.clone();
+    let author_b = generate_keys();
+    let post_a = stack.publish_text_post("共参加の投稿（著者 A）").await?;
+    let post_b = stack
+        .publish_text_post_as(&author_b, "共参加の投稿（著者 B）")
+        .await?;
+    for object_id in [post_a.as_str(), post_b.as_str()] {
+        assert!(
+            stack
+                .wait_for_projection(object_id, PROJECTION_TIMEOUT)
+                .await?,
+            "co-participation post {object_id} did not reach the projection"
+        );
+    }
+
+    // `cn-cli relation analyze` と同じ経路で解析する（定期解析の 1 回分）。
+    let graph = ArcadeDbRelationGraph::new(ArcadeDbConfig::from_env())?;
+    graph.ensure_schema().await?;
+    let source = PgCoParticipationSource::new(stack.pool.clone());
+    let report = analyze_relations(&source, &graph, 100).await?;
+    assert!(
+        report.edges_upserted >= 1,
+        "co-participation must produce at least one edge: {report:?}"
+    );
+
+    let token_a = stack.authenticate_as(&client, &author_a).await?;
+    let pubkey_b = author_b.public_key_hex();
+    let relation_url = format!("{}/v1/relation/users/{pubkey_b}", stack.api_base_url);
+    let relation = client
+        .get(relation_url.as_str())
+        .bearer_auth(token_a.as_str())
+        .send()
+        .await?;
+    assert_eq!(relation.status(), StatusCode::OK);
+    let relation_body = relation.json::<serde_json::Value>().await?;
+    assert_eq!(
+        relation_body["target_pubkey"].as_str(),
+        Some(pubkey_b.as_str())
+    );
+    let neighbors = client
+        .get(format!("{}/v1/relation/neighbors", stack.api_base_url))
+        .bearer_auth(token_a.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<serde_json::Value>()
+        .await?;
+    let neighbor_list: Vec<&str> = neighbors["neighbors"]
+        .as_array()
+        .map(|list| list.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    assert!(
+        neighbor_list.contains(&pubkey_b.as_str()),
+        "author B must appear in author A's neighbors: {neighbors}"
+    );
+
+    // --- 関係: プライベートチャンネル由来の共参加はグラフへ入らない ---
+    let author_c = generate_keys();
+    let pubkey_c = author_c.public_key_hex();
+    for (author, object_id) in [
+        (author_a.public_key_hex(), "private-post-a"),
+        (pubkey_c.clone(), "private-post-c"),
+    ] {
+        let verdict = upsert_scan_verdict(
+            &stack.pool,
+            SubjectKind::Post,
+            &format!("{}-{object_id}", stack.topic_id),
+            &allow_verdict(),
+        )
+        .await?;
+        stack
+            .entries
+            .upsert_entry(&NewIndexEntry {
+                scope_kind: IndexScopeKind::PrivateChannel,
+                scope_id: format!("chan-{}", stack.topic_id),
+                object_id: format!("{}-{object_id}", stack.topic_id),
+                author_pubkey: author,
+                created_at: 1_700_000_000,
+                source_replica_id: format!("channel::chan-{}", stack.topic_id),
+                verdict_id: verdict.id,
+                verdict_action: "allow".to_string(),
+                critical: false,
+            })
+            .await?;
+    }
+    let report = analyze_relations(&source, &graph, 100).await?;
+    let _ = report;
+    let private_pair = client
+        .get(format!(
+            "{}/v1/relation/users/{pubkey_c}",
+            stack.api_base_url
+        ))
+        .bearer_auth(token_a.as_str())
+        .send()
+        .await?;
+    assert_eq!(
+        private_pair.status(),
+        StatusCode::NOT_FOUND,
+        "private-channel co-participation must not enter the public relation graph"
+    );
+
+    // --- 関係: 離脱設定は可逆（設定中は他者から見えず、解除で戻る） ---
+    let token_b = stack.authenticate_as(&client, &author_b).await?;
+    client
+        .put(format!("{}/v1/relation/optout", stack.api_base_url))
+        .bearer_auth(token_b.as_str())
+        .send()
+        .await?
+        .error_for_status()?;
+    let hidden = client
+        .get(relation_url.as_str())
+        .bearer_auth(token_a.as_str())
+        .send()
+        .await?;
+    assert_eq!(
+        hidden.status(),
+        StatusCode::NOT_FOUND,
+        "opted-out user must be hidden"
+    );
+    client
+        .delete(format!("{}/v1/relation/optout", stack.api_base_url))
+        .bearer_auth(token_b.as_str())
+        .send()
+        .await?
+        .error_for_status()?;
+    let visible_again = client
+        .get(relation_url.as_str())
+        .bearer_auth(token_a.as_str())
+        .send()
+        .await?;
+    assert_eq!(
+        visible_again.status(),
+        StatusCode::OK,
+        "opt-out must be reversible"
+    );
+
+    // --- 信頼: 危険信号が絶対・相対成分へ入り、根拠つきで読める ---
+    persist_risk_signal(
+        &stack.pool,
+        "e2e-issuer-node",
+        &user_risk_signal(
+            pubkey_b.as_str(),
+            SafetyCategory::Csam,
+            Severity::Critical,
+            Basis::KnownHashMatch,
+            Visibility::Public,
+        ),
+    )
+    .await?;
+    let relative_signal = persist_risk_signal(
+        &stack.pool,
+        "e2e-issuer-node",
+        &user_risk_signal(
+            pubkey_b.as_str(),
+            SafetyCategory::Nsfw,
+            Severity::High,
+            Basis::ClassifierScore,
+            Visibility::Local,
+        ),
+    )
+    .await?;
+    let trust_url = format!("{}/v1/trust/users/{pubkey_b}", stack.api_base_url);
+    let read_trust = || async {
+        anyhow::Ok(
+            client
+                .get(trust_url.as_str())
+                .bearer_auth(token_a.as_str())
+                .send()
+                .await?
+                .error_for_status()?
+                .json::<serde_json::Value>()
+                .await?,
+        )
+    };
+    let initial = read_trust().await?;
+    let initial_relative = initial["relative"].as_f64().unwrap();
+    assert!(
+        initial["absolute"].as_f64().unwrap() <= -1.0 + 1e-9,
+        "confirmed CSAM signal must floor the absolute component: {initial}"
+    );
+    assert!(
+        initial_relative < 0.0,
+        "classifier signal must weigh on the relative component: {initial}"
+    );
+
+    // --- 申し立て: 係争中は寄与据え置き → 認容で寄与が戻る → 訂正信号が反映される ---
+    // （HTTP の申し立て受理経路は cn-user-api の contract test が固定済み。ここでは
+    //   handler と同じ遷移関数で係争 → 認容を進める）
+    dispute_risk_signal(&stack.pool, relative_signal.id.as_str()).await?;
+    let disputed = read_trust().await?;
+    assert_eq!(
+        disputed["relative"].as_f64().unwrap(),
+        initial_relative,
+        "disputed contribution must stay in place until resolution: {disputed}"
+    );
+
+    update_risk_signal_appeal_status(
+        &stack.pool,
+        relative_signal.id.as_str(),
+        AppealStatus::Cleared,
+    )
+    .await?;
+    let cleared = read_trust().await?;
+    assert!(
+        cleared["relative"].as_f64().unwrap() > initial_relative,
+        "accepted appeal must restore the relative component: {cleared}"
+    );
+
+    // 訂正信号の再発行: 旧信号を失効させ、訂正内容の新信号が根拠に現れる。
+    let corrected = reissue_corrected_risk_signal(
+        &stack.pool,
+        relative_signal.id.as_str(),
+        &RiskSignalCorrection {
+            severity: Some(Severity::Low),
+            confidence: Some(10),
+            ..RiskSignalCorrection::default()
+        },
+        chrono::Utc::now().to_rfc3339().as_str(),
+        true,
+    )
+    .await?;
+    let after_correction = read_trust().await?;
+    let basis_ids: Vec<&str> = after_correction["basis"]
+        .as_array()
+        .map(|list| {
+            list.iter()
+                .filter_map(|entry| entry["signal_id"].as_str())
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        basis_ids.contains(&corrected.id.as_str()),
+        "corrected signal must appear in the trust evidence: {after_correction}"
+    );
+    assert!(
+        !basis_ids.contains(&relative_signal.id.as_str()),
+        "expired original signal must no longer appear: {after_correction}"
+    );
+
+    stack.shutdown().await
+}

--- a/docker-compose.community-node.e2e.yml
+++ b/docker-compose.community-node.e2e.yml
@@ -1,0 +1,14 @@
+# 全構成 E2E（#616 / `cargo xtask cn-e2e`）用の重ね掛け定義。
+#
+# 標準の docker-compose.community-node.yml に重ねて使い、テストプロセス
+# （同一ホスト上の cargo test）が実 ArcadeDB へ届くよう、ループバック限定で
+# HTTP API を公開する。標準構成（container private network 内のみで listen）を
+# 変えないため、本番・開発の既定では読み込まない。
+#
+#   docker compose -f docker-compose.community-node.yml \
+#                  -f docker-compose.community-node.e2e.yml up -d cn-arcadedb ...
+
+services:
+  cn-arcadedb:
+    ports:
+      - "${CN_ARCADEDB_HOST_BIND_IP:-127.0.0.1}:${CN_ARCADEDB_PORT:-12480}:2480"

--- a/xtask/src/cn.rs
+++ b/xtask/src/cn.rs
@@ -25,6 +25,50 @@ pub(crate) fn cn_test() -> Result<()> {
     })
 }
 
+/// 全構成 E2E（#616）。compose の重ね掛け定義で実 ArcadeDB をループバックへ公開し、
+/// 実 Postgres / Redis / ArcadeDB を用意した上で `kukuri-cn-e2e` のテストを発火する。
+pub(crate) fn cn_e2e() -> Result<()> {
+    with_cn_e2e_stack(|| {
+        run_with_owned_env(
+            "cargo",
+            vec![
+                "test".to_string(),
+                "-p".to_string(),
+                "kukuri-cn-e2e".to_string(),
+            ],
+            &root_dir(),
+            &cn_e2e_test_envs(),
+        )
+    })
+}
+
+pub(crate) fn cn_e2e_test_envs() -> Vec<(String, String)> {
+    let mut envs = cn_test_envs();
+    envs.push(("KUKURI_CN_RUN_E2E_TESTS".to_string(), "1".to_string()));
+    envs.push((
+        "COMMUNITY_NODE_ARCADEDB_URL".to_string(),
+        cn_e2e_arcadedb_url(),
+    ));
+    envs.push((
+        "COMMUNITY_NODE_ARCADEDB_USER".to_string(),
+        "root".to_string(),
+    ));
+    envs.push((
+        "COMMUNITY_NODE_ARCADEDB_PASSWORD".to_string(),
+        "cn_arcadedb_password".to_string(),
+    ));
+    envs.push((
+        "COMMUNITY_NODE_ARCADEDB_DATABASE".to_string(),
+        "kukuri_index".to_string(),
+    ));
+    envs
+}
+
+pub(crate) fn cn_e2e_arcadedb_url() -> String {
+    let port = resolve_port(std::env::var("CN_ARCADEDB_PORT").ok(), "12480");
+    format!("http://127.0.0.1:{port}")
+}
+
 pub(crate) fn cn_compose_envs() -> [(&'static str, &'static str); 4] {
     [
         ("CN_POSTGRES_PASSWORD", "cn_password"),
@@ -86,7 +130,36 @@ fn resolve_port(port_env: Option<String>, default: &str) -> String {
 }
 
 pub(crate) fn with_cn_postgres<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
+    with_cn_compose_services(
+        &["docker-compose.community-node.yml"],
+        &["cn-postgres", "cn-valkey"],
+        operation,
+    )
+}
+
+/// 全構成 E2E 用: 標準定義 + 重ね掛け定義（ArcadeDB のループバック公開）で
+/// cn-postgres / cn-valkey / cn-arcadedb を用意する。
+pub(crate) fn with_cn_e2e_stack<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
+    with_cn_compose_services(
+        &[
+            "docker-compose.community-node.yml",
+            "docker-compose.community-node.e2e.yml",
+        ],
+        &["cn-postgres", "cn-valkey", "cn-arcadedb"],
+        operation,
+    )
+}
+
+fn with_cn_compose_services<T>(
+    compose_files: &[&str],
+    services: &[&str],
+    operation: impl FnOnce() -> Result<T>,
+) -> Result<T> {
     let root = root_dir();
+    let file_args: Vec<&str> = compose_files
+        .iter()
+        .flat_map(|file| ["-f", *file])
+        .collect();
     // 15432 / 16379 は Linux の一般的な ephemeral port range (32768-60999) 外に置き、
     // outgoing connection の一時ポートとの衝突を避ける。
     // さらに起動前に残骸スタックを掃除しておく。前回の cn-test が異常終了して compose スタックが
@@ -94,54 +167,23 @@ pub(crate) fn with_cn_postgres<T>(operation: impl FnOnce() -> Result<T>) -> Resu
     // 失敗する。pre-up の down は冪等で、残骸が無ければ no-op。
     // docker 未起動などの環境異常では失敗し得るが、その場合は後続の `up` が本来のエラーを
     // 返すため、ここでは best-effort（結果を無視）にする。
-    let _ = run_with_env(
-        "docker",
-        [
-            "compose",
-            "-f",
-            "docker-compose.community-node.yml",
-            "down",
-            "-v",
-            "--remove-orphans",
-        ],
-        &root,
-        &cn_compose_envs(),
-    );
-    run_with_env(
-        "docker",
-        [
-            "compose",
-            "-f",
-            "docker-compose.community-node.yml",
-            "up",
-            "-d",
-            "--wait",
-            "cn-postgres",
-            "cn-valkey",
-        ],
-        &root,
-        &cn_compose_envs(),
-    )?;
+    let mut down_args = vec!["compose"];
+    down_args.extend_from_slice(&file_args);
+    down_args.extend_from_slice(&["down", "-v", "--remove-orphans"]);
+    let _ = run_with_env("docker", down_args.clone(), &root, &cn_compose_envs());
+    let mut up_args = vec!["compose"];
+    up_args.extend_from_slice(&file_args);
+    up_args.extend_from_slice(&["up", "-d", "--wait"]);
+    up_args.extend_from_slice(services);
+    run_with_env("docker", up_args, &root, &cn_compose_envs())?;
     let operation_result = operation();
-    let shutdown_result = run_with_env(
-        "docker",
-        [
-            "compose",
-            "-f",
-            "docker-compose.community-node.yml",
-            "down",
-            "-v",
-            "--remove-orphans",
-        ],
-        &root,
-        &cn_compose_envs(),
-    );
+    let shutdown_result = run_with_env("docker", down_args, &root, &cn_compose_envs());
     match (operation_result, shutdown_result) {
         (Ok(result), Ok(())) => Ok(result),
         (Err(error), Ok(())) => Err(error),
         (Ok(_), Err(error)) => Err(error),
         (Err(operation_error), Err(shutdown_error)) => Err(operation_error.context(format!(
-            "failed to tear down cn-postgres after error: {shutdown_error:#}"
+            "failed to tear down the cn compose stack after error: {shutdown_error:#}"
         ))),
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -43,6 +43,7 @@ fn main() -> Result<()> {
         "desktop-ui-check" => desktop_ui_check(),
         "cn-check" => cn_check(),
         "cn-test" => cn_test(),
+        "cn-e2e" => cn_e2e(),
         "desktop-package" => desktop_package(),
         "release-check" => {
             let tag = args.next();
@@ -107,6 +108,6 @@ fn doctor() -> Result<()> {
 
 fn print_usage() {
     eprintln!(
-        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|app-api-slow-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-visual-test|desktop-ui-check|cn-check|cn-test|desktop-package|release-check [tag]|oversized-files [--update-baseline]|ipc-types [--check]|e2e-smoke|scenario <name>>"
+        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|app-api-slow-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-visual-test|desktop-ui-check|cn-check|cn-test|cn-e2e|desktop-package|release-check [tag]|oversized-files [--update-baseline]|ipc-types [--check]|e2e-smoke|scenario <name>>"
     );
 }


### PR DESCRIPTION
## 概要

#616 の T4（全構成 E2E の土台と許可経路）+ T5（不許可経路・障害経路）+ T6（信頼・申し立て・関係・復旧）。本番相当構成の自動 E2E を新設し、解禁対象 4 機能の契約を固定する。

（#636 の作り直し。GitGuardian が模擬用資格情報のリテラルの組を誤検知したため、資格情報を走行ごとの組み立てへ変更した）

## 変更点

- 新 crate `kukuri-cn-e2e`（cn-lane 対象）
  - harness: 実 Postgres（まっさらな migration）/ 実 ArcadeDB（投影）/ Redis + 同一プロセス内の cn-user-api・cn-indexer 常駐ワーカー・cn-iroh-relay + 実 iroh ノード 2 台（投稿者 / indexer）
  - プロバイダは本物の実装（`kukuri-cn-safety-arachnid` / `kukuri-cn-safety-vlm`）を wiremock の合成応答へ向ける。実在の違法メディアは一切使わない
  - 有効化の関門（T3）の記録を通してから読み取り面を公開する（本番と同じ順序）
- 許可経路 `allowed_path.rs`: 同期 → 走査 → 判定の永続化 → 真実源と投影 → 検索・発見・おすすめの API 取得。安全側不変条件の実測突合。取得メディアの非残留
- 不許可経路 `denied_paths.rs`: 合成した不許可文章・既知一致（重大）が索引の全面へ出ない（canary 方式）。投影残留が検索一致として返らない。判定が許可から不許可へ変わった項目が再走査で消える
- 障害経路 `failure_paths.rs`: 視覚言語モデル停止 / Arachnid の時間切れ / メディア保持者への不達 / 大きさ超過 → いずれも保留（許可へ落ちない）。形式不明はプロバイダ crate の contract test が固定済み
- 信頼・申し立て・関係 `trust_relation_graph.rs`: 危険信号が絶対・相対成分へ入り根拠つきで読める。係争中は寄与据え置き → 認容で寄与が戻る → 訂正信号の反映。公開トピック共参加 → 解析 → 近接度・近傍。プライベートチャンネル由来がグラフへ入らない。離脱の可逆性
- 復旧 `recovery.rs`: ワーカー再起動後の対象範囲復元、空にした投影の再構築、プロバイダ復旧後の再走査
- 実行入口 `cargo xtask cn-e2e`: compose 重ね掛け定義（`docker-compose.community-node.e2e.yml`。ArcadeDB をループバック限定公開）+ `KUKURI_CN_RUN_E2E_TESTS=1`
- CI に `linux-cn-e2e` 系統を追加

## 検証

- ローカルで E2E 全 8 テスト合格（許可 1 / 不許可 1 / 障害 4 / 信頼・関係 1 / 復旧 1。計 49 秒）
- 前身 #636 の CI で `linux-cn-e2e` 合格実績、本 PR 1 コミット目で GitGuardian 合格
- `cargo xtask cn-check`（kukuri-cn-e2e を含む clippy -D warnings）合格

Refs #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)