### PR TITLE
capability 説明・外部送信・保持・構成図の開示を実態へ同期する (#617 T2-T6)

### DIFF
--- a/crates/cn-e2e/tests/denied_paths.rs
+++ b/crates/cn-e2e/tests/denied_paths.rs
@@ -161,9 +161,28 @@ async fn disallowed_content_never_surfaces_and_verdict_flip_hides_entries() -> R
     }
     assert!(hidden, "flipped verdict must hide the entry");
 
-    // 索引解除後も安全側不変条件は保たれている（非許可の表出 0）。
+    // 索引解除後も安全側不変条件は保たれている。読み取り面の非表示は即時だが、
+    // 真実源の索引行の削除は再走査の巡内でわずかに遅れる（判定更新 → 行削除の間は
+    // 一時的に「非許可の表出」が数えられ得る）ため、削除完了までは有界に待ち、
+    // 最終状態で表出 0 を固定する。
+    let deadline = tokio::time::Instant::now() + PROJECTION_TIMEOUT;
+    let mut deindexed = false;
+    while tokio::time::Instant::now() < deadline {
+        if inspect_index_integrity(&stack.pool)
+            .await?
+            .index_entries_total
+            == 0
+        {
+            deindexed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+    assert!(
+        deindexed,
+        "flipped entry must be removed from the index truth"
+    );
     let findings = inspect_index_integrity(&stack.pool).await?;
-    assert_eq!(findings.index_entries_total, 0, "{findings:?}");
     assert_eq!(findings.non_allow_or_critical_surfaced, 0, "{findings:?}");
 
     stack.shutdown().await

--- a/crates/cn-operator/src/capability.rs
+++ b/crates/cn-operator/src/capability.rs
@@ -243,35 +243,56 @@ impl Capability {
             Capability::CommunityIndex => CapabilityMeta {
                 capability: self,
                 display_name: "コミュニティインデックス (community index)",
-                handled_data: "（計画）index 対象 content のメタデータ、検索インデックス",
-                purpose: "（計画）community node が関与した content の検索・発見の補助",
-                retention_impact: "（計画）index 保持方針はノード設定に従う",
+                handled_data: "サポート対象の公開トピック（共有レプリカ）上の投稿の本文テキストとメタデータ。\
+                    索引の真実源は Postgres、検索投影は ArcadeDB（真実源から再構築可能）。\
+                    生メディアは索引にもデータベースにも保存しない",
+                purpose: "安全性走査を通過した許可 content のみを対象とする検索・発見・おすすめの補助",
+                retention_impact: "索引項目は、対象トピックから外れた時点・判定が許可以外へ変わった時点で\
+                    索引解除される。検索投影は派生データであり真実源から再構築できる",
                 external_transmission: None,
-                telecom_note: "（計画）index はノードの authority scope 内に限定される。",
-                privacy_note: "（計画）index 対象と保持方針を実装時に明記する。",
-                terms_note: "（計画）本ノードが index した content の範囲についてのみ責任を負う旨を記載する。",
+                telecom_note: "索引と検索・発見・おすすめの権限は、本ノードのサポート対象（公開トピック）\
+                    内に限定される。本ノードは content の真実源ではない。",
+                privacy_note: "公開トピックへ公開された投稿のみを対象とし、走査済みの許可 content のみを\
+                    索引する。生メディアを保持しない。",
+                terms_note: "本ノードが索引した content の範囲についてのみ責任を負い、検索・発見・おすすめは\
+                    本ノードの authority scope 内に限定される旨を記載する。",
             },
             Capability::Moderation => CapabilityMeta {
                 capability: self,
                 display_name: "モデレーション (moderation)",
-                handled_data: "（計画）moderation verdict、署名付き moderation event",
-                purpose: "（計画）ノードの index / discovery / recommendation からの critical safety risk の排除",
-                retention_impact: "（計画）moderation ログ保持期間に従う",
+                handled_data: "テキスト・メディアの安全性走査の判定（scan verdict）、署名付き moderation \
+                    event、根拠付き risk signal、申し立て状態。照合プロバイダの生の Match Data・生応答は\
+                    保存・配布せず、AI の入力にも使わない",
+                purpose: "既知一致照合（Project Arachnid Shield）と分類器（OpenAI 互換の視覚言語モデル）に\
+                    よる走査で、critical safety risk を本ノードの索引・発見・おすすめから排除する。\
+                    走査は fail-closed（走査失敗・プロバイダ不達・メディア不達は許可へ落とさず保留）",
+                retention_impact: "判定・moderation event はモデレーションログ保持期間に従う。risk signal \
+                    は失効・訂正再発行・申し立ての対象。走査のため一時取得したメディアは恒久保存しない",
                 external_transmission: None,
-                telecom_note: "（計画）moderation はノードの authority scope 内に限定される。",
-                privacy_note: "（計画）moderation 対象データの扱いを実装時に明記する。",
-                terms_note: "（計画）moderation event は本ノードの authority scope 内でのみ意味を持つ旨を記載する。",
+                telecom_note: "moderation は node-local の判断であり、本ノードの authority scope 内に\
+                    限定される。network 全体への命令ではない。",
+                privacy_note: "走査のためメディアを一時取得する（恒久保存しない）。プロバイダの Match Data \
+                    を保存・配布・AI 入力に使わない。プロバイダへの送信内容は外部送信ポリシーに明記する。",
+                terms_note: "moderation event は本ノードの authority scope 内でのみ意味を持ち、判定への\
+                    申し立て（異議）の導線を提供する旨を記載する。",
             },
             Capability::CommunityLocalTrust => CapabilityMeta {
                 capability: self,
-                display_name: "コミュニティローカル trust signal (community-local trust)",
-                handled_data: "（計画）根拠付き risk signal / trust signal",
-                purpose: "（計画）ノードの authority scope 内での trust / relation signal の発行",
-                retention_impact: "（計画）signal の失効ポリシーに従う",
+                display_name: "コミュニティローカル信頼・関係 (community-local trust / relation)",
+                handled_data: "根拠付き risk signal と信頼合成値（絶対・相対成分）、公開トピックの共参加\
+                    由来の pairwise relation（近接度・近傍。ArcadeDB 上の再構築可能な派生グラフ）、\
+                    関係表示の離脱設定",
+                purpose: "閲覧者に固定された node-local advisory としての信頼・関係の読み取り提供\
+                    （trust と relation の双方を含む）",
+                retention_impact: "risk signal は失効・半減期減衰・申し立てに従う。relation graph は\
+                    公開トピックの共参加から定期解析で再構築できる派生データ",
                 external_transmission: None,
-                telecom_note: "（計画）trust signal はノードの authority scope 内に限定される。",
-                privacy_note: "（計画）signal 対象データの扱いを実装時に明記する。",
-                terms_note: "（計画）trust signal は network-wide command ではなく optional trust input である旨を記載する。",
+                telecom_note: "信頼・関係は node-local advisory であり、本ノードの authority scope 内に\
+                    限定される。canonical な identity / social graph を変更しない。",
+                privacy_note: "関係の入力は公開トピックの共参加のみで、プライベートチャンネル由来の信号は\
+                    使わない。関係表示の離脱（opt-out）は可逆で、信頼値に影響しない。",
+                terms_note: "trust signal は network-wide command ではなく optional な入力であり、\
+                    cross-cluster content を自動抑制しない旨を記載する。",
             },
             Capability::ReportEndpoint => CapabilityMeta {
                 capability: self,

--- a/crates/cn-operator/src/capability_risk.rs
+++ b/crates/cn-operator/src/capability_risk.rs
@@ -202,7 +202,7 @@ impl Capability {
                     "index 前に safety scan を行い、scan 前 / scan 失敗 / critical verdict を index しない（#353 fail-closed）。",
                     "index 除外を signed moderation event として説明・監査可能にする。",
                 ],
-                small_scale_tips: "safety provider を用意できるまで有効化しない判断も妥当（現状 Phase B / 未提供）。",
+                small_scale_tips: "safety provider を用意できるまで有効化しない判断も妥当。",
                 how_to_reduce: "`features.community_index: false`（既定）で無効化できる。",
             },
             Capability::Moderation => CapabilityRiskPractices {

--- a/crates/cn-operator/src/docs.rs
+++ b/crates/cn-operator/src/docs.rs
@@ -486,6 +486,71 @@ fn gen_data_retention(config: &ResolvedConfig) -> String {
         "- モデレーションログ: {} 日\n",
         config.raw.retention.moderation_logs_days
     );
+
+    // データ区分と保存先（#617。索引・モデレーション・信頼・関係の各系統が有効な場合）。
+    let index_stack_active = config.enabled(Capability::CommunityIndex)
+        || config.enabled(Capability::Moderation)
+        || config.enabled(Capability::CommunityLocalTrust);
+    if index_stack_active {
+        let _ = writeln!(s, "## データ区分と保存先\n");
+        let _ = writeln!(s, "| データ | 保存先 | 性質 |");
+        let _ = writeln!(s, "|---|---|---|");
+        let _ = writeln!(
+            s,
+            "| 認証・同意・通報 | Postgres | 管理系の永続データ（同意は撤回まで、通報は保持方針に従う） |"
+        );
+        let _ = writeln!(
+            s,
+            "| 走査判定（scan verdict） | Postgres | fail-closed な索引真実源が参照する判定記録 |"
+        );
+        let _ = writeln!(
+            s,
+            "| 署名付き moderation event / risk signal | Postgres | 保持期間・失効・訂正再発行・申し立ての対象 |"
+        );
+        let _ = writeln!(
+            s,
+            "| 索引の真実源（index truth） | Postgres | 許可判定のみを持つ authoritative な索引記録 |"
+        );
+        let _ = writeln!(
+            s,
+            "| 検索投影 | ArcadeDB | 真実源から再構築可能な派生データ（バックアップ対象外） |"
+        );
+        let _ = writeln!(
+            s,
+            "| relation graph | ArcadeDB | 公開トピック共参加から定期解析で再構築可能な node-local advisory（バックアップ対象外） |"
+        );
+        let _ = writeln!(
+            s,
+            "| ランデブー / presence | Valkey | TTL 付きの揮発データ（短期で自動失効） |"
+        );
+        let _ = writeln!(
+            s,
+            "| 生メディア | （保存しない） | 走査時の一時取得のみで恒久保存しない |"
+        );
+        let _ = writeln!(
+            s,
+            "| indexer のレプリカ同期状態 | ローカル永続 volume | 同期復元用であり content の canonical store ではない |"
+        );
+        s.push('\n');
+        let _ = writeln!(s, "## 削除・再構築・バックアップ\n");
+        let _ = writeln!(
+            s,
+            "- 索引項目は、対象トピックから外れた時点・判定が許可以外へ変わった時点で削除される。"
+        );
+        let _ = writeln!(
+            s,
+            "- risk signal は失効（expires_at）と半減期減衰の対象で、申し立ての認容で寄与から除外される。"
+        );
+        let _ = writeln!(
+            s,
+            "- ArcadeDB（検索投影・relation graph）は失われても真実源とレプリカから再構築できる。"
+        );
+        let _ = writeln!(
+            s,
+            "- バックアップ対象は Postgres のみ。ArcadeDB・Valkey・一時取得メディアはバックアップ対象外。\n"
+        );
+    }
+
     let _ = writeln!(s, "## capability 別の保持への影響（運用中）\n");
     for cap in available_enabled(config) {
         let m = cap.meta();

--- a/crates/cn-operator/src/docs.rs
+++ b/crates/cn-operator/src/docs.rs
@@ -53,6 +53,63 @@ fn external_destinations(config: &ResolvedConfig) -> Vec<ExternalDestination> {
     dests
 }
 
+/// 安全性走査プロバイダへの送信先（operator config 由来の動的開示。#617）。
+///
+/// 真実源はプロバイダ構成そのもの（構成されていれば走査時に送信が発生する）。
+/// 公開資料には送信先名・区分・目的・データ区分のみを出し、接続先 URL・内部
+/// アドレス・資格情報は出さない。
+struct SafetyProviderDestination {
+    display_name: &'static str,
+    /// 真 = 運営者が管理する基盤（第三者への外部送信ではない）。
+    operator_controlled: bool,
+    purpose: &'static str,
+    data_categories: &'static str,
+}
+
+fn safety_provider_destinations(config: &ResolvedConfig) -> Vec<SafetyProviderDestination> {
+    let Some(safety) = config.raw.safety.as_ref() else {
+        return Vec::new();
+    };
+    let providers = &safety.providers;
+    let normalized = |entry: &crate::SafetyProviderEntry| entry.provider.trim().replace('_', "-");
+    let mut dests = Vec::new();
+
+    if let Some(entry) = providers.known_csam.as_ref()
+        && normalized(entry) == "project-arachnid-shield"
+    {
+        dests.push(SafetyProviderDestination {
+            display_name:
+                "Project Arachnid Shield（Canadian Centre for Child Protection が運営する照合 API）",
+            operator_controlled: false,
+            purpose: "既知 CSAM（児童性的虐待コンテンツ）との照合による検知走査",
+            data_categories: "走査対象メディアのバイト列またはそのハッシュ。認証は運営者自身の\
+                資格情報で行う。照合結果の詳細（Match Data）は保存・配布しない",
+        });
+    }
+
+    // 視覚言語モデルは general / unknown_csam のどちらの slot でも同一の送信先として
+    // 1 件に集約する。区分は hosting 宣言に従い、未指定は保守側（第三者への外部送信）。
+    let vlm_entry = [providers.general.as_ref(), providers.unknown_csam.as_ref()]
+        .into_iter()
+        .flatten()
+        .find(|entry| normalized(entry) == "openai-compatible-vlm");
+    if let Some(entry) = vlm_entry {
+        let self_host = matches!(entry.hosting, Some(crate::ProviderHosting::SelfHost));
+        dests.push(SafetyProviderDestination {
+            display_name: if self_host {
+                "運営者が管理する視覚言語モデル基盤（OpenAI 互換 API）"
+            } else {
+                "外部の視覚言語モデル API（OpenAI 互換）"
+            },
+            operator_controlled: self_host,
+            purpose: "投稿本文・メディアのモデレーション目的の分類走査",
+            data_categories: "走査対象の本文テキストおよびメディアのバイト列。モデルの生応答は\
+                保存・配布しない",
+        });
+    }
+    dests
+}
+
 /// 文書ヘッダ（タイトル + 運営者情報 + 注記）。
 fn header(config: &ResolvedConfig, title: &str) -> String {
     let s = &config.raw.server;
@@ -307,6 +364,31 @@ fn gen_external_transmission(config: &ResolvedConfig) -> String {
     for dest in external_destinations(config) {
         let _ = writeln!(s, "### {}\n", dest.display_name());
         let _ = writeln!(s, "{}\n", dest.description());
+    }
+
+    // 安全性走査プロバイダへの送信（構成されている場合のみ。#617）。
+    let safety_dests = safety_provider_destinations(config);
+    if !safety_dests.is_empty() {
+        let _ = writeln!(s, "## 安全性走査プロバイダへの送信\n");
+        let _ = writeln!(
+            s,
+            "モデレーション（安全性走査）のため、構成済みプロバイダへ次の送信が発生します。\
+             接続先の具体的なアドレスは運用上の理由で公開しません。\n"
+        );
+        for dest in safety_dests {
+            let _ = writeln!(s, "### {}\n", dest.display_name);
+            let _ = writeln!(
+                s,
+                "- 区分: {}",
+                if dest.operator_controlled {
+                    "運営者が管理する基盤内の送信（第三者への外部送信ではない）"
+                } else {
+                    "第三者への外部送信"
+                }
+            );
+            let _ = writeln!(s, "- 目的: {}", dest.purpose);
+            let _ = writeln!(s, "- 送信するデータ: {}\n", dest.data_categories);
+        }
     }
 
     // 無効化により送信されないものを明示（analytics: false 等の検証可能性）。

--- a/crates/cn-operator/src/docs.rs
+++ b/crates/cn-operator/src/docs.rs
@@ -53,6 +53,13 @@ fn external_destinations(config: &ResolvedConfig) -> Vec<ExternalDestination> {
     dests
 }
 
+/// 索引・モデレーション・信頼のいずれかが有効か（実データフロー開示の出し分けに使う）。
+fn index_stack_active(config: &ResolvedConfig) -> bool {
+    config.enabled(Capability::CommunityIndex)
+        || config.enabled(Capability::Moderation)
+        || config.enabled(Capability::CommunityLocalTrust)
+}
+
 /// 安全性走査プロバイダへの送信先（operator config 由来の動的開示。#617）。
 ///
 /// 真実源はプロバイダ構成そのもの（構成されていれば走査時に送信が発生する）。
@@ -189,6 +196,100 @@ fn gen_network_diagram(config: &ResolvedConfig) -> String {
         );
     }
 
+    // 索引・モデレーション・信頼の系統が有効な node の実データフロー（#617）。
+    if index_stack_active(config) {
+        if let Some(cloud) = config.raw.server.cloud_provider.as_deref() {
+            let _ = writeln!(s, "使用するサーバー: {cloud}\n");
+        }
+        let _ = writeln!(s, "## 構成要素とデータフロー\n");
+        let _ = writeln!(s, "```text");
+        let _ = writeln!(s, "利用者端末 / 他ピア");
+        let _ = writeln!(
+            s,
+            "  ├─ Direct P2P … 端末間の直接通信（本ノードを経由しない）"
+        );
+        let _ = writeln!(
+            s,
+            "  ├─ cn-user-api（HTTPS。リバースプロキシ経由）… 認証・同意・検索/発見/おすすめ・\
+             信頼/関係の読み取り・通報"
+        );
+        let _ = writeln!(
+            s,
+            "  └─ cn-iroh-relay（HTTP/QUIC）… 接続補助と、直接通信が成立しない場合の\
+             暗号化済み traffic の中継"
+        );
+        let _ = writeln!(s);
+        let _ = writeln!(s, "ノード内部（private network。外部へ公開しない）");
+        let _ = writeln!(
+            s,
+            "  ├─ cn-indexer … 公開トピックのレプリカ同期（iroh-docs）・安全性走査・索引書き込み\
+             の常駐ワーカー"
+        );
+        let _ = writeln!(
+            s,
+            "  ├─ Postgres … 管理系データ・走査判定・署名付き event / risk signal・索引の真実源（永続）"
+        );
+        let _ = writeln!(
+            s,
+            "  ├─ Valkey … ランデブー / presence（TTL 付きの揮発データ）"
+        );
+        let _ = writeln!(
+            s,
+            "  ├─ ArcadeDB … 検索投影・relation graph（真実源から再構築可能な派生データ）"
+        );
+        let _ = writeln!(
+            s,
+            "  └─ 関係解析の定期実行 … 公開トピックの共参加から relation graph を更新"
+        );
+        let _ = writeln!(s);
+        let _ = writeln!(s, "外部 / 運営者基盤（ノードからの outbound のみ）");
+        let safety_dests = safety_provider_destinations(config);
+        let _ = writeln!(
+            s,
+            "  {} iroh docs / blob ピア … レプリカ同期と、走査用メディアの一時取得（恒久保存しない）",
+            if safety_dests.is_empty() {
+                "└─"
+            } else {
+                "├─"
+            }
+        );
+        for (index, dest) in safety_dests.iter().enumerate() {
+            let branch = if index + 1 == safety_dests.len() {
+                "└─"
+            } else {
+                "├─"
+            };
+            let _ = writeln!(
+                s,
+                "  {branch} {} … {}",
+                dest.display_name,
+                if dest.operator_controlled {
+                    "運営者が管理する基盤（第三者への外部送信ではない）"
+                } else {
+                    "第三者への外部送信（outbound HTTPS）"
+                }
+            );
+        }
+        let _ = writeln!(s, "```");
+        let _ = writeln!(s);
+        let _ = writeln!(s, "境界の要点:\n");
+        let _ = writeln!(
+            s,
+            "- 公開するのは利用者向け API（HTTPS）と relay（HTTP/QUIC）のみ。データベース類は\
+             外部へ公開しない。"
+        );
+        let _ = writeln!(
+            s,
+            "- 索引・モデレーション・信頼・関係の権限は、本ノードのサポート対象（公開トピック）内に\
+             限定される。"
+        );
+        let _ = writeln!(
+            s,
+            "- 保存区分: 永続（Postgres）/ 揮発（Valkey、TTL）/ 再構築可能（ArcadeDB）/ \
+             一時（走査用メディア。恒久保存しない）。\n"
+        );
+    }
+
     // manifest の authority scope / P2P boundary を文書へ反映する。
     let manifest = build_manifest(config);
     let _ = writeln!(s, "## node role と責任境界 (authority scope)\n");
@@ -236,6 +337,14 @@ fn gen_telecom_notification(config: &ResolvedConfig) -> String {
          自宅サーバー構成や回線設置を伴う構成は advanced であり、個別確認が必要です。\n"
     );
     let _ = writeln!(s, "## 役務の概要\n");
+    let _ = writeln!(
+        s,
+        "提供するサービス: P2P コミュニケーションネットワークの補助サービス"
+    );
+    if let Some(cloud) = config.raw.server.cloud_provider.as_deref() {
+        let _ = writeln!(s, "使用するサーバー: {cloud}");
+    }
+    let _ = writeln!(s);
     let _ = writeln!(
         s,
         "本サービスは、P2P network の補助層として動作する community node です。\
@@ -453,9 +562,34 @@ fn gen_moderation_policy(config: &ResolvedConfig) -> String {
          これらは network-wide command ではなく、他ノード・client が任意に採用し得る optional trust input です。\n"
     );
     if config.enabled(Capability::Moderation) || config.enabled(Capability::CommunityLocalTrust) {
+        let _ = writeln!(s, "## 走査と判定の流れ\n");
         let _ = writeln!(
             s,
-            "（計画中）moderation / trust signal は現行実装では未提供です。実装方針は #353 / #362 に従います。\n"
+            "- 索引対象は走査後にのみ索引へ入ります（index_before_scan は無効。fail-closed）。"
+        );
+        let _ = writeln!(
+            s,
+            "- 既知一致照合（known-match）と分類器（OpenAI 互換の視覚言語モデル）で本文テキスト・\
+             メディアを走査します。走査失敗・プロバイダ不達・メディア不達は許可へ落とさず保留します。"
+        );
+        let _ = writeln!(
+            s,
+            "- 判定は scan verdict として保存され、非許可・重大への変化は索引から除外されます。"
+        );
+        let _ = writeln!(
+            s,
+            "- 判定に基づく moderation event は署名付きで発行され、risk signal は根拠つきで保存されます。"
+        );
+        let _ = writeln!(
+            s,
+            "- 照合プロバイダの Match Data・モデルの生応答は保存・配布せず、AI の入力にも使いません。\n"
+        );
+        let _ = writeln!(s, "## 申し立て（異議）\n");
+        let _ = writeln!(
+            s,
+            "本ノードが発行した moderation advisory（risk signal）へは、通報導線から申し立てできます。\
+             係争中の寄与は据え置かれ、認容された場合は寄与から除外され、必要に応じて訂正信号を\
+             再発行します。\n"
         );
     } else {
         let _ = writeln!(
@@ -488,10 +622,7 @@ fn gen_data_retention(config: &ResolvedConfig) -> String {
     );
 
     // データ区分と保存先（#617。索引・モデレーション・信頼・関係の各系統が有効な場合）。
-    let index_stack_active = config.enabled(Capability::CommunityIndex)
-        || config.enabled(Capability::Moderation)
-        || config.enabled(Capability::CommunityLocalTrust);
-    if index_stack_active {
+    if index_stack_active(config) {
         let _ = writeln!(s, "## データ区分と保存先\n");
         let _ = writeln!(s, "| データ | 保存先 | 性質 |");
         let _ = writeln!(s, "|---|---|---|");

--- a/crates/cn-operator/src/lib.rs
+++ b/crates/cn-operator/src/lib.rs
@@ -39,8 +39,8 @@ pub use manifest::{
 };
 pub use profile::Profile;
 pub use safety_config::{
-    SafetyConfig, SafetyErrorAction, SafetyEventsConfig, SafetyIndexingConfig, SafetyProviderEntry,
-    SafetyProvidersConfig, SafetyStorageConfig,
+    ProviderHosting, SafetyConfig, SafetyErrorAction, SafetyEventsConfig, SafetyIndexingConfig,
+    SafetyProviderEntry, SafetyProvidersConfig, SafetyStorageConfig,
 };
 pub use safety_readiness::{
     PUBLIC_NODE_PROFILE, READINESS_CHECK_IDS, RUNTIME_CHECK_IDS, ReadinessCheck, ReadinessReport,

--- a/crates/cn-operator/src/safety_config.rs
+++ b/crates/cn-operator/src/safety_config.rs
@@ -134,6 +134,23 @@ pub struct SafetyProviderEntry {
     /// readiness 判定には使用しない。実際の効果は後続の runtime scan orchestration で適用する。
     #[serde(default)]
     pub on_high_confidence: Option<SafetyErrorAction>,
+    /// プロバイダ基盤の区分（外部送信表示の生成に使う。#617）。
+    ///
+    /// - `self_host`: 運営者が管理する基盤（第三者への外部送信ではない）
+    /// - `external`: 第三者の API（第三者への外部送信として開示する）
+    ///
+    /// 未指定は保守側（`external` 相当 = 第三者への外部送信として開示）で扱う。
+    /// 開示にはこの区分のみを使い、接続先 URL・内部アドレスは公開資料へ出さない。
+    #[serde(default)]
+    pub hosting: Option<ProviderHosting>,
+}
+
+/// 安全性プロバイダの基盤区分（開示用）。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderHosting {
+    SelfHost,
+    External,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]

--- a/crates/cn-operator/tests/generate.rs
+++ b/crates/cn-operator/tests/generate.rs
@@ -255,6 +255,76 @@ fn cloudflare_enabled_emits_external_transmission() {
     assert!(active_section.contains("Cloudflare"));
 }
 
+/// safety providers 付きの config（外部送信の動的開示の検証用）。
+/// `vlm_hosting_line` は general provider 配下の行（例: `"      hosting: self_host\n"`）か空。
+fn config_with_safety_providers(vlm_hosting_line: &str) -> String {
+    let base = r#"server:
+  domain: example-kukuri.net
+  operator_name: Example Operator
+  country: JP
+features:
+  moderation: true
+retention:
+  connection_logs_days: 30
+  moderation_logs_days: 180
+safety:
+  profile: public-node
+  policy_version: 2026-06-public-node-v1
+  providers:
+    known_csam:
+      provider: project-arachnid-shield
+      required: true
+      credential_secret_id: kukuri-cn-safety-known-csam
+    general:
+      provider: openai-compatible-vlm
+"#;
+    format!("{base}{vlm_hosting_line}")
+}
+
+#[test]
+fn safety_providers_surface_in_external_transmission_notice() {
+    // 自前ホスト宣言: 視覚言語モデルは運営者管理基盤、Arachnid は第三者への外部送信。
+    let yaml = config_with_safety_providers("      hosting: self_host\n");
+    let resolved = load_and_validate(&yaml).unwrap();
+    let ext = doc(&generate_all(&resolved), "external-transmission-notice.md");
+    assert!(ext.contains("安全性走査プロバイダへの送信"));
+    assert!(ext.contains("Project Arachnid Shield"));
+    assert!(ext.contains("第三者への外部送信"));
+    assert!(ext.contains("運営者が管理する視覚言語モデル基盤"));
+    assert!(ext.contains("第三者への外部送信ではない"));
+
+    // 外部 API 宣言: 視覚言語モデルも第三者への外部送信として表示される。
+    let yaml = config_with_safety_providers("      hosting: external\n");
+    let resolved = load_and_validate(&yaml).unwrap();
+    let ext = doc(&generate_all(&resolved), "external-transmission-notice.md");
+    assert!(ext.contains("外部の視覚言語モデル API"));
+    assert!(!ext.contains("運営者が管理する視覚言語モデル基盤"));
+
+    // 未指定は保守側（第三者への外部送信）として扱う。
+    let yaml = config_with_safety_providers("");
+    let resolved = load_and_validate(&yaml).unwrap();
+    let ext = doc(&generate_all(&resolved), "external-transmission-notice.md");
+    assert!(ext.contains("外部の視覚言語モデル API"));
+}
+
+#[test]
+fn generated_docs_never_contain_private_endpoints_or_secret_ids_values() {
+    // 公開資料の非含有監査: URL・secret 値らしき文字列が生成物に出ないこと。
+    // （secret は ID のみ config に書かれ、値はそもそも config に無い。ここでは
+    //   接続先アドレスの類が漏れないことを固定する）
+    let yaml = config_with_safety_providers("      hosting: self_host\n");
+    let resolved = load_and_validate(&yaml).unwrap();
+    for file in generate_all(&resolved) {
+        for needle in ["http://10.", "http://192.168.", "wireguard", "WireGuard"] {
+            assert!(
+                !file.content.contains(needle),
+                "{}: must not leak private endpoints: {needle}",
+                file.filename
+            );
+        }
+    }
+}
+
 #[test]
 fn promoted_capability_metadata_describes_implemented_behavior() {
     // #617 T2: 昇格した 3 capability の説明が「（計画）」ではなく実装済みのデータフローを

--- a/crates/cn-operator/tests/generate.rs
+++ b/crates/cn-operator/tests/generate.rs
@@ -256,6 +256,60 @@ fn cloudflare_enabled_emits_external_transmission() {
 }
 
 #[test]
+fn promoted_capability_metadata_describes_implemented_behavior() {
+    // #617 T2: 昇格した 3 capability の説明が「（計画）」ではなく実装済みのデータフローを
+    // 記述していることを固定する（開示文書の生成元となる契約）。
+    for cap in [
+        Capability::CommunityIndex,
+        Capability::Moderation,
+        Capability::CommunityLocalTrust,
+    ] {
+        let meta = cap.meta();
+        for text in [
+            meta.handled_data,
+            meta.purpose,
+            meta.retention_impact,
+            meta.telecom_note,
+            meta.privacy_note,
+            meta.terms_note,
+        ] {
+            assert!(
+                !text.contains("計画"),
+                "{cap}: metadata must not read as planned: {text}"
+            );
+        }
+    }
+
+    // index: 許可 content のみ・真実源と投影の分離・生メディア非保存。
+    let index = Capability::CommunityIndex.meta();
+    assert!(index.handled_data.contains("公開トピック"));
+    assert!(index.handled_data.contains("Postgres"));
+    assert!(index.handled_data.contains("ArcadeDB"));
+    assert!(index.handled_data.contains("生メディア"));
+    assert!(index.purpose.contains("走査を通過した許可"));
+    assert!(index.telecom_note.contains("真実源ではない"));
+
+    // moderation: 既知一致 + 分類器・fail-closed・Match Data 非保存・authority 限定。
+    let moderation = Capability::Moderation.meta();
+    assert!(moderation.purpose.contains("Project Arachnid Shield"));
+    assert!(moderation.purpose.contains("視覚言語モデル"));
+    assert!(moderation.purpose.contains("fail-closed"));
+    assert!(moderation.handled_data.contains("Match Data"));
+    assert!(moderation.telecom_note.contains("authority scope"));
+    assert!(moderation.terms_note.contains("申し立て"));
+
+    // trust / relation: 双方を含む・node-local advisory・共参加のみ・opt-out 可逆。
+    let trust = Capability::CommunityLocalTrust.meta();
+    assert!(trust.display_name.contains("relation"));
+    assert!(trust.purpose.contains("node-local advisory"));
+    assert!(trust.privacy_note.contains("共参加"));
+    assert!(trust.privacy_note.contains("プライベートチャンネル"));
+    assert!(trust.privacy_note.contains("可逆"));
+    assert!(trust.telecom_note.contains("canonical"));
+    assert!(trust.terms_note.contains("network-wide command"));
+}
+
+#[test]
 fn promoted_capability_listed_as_operating() {
     // #617 の昇格後、moderation は運用中の補助機能として記載され、「計画中」分離は出ない。
     let yaml = base_config("  moderation: true\n", false);

--- a/crates/cn-operator/tests/generate.rs
+++ b/crates/cn-operator/tests/generate.rs
@@ -308,6 +308,91 @@ fn safety_providers_surface_in_external_transmission_notice() {
 }
 
 #[test]
+fn moderation_policy_describes_scan_flow_and_appeals() {
+    // #617 T6: moderation-policy が「未提供」ではなく走査の流れ・申し立て導線を説明する。
+    let yaml = config_with_safety_providers("      hosting: self_host\n");
+    let resolved = load_and_validate(&yaml).unwrap();
+    let policy = doc(&generate_all(&resolved), "moderation-policy.md");
+    for needle in [
+        "走査と判定の流れ",
+        "fail-closed",
+        "視覚言語モデル",
+        "Match Data",
+        "申し立て",
+    ] {
+        assert!(policy.contains(needle), "missing: {needle}");
+    }
+    assert!(!policy.contains("未提供"));
+}
+
+#[test]
+fn generated_docs_contain_no_planned_wording_after_promotion() {
+    // #617 T6: 昇格後、全生成物から「計画中」表記が消えている（分離セクション含む）。
+    let yaml = config_with_safety_providers("      hosting: self_host\n");
+    let resolved = load_and_validate(&yaml).unwrap();
+    for file in generate_all(&resolved) {
+        assert!(
+            !file.content.contains("計画中"),
+            "{}: planned wording must not remain",
+            file.filename
+        );
+    }
+}
+
+#[test]
+fn network_diagram_shows_index_stack_data_flow() {
+    // #617 T5: 索引系が有効な node の構成図に、実データフロー（3 ブロック）と境界説明が載る。
+    let yaml = config_with_safety_providers("      hosting: self_host\n");
+    let resolved = load_and_validate(&yaml).unwrap();
+    let diagram = doc(&generate_all(&resolved), "network-diagram.md");
+    for needle in [
+        "構成要素とデータフロー",
+        "利用者端末 / 他ピア",
+        "Direct P2P",
+        "cn-user-api",
+        "cn-indexer",
+        "Postgres",
+        "Valkey",
+        "ArcadeDB",
+        "関係解析の定期実行",
+        "iroh docs / blob ピア",
+        "Project Arachnid Shield",
+        "運営者が管理する視覚言語モデル基盤",
+        "サポート対象（公開トピック）内に",
+        "恒久保存しない",
+    ] {
+        assert!(diagram.contains(needle), "missing: {needle}");
+    }
+
+    // 索引系が無効な node には実データフロー節を出さない（過大表示の防止）。
+    let yaml = base_config("", false);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let diagram = doc(&generate_all(&resolved), "network-diagram.md");
+    assert!(!diagram.contains("構成要素とデータフロー"));
+}
+
+#[test]
+fn telecom_notification_carries_service_name_and_server() {
+    // 届出様式への転記元: サービス名と使用サーバーの行を持つ。
+    let yaml = config_with_safety_providers("      hosting: self_host\n");
+    let resolved = load_and_validate(&yaml).unwrap();
+    let telecom = doc(&generate_all(&resolved), "telecom-notification-draft.md");
+    assert!(telecom.contains("提供するサービス: P2P コミュニケーションネットワークの補助サービス"));
+    // fixture に cloud_provider が無い場合は行ごと出ない（誤記入の防止）。
+    assert!(!telecom.contains("使用するサーバー:"));
+
+    let with_cloud = yaml.replace(
+        "  country: JP\n",
+        "  country: JP\n  cloud_provider: Google Cloud\n",
+    );
+    let resolved = load_and_validate(&with_cloud).unwrap();
+    let telecom = doc(&generate_all(&resolved), "telecom-notification-draft.md");
+    assert!(telecom.contains("使用するサーバー: Google Cloud"));
+    let diagram = doc(&generate_all(&resolved), "network-diagram.md");
+    assert!(diagram.contains("使用するサーバー: Google Cloud"));
+}
+
+#[test]
 fn data_retention_lists_storage_classes_for_index_stack() {
     // #617 T4: 索引・モデレーション・信頼の系統が有効な node では、データ区分と保存先・
     // 再構築/バックアップ区分が保持ポリシーへ載る。

--- a/crates/cn-operator/tests/generate.rs
+++ b/crates/cn-operator/tests/generate.rs
@@ -308,6 +308,33 @@ fn safety_providers_surface_in_external_transmission_notice() {
 }
 
 #[test]
+fn data_retention_lists_storage_classes_for_index_stack() {
+    // #617 T4: 索引・モデレーション・信頼の系統が有効な node では、データ区分と保存先・
+    // 再構築/バックアップ区分が保持ポリシーへ載る。
+    let yaml = config_with_safety_providers("      hosting: self_host\n");
+    let resolved = load_and_validate(&yaml).unwrap();
+    let retention = doc(&generate_all(&resolved), "data-retention-policy.md");
+    assert!(retention.contains("データ区分と保存先"));
+    for needle in [
+        "Postgres",
+        "ArcadeDB",
+        "Valkey",
+        "恒久保存しない",
+        "再構築可能",
+        "バックアップ対象は Postgres のみ",
+        "canonical store ではない",
+    ] {
+        assert!(retention.contains(needle), "missing: {needle}");
+    }
+
+    // 系統が無効な node には索引系の保存先区分を書かない（誤開示防止）。
+    let yaml = base_config("", false);
+    let resolved = load_and_validate(&yaml).unwrap();
+    let retention = doc(&generate_all(&resolved), "data-retention-policy.md");
+    assert!(!retention.contains("データ区分と保存先"));
+}
+
+#[test]
 fn generated_docs_never_contain_private_endpoints_or_secret_ids_values() {
     // 公開資料の非含有監査: URL・secret 値らしき文字列が生成物に出ないこと。
     // （secret は ID のみ config に書かれ、値はそもそも config に無い。ここでは


### PR DESCRIPTION
## 概要

#617 の T2（metadata 更新）+ T3（外部送信の動的開示）+ T4（保存・保持の開示）+ T5（構成図・役務説明）+ T6（生成文書全体の同期）。#640（T1 昇格）の後続。

## 変更点

- **T2 metadata**: 昇格した 3 capability の説明を「（計画）」から実装済みのデータフローへ更新
  - index: 公開トピック対象・走査を通過した許可 content のみ・Postgres 真実源 + ArcadeDB 投影・生メディア非保存・authority scope 内限定
  - moderation: 既知一致照合 + 分類器・fail-closed・署名付き event / risk signal / 申し立て・Match Data を保存/配布/AI 入力に使わない・node-local の判断
  - trust / relation: 表示名に双方を明記・node-local advisory・公開トピック共参加のみ・opt-out 可逆・canonical を変更しない
- **T3 外部送信**: `SafetyProviderEntry` に `hosting`（self_host / external。未指定は保守側 = 第三者への外部送信）を追加し、外部送信表示へ「安全性走査プロバイダへの送信」節を動的生成（Arachnid = 第三者、視覚言語モデル = hosting で切替）。接続先 URL・内部アドレスは出さない（非含有監査テスト）
- **T4 保持**: データ保持ポリシーへ「データ区分と保存先」表（Postgres / ArcadeDB / Valkey / 生メディア非保存 / indexer ローカル状態）と削除・再構築・バックアップの節を追加。索引系が無効な node には出さない
- **T5 構成図・役務説明**: 構成図に「構成要素とデータフロー」（利用者端末/他ピア・ノード内部・外部/運営者基盤）と境界の要点を追加。届出補助資料へサービス名・使用サーバーの転記用行を追加
- **T6 同期**: moderation-policy の「未提供」分岐を走査の流れ・申し立て導線の説明へ置換。昇格後の全生成物に「計画中」表記が残らないことを監査テストで固定
- 併せて denied_paths E2E の索引解除待ちを有界待機へ修正（#640 の CI で実発生した競合 flake の解消）

## 検証

- `cargo test -p kukuri-cn-operator` 全 7 suite 緑（generate 39 本。自前/外部 VLM の出力差・非含有監査・「計画中」不在を含む）
- `cargo xtask cn-check`（clippy -D warnings）合格
- 実運用 operator-config からの試し生成で 12 文書とも整合・非含有監査クリーンを確認済み
- denied_paths E2E はローカルで修正後合格

Refs #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)