### PR TITLE
generate-tfvars が読み取り面の環境変数 gate を features から導出する (#616 T7 準備)

### DIFF
--- a/crates/cn-operator/src/deploy.rs
+++ b/crates/cn-operator/src/deploy.rs
@@ -357,6 +357,21 @@ fn render_low_cost_tfvars(config: &ResolvedConfig, deploy: &DeployConfig) -> Str
         deploy.media_fetch_timeout_secs
     );
 
+    // ユーザー向け読み取り面（索引 query / 信頼 read）の環境変数 gate。features の
+    // community_index / community_local_trust を真実源として導出する。環境変数が真でも、
+    // `cn-cli readiness` の全項目合格記録（有効化の関門）が無ければ面は公開されない。
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "index_query_enabled = {}",
+        config.enabled(crate::Capability::CommunityIndex)
+    );
+    let _ = writeln!(
+        out,
+        "trust_read_enabled  = {}",
+        config.enabled(crate::Capability::CommunityLocalTrust)
+    );
+
     // operator-config.yaml 自体を VM に配置して manifest endpoint / report_endpoint gating を
     // 有効化する。中身はこの tfvars には埋めず、Terraform 側の .tf で file() する。
     let _ = writeln!(out);

--- a/crates/cn-operator/tests/deploy.rs
+++ b/crates/cn-operator/tests/deploy.rs
@@ -81,6 +81,32 @@ fn blob_cache_enabled_derives_from_features_false() {
 }
 
 #[test]
+fn read_surface_flags_derive_from_planned_capabilities() {
+    // community_index / community_local_trust を有効化（承認済み）した config では
+    // 環境変数 gate の tfvars も true になる（実際の公開は readiness の有効化記録が関門）。
+    let yaml = config_with_deploy(
+        "  relay_domain: relay.example-kukuri.net\n",
+        "  community_index: true\n  community_local_trust: true\n",
+        true,
+    );
+    let resolved = load_and_validate(&yaml).unwrap();
+    assert!(resolved.enabled(Capability::CommunityIndex));
+    assert!(resolved.enabled(Capability::CommunityLocalTrust));
+    let tfvars = generate_tfvars(&resolved).unwrap();
+    assert!(tfvars.contains("index_query_enabled = true"));
+    assert!(tfvars.contains("trust_read_enabled  = true"));
+}
+
+#[test]
+fn read_surface_flags_default_to_false() {
+    let yaml = config_with_deploy("  relay_domain: relay.example-kukuri.net\n", "", false);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let tfvars = generate_tfvars(&resolved).unwrap();
+    assert!(tfvars.contains("index_query_enabled = false"));
+    assert!(tfvars.contains("trust_read_enabled  = false"));
+}
+
+#[test]
 fn blob_cache_size_without_feature_is_rejected() {
     // features.blob_cache=false なのに sizing > 0 は矛盾（真実源は features 側）。
     let yaml = config_with_deploy(


### PR DESCRIPTION
## 概要

#616 T7（解禁）の準備。`index_query_enabled` / `trust_read_enabled` は low-cost env の Terraform 変数（既定 false）だが、`generate-tfvars` が出力しないため、解禁時に手動追記すると次回の再生成で消える運用ハザードがあった。

## 変更点

- `generate-tfvars` が features の `community_index` / `community_local_trust`（承認済みの計画中 capability）を真実源として `index_query_enabled` / `trust_read_enabled` を出力する
- 環境変数が真でも `cn-cli readiness` の全項目合格記録（T3 の有効化の関門）が無ければ読み取り面は公開されないため、features 由来で真にしても安全側は保たれる

## 検証

- `cargo test -p kukuri-cn-operator --test deploy` 26 本合格（導出 true / 既定 false の 2 本を追加）
- 実運用の operator-config（full-service + 承認済み）からの生成で両フラグ true を確認
- clippy -D warnings 合格

Refs #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)