### PR TITLE
#616 の実機解禁記録と readiness 運用手順を追加する

### DIFF
--- a/docs/progress/2026-08-06-616-activation.md
+++ b/docs/progress/2026-08-06-616-activation.md
@@ -1,0 +1,99 @@
+# 2026-08-06 — #616 公開ノードの実行時準備判定と全構成 E2E の完成、読み取り面の解禁
+
+参照: [Issue #616](https://github.com/KingYoSun/kukuri/issues/616)（親: [#612](https://github.com/KingYoSun/kukuri/issues/612)）/
+計画: `.claude/plans/2026-08-05-issue-616-runtime-readiness-e2e.md` /
+PR: [#633](https://github.com/KingYoSun/kukuri/pull/633)（T1）· [#634](https://github.com/KingYoSun/kukuri/pull/634)（T2）·
+[#635](https://github.com/KingYoSun/kukuri/pull/635)（T3）· [#637](https://github.com/KingYoSun/kukuri/pull/637)（T4-T6）·
+[#638](https://github.com/KingYoSun/kukuri/pull/638)（T7 準備）
+
+## 到達点
+
+索引・モデレーション・信頼・関係の各読み取り面を、次の三段の関門を全部通した上で本番解禁した。
+
+1. **実行時準備判定**: `cn-cli readiness` が全 22 項目を「不明」なしで機械判定する
+   （プロバイダの実疎通確認・走査網羅の実測・投影と真実源の突合を含む）。
+2. **有効化の関門**: 全項目合格のときにのみ `cn_admin.readiness_activations` へ記録が書かれ、
+   cn-user-api は環境変数が真でもこの記録（+ 判定項目集合の現行一致）が無ければ面を公開しない。
+3. **全構成 E2E**: 本番相当構成の自動 E2E（`cargo xtask cn-e2e` / CI の `linux-cn-e2e` 系統）が
+   許可・不許可・障害・信頼・申し立て・関係・復旧の各筋書きを緑で通す。
+
+## 本番構成の記録（2026-08-05 21:10 UTC 有効化）
+
+- **image（digest 固定。main `d7261979` からのビルド）**
+  - cn-user-api: `ghcr.io/kingyosun/kukuri-cn-user-api@sha256:93a6615c8c7140ef880b488945f61e8896e9d71a0b13194884c4d233132e760e`
+  - cn-iroh-relay: `ghcr.io/kingyosun/kukuri-cn-iroh-relay@sha256:4c18b4d178b943003cce466c6807a15615b8014609cf6af1198637ee3ba5e575`
+  - cn-cli: `ghcr.io/kingyosun/kukuri-cn-cli@sha256:d57796457146c65d276470bfcdb05b4ff3beb24f2dd38a3b585a748deeebe22e`
+  - cn-indexer: `ghcr.io/kingyosun/kukuri-cn-indexer@sha256:96f6a7fd70d699c7d0f34758a06f89fbbe0897ef6202724bc17e11fd2e94ef9e`
+  - ArcadeDB: `arcadedata/arcadedb:26.8.1`
+- **設定の版**: operator-config.yaml（repo 外・git 管理外）: profile=full-service、
+  safety.profile=public-node、policy_version=`2026-06-public-node-v1`、
+  index_before_scan=false、on_scan_error=hold、permanent_blob_storage=false、
+  emit_signed_moderation_events=true。terraform.tfvars は `cn-operator generate-tfvars` で再生成し、
+  #638 以降は `index_query_enabled` / `trust_read_enabled` を features
+  （community_index / community_local_trust）から導出する。
+- **プロバイダの種別と自前/外部の区分**（資格情報の値は記録しない）
+  - known_csam: `project-arachnid-shield`（外部。合成ハッシュ送信で認証と応答受信を実測確認）
+  - general / unknown_csam: `openai-compatible-vlm`（自前。`https://vlm.kukuri.app`、
+    さくら VPS の Caddy 経由。guard 形式・応答解析の成功を実測確認）
+- **判定結果**: `readiness profile=public-node ready=true fail=0 unknown=0`（22/22 合格）。
+  有効化記録 activated_at=2026-08-05T21:10:51Z。主な実測値: worker_running=true /
+  opened_scopes=4 / 判定無し索引=0 / 非許可・重大の表出=0 / 失敗→許可=0 /
+  プライベートチャンネルの索引対象=0 / truth=projection=0（突合一致）。
+
+## 全構成 E2E の結果（#637、CI `linux-cn-e2e` 緑）
+
+crate `kukuri-cn-e2e`（実 Postgres / 実 ArcadeDB / Redis + 同一プロセス内の cn-user-api・
+cn-indexer 常駐ワーカー・cn-iroh-relay + 実 iroh ノード 2 台 + wiremock によるプロバイダ模擬。
+実在の違法メディアは一切使わない）:
+
+- 許可経路: 無害な文章・画像の投稿 → 同期 → 走査 → 判定の永続化 → 真実源と投影 →
+  検索・発見・おすすめから取得。走査用に一時取得したメディアが indexer 側の blob
+  保存領域に残らないことを構造的に固定。
+- 不許可経路: 合成した不許可文章・既知一致（重大）が索引の全面へ出ない。投影残留が
+  検索一致として返らない（fail-closed 突合）。判定が許可→不許可へ変わった項目が
+  再走査で読み取り面から消える。
+- 障害経路（障害注入）: 視覚言語モデル停止 / Arachnid の時間切れ / メディア保持者への不達 /
+  大きさ超過 → いずれも保留（`provider_failure_allowed=0`、許可へ落ちない）。
+- 信頼・申し立て・関係: 危険信号が絶対・相対成分へ入り根拠つきで読める。係争中は寄与据え置き →
+  認容で寄与が戻る → 訂正信号の反映。公開トピック共参加 → 解析 → 近接度・近傍。
+  プライベートチャンネル由来がグラフへ入らない。離脱の可逆性。
+- 復旧: ワーカー再起動後の対象範囲復元 / 空にした投影の再構築 / プロバイダ復旧後の再走査。
+
+## 実機での障害注入と復旧
+
+意図しない実地検証として、readiness 初回実行時に自前 VLM（vlm.kukuri.app）の上流が停止して
+おり（HTTP 502）、`provider_credential_valid` が不合格 → 解禁が止まることを実機で確認した
+（fail-closed の実証）。上流復旧後の再実行で全項目合格し、有効化記録が書かれた。
+
+## 解禁と外形確認
+
+- 有効化記録の書き込み後に cn-user-api を再起動し、起動ログで関門の遷移を確認:
+  記録なし時「読み取り面を公開しません」（警告）→ 記録確認後「有効化記録を確認しました」。
+- 未認証: `/v1/index/search|discovery|recommendations` / `/v1/trust/users/*` /
+  `/v1/relation/neighbors` すべて **401**（有効化前の 404 から遷移。認証必須の gate が有効）。
+- 認証済み（検証用の使い捨て鍵で挑戦署名 + 同意受諾）: 上記すべて **200** + 正常な JSON 応答。
+- `/healthz` 200。索引対象は公開トピックのみ（readiness 実測 private=0）。メディア取得の
+  計数は 0（恒久保存の構成自体が無効）。
+
+## 切り戻し手段
+
+- image: operator-config.yaml の digest を直前値へ戻して `generate-tfvars` → apply。
+  直前 digest（記録）: cn-user-api `sha256:81f18daf…c63c8` / cn-iroh-relay `sha256:90bd48a3…a53d` /
+  cn-cli `sha256:6d0e78d3…4164` / cn-indexer `sha256:e87db0d7…4875`。
+- 環境変数: features の community_index / community_local_trust を false にして再生成すれば
+  `*_ENABLED=false` に戻る（面は即 404）。また記録が無効になる判定基準変更時は自動で閉じる。
+- 復旧経路そのもの（ワーカー再起動・投影再構築・再走査）は E2E `recovery.rs` が固定。
+
+## 運用メモ
+
+- VM 上での readiness 実行は `cn-relation-analyze` サービス（cn-cli image）を流用するが、
+  プロバイダ資格情報の env はサービス定義に含まれないため、project `.env` を source して
+  `-e` で転送する（runbook に追記済み）。
+- readiness の疎通確認結果は 15 分 TTL で `cn_admin.readiness_probe_cache` に保存され、
+  `--force-probe` で強制再実行できる。
+
+## 残作業（後続 Issue）
+
+- 実運用の投稿が索引へ入った後の実測値の見直し（現時点で対象 4 トピックは投稿 0 件）。
+- 届出受領前の拘束条件（#612 / #617 に記載: DNS の停止か招待制への切替）の適用判断。
+- プライベートチャンネル索引の本番解禁（申請ベース。#612 側の後続）。

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -283,6 +283,37 @@ journalctl -u kukuri-relation-analyze.service -n 50
 外部からの port scan で 80/443/`relay_quic_port`/udp 以外（2480 / 8630 / 5432 / 6379）が
 閉じていることも確認する（firewall には新規 ingress を追加していない）。
 
+### readiness（読み取り面の解禁判定、#616）
+
+読み取り面（索引 query / 信頼 read）は、環境変数（`COMMUNITY_NODE_INDEX_QUERY_ENABLED` /
+`COMMUNITY_NODE_TRUST_READ_ENABLED`）が真でも、`cn-cli readiness` の全項目合格記録
+（`cn_admin.readiness_activations`）が無ければ公開されない（有効化の関門）。
+全項目合格すると記録は自動で書かれる。反映には cn-user-api の再起動が必要
+（関門は起動時に評価される）。
+
+`cn-relation-analyze` サービス（cn-cli image）を流用して実行するが、プロバイダ資格情報の
+env はサービス定義に含まれないため、project `.env` を source して `-e` で転送する:
+
+```bash
+# VM 上で:
+cd /var/lib/kukuri/community-node
+sudo bash -c 'set -a; . ./.env; set +a; \
+  /var/lib/toolbox/kukuri/bin/docker-compose run --rm \
+    -e PROJECT_ARACHNID_API_USERNAME -e PROJECT_ARACHNID_API_PASSWORD \
+    -e COMMUNITY_NODE_VLM_API_KEY \
+    -v /var/lib/kukuri/community-node/operator-config.yaml:/work/operator-config.yaml:ro \
+    cn-relation-analyze readiness --config /work/operator-config.yaml'
+# 全項目合格 → 有効化記録が書かれる → cn-user-api を再起動して反映:
+sudo /var/lib/toolbox/kukuri/bin/docker-compose restart cn-user-api
+```
+
+- 疎通確認（Arachnid への合成ハッシュ送信 / VLM への無害な 1 リクエスト）の結果は
+  15 分 TTL で保存され、`--force-probe` で強制再実行できる。
+- `relation_analysis_recent` が不合格の場合は relation analyze を 1 回実行する
+  （`docker-compose run --rm cn-relation-analyze`。既定の許容は 7200 秒以内の成功記録）。
+- 判定項目集合が変わる更新を入れた場合、古い記録は無効になり面は自動で閉じる
+  （readiness の再実行 + 再起動で再解禁する）。
+
 ### VLM の private 経路（self-host endpoint）
 
 - self-host VLM（DGX Spark 等の OpenAI-compatible endpoint）は public internet へ直接公開しない。


### PR DESCRIPTION
## 概要

#616 T7（実機検証・解禁・記録)の記録文書と運用手順。

- `docs/progress/2026-08-06-616-activation.md`: 三段の関門（実行時準備判定 22/22 → 有効化記録 → 全構成 E2E）を通した本番解禁の記録。image digest・設定の版・プロバイダの種別と自前/外部の区分・判定結果・E2E 結果・障害注入結果（実機での VLM 停止 → fail-closed 実証を含む）・切り戻し手段。資格情報の値は記録しない
- runbook（community-node-gcp-terraform.md）: VM 上での readiness 実行手順（`cn-relation-analyze` サービス流用時の資格情報 env 転送、有効化記録の反映には cn-user-api 再起動が必要、probe TTL、判定基準変更時の自動閉鎖と再解禁）

## 実機の外形確認（記録済み）

- 未認証: 索引・信頼・関係の全面が 401（有効化前の 404 から遷移）
- 認証済み（使い捨て鍵）: 全面 200 + 正常応答
- 索引対象は公開トピックのみ、生メディアの恒久保存なし（構成 + 実測 0 件）

Refs #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)