### PR TITLE
Complete community node operational hardening

### DIFF
--- a/.env.community-node.example
+++ b/.env.community-node.example
@@ -68,6 +68,10 @@ COMMUNITY_NODE_CHANNEL_SECRET_KEY=dev-only-channel-secret-key-0123456789abcdef
 # 既定 false（full-stack E2E 完了までは無効のまま維持する。無効時は 404）。
 # relation graph は cn-relation-analyze service（定期 batch）が構築する。
 # COMMUNITY_NODE_TRUST_READ_ENABLED=false
+# readiness activation はこのdeploy revision、operator config、check集合へ拘束される。
+# image/config/providerを変更したら値を更新し、readinessを再実行する。
+COMMUNITY_NODE_DEPLOYMENT_REVISION=local-compose-v1
+COMMUNITY_NODE_READINESS_ACTIVATION_MAX_AGE_SECS=900
 # trust 合成の operator 可変パラメータ（ADR 0026 §6.2。未設定は初期決め打ち値）:
 # w_abs（絶対成分マイナス時の重み。既定 2.0）/ w_abs（0 以上時。既定 1.0）/ 相対成分の半減期（日。既定 30）。
 # COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE=2.0
@@ -105,6 +109,12 @@ COMMUNITY_NODE_CHANNEL_SECRET_KEY=dev-only-channel-secret-key-0123456789abcdef
 # COMMUNITY_NODE_SAFETY_SUSPECTED_SIGNAL_VISIBILITY=local
 # operator レビュー（検知メタデータ編集。cn-cli moderation コマンド）を有効化するか。既定 false。
 # COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW=false
+# 署名付きmoderation eventを発行する鍵。production providerを有効にする場合は必須。
+# COMMUNITY_NODE_SAFETY_SIGNING_KEY=64_hex_chars
+# COMMUNITY_NODE_SAFETY_EMIT_SIGNED_EVENTS=true
+# ephemeral media fetchの上限とtimeout（未設定時はbinary既定）。
+# COMMUNITY_NODE_MEDIA_FETCH_MAX_BYTES=33554432
+# COMMUNITY_NODE_MEDIA_FETCH_TIMEOUT_SECS=30
 
 CN_USER_API_HOST_BIND_IP=127.0.0.1
 CN_USER_API_PORT=18080

--- a/crates/cn-cli/src/commands/readiness.rs
+++ b/crates/cn-cli/src/commands/readiness.rs
@@ -12,7 +12,8 @@ use chrono::{Duration, Utc};
 use sqlx::PgPool;
 
 use kukuri_cn_core::{
-    ReadinessProbeRecord, initialize_database, list_readiness_probes, record_readiness_activation,
+    ReadinessProbeRecord, initialize_database, list_readiness_probes,
+    readiness_context_fingerprint, record_readiness_activation, record_readiness_revocation,
     upsert_readiness_probe,
 };
 use kukuri_cn_operator::{
@@ -160,6 +161,12 @@ pub(super) async fn run(
 
     let yaml = std::fs::read_to_string(config_path)
         .with_context(|| format!("{} を読み込めません", config_path.display()))?;
+    let deployment_revision = std::env::var("COMMUNITY_NODE_DEPLOYMENT_REVISION")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .context("COMMUNITY_NODE_DEPLOYMENT_REVISION is required for readiness activation")?;
+    let context_fingerprint =
+        readiness_context_fingerprint(profile, &deployment_revision, yaml.as_bytes());
     let resolved = load_and_validate(&yaml)?;
     let mut report = evaluate_public_node_readiness(&resolved, profile);
 
@@ -300,6 +307,14 @@ pub(super) async fn run(
     }
 
     if report.has_blocking_failures() {
+        record_readiness_revocation(
+            pool,
+            now,
+            &report.profile,
+            &context_fingerprint,
+            "readiness_failed",
+        )
+        .await?;
         bail!(
             "readiness に不合格の項目があります (fail={})",
             report.fail_count()
@@ -321,7 +336,15 @@ pub(super) async fn run(
                 })
                 .collect::<Vec<_>>()
         );
-        record_readiness_activation(pool, now, &report.profile, &check_ids, &report_json).await?;
+        record_readiness_activation(
+            pool,
+            now,
+            &report.profile,
+            &check_ids,
+            &context_fingerprint,
+            &report_json,
+        )
+        .await?;
         println!("OK: すべての readiness check を満たしています。有効化記録を書き込みました。");
     } else {
         println!(

--- a/crates/cn-cli/src/commands/readiness_runtime.rs
+++ b/crates/cn-cli/src/commands/readiness_runtime.rs
@@ -106,19 +106,20 @@ pub(crate) fn evaluate(findings: &RuntimeFindings) -> Vec<ReadinessCheck> {
                 snapshot.opened_scopes >= 1,
                 format!("opened_scopes={}", snapshot.opened_scopes),
             ));
+            let now = findings.now.timestamp();
             let fresh = snapshot
                 .last_sync_at
-                .is_some_and(|at| findings.now.timestamp() - at <= findings.ingest_max_age_secs);
+                .is_some_and(|at| now - at <= findings.ingest_max_age_secs)
+                && snapshot
+                    .last_ingest_at
+                    .is_some_and(|at| now - at <= findings.ingest_max_age_secs);
             checks.push(check(
                 "indexer_ingest_fresh",
                 fresh,
-                match snapshot.last_sync_at {
-                    Some(at) => format!(
-                        "last_sync_at={} (許容 {} 秒)",
-                        at, findings.ingest_max_age_secs
-                    ),
-                    None => "全件見直しの成功記録がありません".to_string(),
-                },
+                format!(
+                    "last_sync_at={:?} last_ingest_at={:?} (許容 {} 秒)",
+                    snapshot.last_sync_at, snapshot.last_ingest_at, findings.ingest_max_age_secs
+                ),
             ));
         }
         Err(error) => {
@@ -269,6 +270,7 @@ mod tests {
                 ingest_enabled: true,
                 opened_scopes: 4,
                 last_sync_at: Some(now.timestamp() - 60),
+                last_ingest_at: Some(now.timestamp() - 60),
                 ..IndexerStateSnapshot::default()
             }),
             migrations_ready: Ok(()),
@@ -329,6 +331,19 @@ mod tests {
         );
         assert_eq!(
             status_of(&checks, "relation_analysis_recent").status,
+            ReadinessStatus::Fail
+        );
+    }
+
+    #[test]
+    fn full_pass_timestamp_without_successful_ingest_fails_freshness() {
+        let mut findings = healthy_findings();
+        if let Ok(snapshot) = &mut findings.snapshot {
+            snapshot.last_ingest_at = None;
+        }
+        let checks = evaluate(&findings);
+        assert_eq!(
+            status_of(&checks, "indexer_ingest_fresh").status,
             ReadinessStatus::Fail
         );
     }

--- a/crates/cn-core/migrations/202608060002_risk_signal_subject_authors.sql
+++ b/crates/cn-core/migrations/202608060002_risk_signal_subject_authors.sql
@@ -1,0 +1,17 @@
+-- Preserve the relationship between a content-scoped risk signal and the
+-- author whose trust score consumes it. A content item can have more than one
+-- observed author (for example, a shared blob), so the relationship is
+-- intentionally many-to-many.
+CREATE TABLE cn_safety.risk_signal_subject_authors (
+    target TEXT NOT NULL,
+    target_id TEXT NOT NULL,
+    author_pubkey TEXT NOT NULL,
+    first_observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (target, target_id, author_pubkey),
+    CHECK (target IN ('post_id', 'blob_cid')),
+    CHECK (target_id <> ''),
+    CHECK (author_pubkey <> '')
+);
+
+CREATE INDEX idx_cn_safety_signal_subject_authors_author
+    ON cn_safety.risk_signal_subject_authors (author_pubkey, target, target_id);

--- a/crates/cn-core/src/lib.rs
+++ b/crates/cn-core/src/lib.rs
@@ -82,7 +82,8 @@ pub use index_scope::{
     reject_indexing_request, remove_channel_secret, remove_supported_topic, upsert_channel_secret,
 };
 pub use readiness_activation::{
-    ReadinessActivation, latest_readiness_activation, record_readiness_activation,
+    ReadinessActivation, latest_readiness_activation, readiness_context_fingerprint,
+    record_readiness_activation, record_readiness_revocation,
 };
 pub use readiness_probe::{ReadinessProbeRecord, list_readiness_probes, upsert_readiness_probe};
 pub use readiness_runtime::{
@@ -108,7 +109,8 @@ pub use safety_events::{
     DistributionAudience, StoredModerationEvent, StoredRiskSignal, get_risk_signal,
     get_signed_moderation_event, list_distributable_moderation_events,
     list_distributable_risk_signals, list_risk_signals, list_risk_signals_for_target,
-    list_signed_moderation_events, persist_risk_signal, persist_signed_moderation_event,
+    list_risk_signals_for_user, list_signed_moderation_events, persist_risk_signal,
+    persist_risk_signal_with_author, persist_signed_moderation_event,
 };
 pub use safety_runtime::{PgSafetyArtifactStore, resolve_safety_providers};
 pub use scan_verdicts::{StoredScanVerdict, get_scan_verdict, upsert_scan_verdict};

--- a/crates/cn-core/src/readiness_activation.rs
+++ b/crates/cn-core/src/readiness_activation.rs
@@ -7,6 +7,7 @@
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 
 /// 有効化記録 1 件。
@@ -16,6 +17,10 @@ pub struct ReadinessActivation {
     pub profile: String,
     /// 評価時点の判定項目 id の配列。
     pub check_ids: Vec<String>,
+    /// operator config と deployment revision を束ねた安全な指紋。
+    pub context_fingerprint: String,
+    /// readiness 不合格による明示的な失効記録か。
+    pub revoked: bool,
 }
 
 impl ReadinessActivation {
@@ -30,6 +35,40 @@ impl ReadinessActivation {
         expected.sort_unstable();
         recorded == expected
     }
+
+    /// 現在の profile / deploy context / 判定基準 / 有効期限に対して有効か。
+    pub fn is_valid(
+        &self,
+        expected_profile: &str,
+        expected_check_ids: &[&str],
+        expected_context_fingerprint: &str,
+        now: DateTime<Utc>,
+        max_age: chrono::Duration,
+    ) -> bool {
+        let age = now.signed_duration_since(self.activated_at);
+        !self.revoked
+            && self.profile == expected_profile
+            && self.context_fingerprint == expected_context_fingerprint
+            && self.matches_check_ids(expected_check_ids)
+            && age >= chrono::Duration::zero()
+            && age <= max_age
+    }
+}
+
+/// profile、operator-config、image/deployment revision を同じ activation context に束ねる。
+pub fn readiness_context_fingerprint(
+    profile: &str,
+    deployment_revision: &str,
+    operator_config_yaml: &[u8],
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"kukuri-readiness-activation-v1\0");
+    hasher.update(profile.trim().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(deployment_revision.trim().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(operator_config_yaml);
+    hex::encode(hasher.finalize())
 }
 
 /// 全項目合格の有効化記録を追加する。
@@ -38,8 +77,14 @@ pub async fn record_readiness_activation(
     activated_at: DateTime<Utc>,
     profile: &str,
     check_ids: &[&str],
+    context_fingerprint: &str,
     report: &serde_json::Value,
 ) -> Result<()> {
+    let report = serde_json::json!({
+        "context_fingerprint": context_fingerprint,
+        "revoked": false,
+        "checks": report,
+    });
     sqlx::query(
         "INSERT INTO cn_admin.readiness_activations (activated_at, profile, check_ids, report) \
          VALUES ($1, $2, $3, $4)",
@@ -54,17 +99,45 @@ pub async fn record_readiness_activation(
     Ok(())
 }
 
+/// readiness 不合格をappend-onlyな失効記録として残す。
+pub async fn record_readiness_revocation(
+    pool: &PgPool,
+    revoked_at: DateTime<Utc>,
+    profile: &str,
+    context_fingerprint: &str,
+    reason: &str,
+) -> Result<()> {
+    let report = serde_json::json!({
+        "context_fingerprint": context_fingerprint,
+        "revoked": true,
+        "reason": reason,
+    });
+    sqlx::query(
+        "INSERT INTO cn_admin.readiness_activations (activated_at, profile, check_ids, report) \
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(revoked_at)
+    .bind(profile)
+    .bind(serde_json::json!([]))
+    .bind(report)
+    .execute(pool)
+    .await
+    .context("failed to record the readiness revocation")?;
+    Ok(())
+}
+
 /// 最新の有効化記録を返す（無ければ None）。
 pub async fn latest_readiness_activation(pool: &PgPool) -> Result<Option<ReadinessActivation>> {
-    let row: Option<(DateTime<Utc>, String, serde_json::Value)> = sqlx::query_as(
-        "SELECT activated_at, profile, check_ids FROM cn_admin.readiness_activations \
+    let row: Option<(DateTime<Utc>, String, serde_json::Value, serde_json::Value)> =
+        sqlx::query_as(
+            "SELECT activated_at, profile, check_ids, report FROM cn_admin.readiness_activations \
          ORDER BY activated_at DESC, id DESC LIMIT 1",
-    )
-    .fetch_optional(pool)
-    .await
-    .context("failed to fetch the latest readiness activation")?;
-    Ok(
-        row.map(|(activated_at, profile, check_ids)| ReadinessActivation {
+        )
+        .fetch_optional(pool)
+        .await
+        .context("failed to fetch the latest readiness activation")?;
+    Ok(row.map(
+        |(activated_at, profile, check_ids, report)| ReadinessActivation {
             activated_at,
             profile,
             check_ids: check_ids
@@ -76,8 +149,17 @@ pub async fn latest_readiness_activation(pool: &PgPool) -> Result<Option<Readine
                         .collect()
                 })
                 .unwrap_or_default(),
-        }),
-    )
+            context_fingerprint: report
+                .get("context_fingerprint")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            revoked: report
+                .get("revoked")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+        },
+    ))
 }
 
 #[cfg(test)]
@@ -90,6 +172,8 @@ mod tests {
             activated_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
             profile: "public-node".to_string(),
             check_ids: check_ids.iter().map(|id| id.to_string()).collect(),
+            context_fingerprint: "deployment-v1".to_string(),
+            revoked: false,
         }
     }
 
@@ -102,5 +186,52 @@ mod tests {
         assert!(!recorded.matches_check_ids(&["a", "b"]));
         assert!(!recorded.matches_check_ids(&["a", "b", "c", "d"]));
         assert!(!recorded.matches_check_ids(&["a", "b", "x"]));
+    }
+
+    #[test]
+    fn validity_binds_profile_context_and_age() {
+        let recorded = activation(&["a", "b"]);
+        let now = recorded.activated_at + chrono::Duration::seconds(60);
+        assert!(recorded.is_valid(
+            "public-node",
+            &["a", "b"],
+            "deployment-v1",
+            now,
+            chrono::Duration::seconds(300),
+        ));
+        assert!(!recorded.is_valid(
+            "private-node",
+            &["a", "b"],
+            "deployment-v1",
+            now,
+            chrono::Duration::seconds(300),
+        ));
+        assert!(!recorded.is_valid(
+            "public-node",
+            &["a", "b"],
+            "deployment-v2",
+            now,
+            chrono::Duration::seconds(300),
+        ));
+        assert!(!recorded.is_valid(
+            "public-node",
+            &["a", "b"],
+            "deployment-v1",
+            recorded.activated_at + chrono::Duration::seconds(301),
+            chrono::Duration::seconds(300),
+        ));
+    }
+
+    #[test]
+    fn revoked_activation_is_never_valid() {
+        let mut recorded = activation(&["a"]);
+        recorded.revoked = true;
+        assert!(!recorded.is_valid(
+            "public-node",
+            &["a"],
+            "deployment-v1",
+            recorded.activated_at,
+            chrono::Duration::seconds(300),
+        ));
     }
 }

--- a/crates/cn-core/src/safety_events.rs
+++ b/crates/cn-core/src/safety_events.rs
@@ -196,12 +196,35 @@ pub async fn persist_risk_signal(
     issuer_node_id: &str,
     signal: &SafetyRiskSignal,
 ) -> Result<StoredRiskSignal> {
+    persist_risk_signal_with_author(pool, issuer_node_id, signal, None).await
+}
+
+/// Persist a risk signal and, for content targets, atomically associate it with
+/// the author whose trust calculation should consume the signal.
+pub async fn persist_risk_signal_with_author(
+    pool: &PgPool,
+    issuer_node_id: &str,
+    signal: &SafetyRiskSignal,
+    subject_author: Option<&str>,
+) -> Result<StoredRiskSignal> {
     if issuer_node_id.trim().is_empty() {
         bail!("risk signal issuer_node_id must not be empty");
     }
     if signal.target_id.trim().is_empty() {
         bail!("risk signal target_id must not be empty");
     }
+    if let Some(author) = subject_author {
+        if author.trim().is_empty() {
+            bail!("risk signal subject author must not be empty");
+        }
+        if !matches!(
+            signal.target,
+            RiskSignalTarget::PostId | RiskSignalTarget::BlobCid
+        ) {
+            bail!("only post_id/blob_cid risk signals can be attributed to an author");
+        }
+    }
+    let mut tx = pool.begin().await?;
     let id = Uuid::new_v4().to_string();
     let row = sqlx::query(
         "INSERT INTO cn_safety.risk_signals
@@ -222,8 +245,22 @@ pub async fn persist_risk_signal(
     .bind(signal.confidence.map(i16::from))
     .bind(signal.expires_at.as_deref())
     .bind(signal.appeal_status.map(|s| to_db_enum(&s)).transpose()?)
-    .fetch_one(pool)
+    .fetch_one(&mut *tx)
     .await?;
+    if let Some(author) = subject_author {
+        sqlx::query(
+            "INSERT INTO cn_safety.risk_signal_subject_authors
+                (target, target_id, author_pubkey)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (target, target_id, author_pubkey) DO NOTHING",
+        )
+        .bind(to_db_enum(&signal.target)?)
+        .bind(&signal.target_id)
+        .bind(author)
+        .execute(&mut *tx)
+        .await?;
+    }
+    tx.commit().await?;
     risk_signal_from_row(&row)
 }
 
@@ -276,6 +313,30 @@ pub async fn list_risk_signals_for_target(
     )
     .bind(to_db_enum(&target)?)
     .bind(target_id)
+    .fetch_all(pool)
+    .await?;
+    rows.iter().map(risk_signal_from_row).collect()
+}
+
+/// Return both user-scoped signals and content-scoped signals attributed to
+/// the user. The original content signal row is returned so expiry and appeal
+/// state remain connected to the moderation artifact that produced it.
+pub async fn list_risk_signals_for_user(
+    pool: &PgPool,
+    user_pubkey: &str,
+) -> Result<Vec<StoredRiskSignal>> {
+    let rows = sqlx::query(
+        "SELECT DISTINCT rs.id, rs.issuer_node_id, rs.target, rs.target_id, rs.category,
+                rs.severity, rs.basis, rs.visibility, rs.confidence, rs.expires_at,
+                rs.appeal_status, rs.persisted_at
+         FROM cn_safety.risk_signals rs
+         LEFT JOIN cn_safety.risk_signal_subject_authors rsa
+           ON rsa.target = rs.target AND rsa.target_id = rs.target_id
+         WHERE (rs.target = 'user_pubkey' AND rs.target_id = $1)
+            OR rsa.author_pubkey = $1
+         ORDER BY rs.persisted_at DESC",
+    )
+    .bind(user_pubkey)
     .fetch_all(pool)
     .await?;
     rows.iter().map(risk_signal_from_row).collect()

--- a/crates/cn-core/src/safety_runtime.rs
+++ b/crates/cn-core/src/safety_runtime.rs
@@ -15,7 +15,7 @@ use kukuri_cn_safety_runtime::{
     SafetyArtifactStore, SafetyRuntimeProviderEntry, SafetyRuntimeProvidersConfig,
 };
 
-use crate::safety_events::{persist_risk_signal, persist_signed_moderation_event};
+use crate::safety_events::{persist_risk_signal_with_author, persist_signed_moderation_event};
 use crate::scan_verdicts::upsert_scan_verdict;
 
 #[derive(Clone, Debug)]
@@ -41,8 +41,9 @@ impl SafetyArtifactStore for PgSafetyArtifactStore {
         &self,
         issuer_node_id: &str,
         signal: &SafetyRiskSignal,
+        subject_author: Option<&str>,
     ) -> Result<String> {
-        persist_risk_signal(&self.pool, issuer_node_id, signal)
+        persist_risk_signal_with_author(&self.pool, issuer_node_id, signal, subject_author)
             .await
             .map(|stored| stored.id)
     }

--- a/crates/cn-core/src/trust_inputs.rs
+++ b/crates/cn-core/src/trust_inputs.rs
@@ -30,7 +30,9 @@ use kukuri_cn_safety::{AppealStatus, RiskSignalTarget};
 // 組み立て（供給契約）のみを担う。
 use kukuri_cn_trust::{TrustComponentKind, TrustRiskInput, TrustRiskInputs, trust_component_for};
 
-use crate::safety_events::{StoredRiskSignal, list_risk_signals_for_target};
+use crate::safety_events::{
+    StoredRiskSignal, list_risk_signals_for_target, list_risk_signals_for_user,
+};
 
 /// 永続化済み risk signal 列から trust 入力を組み立てる純関数。
 ///
@@ -102,6 +104,10 @@ pub async fn list_trust_risk_inputs(
     target_id: &str,
     now_rfc3339: &str,
 ) -> Result<TrustRiskInputs> {
-    let signals = list_risk_signals_for_target(pool, target, target_id).await?;
+    let signals = if target == RiskSignalTarget::UserPubkey {
+        list_risk_signals_for_user(pool, target_id).await?
+    } else {
+        list_risk_signals_for_target(pool, target, target_id).await?
+    };
     trust_risk_inputs_from(&signals, now_rfc3339)
 }

--- a/crates/cn-core/tests/safety_events.rs
+++ b/crates/cn-core/tests/safety_events.rs
@@ -9,10 +9,11 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use kukuri_cn_core::{
-    DistributionAudience, PgSafetyArtifactStore, TestDatabase, connect_postgres, get_risk_signal,
-    get_signed_moderation_event, initialize_database, list_distributable_moderation_events,
-    list_distributable_risk_signals, list_risk_signals_for_target, list_trust_risk_inputs,
-    persist_risk_signal, persist_signed_moderation_event,
+    DistributionAudience, PgSafetyArtifactStore, TestDatabase, connect_postgres,
+    dispute_risk_signal, get_risk_signal, get_signed_moderation_event, initialize_database,
+    list_distributable_moderation_events, list_distributable_risk_signals,
+    list_risk_signals_for_target, list_trust_risk_inputs, persist_risk_signal,
+    persist_signed_moderation_event, update_risk_signal_appeal_status,
 };
 use kukuri_cn_safety::event::{ModerationEventBody, SignedModerationEvent, issue_signed_event};
 use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
@@ -289,6 +290,74 @@ async fn risk_signal_persists_and_distribution_respects_visibility_and_expiry() 
         let public_targets: Vec<&str> =
             public.iter().map(|s| s.signal.target_id.as_str()).collect();
         assert_eq!(public_targets, vec!["bafy-future"]);
+
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+    database.cleanup().await?;
+    result
+}
+
+#[tokio::test]
+async fn content_scan_is_attributed_to_author_and_appeal_updates_trust_input() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!(
+            "skipping cn-core safety integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1"
+        );
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_core_safety_attribution").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    let result = async {
+        initialize_database(&pool).await?;
+        let signer = signer();
+        let issuer = signer.issuer_node_id().to_string();
+        let provider = MockSafetyProvider::known_csam("mock-known-csam")
+            .with_known_hash_match("post-attributed");
+        let orchestrator = Arc::new(
+            SafetyOrchestrator::builder(
+                &issuer,
+                Arc::new(SystemScanClock),
+                Arc::new(UuidEventIdGenerator),
+            )
+            .provider(Arc::new(provider))
+            .build()?,
+        );
+        let store = Arc::new(PgSafetyArtifactStore::new(pool.clone()));
+        let service = SafetyScanService::builder(orchestrator, store)
+            .signer(Arc::new(signer))
+            .build()?;
+
+        let outcome = service
+            .scan_and_record_for_author(
+                &ProviderScanRequest::for_subject(SubjectKind::Post, "post-attributed"),
+                "author-pubkey",
+            )
+            .await?;
+        let signal_id = outcome
+            .persisted_signal_id
+            .expect("known match persists a risk signal");
+
+        let attributed = list_trust_risk_inputs(
+            &pool,
+            RiskSignalTarget::UserPubkey,
+            "author-pubkey",
+            "2026-08-06T00:00:00Z",
+        )
+        .await?;
+        assert_eq!(attributed.absolute.len(), 1);
+        assert_eq!(attributed.absolute[0].signal_id, signal_id);
+
+        dispute_risk_signal(&pool, &signal_id).await?;
+        update_risk_signal_appeal_status(&pool, &signal_id, AppealStatus::Cleared).await?;
+        let cleared = list_trust_risk_inputs(
+            &pool,
+            RiskSignalTarget::UserPubkey,
+            "author-pubkey",
+            "2026-08-06T00:00:00Z",
+        )
+        .await?;
+        assert!(cleared.absolute.is_empty());
 
         Ok::<(), anyhow::Error>(())
     }

--- a/crates/cn-core/tests/safety_runtime.rs
+++ b/crates/cn-core/tests/safety_runtime.rs
@@ -107,6 +107,7 @@ impl SafetyArtifactStore for FailingSafetyArtifactStore {
         &self,
         _issuer_node_id: &str,
         _signal: &SafetyRiskSignal,
+        _subject_author: Option<&str>,
     ) -> Result<String> {
         if matches!(self.operation, FailingStoreOperation::Signal) {
             bail!("signal persistence rejected by contract double");
@@ -164,6 +165,27 @@ async fn runtime_scan_known_csam_persists_signed_event_and_risk_signal() {
     assert_eq!(signal.target_id, "post-1");
     assert_eq!(signal.category, SafetyCategory::Csam);
     assert!(outcome.persisted_signal_id.is_some());
+}
+
+#[tokio::test]
+async fn attributed_post_scan_records_subject_author() {
+    let provider =
+        MockSafetyProvider::known_csam("mock-known-csam").with_known_hash_match("post-1");
+    let (service, store, _issuer) = signed_service(provider);
+
+    service
+        .scan_and_record_for_author(&post_request("post-1"), "author-pubkey")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.signal_subject_authors(),
+        vec![(
+            RiskSignalTarget::PostId,
+            "post-1".to_string(),
+            "author-pubkey".to_string(),
+        )]
+    );
 }
 
 #[tokio::test]

--- a/crates/cn-e2e/src/lib.rs
+++ b/crates/cn-e2e/src/lib.rs
@@ -26,7 +26,7 @@ use kukuri_blob_service::{BlobService, BlobStatus, IrohBlobService};
 use kukuri_cn_core::{
     ChannelSecretCipher, IndexScopeKind, JwtConfig, PgIndexEntryStore, PgSafetyArtifactStore,
     TestDatabase, add_supported_topic, connect_postgres, initialize_database,
-    record_readiness_activation,
+    readiness_context_fingerprint, record_readiness_activation,
 };
 use kukuri_cn_indexer::ArcadeDbProjection;
 use kukuri_cn_indexer::config::{ArcadeDbConfig, MediaFetchConfig};
@@ -52,7 +52,8 @@ use kukuri_cn_safety_vlm::{
 };
 use kukuri_cn_user_api::{UserApiConfig, app_router, build_state};
 use kukuri_core::{
-    AssetRef, AssetRole, BlobHash, KukuriKeys, ObjectVisibility, PayloadRef, TopicId,
+    AssetRef, AssetRole, BlobHash, KukuriKeys, KukuriMediaManifestV1, MediaManifestItem,
+    ObjectVisibility, PayloadRef, TopicId, build_media_manifest_envelope,
     build_post_envelope_with_payload, generate_keys,
 };
 use kukuri_docs_sync::{DocOp, DocsSync, IrohDocsSync, stable_key, topic_replica_id};
@@ -407,6 +408,7 @@ impl E2eStack {
             Utc::now(),
             "public-node",
             &READINESS_CHECK_IDS,
+            &readiness_context_fingerprint("public-node", "cn-e2e-v1", b""),
             &serde_json::json!([]),
         )
         .await?;
@@ -428,6 +430,8 @@ impl E2eStack {
             channel_secret_key: None,
             index_query_enabled: true,
             trust_read_enabled: true,
+            deployment_revision: "cn-e2e-v1".to_string(),
+            readiness_activation_max_age_secs: 3600,
         })
         .await?;
         let app = app_router(state);
@@ -491,6 +495,92 @@ impl E2eStack {
             .publish_post(&self.author.keys.clone(), body, vec![attachment])
             .await?;
         Ok((object_id, stored.hash.as_str().to_string()))
+    }
+
+    /// Publish a manifest whose thumbnail has no MIME metadata and bytes that
+    /// cannot be recognized by magic-byte sniffing. The indexer must hold the
+    /// whole post fail-closed while keeping the fetched blob ephemeral.
+    pub async fn publish_post_with_unknown_mime_thumbnail(
+        &self,
+        body: &str,
+    ) -> Result<(String, String)> {
+        const ITEM_BYTES: &[u8] = &[
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+        ];
+        const UNKNOWN_THUMBNAIL_BYTES: &[u8] = b"unrecognized-thumbnail-fixture";
+        let item = self
+            .author
+            .blobs
+            .put_blob(ITEM_BYTES.to_vec(), "image/png")
+            .await?;
+        let thumbnail = self
+            .author
+            .blobs
+            .put_blob(UNKNOWN_THUMBNAIL_BYTES.to_vec(), "application/octet-stream")
+            .await?;
+        let manifest_id = format!(
+            "e2e-manifest-{}-{}",
+            self.topic_id,
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        );
+        let topic = TopicId::new(self.topic_id.clone());
+        let replica = topic_replica_id(self.topic_id.as_str());
+        let manifest = KukuriMediaManifestV1 {
+            manifest_id: manifest_id.clone(),
+            owner_pubkey: self.author.keys.public_key(),
+            created_at: Utc::now().timestamp(),
+            items: vec![MediaManifestItem {
+                blob_hash: BlobHash::new(item.hash.as_str().to_string()),
+                mime: "image/png".to_string(),
+                size: ITEM_BYTES.len() as u64,
+                width: None,
+                height: None,
+                duration_ms: None,
+                codec: None,
+                thumbnail_blob_hash: Some(BlobHash::new(thumbnail.hash.as_str().to_string())),
+            }],
+        };
+        let manifest_envelope =
+            build_media_manifest_envelope(&self.author.keys, &topic, &manifest)?;
+        let post_envelope = build_post_envelope_with_payload(
+            &self.author.keys,
+            &topic,
+            PayloadRef::InlineText {
+                text: body.to_string(),
+            },
+            Vec::new(),
+            vec![manifest_id.clone()],
+            None,
+            ObjectVisibility::Public,
+        )?;
+        let object = post_envelope
+            .to_post_object()?
+            .context("post envelope must yield a post object")?;
+        let object_id = object.object_id.as_str().to_string();
+        let docs = &self.author.docs;
+        docs.open_replica(&replica).await?;
+        for (key, value) in [
+            (
+                stable_key("objects", &format!("{object_id}/state")),
+                serde_json::to_value(&object)?,
+            ),
+            (
+                stable_key("objects", &format!("{object_id}/envelope")),
+                serde_json::to_value(&post_envelope)?,
+            ),
+            (
+                stable_key("manifests/media", &format!("{manifest_id}/state")),
+                serde_json::to_value(&manifest)?,
+            ),
+            (
+                stable_key("manifests/media", &format!("{manifest_id}/envelope")),
+                serde_json::to_value(&manifest_envelope)?,
+            ),
+        ] {
+            docs.apply_doc_op(&replica, DocOp::SetJson { key, value })
+                .await?;
+        }
+        Ok((object_id, thumbnail.hash.as_str().to_string()))
     }
 
     /// blob の実体を置かずに、指定 hash を参照する添付つき投稿を置く（不達の再現用）。

--- a/crates/cn-e2e/tests/failure_paths.rs
+++ b/crates/cn-e2e/tests/failure_paths.rs
@@ -112,6 +112,33 @@ async fn missing_media_holder_holds_posts() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn unknown_mime_media_holds_posts_without_retaining_the_blob() -> Result<()> {
+    let Some(stack) = E2eStack::boot("unknownmime").await? else {
+        return Ok(());
+    };
+    let (object_id, thumbnail_hash) = stack
+        .publish_post_with_unknown_mime_thumbnail("unknown MIME thumbnail")
+        .await?;
+    assert!(
+        stack
+            .wait_for_state(
+                |state| state.skipped_non_allow >= 1 || state.scan_errors >= 1,
+                HOLD_TIMEOUT
+            )
+            .await?,
+        "scan must hold when MIME metadata and recognizable magic bytes are both absent"
+    );
+    assert_held(&stack, object_id.as_str()).await?;
+    assert!(
+        stack
+            .blob_is_absent_locally(thumbnail_hash.as_str())
+            .await?,
+        "unknown-MIME media must remain ephemeral on the indexer"
+    );
+    stack.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn oversize_media_holds_posts() -> Result<()> {
     let Some(stack) = E2eStack::boot_with(
         "oversize",

--- a/crates/cn-e2e/tests/trust_relation_graph.rs
+++ b/crates/cn-e2e/tests/trust_relation_graph.rs
@@ -267,10 +267,11 @@ async fn trust_appeal_and_relation_graph_work_end_to_end() -> Result<()> {
         )
     };
     let initial = read_trust().await?;
+    let initial_absolute = initial["absolute"].as_f64().unwrap();
     let initial_relative = initial["relative"].as_f64().unwrap();
     assert!(
-        initial["absolute"].as_f64().unwrap() <= -1.0 + 1e-9,
-        "confirmed CSAM signal must floor the absolute component: {initial}"
+        initial_absolute < 0.0,
+        "scan-derived CSAM signal must reduce the absolute component: {initial}"
     );
     assert!(
         initial_relative < 0.0,
@@ -300,8 +301,9 @@ async fn trust_appeal_and_relation_graph_work_end_to_end() -> Result<()> {
         dispute_risk_signal(&stack.pool, signal.id.as_str()).await?;
     }
     let disputed_content = read_trust().await?;
-    assert!(
-        disputed_content["absolute"].as_f64().unwrap() <= -1.0 + 1e-9,
+    assert_eq!(
+        disputed_content["absolute"].as_f64().unwrap(),
+        initial_absolute,
         "a disputed content signal must remain effective: {disputed_content}"
     );
     for signal in &attributed_signals {
@@ -310,7 +312,7 @@ async fn trust_appeal_and_relation_graph_work_end_to_end() -> Result<()> {
     }
     let cleared_content = read_trust().await?;
     assert!(
-        cleared_content["absolute"].as_f64().unwrap() > -1.0 + 1e-9,
+        cleared_content["absolute"].as_f64().unwrap() > initial_absolute,
         "clearing the content signal must restore the author's absolute trust: {cleared_content}"
     );
 

--- a/crates/cn-e2e/tests/trust_relation_graph.rs
+++ b/crates/cn-e2e/tests/trust_relation_graph.rs
@@ -17,8 +17,8 @@ use anyhow::Result;
 use kukuri_cn_core::{IndexEntryStore, RiskSignalCorrection};
 use kukuri_cn_core::{
     IndexScopeKind, NewIndexEntry, PgCoParticipationSource, dispute_risk_signal,
-    persist_risk_signal, reissue_corrected_risk_signal, update_risk_signal_appeal_status,
-    upsert_scan_verdict,
+    list_risk_signals_for_target, persist_risk_signal, reissue_corrected_risk_signal,
+    update_risk_signal_appeal_status, upsert_scan_verdict,
 };
 use kukuri_cn_e2e::E2eStack;
 use kukuri_cn_indexer::{ArcadeDbConfig, ArcadeDbRelationGraph, analyze_relations};
@@ -211,18 +211,36 @@ async fn trust_appeal_and_relation_graph_work_end_to_end() -> Result<()> {
     );
 
     // --- 信頼: 危険信号が絶対・相対成分へ入り、根拠つきで読める ---
-    persist_risk_signal(
-        &stack.pool,
-        "e2e-issuer-node",
-        &user_risk_signal(
-            pubkey_b.as_str(),
-            SafetyCategory::Csam,
-            Severity::Critical,
-            Basis::KnownHashMatch,
-            Visibility::Public,
-        ),
-    )
-    .await?;
+    const ATTRIBUTED_MARKER: &str = "e2e-attributed-csam-marker";
+    stack
+        .mount_vlm_response_for_marker(
+            ATTRIBUTED_MARKER,
+            r#"{"categories":[{"category":"csam","score":0.97}],"tags":[]}"#,
+        )
+        .await;
+    let attributed_post = stack
+        .publish_text_post_as(
+            &author_b,
+            &format!("synthetic moderation contract marker: {ATTRIBUTED_MARKER}"),
+        )
+        .await?;
+    let deadline = tokio::time::Instant::now() + PROJECTION_TIMEOUT;
+    let attributed_signals = loop {
+        let signals = list_risk_signals_for_target(
+            &stack.pool,
+            RiskSignalTarget::PostId,
+            attributed_post.as_str(),
+        )
+        .await?;
+        if !signals.is_empty() {
+            break signals;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "scan-derived risk signal was not persisted"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    };
     let relative_signal = persist_risk_signal(
         &stack.pool,
         "e2e-issuer-node",
@@ -262,6 +280,40 @@ async fn trust_appeal_and_relation_graph_work_end_to_end() -> Result<()> {
     // --- 申し立て: 係争中は寄与据え置き → 認容で寄与が戻る → 訂正信号が反映される ---
     // （HTTP の申し立て受理経路は cn-user-api の contract test が固定済み。ここでは
     //   handler と同じ遷移関数で係争 → 認容を進める）
+    // Stop producing duplicate scan artifacts, then prove that appeal state on
+    // the original content signal controls the author's absolute trust input.
+    stack.vlm.reset().await;
+    stack.restore_default_provider_mocks().await;
+    let mut attributed_signals = attributed_signals;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    attributed_signals.extend(
+        list_risk_signals_for_target(
+            &stack.pool,
+            RiskSignalTarget::PostId,
+            attributed_post.as_str(),
+        )
+        .await?,
+    );
+    attributed_signals.sort_by(|a, b| a.id.cmp(&b.id));
+    attributed_signals.dedup_by(|a, b| a.id == b.id);
+    for signal in &attributed_signals {
+        dispute_risk_signal(&stack.pool, signal.id.as_str()).await?;
+    }
+    let disputed_content = read_trust().await?;
+    assert!(
+        disputed_content["absolute"].as_f64().unwrap() <= -1.0 + 1e-9,
+        "a disputed content signal must remain effective: {disputed_content}"
+    );
+    for signal in &attributed_signals {
+        update_risk_signal_appeal_status(&stack.pool, signal.id.as_str(), AppealStatus::Cleared)
+            .await?;
+    }
+    let cleared_content = read_trust().await?;
+    assert!(
+        cleared_content["absolute"].as_f64().unwrap() > -1.0 + 1e-9,
+        "clearing the content signal must restore the author's absolute trust: {cleared_content}"
+    );
+
     dispute_risk_signal(&stack.pool, relative_signal.id.as_str()).await?;
     let disputed = read_trust().await?;
     assert_eq!(

--- a/crates/cn-indexer/src/ingest.rs
+++ b/crates/cn-indexer/src/ingest.rs
@@ -95,8 +95,13 @@ impl IngestPipeline {
     async fn scan_and_record_with_metrics(
         &self,
         request: &ProviderScanRequest,
+        subject_author: &str,
     ) -> Result<SafetyScanOutcome> {
-        let outcome = match self.safety.scan_and_record(request).await {
+        let outcome = match self
+            .safety
+            .scan_and_record_for_author(request, subject_author)
+            .await
+        {
             Ok(outcome) => outcome,
             Err(error) => {
                 if let Some(metrics) = &self.metrics {
@@ -217,7 +222,9 @@ impl IngestPipeline {
         // 永続化失敗は `?` で呼び出し側の per-entry fail-closed（投影しない）に乗る。
         let request = ProviderScanRequest::for_subject(SubjectKind::Post, object.object_id.clone())
             .with_text(text.clone());
-        let outcome = self.scan_and_record_with_metrics(&request).await?;
+        let outcome = self
+            .scan_and_record_with_metrics(&request, &object.author)
+            .await?;
         let report = &outcome.report;
 
         if !report.verdict.is_indexable() {
@@ -263,7 +270,9 @@ impl IngestPipeline {
             if let Some(mime) = &target.mime {
                 request = request.with_media_mime(mime.clone());
             }
-            let media_outcome = self.scan_and_record_with_metrics(&request).await?;
+            let media_outcome = self
+                .scan_and_record_with_metrics(&request, &object.author)
+                .await?;
             let media_report = &media_outcome.report;
             if !media_report.verdict.is_indexable() {
                 self.deindex_object(scope_kind, scope_id, object.object_id.as_str())

--- a/crates/cn-indexer/src/worker.rs
+++ b/crates/cn-indexer/src/worker.rs
@@ -285,11 +285,14 @@ impl IndexerWorker {
         self.state.set_opened_scopes(opened.len() as u64);
 
         // 4. 各 scope の取り込み。
+        let mut all_scopes_ingested = !opened.is_empty();
         for scope in &opened {
-            self.ingest_scope_with_backoff(scope, backoff).await;
+            all_scopes_ingested &= self.ingest_scope_with_backoff(scope, backoff).await;
         }
-        self.state
-            .record_sync_success(chrono::Utc::now().timestamp());
+        if all_scopes_ingested {
+            self.state
+                .record_sync_success(chrono::Utc::now().timestamp());
+        }
     }
 
     /// scope を 1 つ取り込む。再試行間隔中なら何もしない。
@@ -297,13 +300,13 @@ impl IndexerWorker {
         &self,
         scope: &ScopeReplica,
         backoff: &mut HashMap<String, BackoffEntry>,
-    ) {
+    ) -> bool {
         let key = scope.replica_id.as_str();
         if let Some(entry) = backoff.get(key)
             && tokio::time::Instant::now() < entry.ready_at
         {
             debug!(replica_id = %key, "scope is backing off; skipping this round");
-            return;
+            return false;
         }
         match self.participant.ingest_scope(scope).await {
             Ok(summary) => {
@@ -316,6 +319,7 @@ impl IndexerWorker {
                     indexed = summary.indexed,
                     "scope ingested"
                 );
+                true
             }
             Err(error) => {
                 let failures = backoff.get(key).map(|entry| entry.failures).unwrap_or(0) + 1;
@@ -341,6 +345,7 @@ impl IndexerWorker {
                     "failed to ingest scope; backing off"
                 );
                 self.state.record_error(Some(key), &format!("{error:#}"));
+                false
             }
         }
     }

--- a/crates/cn-indexer/tests/ingestion_contracts.rs
+++ b/crates/cn-indexer/tests/ingestion_contracts.rs
@@ -729,60 +729,62 @@ async fn indexing_startup_requires_validated_relay() -> Result<()> {
 }
 
 #[tokio::test]
-async fn deleted_objects_are_deindexed() -> Result<()> {
-    // replica 上で deleted / tombstoned になった object は de-index する。
-    let docs = Arc::new(MemoryDocsSync::default());
-    let projection = Arc::new(MemoryIndexProjection::new());
-    let topic = TopicId::new("rust");
-    let replica = topic_replica_id("rust");
-    let object_id = persist_post(&docs, &replica, &topic, "to be deleted").await;
+async fn deleted_and_tombstoned_objects_are_deindexed() -> Result<()> {
+    for status in ["deleted", "tombstoned"] {
+        // replica 上で deleted / tombstoned になった object は de-index する。
+        let docs = Arc::new(MemoryDocsSync::default());
+        let projection = Arc::new(MemoryIndexProjection::new());
+        let topic = TopicId::new("rust");
+        let replica = topic_replica_id("rust");
+        let object_id = persist_post(&docs, &replica, &topic, "to be deleted").await;
 
-    let (pipeline, entries, _) = pipeline_with(&docs, &projection, allow_service());
-    pipeline
+        let (pipeline, entries, _) = pipeline_with(&docs, &projection, allow_service());
+        pipeline
+            .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+            .await?;
+        assert!(
+            projection
+                .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+                .await?
+        );
+
+        // object state を deleted に更新する。
+        let mut object: serde_json::Value = {
+            let records = docs
+                .query_replica(
+                    &replica,
+                    DocQuery::Exact(stable_key("objects", &format!("{object_id}/state"))),
+                )
+                .await?;
+            serde_json::from_slice(&records[0].value)?
+        };
+        object["status"] = serde_json::json!(status);
+        docs.apply_doc_op(
+            &replica,
+            DocOp::SetJson {
+                key: stable_key("objects", &format!("{object_id}/state")),
+                value: object,
+            },
+        )
+        .await?;
+
+        // 真実源 store を共有した再 ingest で de-index が両方へ届く。
+        let summary = IngestPipeline::new(
+            docs.clone(),
+            allow_service().0,
+            entries.clone(),
+            projection.clone(),
+        )
         .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
         .await?;
-    assert!(
-        projection
-            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
-            .await?
-    );
-
-    // object state を deleted に更新する。
-    let mut object: serde_json::Value = {
-        let records = docs
-            .query_replica(
-                &replica,
-                DocQuery::Exact(stable_key("objects", &format!("{object_id}/state"))),
-            )
-            .await?;
-        serde_json::from_slice(&records[0].value)?
-    };
-    object["status"] = serde_json::json!("deleted");
-    docs.apply_doc_op(
-        &replica,
-        DocOp::SetJson {
-            key: stable_key("objects", &format!("{object_id}/state")),
-            value: object,
-        },
-    )
-    .await?;
-
-    // 真実源 store を共有した再 ingest で de-index が両方へ届く。
-    let summary = IngestPipeline::new(
-        docs.clone(),
-        allow_service().0,
-        entries.clone(),
-        projection.clone(),
-    )
-    .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
-    .await?;
-    assert_eq!(summary.deindexed, 1);
-    assert!(
-        !projection
-            .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
-            .await?
-    );
-    assert!(!entries.contains(IndexScopeKind::PublicTopic, "rust", &object_id));
+        assert_eq!(summary.deindexed, 1);
+        assert!(
+            !projection
+                .contains_object(IndexScopeKind::PublicTopic, "rust", &object_id)
+                .await?
+        );
+        assert!(!entries.contains(IndexScopeKind::PublicTopic, "rust", &object_id));
+    }
     Ok(())
 }
 

--- a/crates/cn-indexer/tests/worker_contracts.rs
+++ b/crates/cn-indexer/tests/worker_contracts.rs
@@ -457,6 +457,16 @@ async fn failing_scope_backs_off_without_blocking_others() -> Result<()> {
     })
     .await;
 
+    let snapshot = state.snapshot();
+    assert!(
+        snapshot.last_ingest_at.is_some(),
+        "healthy scope success must remain observable"
+    );
+    assert!(
+        snapshot.last_sync_at.is_none(),
+        "a full pass with any failed scope must not be recorded as successful"
+    );
+
     handle.shutdown().await;
     Ok(())
 }

--- a/crates/cn-operator/src/capability.rs
+++ b/crates/cn-operator/src/capability.rs
@@ -7,8 +7,8 @@
 //!
 //! - `Availability::Available` (Phase A): 現行の community node 実装が実際に提供できる、
 //!   またはデプロイ構成として確定できる capability。生成文書では「運用中」として開示してよい。
-//! - `Availability::Planned` (Phase B): 現行実装に存在しない capability（index / moderation /
-//!   trust signal / report endpoint など）。config 上は宣言できるが、生成文書では
+//! - `Availability::Planned` (Phase B): 将来追加され、現行実装に存在しない capability。
+//!   config 上は宣言できるが、生成文書では
 //!   「計画中・この配布物では未提供」として扱い、運用中の外部送信・データ取扱い開示には載せない。
 //!
 //! これは `docs/architecture/p2p-first-community-node-responsibility-boundary.md` の
@@ -57,7 +57,7 @@ pub enum Capability {
     CrashReport,
     CloudflareProxy,
     PushNotification,
-    // --- Phase B: 未実装（spec のみ） ---
+    // Operational capabilities (availability is decided by `availability()`).
     CommunityIndex,
     Moderation,
     CommunityLocalTrust,

--- a/crates/cn-operator/src/drift.rs
+++ b/crates/cn-operator/src/drift.rs
@@ -20,11 +20,16 @@ pub struct DriftReport {
     pub missing: Vec<String>,
     /// 出力ディレクトリにあるが生成対象でない余分なファイル。
     pub unexpected: Vec<String>,
+    /// config 由来の secret ID または private endpoint を含むファイル。
+    pub sensitive: Vec<String>,
 }
 
 impl DriftReport {
     pub fn is_clean(&self) -> bool {
-        self.changed.is_empty() && self.missing.is_empty() && self.unexpected.is_empty()
+        self.changed.is_empty()
+            && self.missing.is_empty()
+            && self.unexpected.is_empty()
+            && self.sensitive.is_empty()
     }
 
     /// 人間可読なサマリ。
@@ -42,6 +47,12 @@ impl DriftReport {
         if !self.unexpected.is_empty() {
             s.push_str(&format!("余分なファイル: {}\n", self.unexpected.join(", ")));
         }
+        if !self.sensitive.is_empty() {
+            s.push_str(&format!(
+                "機密識別子・内部 endpoint の混入: {}\n",
+                self.sensitive.join(", ")
+            ));
+        }
         s.push_str("`generate-docs` で再生成してください。");
         s
     }
@@ -50,6 +61,7 @@ impl DriftReport {
 /// config から再生成した内容と `dir` 配下の内容を比較する。
 pub fn check_drift(config: &ResolvedConfig, dir: &Path) -> Result<DriftReport> {
     let expected = generate_all(config);
+    let forbidden = forbidden_disclosure_values(config);
     let mut report = DriftReport::default();
 
     let mut expected_names: Vec<String> = Vec::new();
@@ -60,6 +72,9 @@ pub fn check_drift(config: &ResolvedConfig, dir: &Path) -> Result<DriftReport> {
             Ok(actual) => {
                 if actual != file.content {
                     report.changed.push(file.filename.clone());
+                }
+                if contains_sensitive_value(&actual, &forbidden) {
+                    report.sensitive.push(file.filename.clone());
                 }
             }
             Err(_) => report.missing.push(file.filename.clone()),
@@ -81,5 +96,61 @@ pub fn check_drift(config: &ResolvedConfig, dir: &Path) -> Result<DriftReport> {
     report.changed.sort();
     report.missing.sort();
     report.unexpected.sort();
+    report.sensitive.sort();
+    report.sensitive.dedup();
     Ok(report)
+}
+
+fn forbidden_disclosure_values(config: &ResolvedConfig) -> Vec<String> {
+    let mut values = vec![
+        "127.0.0.1".to_string(),
+        "localhost".to_string(),
+        "0.0.0.0".to_string(),
+    ];
+    if let Some(deploy) = config.deploy() {
+        values.extend(
+            [
+                Some(deploy.jwt_secret_id.clone()),
+                Some(deploy.postgres_password_secret_id.clone()),
+                deploy.channel_secret_key_secret_id.clone(),
+                deploy.arcadedb_password_secret_id.clone(),
+                deploy.arachnid_username_secret_id.clone(),
+                deploy.arachnid_password_secret_id.clone(),
+                deploy.vlm_api_key_secret_id.clone(),
+                deploy.vlm_api_base_url.clone(),
+            ]
+            .into_iter()
+            .flatten(),
+        );
+        values.extend(deploy.indexer_external_relay_urls.iter().cloned());
+    }
+    values.retain(|value| value.trim().len() >= 4);
+    values.sort();
+    values.dedup();
+    values
+}
+
+fn contains_sensitive_value(content: &str, forbidden: &[String]) -> bool {
+    let lower = content.to_ascii_lowercase();
+    forbidden
+        .iter()
+        .any(|value| lower.contains(&value.to_ascii_lowercase()))
+        || lower
+            .split(|c: char| c.is_whitespace() || matches!(c, '/' | ':' | '(' | ')' | ','))
+            .any(is_private_ipv4)
+}
+
+fn is_private_ipv4(token: &str) -> bool {
+    let token = token.trim_matches(|c: char| !c.is_ascii_digit() && c != '.');
+    let octets = token
+        .split('.')
+        .map(str::parse::<u8>)
+        .collect::<Result<Vec<_>, _>>();
+    let Ok(octets) = octets else { return false };
+    if octets.len() != 4 {
+        return false;
+    }
+    octets[0] == 10
+        || (octets[0] == 172 && (16..=31).contains(&octets[1]))
+        || (octets[0] == 192 && octets[1] == 168)
 }

--- a/crates/cn-operator/tests/generate.rs
+++ b/crates/cn-operator/tests/generate.rs
@@ -533,6 +533,23 @@ fn drift_check_detects_changes_and_clean() {
 }
 
 #[test]
+fn disclosure_check_rejects_private_endpoint_leaks() {
+    let resolved = load_and_validate(SAMPLE_CONFIG).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    for file in generate_all(&resolved) {
+        std::fs::write(dir.path().join(&file.filename), &file.content).unwrap();
+    }
+    let terms = dir.path().join("terms.md");
+    let mut content = std::fs::read_to_string(&terms).unwrap();
+    content.push_str("\ninternal endpoint: http://10.24.1.8:8000\n");
+    std::fs::write(&terms, content).unwrap();
+
+    let report = check_drift(&resolved, dir.path()).unwrap();
+    assert!(!report.is_clean());
+    assert_eq!(report.sensitive, vec!["terms.md".to_string()]);
+}
+
+#[test]
 fn parse_then_resolve_roundtrip() {
     let cfg = parse_config(SAMPLE_CONFIG).unwrap();
     assert_eq!(cfg.server.country, "JP");

--- a/crates/cn-safety-runtime/src/service.rs
+++ b/crates/cn-safety-runtime/src/service.rs
@@ -8,8 +8,8 @@ use async_trait::async_trait;
 
 use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
 use kukuri_cn_safety::{
-    ModerationEventSigner, SafetyPolicy, SafetyProvider, SafetyRiskSignal, SafetyVerdict,
-    SignedModerationEvent, Visibility, issue_signed_event,
+    ModerationEventSigner, RiskSignalTarget, SafetyPolicy, SafetyProvider, SafetyRiskSignal,
+    SafetyVerdict, SignedModerationEvent, Visibility, issue_signed_event,
 };
 
 use crate::{
@@ -112,6 +112,7 @@ pub trait SafetyArtifactStore: Send + Sync {
         &self,
         issuer_node_id: &str,
         signal: &SafetyRiskSignal,
+        subject_author: Option<&str>,
     ) -> Result<String>;
 
     async fn persist_verdict(
@@ -126,6 +127,7 @@ pub trait SafetyArtifactStore: Send + Sync {
 pub struct MemorySafetyArtifactStore {
     events: Mutex<Vec<SignedModerationEvent>>,
     signals: Mutex<Vec<(String, SafetyRiskSignal)>>,
+    signal_subject_authors: Mutex<Vec<(RiskSignalTarget, String, String)>>,
     verdicts: Mutex<HashMap<(String, String), (String, SafetyVerdict)>>,
 }
 
@@ -140,6 +142,13 @@ impl MemorySafetyArtifactStore {
 
     pub fn signals(&self) -> Vec<(String, SafetyRiskSignal)> {
         self.signals.lock().expect("signals mutex poisoned").clone()
+    }
+
+    pub fn signal_subject_authors(&self) -> Vec<(RiskSignalTarget, String, String)> {
+        self.signal_subject_authors
+            .lock()
+            .expect("signal subject authors mutex poisoned")
+            .clone()
     }
 
     pub fn verdict_for(
@@ -188,10 +197,17 @@ impl SafetyArtifactStore for MemorySafetyArtifactStore {
         &self,
         issuer_node_id: &str,
         signal: &SafetyRiskSignal,
+        subject_author: Option<&str>,
     ) -> Result<String> {
         let mut signals = self.signals.lock().expect("signals mutex poisoned");
         let id = format!("memory-signal-{}", signals.len() + 1);
         signals.push((issuer_node_id.to_string(), signal.clone()));
+        if let Some(author) = subject_author {
+            self.signal_subject_authors
+                .lock()
+                .expect("signal subject authors mutex poisoned")
+                .push((signal.target, signal.target_id.clone(), author.to_string()));
+        }
         Ok(id)
     }
 
@@ -260,6 +276,26 @@ impl SafetyScanService {
         &self,
         request: &ProviderScanRequest,
     ) -> Result<SafetyScanOutcome> {
+        self.scan_and_record_inner(request, None).await
+    }
+
+    pub async fn scan_and_record_for_author(
+        &self,
+        request: &ProviderScanRequest,
+        subject_author: &str,
+    ) -> Result<SafetyScanOutcome> {
+        if subject_author.trim().is_empty() {
+            bail!("scan subject author must not be empty");
+        }
+        self.scan_and_record_inner(request, Some(subject_author))
+            .await
+    }
+
+    async fn scan_and_record_inner(
+        &self,
+        request: &ProviderScanRequest,
+        subject_author: Option<&str>,
+    ) -> Result<SafetyScanOutcome> {
         let report = self.orchestrator.scan_subject(request).await;
         let verdict_id = match (request.subject_kind, request.subject_id.as_deref()) {
             (Some(kind), Some(subject_id)) if !subject_id.trim().is_empty() => Some(
@@ -273,7 +309,7 @@ impl SafetyScanService {
         let persisted_signal_id = match report.risk_signal.as_ref() {
             Some(signal) => Some(
                 self.store
-                    .persist_signal(&self.issuer_node_id, signal)
+                    .persist_signal(&self.issuer_node_id, signal, subject_author)
                     .await
                     .context("failed to persist safety risk signal")?,
             ),

--- a/crates/cn-user-api/src/config.rs
+++ b/crates/cn-user-api/src/config.rs
@@ -27,15 +27,20 @@ pub struct UserApiConfig {
     /// 未設定なら private channel の indexing request は受け付けない(#413 / ADR 0025 §6.3)。
     pub channel_secret_key: Option<String>,
     /// ユーザー向け index query(search / discovery / recommendation)を公開するか(#404)。
-    /// 既定 false(`CommunityIndex` が `Availability::Planned` の現状と整合。`/v1/index/*` は 404)。
+    /// 既定 false。capability は Available だが、readiness activation 完了までは
+    /// `/v1/index/*` を公開しない。
     /// 有効化すると ArcadeDB(`COMMUNITY_NODE_ARCADEDB_*`)へ接続する。
     pub index_query_enabled: bool,
     /// trust / relation read surface を公開するか(#415)。
-    /// 既定 false(`CommunityLocalTrust` が `Availability::Planned` の現状と整合。
-    /// `/v1/trust/*` / `/v1/relation/*` は 404)。有効化すると relation graph の
+    /// 既定 false。capability は Available だが、readiness activation 完了までは
+    /// `/v1/trust/*` / `/v1/relation/*` は 404。有効化すると relation graph の
     /// ArcadeDB(`COMMUNITY_NODE_ARCADEDB_*`)へ接続し、trust パラメータを
     /// `COMMUNITY_NODE_TRUST_*` env から読む。
     pub trust_read_enabled: bool,
+    /// image/config/provider一式を識別する非秘匿のdeploy revision。
+    pub deployment_revision: String,
+    /// readiness activationを有効とみなす最大経過秒数。
+    pub readiness_activation_max_age_secs: u64,
 }
 
 impl std::fmt::Debug for UserApiConfig {
@@ -57,6 +62,11 @@ impl std::fmt::Debug for UserApiConfig {
             )
             .field("index_query_enabled", &self.index_query_enabled)
             .field("trust_read_enabled", &self.trust_read_enabled)
+            .field("deployment_revision", &self.deployment_revision)
+            .field(
+                "readiness_activation_max_age_secs",
+                &self.readiness_activation_max_age_secs,
+            )
             .finish()
     }
 }
@@ -97,6 +107,17 @@ impl UserApiConfig {
             .filter(|value| !value.trim().is_empty());
         let index_query_enabled = parse_bool_env("COMMUNITY_NODE_INDEX_QUERY_ENABLED", false)?;
         let trust_read_enabled = parse_bool_env("COMMUNITY_NODE_TRUST_READ_ENABLED", false)?;
+        let deployment_revision = std::env::var("COMMUNITY_NODE_DEPLOYMENT_REVISION")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_default();
+        if (index_query_enabled || trust_read_enabled) && deployment_revision.is_empty() {
+            anyhow::bail!(
+                "COMMUNITY_NODE_DEPLOYMENT_REVISION is required when index/trust surfaces are enabled"
+            );
+        }
+        let readiness_activation_max_age_secs =
+            parse_u64_env("COMMUNITY_NODE_READINESS_ACTIVATION_MAX_AGE_SECS", 900)?.max(1);
         Ok(Self {
             bind_addr,
             database_url,
@@ -110,6 +131,8 @@ impl UserApiConfig {
             channel_secret_key,
             index_query_enabled,
             trust_read_enabled,
+            deployment_revision,
+            readiness_activation_max_age_secs,
         })
     }
 }

--- a/crates/cn-user-api/src/handlers/indexing.rs
+++ b/crates/cn-user-api/src/handlers/indexing.rs
@@ -254,6 +254,13 @@ async fn require_index_query(
             "this community node does not provide index queries",
         ));
     };
+    if !state.readiness_activation_is_valid().await {
+        return Err(ApiError::new(
+            StatusCode::NOT_FOUND,
+            "INDEX_QUERY_NOT_ACTIVATED",
+            "this community node index activation is not current",
+        ));
+    }
     let identity = require_bearer_identity(&state.pool, &state.jwt_config, headers).await?;
     let _ = require_consents(&state.pool, identity.pubkey.as_str()).await?;
     Ok(index_query)

--- a/crates/cn-user-api/src/handlers/trust_relation.rs
+++ b/crates/cn-user-api/src/handlers/trust_relation.rs
@@ -39,6 +39,13 @@ async fn require_trust_read(
             "this community node does not provide trust / relation reads",
         ));
     };
+    if !state.readiness_activation_is_valid().await {
+        return Err(ApiError::new(
+            StatusCode::NOT_FOUND,
+            "TRUST_READ_NOT_ACTIVATED",
+            "this community node trust activation is not current",
+        ));
+    }
     let identity = require_bearer_identity(&state.pool, &state.jwt_config, headers).await?;
     let _ = require_consents(&state.pool, identity.pubkey.as_str()).await?;
     Ok((trust_read, identity.pubkey))
@@ -120,6 +127,13 @@ pub(crate) async fn trust_pull(
             "this community node does not provide trust / relation reads",
         ));
     };
+    if !state.readiness_activation_is_valid().await {
+        return Err(ApiError::new(
+            StatusCode::NOT_FOUND,
+            "TRUST_READ_NOT_ACTIVATED",
+            "this community node trust activation is not current",
+        ));
+    }
     // bearer が有効な subscriber なら SubscribedNodes、無ければ匿名(Public visibility のみ)。
     let audience = match require_bearer_identity(&state.pool, &state.jwt_config, &headers).await {
         Ok(_) => PullAudience::SubscribedNodes,

--- a/crates/cn-user-api/src/state.rs
+++ b/crates/cn-user-api/src/state.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use kukuri_cn_core::{
     ChannelSecretCipher, DatabaseInitMode, JwtConfig, PgIndexEntryStore, TopicRendezvousStore,
     connect_postgres, initialize_database, initialize_database_for_runtime,
+    latest_readiness_activation, readiness_context_fingerprint,
 };
 use kukuri_cn_indexer::{
     ArcadeDbConfig, ArcadeDbProjection, ArcadeDbRelationGraph, FailClosedIndexQuery, IndexQuery,
@@ -33,13 +34,21 @@ pub struct UserApiState {
     pub(crate) channel_secret_cipher: Option<Arc<ChannelSecretCipher>>,
     /// ユーザー向け search / discovery / recommendation の query 境界(#404)。
     /// fail-closed query gate(`FailClosedIndexQuery`)を通した読み口のみを持つ。
-    /// None = 機能無効(`CommunityIndex` が `Availability::Planned` の既定状態)で、
+    /// None = 設定無効または現在の deployment/config に有効な readiness activation がなく、
     /// `/v1/index/*` は 404 を返す。
     pub(crate) index_query: Option<Arc<dyn IndexQuery>>,
     /// trust / relation read surface(#415 / ADR 0026)。
-    /// None = 機能無効(`CommunityLocalTrust` が `Availability::Planned` の既定状態)で、
+    /// None = 設定無効または現在の deployment/config に有効な readiness activation がなく、
     /// `/v1/trust/*` / `/v1/relation/*` は 404 を返す。
     pub(crate) trust_read: Option<Arc<TrustReadState>>,
+    readiness_activation_requirement: Option<ReadinessActivationRequirement>,
+}
+
+#[derive(Clone)]
+struct ReadinessActivationRequirement {
+    profile: String,
+    context_fingerprint: String,
+    max_age: chrono::Duration,
 }
 
 /// trust / relation read surface の依存一式(#415)。
@@ -68,6 +77,20 @@ impl UserApiState {
         self.trust_read = Some(trust_read);
         self
     }
+
+    /// 起動後もactivationの期限・失効を各read requestで再確認する。
+    pub(crate) async fn readiness_activation_is_valid(&self) -> bool {
+        let Some(requirement) = self.readiness_activation_requirement.as_ref() else {
+            return true;
+        };
+        match activation_is_valid(&self.pool, requirement).await {
+            Ok(valid) => valid,
+            Err(error) => {
+                tracing::warn!(error = %format!("{error:#}"), "readiness activationの再確認に失敗しました");
+                false
+            }
+        }
+    }
 }
 
 /// public manifest endpoint 用の最小 state。DB を必要としないため、
@@ -94,7 +117,7 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
         config.rendezvous_redis_url.as_str(),
         config.rendezvous_key_prefix.as_str(),
     )?;
-    let manifest = load_manifest(config.operator_config_path.as_deref())?;
+    let (manifest, operator_config_yaml) = load_manifest(config.operator_config_path.as_deref())?;
     let channel_secret_cipher = config
         .channel_secret_key
         .as_deref()
@@ -105,9 +128,33 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
     // 有効化の関門（#616）。環境変数が真でも、`cn-cli readiness` の全項目合格記録が
     // 無ければ索引・信頼の読み取り面を公開しない（該当 surface は 404 のまま）。
     // 記録の判定項目集合が現行と不一致（判定基準の変更後）も無効に倒す（安全側）。
-    let readiness_activated = if config.index_query_enabled || config.trust_read_enabled {
-        match kukuri_cn_core::latest_readiness_activation(&pool).await? {
-            Some(activation) if activation.matches_check_ids(&READINESS_CHECK_IDS) => {
+    let readiness_activation_requirement =
+        if config.index_query_enabled || config.trust_read_enabled {
+            Some(ReadinessActivationRequirement {
+                profile: "public-node".to_string(),
+                context_fingerprint: readiness_context_fingerprint(
+                    "public-node",
+                    &config.deployment_revision,
+                    &operator_config_yaml,
+                ),
+                max_age: chrono::Duration::seconds(
+                    i64::try_from(config.readiness_activation_max_age_secs).unwrap_or(i64::MAX),
+                ),
+            })
+        } else {
+            None
+        };
+    let readiness_activated = if let Some(requirement) = readiness_activation_requirement.as_ref() {
+        match latest_readiness_activation(&pool).await? {
+            Some(activation)
+                if activation.is_valid(
+                    &requirement.profile,
+                    &READINESS_CHECK_IDS,
+                    &requirement.context_fingerprint,
+                    chrono::Utc::now(),
+                    requirement.max_age,
+                ) =>
+            {
                 tracing::info!(
                     activated_at = %activation.activated_at.to_rfc3339(),
                     "readiness の有効化記録を確認しました"
@@ -117,7 +164,7 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
             Some(activation) => {
                 tracing::warn!(
                     activated_at = %activation.activated_at.to_rfc3339(),
-                    "readiness の有効化記録の判定項目集合が現行と一致しないため、                     index / trust の読み取り面を公開しません（`cn-cli readiness` を再実行してください）"
+                    "readiness の有効化記録が現在のprofile/config/deploy/期限と一致しないため、                     index / trust の読み取り面を公開しません（`cn-cli readiness` を再実行してください）"
                 );
                 false
             }
@@ -177,20 +224,41 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
         channel_secret_cipher,
         index_query,
         trust_read,
+        readiness_activation_requirement,
     })
+}
+
+async fn activation_is_valid(
+    pool: &PgPool,
+    requirement: &ReadinessActivationRequirement,
+) -> Result<bool> {
+    Ok(latest_readiness_activation(pool)
+        .await?
+        .is_some_and(|activation| {
+            activation.is_valid(
+                &requirement.profile,
+                &READINESS_CHECK_IDS,
+                &requirement.context_fingerprint,
+                chrono::Utc::now(),
+                requirement.max_age,
+            )
+        }))
 }
 
 /// operator config から公開 manifest を構築する。
 ///
 /// config が指定されているのに読込・検証に失敗した場合は起動を失敗させる
 /// (運営者の設定ミスを黙って無視せず、明示的に止める)。
-fn load_manifest(path: Option<&std::path::Path>) -> Result<Option<Arc<CommunityNodeManifest>>> {
+fn load_manifest(
+    path: Option<&std::path::Path>,
+) -> Result<(Option<Arc<CommunityNodeManifest>>, Vec<u8>)> {
     let Some(path) = path else {
-        return Ok(None);
+        return Ok((None, Vec::new()));
     };
     let yaml = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read operator config at {}", path.display()))?;
     let resolved = load_and_validate(&yaml)
         .with_context(|| format!("invalid operator config at {}", path.display()))?;
-    Ok(Some(Arc::new(build_manifest(&resolved))))
+    let bytes = yaml.as_bytes().to_vec();
+    Ok((Some(Arc::new(build_manifest(&resolved))), bytes))
 }

--- a/crates/cn-user-api/tests/activation_gate.rs
+++ b/crates/cn-user-api/tests/activation_gate.rs
@@ -13,7 +13,10 @@ use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
 use chrono::Utc;
-use kukuri_cn_core::{JwtConfig, TestDatabase, connect_postgres, record_readiness_activation};
+use kukuri_cn_core::{
+    JwtConfig, TestDatabase, connect_postgres, readiness_context_fingerprint,
+    record_readiness_activation, record_readiness_revocation,
+};
 use kukuri_cn_operator::READINESS_CHECK_IDS;
 use kukuri_cn_user_api::{UserApiConfig, app_router, build_state};
 use reqwest::{Client, StatusCode};
@@ -26,6 +29,10 @@ const SURFACES: [&str; 3] = [
     "/v1/trust/users/0000000000000000000000000000000000000000000000000000000000000001",
     "/v1/relation/users/0000000000000000000000000000000000000000000000000000000000000001",
 ];
+
+fn activation_context(revision: &str) -> String {
+    readiness_context_fingerprint("public-node", revision, b"")
+}
 
 async fn spawn_api(
     database_url: &str,
@@ -49,6 +56,8 @@ async fn spawn_api(
         channel_secret_key: None,
         index_query_enabled: true,
         trust_read_enabled: true,
+        deployment_revision: "test-deployment-v1".to_string(),
+        readiness_activation_max_age_secs: 3600,
     })
     .await?;
     let app = app_router(state);
@@ -108,6 +117,7 @@ async fn stale_check_id_set_keeps_surfaces_hidden() -> Result<()> {
         Utc::now(),
         "public-node",
         &["old_check_only"],
+        &activation_context("test-deployment-v1"),
         &serde_json::json!([]),
     )
     .await?;
@@ -134,6 +144,7 @@ async fn valid_activation_record_enables_surfaces() -> Result<()> {
         Utc::now(),
         "public-node",
         &READINESS_CHECK_IDS,
+        &activation_context("test-deployment-v1"),
         &serde_json::json!([]),
     )
     .await?;
@@ -146,6 +157,90 @@ async fn valid_activation_record_enables_surfaces() -> Result<()> {
             StatusCode::NOT_FOUND,
             "surface が 404 のまま: {path}: {body}"
         );
+    }
+    task.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn different_deployment_context_keeps_surfaces_hidden() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping activation gate test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_activation_context").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    kukuri_cn_core::initialize_database(&pool).await?;
+    record_readiness_activation(
+        &pool,
+        Utc::now(),
+        "public-node",
+        &READINESS_CHECK_IDS,
+        &activation_context("different-deployment"),
+        &serde_json::json!([]),
+    )
+    .await?;
+    let (base_url, task) = spawn_api(database.database_url.as_str(), "act-context").await?;
+    for (path, status, body) in surface_statuses(&base_url).await? {
+        assert_eq!(status, StatusCode::NOT_FOUND, "{path}: {body}");
+    }
+    task.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn expired_activation_keeps_surfaces_hidden() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping activation gate test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_activation_expired").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    kukuri_cn_core::initialize_database(&pool).await?;
+    record_readiness_activation(
+        &pool,
+        Utc::now() - chrono::Duration::hours(2),
+        "public-node",
+        &READINESS_CHECK_IDS,
+        &activation_context("test-deployment-v1"),
+        &serde_json::json!([]),
+    )
+    .await?;
+    let (base_url, task) = spawn_api(database.database_url.as_str(), "act-expired").await?;
+    for (path, status, body) in surface_statuses(&base_url).await? {
+        assert_eq!(status, StatusCode::NOT_FOUND, "{path}: {body}");
+    }
+    task.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn revocation_hides_already_started_surfaces() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping activation gate test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_activation_revoked").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    kukuri_cn_core::initialize_database(&pool).await?;
+    let context = activation_context("test-deployment-v1");
+    record_readiness_activation(
+        &pool,
+        Utc::now(),
+        "public-node",
+        &READINESS_CHECK_IDS,
+        &context,
+        &serde_json::json!([]),
+    )
+    .await?;
+    let (base_url, task) = spawn_api(database.database_url.as_str(), "act-revoked").await?;
+    for (path, status, body) in surface_statuses(&base_url).await? {
+        assert_ne!(status, StatusCode::NOT_FOUND, "{path}: {body}");
+    }
+
+    record_readiness_revocation(&pool, Utc::now(), "public-node", &context, "test_failure").await?;
+    for (path, status, body) in surface_statuses(&base_url).await? {
+        assert_eq!(status, StatusCode::NOT_FOUND, "{path}: {body}");
     }
     task.abort();
     Ok(())

--- a/crates/cn-user-api/tests/index_query.rs
+++ b/crates/cn-user-api/tests/index_query.rs
@@ -155,6 +155,8 @@ impl TestServer {
             channel_secret_key: None,
             index_query_enabled: false,
             trust_read_enabled: false,
+            deployment_revision: "test-deployment-v1".to_string(),
+            readiness_activation_max_age_secs: 3600,
         })
         .await?;
         if let Some(index) = index {

--- a/crates/cn-user-api/tests/indexing_requests.rs
+++ b/crates/cn-user-api/tests/indexing_requests.rs
@@ -52,6 +52,8 @@ impl TestServer {
             channel_secret_key,
             index_query_enabled: false,
             trust_read_enabled: false,
+            deployment_revision: "test-deployment-v1".to_string(),
+            readiness_activation_max_age_secs: 3600,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-user-api/tests/reports.rs
+++ b/crates/cn-user-api/tests/reports.rs
@@ -73,6 +73,8 @@ impl TestServer {
             channel_secret_key: None,
             index_query_enabled: false,
             trust_read_enabled: false,
+            deployment_revision: "test-deployment-v1".to_string(),
+            readiness_activation_max_age_secs: 3600,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-user-api/tests/support/mod.rs
+++ b/crates/cn-user-api/tests/support/mod.rs
@@ -46,6 +46,8 @@ impl TestServer {
             channel_secret_key: None,
             index_query_enabled: false,
             trust_read_enabled: false,
+            deployment_revision: "test-deployment-v1".to_string(),
+            readiness_activation_max_age_secs: 3600,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-user-api/tests/trust_relation.rs
+++ b/crates/cn-user-api/tests/trust_relation.rs
@@ -65,6 +65,8 @@ impl TestServer {
             channel_secret_key: None,
             index_query_enabled: false,
             trust_read_enabled: false,
+            deployment_revision: "test-deployment-v1".to_string(),
+            readiness_activation_max_age_secs: 3600,
         })
         .await?;
         if let Some(trust) = trust {

--- a/crates/harness/src/runtime.rs
+++ b/crates/harness/src/runtime.rs
@@ -104,6 +104,8 @@ impl CommunityNodeStack {
             channel_secret_key: None,
             index_query_enabled: false,
             trust_read_enabled: false,
+            deployment_revision: String::new(),
+            readiness_activation_max_age_secs: 900,
         })
         .await
         .context("failed to build community-node user-api state")?;

--- a/docker-compose.community-node.yml
+++ b/docker-compose.community-node.yml
@@ -11,8 +11,15 @@ x-cn-service-env: &cn-service-env
   COMMUNITY_NODE_PUBLIC_BASE_URL: ${CN_PUBLIC_BASE_URL:-http://127.0.0.1:18080}
   COMMUNITY_NODE_CONNECTIVITY_URLS: ${COMMUNITY_NODE_CONNECTIVITY_URLS:-http://127.0.0.1:13340}
 
+x-cn-logging: &cn-logging
+  driver: json-file
+  options:
+    max-size: "20m"
+    max-file: "5"
+
 services:
   cn-postgres:
+    logging: *cn-logging
     image: postgres:17-bookworm
     environment: *cn-postgres-env
     restart: unless-stopped
@@ -31,6 +38,7 @@ services:
       - cn-postgres-data:/var/lib/postgresql/data
 
   cn-valkey:
+    logging: *cn-logging
     image: valkey/valkey:8-alpine
     restart: unless-stopped
     ports:
@@ -45,6 +53,7 @@ services:
   # （真実源は Postgres。ADR 0025 / 0026）。container private network 内のみで listen し、
   # host / internet へ port を公開しない（デバッグは `docker compose exec cn-arcadedb` を使う）。
   cn-arcadedb:
+    logging: *cn-logging
     image: ${CN_ARCADEDB_IMAGE:-arcadedata/arcadedb:26.8.1}
     restart: unless-stopped
     environment:
@@ -62,6 +71,7 @@ services:
       - cn-arcadedb-data:/home/arcadedb/databases
 
   cn-migrate:
+    logging: *cn-logging
     build:
       context: .
       dockerfile: docker/cn/Dockerfile
@@ -81,6 +91,7 @@ services:
     restart: "no"
 
   cn-user-api:
+    logging: *cn-logging
     build:
       context: .
       dockerfile: docker/cn/Dockerfile
@@ -112,6 +123,8 @@ services:
       COMMUNITY_NODE_ARCADEDB_PASSWORD: ${CN_ARCADEDB_ROOT_PASSWORD:?set CN_ARCADEDB_ROOT_PASSWORD}
       COMMUNITY_NODE_INDEX_QUERY_ENABLED: ${COMMUNITY_NODE_INDEX_QUERY_ENABLED:-false}
       COMMUNITY_NODE_TRUST_READ_ENABLED: ${COMMUNITY_NODE_TRUST_READ_ENABLED:-false}
+      COMMUNITY_NODE_DEPLOYMENT_REVISION: ${COMMUNITY_NODE_DEPLOYMENT_REVISION:?set COMMUNITY_NODE_DEPLOYMENT_REVISION}
+      COMMUNITY_NODE_READINESS_ACTIVATION_MAX_AGE_SECS: ${COMMUNITY_NODE_READINESS_ACTIVATION_MAX_AGE_SECS:-900}
       COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE: ${COMMUNITY_NODE_TRUST_W_ABS_NEGATIVE:-}
       COMMUNITY_NODE_TRUST_W_ABS_POSITIVE: ${COMMUNITY_NODE_TRUST_W_ABS_POSITIVE:-}
       COMMUNITY_NODE_TRUST_RELATIVE_HALF_LIFE_DAYS: ${COMMUNITY_NODE_TRUST_RELATIVE_HALF_LIFE_DAYS:-}
@@ -126,6 +139,7 @@ services:
       - "${CN_USER_API_HOST_BIND_IP:-127.0.0.1}:${CN_USER_API_PORT:-18080}:8080"
 
   cn-iroh-relay:
+    logging: *cn-logging
     build:
       context: .
       dockerfile: docker/cn/Dockerfile
@@ -150,6 +164,7 @@ services:
   # provider 未構成なら ingest 無効の fail-closed 常駐（scan なしで index に載せない）。
   # port は status endpoint の loopback bind のみで、iroh 通信は outbound で成立する。
   cn-indexer:
+    logging: *cn-logging
     build:
       context: .
       dockerfile: docker/cn/Dockerfile
@@ -217,6 +232,7 @@ services:
   # relation graph の定期 batch 解析（#415 / #615）。ループは直列実行なので overlap は
   # 構造的に発生しない。成否は stdout log（[relation-analyze] 行）で観測する。
   cn-relation-analyze:
+    logging: *cn-logging
     build:
       context: .
       dockerfile: docker/cn/Dockerfile

--- a/docs/architecture/default-community-node-dependency-reduction.md
+++ b/docs/architecture/default-community-node-dependency-reduction.md
@@ -1,6 +1,6 @@
 # Default Community Node 依存低減ロードマップ
 
-最終更新日: 2026-06-19
+最終更新日: 2026-08-06
 
 ## この文書の位置づけ
 
@@ -28,7 +28,7 @@ kukuri には onboarding のための **default community node** が存在する
 | relay assist（NAT 越え） | 中（直接 P2P 不可時に default relay へ） | 補助。直接 P2P / 別 relay で代替可能。 |
 | topic rendezvous（topic peer 合流） | 中 | 補助。別 rendezvous / 既存 peer で代替可能。 |
 | consent / auth | 中（補助機能利用時） | 補助。利用する capability にのみ必要。 |
-| future index / moderation / trust signal | 低（未実装 / 計画中, Phase B） | 補助かつ optional trust input（`docs/adr/0027-deterministic-moderation-critical-safety.md` §2.1）。 |
+| index / moderation / trust signal | 低（実装済み。利用時だけ activation 付きで有効化） | 補助かつ node-local advisory / optional trust input（`docs/adr/0027-deterministic-moderation-critical-safety.md` §2.1）。canonical content・identity・social graph ではない。 |
 | generated policy / manifest display | 低（表示のみ） | 補助。manifest 取得失敗時は fallback 表示（client settings の node 依存度表示）。 |
 
 重要: いずれも **補助 capability** であり、user identity / profile / social graph という canonical state は default node に依存しない。依存低減とは「補助経路を default node 以外でも自然に賄えるようにする」ことであり、「user の存在を default node から切り離す」ことではない（それは既に切り離されている）。

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -1,6 +1,6 @@
 # Community Node GCP Terraform Deploy
 
-最終更新日: 2026-08-04
+最終更新日: 2026-08-06
 
 ## 目的
 
@@ -35,7 +35,7 @@ deploy_indexer_stack=true 時（#615）:
 VM 内: cn-arcadedb(:2480) / cn-indexer(:8630) も private（compose network 内のみ。
        firewall / Caddy へ新規公開 port は追加しない）
 VM 外: cn-indexer ─outbound HTTPS─▶ Project Arachnid Shield
-       cn-indexer ─private 経路（WireGuard 等）─▶ self-host VLM endpoint
+       cn-indexer ─承認済み境界（private tunnel または public TLS + API key + source allowlist）─▶ self-host VLM endpoint
 ```
 
 ### TLS / 証明書
@@ -243,10 +243,10 @@ deploy:
   arcadedb_password_secret_id: kukuri-cn-arcadedb-password
   arachnid_username_secret_id: kukuri-cn-arachnid-username
   arachnid_password_secret_id: kukuri-cn-arachnid-password
-  vlm_api_base_url: http://192.0.2.10:8000   # self-host VLM は private 経路の先のアドレス
+  vlm_api_base_url: https://vlm.example.net   # public TLS + source allowlist の例
   vlm_model: inclusionAI/SingGuard-2b
   vlm_response_format: guard
-  # vlm_api_key_secret_id: kukuri-cn-vlm-api-key   # 無認証 self-host endpoint なら省略
+  vlm_api_key_secret_id: kukuri-cn-vlm-api-key
 ```
 
 `validate-config` が runtime の起動 gate（必須 secret ID / relay / provider credential /
@@ -314,16 +314,31 @@ sudo /var/lib/toolbox/kukuri/bin/docker-compose restart cn-user-api
 - 判定項目集合が変わる更新を入れた場合、古い記録は無効になり面は自動で閉じる
   （readiness の再実行 + 再起動で再解禁する）。
 
-### VLM の private 経路（self-host endpoint）
+### VLM のネットワーク境界（self-host endpoint）
 
-- self-host VLM（DGX Spark 等の OpenAI-compatible endpoint）は public internet へ直接公開しない。
-- GCP VM から WireGuard / VPN / private tunnel 等で到達させ、`vlm_api_base_url` には tunnel 先の
-  private アドレスを指定する（例: `http://192.0.2.10:8000`）。WireGuard peer の設定は
-  `docs/runbooks/community-node-self-host-vps.md` の WireGuard 節が参考になる（COS では
-  Terraform 管理外の手動設定。VM 置換時は再設定が必要）。
-- API key が必要な external VLM を使う場合は `vlm_api_key_secret_id` で注入する。
+self-host VLM は次のどちらか一方の境界に固定し、runbook・network diagram・実配備を一致させる。
+
+1. **private tunnel**: GCP VM から WireGuard / VPN 等で到達し、`vlm_api_base_url` に tunnel 先の
+   private アドレスを指定する。WireGuard peer の設定は
+   `docs/runbooks/community-node-self-host-vps.md` を参照する。
+2. **public TLS + source allowlist**: HTTPS endpoint、API key、GCP VM の static egress IP の
+   source allowlist をすべて必須とする。`vlm_api_key_secret_id` から鍵を注入し、VLM 側では
+   allowlist 外と無認証のリクエストを拒否する。現行 `vlm.kukuri.app` はこの境界を採用する。
+
+平文HTTPのpublic公開、API keyだけでsource restrictionが無い構成、検証を無効化したTLSは不可。
 - VLM 不達時は cn-indexer が fail-closed（scan 失敗 = hold。allow に落ちない）。
 - Project Arachnid Shield への通信は outbound HTTPS のみで、callback / inbound port は無い。
+
+### Cloud Monitoring / log retention
+
+- VM の `kukuri-monitor.timer` が5分ごとに disk使用率、Postgres/ArcadeDB/indexer health、
+  last ingest age、backoff、provider failure、relation最終成功時刻を custom metrics へ送る。
+- Terraform は各 custom metric descriptor と alert policy を作成する。通知を実配送するには、
+  `monitoring_notification_channels` に既存 channel の resource name を設定して apply する。
+- 確認: `systemctl status kukuri-monitor.timer`、`systemctl start kukuri-monitor.service`、
+  `journalctl -u kukuri-monitor.service -n 50`。
+- compose 全serviceは `json-file` の `max-size=20m` / `max-file=5` を共通適用する。
+  `docker inspect <container> --format '{{json .HostConfig.LogConfig}}'` で実値を確認する。
 
 ### ArcadeDB を空から再構築する
 
@@ -371,6 +386,26 @@ cat cn-postgres.dump | docker compose exec -T cn-postgres \
   sh -lc 'pg_restore --clean --if-exists --no-owner -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
 docker compose start cn-user-api
 ```
+
+restore drill は本番DBへ直接上書きせず、隔離した一時DBへ復元して次を確認する。
+
+1. 最新dumpのGCS object generationとSHA-256を記録する。
+2. 一時Postgresを起動し `pg_restore --exit-on-error --no-owner` で復元する。
+3. `cn-cli prepare` を実行し、主要table件数、readiness activation、risk signal / index truthを照合する。
+4. 一時DBを削除し、実施日時・dump generation・検証結果を運用記録へ残す。
+
+## secret rotation
+
+- JWT / provider API key / Arachnid credential / safety signing keyは、Secret Managerへ新versionを追加し、
+  VMを再起動してstartup scriptに `.env` を再生成させる。再起動後に旧versionを無効化する。
+- Postgres passwordは、backup取得 → DB role password変更 → Secret Manager新version追加 → VM再起動を
+  連続したmaintenance windowで行い、`cn-migrate`・API health・readinessを確認後に旧versionを無効化する。
+- `COMMUNITY_NODE_CHANNEL_SECRET_KEY` は保存済みchannel secretの復号鍵なので、単純な値差替えは禁止。
+  再暗号化migrationとrollback可能な二重読取期間を用意した専用変更として扱う。
+- ArcadeDB passwordはprojection停止・再構築可能性を前提に、password変更とcompose secret更新を同じ
+  maintenance windowで行う。失敗時はArcadeDBを空から再構築する。
+- rotation後は `docker compose config` やjournalへ値を出力しない。secret名だけを記録し、
+  `cn-operator check-disclosures` とruntime/boot logの旧値・新値非含有検査を行う。
 
 ## managed-db / ha（拡張点）
 

--- a/docs/runbooks/community-node-operator-docs.md
+++ b/docs/runbooks/community-node-operator-docs.md
@@ -1,6 +1,6 @@
 # Community Node Operator Docs Generator (`cn-operator`)
 
-最終更新日: 2026-06-19
+最終更新日: 2026-08-06
 
 ## 目的
 
@@ -25,16 +25,18 @@ node 単位の説明責任に閉じる。
 `cn-operator` は各機能を capability として扱い、`availability` を持たせている。
 
 - **Phase A (`Available`)**: 現行 community node 実装（auth / consent / bootstrap / topic
-  rendezvous / iroh relay / `report_endpoint`）またはデプロイ構成（Cloudflare / analytics /
-  crash report / blob cache / private message storage / push）として提供できる capability。
+  rendezvous / iroh relay / `report_endpoint` / `community_index` / `moderation` /
+  `community_local_trust`）またはデプロイ構成（Cloudflare / analytics / crash report /
+  blob cache / private message storage / push）として提供できる capability。
   生成文書では「運用中」として開示してよい。`report_endpoint` は `POST /v1/report` で
   通報を受信・保存し、`cn-cli reports` で運営者が確認できる。
-- **Phase B (`Planned`)**: 現行実装に存在しない capability（`community_index` / `moderation` /
-  `community_local_trust`）。config で宣言できるが、生成文書では
-  「計画中（この配布物では未提供）」として扱い、運用中の外部送信・データ取扱い開示には載せない。
+- **Phase B (`Planned`)**: 将来追加され、まだ現行配布物に実装されていない capability。
+  config で宣言できても、生成文書では「計画中（この配布物では未提供）」として分離し、
+  運用中の外部送信・データ取扱い開示には載せない。2026-08-06 時点の定義には該当項目がない。
 
-Phase B capability を有効化するには、config に `acknowledge_planned_capabilities: true` を
-明示する必要がある。これがないと検証で失敗する。実体のない「運用中」開示を生成しないためのガード。
+将来 Phase B capability が追加された場合、それを有効化するには config に
+`acknowledge_planned_capabilities: true` を明示する必要がある。現行3機能の有効化には不要だが、
+実体のない「運用中」開示を生成しないためフィールドと検証機構は維持する。
 
 ## サブコマンド
 
@@ -42,7 +44,7 @@ Phase B capability を有効化するには、config に `acknowledge_planned_ca
 # サンプル config を出力
 cn-operator init --out operator-config.yaml
 
-# config を検証（Phase B 承認ガードを含む）
+# config を検証（将来の Planned capability 承認ガードを含む）
 cn-operator validate-config --config operator-config.yaml
 
 # 文書群を生成
@@ -51,7 +53,8 @@ cn-operator generate-docs --config operator-config.yaml --out-dir dist/operator-
 # terraform.tfvars を生成（deploy セクションが必要・#380）
 cn-operator generate-tfvars --config operator-config.yaml --out infra/terraform/envs/low-cost/terraform.tfvars
 
-# 生成済み文書と config の drift を検出（差分があれば non-zero exit）
+# 生成済み文書と config の drift、および secret ID / private endpoint 混入を検出
+# （いずれかがあれば non-zero exit）
 cn-operator check-disclosures --config operator-config.yaml --out-dir dist/operator-docs
 ```
 
@@ -66,8 +69,8 @@ cargo run -p kukuri-cn-operator --bin cn-operator -- generate-docs \
 
 `profile` は features の既定値を与え、個別の `features` キーで上書きできる。
 
-- `minimal`: index / moderation / community-local trust（いずれも計画中）。relay / cache /
-  analytics / crash report は無効。
+- `minimal`: index / moderation / community-local trust を含め、任意 capability は既定で無効。
+  relay / cache / analytics / crash report も無効。
 - `relay-enabled`: minimal + 専用 iroh relay + 暗号化済み traffic fallback 開示。
 - `full-service`: relay-enabled + blob cache + push 通知 + report endpoint。analytics /
   crash report は任意（既定無効）。

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -174,17 +174,24 @@ cargo run -p kukuri-cn-cli -- --database-url "$COMMUNITY_NODE_DATABASE_URL" prep
 cargo run -p kukuri-cn-cli -- --database-url "$COMMUNITY_NODE_DATABASE_URL" set-auth-rollout --mode off
 cargo run -p kukuri-cn-user-api
 cargo run -p kukuri-cn-iroh-relay
+# index/moderation/trust/relation を使う構成では、provider・署名鍵・ArcadeDB・relay を設定して起動
+cargo run -p kukuri-cn-indexer
+# 全 readiness が Pass のときだけ、現在の config/deployment revision に結び付いた activation を記録
+cargo run -p kukuri-cn-cli -- readiness --profile public-node --config operator-config.yaml
 ```
 
 1. migration/seed は `cn-cli prepare` だけで行う
 2. `cn-user-api` は prepared DB を前提に起動する
-3. rollout 変更は deploy 後に `cn-cli set-auth-rollout` で行う
-4. `COMMUNITY_NODE_DATABASE_INIT_MODE=prepare` は local bring-up と test 用に限定し、常用しない
+3. index/moderation stack は `cn-indexer` と relation timer を起動し、`cn-cli readiness` の全項目合格後にのみ read surface を解禁する
+4. rollout 変更は deploy 後に `cn-cli set-auth-rollout` で行う
+5. `COMMUNITY_NODE_DATABASE_INIT_MODE=prepare` は local bring-up と test 用に限定し、常用しない
 
 compose を使う場合:
 ```bash
 docker compose --env-file .env.community-node -f docker-compose.community-node.yml run --rm cn-migrate
-docker compose --env-file .env.community-node -f docker-compose.community-node.yml up -d cn-user-api cn-iroh-relay
+# production provider + signing keyを設定した構成のpositive startup smoke
+docker compose --env-file .env.community-node -f docker-compose.community-node.yml run --rm cn-indexer validate-config
+docker compose --env-file .env.community-node -f docker-compose.community-node.yml up -d
 ```
 
 ## community-node backup / restore

--- a/infra/terraform/envs/low-cost/main.tf
+++ b/infra/terraform/envs/low-cost/main.tf
@@ -187,9 +187,140 @@ resource "google_compute_disk_resource_policy_attachment" "postgres_data" {
 }
 
 resource "google_compute_disk_resource_policy_attachment" "indexer_data" {
-  count   = var.enable_disk_snapshots && var.deploy_indexer_stack && var.indexer_data_disk_gb > 0 ? 1 : 0
+  count   = var.enable_disk_snapshots && var.indexer_data_disk_gb > 0 ? 1 : 0
   name    = google_compute_resource_policy.disk_snapshot[0].name
   disk    = module.vm.indexer_data_disk_name
   zone    = var.zone
   project = var.project_id
+}
+
+locals {
+  community_node_metric_descriptors = {
+    disk_percent_used = {
+      display_name = "Community Node disk used"
+      unit         = "%"
+    }
+    postgres_healthy = {
+      display_name = "Community Node Postgres healthy"
+      unit         = "1"
+    }
+    arcadedb_healthy = {
+      display_name = "Community Node ArcadeDB healthy"
+      unit         = "1"
+    }
+    indexer_healthy = {
+      display_name = "Community Node indexer healthy"
+      unit         = "1"
+    }
+    indexer_last_ingest_age_seconds = {
+      display_name = "Community Node last ingest age"
+      unit         = "s"
+    }
+    indexer_backoff_active = {
+      display_name = "Community Node indexer backoff active"
+      unit         = "1"
+    }
+    provider_failure_detected = {
+      display_name = "Community Node provider failure detected"
+      unit         = "1"
+    }
+    relation_last_success_age_seconds = {
+      display_name = "Community Node relation analysis age"
+      unit         = "s"
+    }
+  }
+
+  community_node_alerts = merge(
+    {
+      disk = {
+        metric     = "disk_percent_used"
+        display    = "Community Node disk usage high"
+        comparison = "COMPARISON_GT"
+        threshold  = 85
+      }
+      postgres = {
+        metric     = "postgres_healthy"
+        display    = "Community Node Postgres unhealthy"
+        comparison = "COMPARISON_LT"
+        threshold  = 0.5
+      }
+    },
+    var.deploy_indexer_stack ? {
+      arcadedb = {
+        metric     = "arcadedb_healthy"
+        display    = "Community Node ArcadeDB unhealthy"
+        comparison = "COMPARISON_LT"
+        threshold  = 0.5
+      }
+      indexer = {
+        metric     = "indexer_healthy"
+        display    = "Community Node indexer unhealthy"
+        comparison = "COMPARISON_LT"
+        threshold  = 0.5
+      }
+      ingest_stale = {
+        metric     = "indexer_last_ingest_age_seconds"
+        display    = "Community Node ingest stale"
+        comparison = "COMPARISON_GT"
+        threshold  = 900
+      }
+      backoff = {
+        metric     = "indexer_backoff_active"
+        display    = "Community Node indexer backoff active"
+        comparison = "COMPARISON_GT"
+        threshold  = 0.5
+      }
+      provider = {
+        metric     = "provider_failure_detected"
+        display    = "Community Node safety provider failure"
+        comparison = "COMPARISON_GT"
+        threshold  = 0.5
+      }
+      relation = {
+        metric     = "relation_last_success_age_seconds"
+        display    = "Community Node relation analysis stale"
+        comparison = "COMPARISON_GT"
+        threshold  = var.relation_analyze_interval_minutes * 180
+      }
+    } : {}
+  )
+}
+
+resource "google_monitoring_metric_descriptor" "community_node" {
+  for_each = var.enable_community_node_monitoring ? local.community_node_metric_descriptors : {}
+
+  project      = var.project_id
+  type         = "custom.googleapis.com/kukuri/community_node/${each.key}"
+  metric_kind  = "GAUGE"
+  value_type   = "DOUBLE"
+  display_name = each.value.display_name
+  unit         = each.value.unit
+}
+
+resource "google_monitoring_alert_policy" "community_node" {
+  for_each = var.enable_community_node_monitoring ? local.community_node_alerts : {}
+
+  project               = var.project_id
+  display_name          = each.value.display
+  combiner              = "OR"
+  enabled               = true
+  notification_channels = var.monitoring_notification_channels
+
+  conditions {
+    display_name = each.value.display
+    condition_threshold {
+      filter                  = "resource.type = \"gce_instance\" AND metric.type = \"custom.googleapis.com/kukuri/community_node/${each.value.metric}\""
+      comparison              = each.value.comparison
+      threshold_value         = each.value.threshold
+      duration                = "300s"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_ACTIVE"
+    }
+  }
+
+  documentation {
+    mime_type = "text/markdown"
+    content   = "Inspect `kukuri-monitor.service`, container health, and the Community Node operator runbook before recovery or rollback."
+  }
+
+  depends_on = [google_monitoring_metric_descriptor.community_node]
 }

--- a/infra/terraform/envs/low-cost/terraform.tfvars.example
+++ b/infra/terraform/envs/low-cost/terraform.tfvars.example
@@ -31,6 +31,13 @@ disk_size_gb = 30
 backup_enabled        = true
 backup_retention_days = 30
 
+# Cloud Monitoring alert policies are enabled by default. Add one or more
+# pre-created notification channel resource names before production apply.
+enable_community_node_monitoring = true
+# monitoring_notification_channels = [
+#   "projects/your-gcp-project/notificationChannels/1234567890",
+# ]
+
 # operator-config.yaml を VM へ配置して public manifest endpoint /
 # report_endpoint gating を有効化する（#380, 任意）。
 # この env ディレクトリに operator-config.yaml を置き、相対パスを指定する。

--- a/infra/terraform/envs/low-cost/variables.tf
+++ b/infra/terraform/envs/low-cost/variables.tf
@@ -219,6 +219,18 @@ variable "snapshot_schedule_days" {
   default     = 14
 }
 
+variable "enable_community_node_monitoring" {
+  description = "Create Community Node custom metric descriptors and alert policies."
+  type        = bool
+  default     = true
+}
+
+variable "monitoring_notification_channels" {
+  description = "Cloud Monitoring notification channel resource names used by Community Node alert policies."
+  type        = list(string)
+  default     = []
+}
+
 # --- ingress hardening (optional) ---
 variable "extra_ingress_source_ranges" {
   description = "API/relay public ingress を絞る場合の許可レンジ。既定は全公開。"

--- a/infra/terraform/modules/gcp-vm-compose/main.tf
+++ b/infra/terraform/modules/gcp-vm-compose/main.tf
@@ -29,14 +29,35 @@ locals {
   # index / moderation stack（#615）。indexer data（iroh endpoint 同一性 / docs replica）は
   # 別 PD に置けるようにする。ArcadeDB data は rebuildable projection（canonical store では
   # ない）ため docker named volume に置き、空からの再構築手順を runbook に持つ。
-  indexer_data_path   = "/var/lib/kukuri/cn-indexer"
-  use_indexer_disk    = var.deploy_indexer_stack && var.indexer_data_disk_gb > 0
+  indexer_data_path = "/var/lib/kukuri/cn-indexer"
+  # Disk ownership is independent from whether the indexer containers are
+  # currently enabled. A feature-flag rollback must not plan data deletion.
+  use_indexer_disk    = var.indexer_data_disk_gb > 0
   indexer_status_port = 8630
 
   # operator-config.yaml を VM に配置するか（#380）。空文字なら配置せず manifest endpoint は 404。
   operator_config_enabled = trimspace(var.operator_config_file) != ""
   operator_config_path    = "/etc/kukuri/operator-config.yaml"
   operator_config_b64     = local.operator_config_enabled ? base64encode(var.operator_config_file) : ""
+  deployment_revision = sha256(jsonencode({
+    cn_user_api_image                  = var.cn_user_api_image
+    cn_indexer_image                   = var.cn_indexer_image
+    cn_cli_image                       = var.cn_cli_image
+    operator_config_sha256             = sha256(var.operator_config_file)
+    index_query_enabled                = var.index_query_enabled
+    trust_read_enabled                 = var.trust_read_enabled
+    safety_provider_known_csam         = var.safety_provider_known_csam
+    safety_provider_general            = var.safety_provider_general
+    safety_provider_unknown_csam       = var.safety_provider_unknown_csam
+    vlm_api_base_url                   = var.vlm_api_base_url
+    vlm_model                          = var.vlm_model
+    vlm_response_format                = var.vlm_response_format
+    safety_emit_signed_events          = var.safety_emit_signed_events
+    safety_suspected_threshold         = var.safety_suspected_threshold
+    safety_suspected_signal_visibility = var.safety_suspected_signal_visibility
+    media_fetch_max_bytes              = var.media_fetch_max_bytes
+    media_fetch_timeout_secs           = var.media_fetch_timeout_secs
+  }))
 
   # 各テンプレートを base64 で metadata に渡し、startup script が展開する。
   compose_b64 = base64encode(replace(templatefile("${path.module}/templates/docker-compose.yml.tftpl", {
@@ -123,6 +144,7 @@ locals {
     vlm_model                             = var.vlm_model
     vlm_response_format                   = var.vlm_response_format
     vlm_api_timeout_secs                  = var.vlm_api_timeout_secs
+    deployment_revision                   = local.deployment_revision
   }), "\r\n", "\n"))
 
   backup_script_b64 = base64encode(replace(templatefile("${path.module}/templates/backup.sh.tftpl", {
@@ -140,6 +162,14 @@ locals {
     relay_domain = var.relay_domain
     acme_email   = var.acme_email
     cert_name    = local.cert_name
+  }), "\r\n", "\n"))
+
+  monitor_script_b64 = base64encode(replace(templatefile("${path.module}/templates/monitor.sh.tftpl", {
+    install_dir          = local.install_dir
+    postgres_data_path   = local.postgres_data_path
+    indexer_data_path    = local.indexer_data_path
+    deploy_indexer_stack = var.deploy_indexer_stack
+    indexer_status_port  = local.indexer_status_port
   }), "\r\n", "\n"))
 
   startup_script = replace(templatefile("${path.module}/templates/startup.sh.tftpl", {
@@ -191,6 +221,7 @@ locals {
     env_runtime_b64                     = local.env_runtime_b64
     backup_script_b64                   = local.backup_script_b64
     renew_script_b64                    = local.renew_script_b64
+    monitor_script_b64                  = local.monitor_script_b64
   }), "\r\n", "\n")
 }
 
@@ -255,6 +286,16 @@ resource "google_compute_disk" "indexer_data" {
   zone    = var.zone
   size    = var.indexer_data_disk_gb
   project = var.project_id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_iam_member" "monitoring" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.vm.email}"
 }
 
 resource "google_compute_instance" "vm" {
@@ -321,5 +362,6 @@ resource "google_compute_instance" "vm" {
   depends_on = [
     google_secret_manager_secret_iam_member.accessor,
     google_project_iam_member.logging,
+    google_project_iam_member.monitoring,
   ]
 }

--- a/infra/terraform/modules/gcp-vm-compose/templates/community-node.env.tftpl
+++ b/infra/terraform/modules/gcp-vm-compose/templates/community-node.env.tftpl
@@ -17,6 +17,8 @@ COMMUNITY_NODE_RATE_LIMIT_BURST=${rate_limit_burst}
 # Caddy は信頼できる reverse proxy なので、クライアント単位 rate limit のため
 # X-Forwarded-For を信頼させる。
 COMMUNITY_NODE_RATE_LIMIT_TRUST_FORWARDED_FOR=true
+COMMUNITY_NODE_DEPLOYMENT_REVISION=${deployment_revision}
+COMMUNITY_NODE_READINESS_ACTIVATION_MAX_AGE_SECS=900
 
 # --- cn-iroh-relay ---
 COMMUNITY_NODE_IROH_RELAY_HTTP_BIND_ADDR=0.0.0.0:${relay_http_port}

--- a/infra/terraform/modules/gcp-vm-compose/templates/docker-compose.yml.tftpl
+++ b/infra/terraform/modules/gcp-vm-compose/templates/docker-compose.yml.tftpl
@@ -3,9 +3,16 @@
 # COMMUNITY_NODE_RENDEZVOUS_REDIS_URL) are provided at boot via the project .env file,
 # fetched from Secret Manager by the startup script. Non-secret container env lives in
 # community-node.env (passed literally via env_file).
+x-cn-logging: &cn-logging
+  driver: json-file
+  options:
+    max-size: "20m"
+    max-file: "5"
+
 services:
 %{ if deploy_local_postgres ~}
   cn-postgres:
+    logging: *cn-logging
     image: ${postgres_image}
     restart: unless-stopped
     environment:
@@ -32,6 +39,7 @@ services:
 %{ endif ~}
 %{ if deploy_local_valkey ~}
   cn-valkey:
+    logging: *cn-logging
     image: ${valkey_image}
     restart: unless-stopped
     healthcheck:
@@ -41,6 +49,7 @@ services:
       retries: 20
 %{ endif ~}
   cn-migrate:
+    logging: *cn-logging
     image: ${cn_cli_image}
     restart: "no"
     environment:
@@ -53,6 +62,7 @@ services:
     command: ["prepare"]
 
   cn-user-api:
+    logging: *cn-logging
     image: ${cn_user_api_image}
     restart: unless-stopped
     env_file:
@@ -90,6 +100,7 @@ services:
       - "${api_port}"
 
   cn-iroh-relay:
+    logging: *cn-logging
     image: ${cn_iroh_relay_image}
     restart: unless-stopped
     env_file:
@@ -105,6 +116,7 @@ services:
   # index 投影 + relation graph（#615）。rebuildable projection（canonical store ではない）。
   # container private network 内のみで listen し、host / internet へ port を公開しない。
   cn-arcadedb:
+    logging: *cn-logging
     image: ${arcadedb_image}
     restart: unless-stopped
     environment:
@@ -126,6 +138,7 @@ services:
   # 常駐 indexing ワーカー（#613 / #615）。provider 未構成なら ingest 無効の fail-closed 常駐。
   # port は expose のみ（host 公開しない）。iroh 通信は outbound で成立する。
   cn-indexer:
+    logging: *cn-logging
     image: ${cn_indexer_image}
     restart: unless-stopped
     env_file:
@@ -162,6 +175,7 @@ services:
   # `docker-compose run --rm cn-relation-analyze` として起動する one-shot。
   # profiles により `up -d` では起動しない。
   cn-relation-analyze:
+    logging: *cn-logging
     image: ${cn_cli_image}
     profiles: ["ops"]
     env_file:
@@ -174,6 +188,7 @@ services:
 %{ endif ~}
 
   caddy:
+    logging: *cn-logging
     image: ${caddy_image}
     restart: unless-stopped
     depends_on:

--- a/infra/terraform/modules/gcp-vm-compose/templates/monitor.sh.tftpl
+++ b/infra/terraform/modules/gcp-vm-compose/templates/monitor.sh.tftpl
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -euo pipefail
+
+INSTALL_DIR="${install_dir}"
+COMPOSE_BIN="/var/lib/toolbox/kukuri/bin/docker-compose"
+METADATA="http://metadata.google.internal/computeMetadata/v1"
+
+metadata() {
+  curl -fsS -H "Metadata-Flavor: Google" "$METADATA/$1"
+}
+
+TOKEN="$(metadata instance/service-accounts/default/token | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')"
+PROJECT="$(metadata project/project-id)"
+INSTANCE_ID="$(metadata instance/id)"
+ZONE="$(basename "$(metadata instance/zone)")"
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+write_metric() {
+  local name="$1" value="$2"
+  local body
+  body="$(printf '{"timeSeries":[{"metric":{"type":"custom.googleapis.com/kukuri/community_node/%s"},"resource":{"type":"gce_instance","labels":{"project_id":"%s","instance_id":"%s","zone":"%s"}},"points":[{"interval":{"endTime":"%s"},"value":{"doubleValue":%s}}]}]}' "$name" "$PROJECT" "$INSTANCE_ID" "$ZONE" "$NOW" "$value")"
+  curl -fsS -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    "https://monitoring.googleapis.com/v3/projects/$PROJECT/timeSeries" \
+    --data-binary "$body" >/dev/null
+}
+
+container_healthy() {
+  local service="$1" container status
+  container="$(cd "$INSTALL_DIR" && "$COMPOSE_BIN" ps -q "$service" 2>/dev/null || true)"
+  if [ -z "$container" ]; then
+    echo 0
+    return
+  fi
+  status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container" 2>/dev/null || true)"
+  if [ "$status" = "healthy" ] || [ "$status" = "running" ]; then echo 1; else echo 0; fi
+}
+
+disk_paths=(/)
+[ -e "${postgres_data_path}" ] && disk_paths+=("${postgres_data_path}")
+[ -e "${indexer_data_path}" ] && disk_paths+=("${indexer_data_path}")
+disk_percent="$(df -P "$${disk_paths[@]}" | awk 'NR > 1 {gsub(/%/, "", $5); if ($5 > max) max=$5} END {print max+0}')"
+write_metric disk_percent_used "$disk_percent"
+write_metric postgres_healthy "$(container_healthy cn-postgres)"
+
+%{ if deploy_indexer_stack ~}
+write_metric arcadedb_healthy "$(container_healthy cn-arcadedb)"
+write_metric indexer_healthy "$(container_healthy cn-indexer)"
+
+indexer_container="$(cd "$INSTALL_DIR" && "$COMPOSE_BIN" ps -q cn-indexer 2>/dev/null || true)"
+status_json=""
+if [ -n "$indexer_container" ]; then
+  status_json="$(docker exec "$indexer_container" curl -fsS http://127.0.0.1:${indexer_status_port}/v1/status 2>/dev/null || true)"
+fi
+last_ingest="$(printf '%s' "$status_json" | sed -n 's/.*"last_ingest_at"[ ]*:[ ]*\([0-9][0-9]*\).*/\1/p')"
+if [ -n "$last_ingest" ]; then
+  ingest_age="$(( $(date +%s) - last_ingest ))"
+else
+  ingest_age=1000000000
+fi
+write_metric indexer_last_ingest_age_seconds "$ingest_age"
+
+if printf '%s' "$status_json" | grep -Eq '"consecutive_failures"[ ]*:[ ]*[1-9]'; then
+  backoff_active=1
+else
+  backoff_active=0
+fi
+write_metric indexer_backoff_active "$backoff_active"
+
+provider_total="$(printf '%s' "$status_json" | sed -n 's/.*"provider_unavailable"[ ]*:[ ]*\([0-9][0-9]*\).*/\1/p')"
+provider_total="$${provider_total:-0}"
+provider_state="$INSTALL_DIR/.monitor-provider-unavailable"
+previous_total="$(cat "$provider_state" 2>/dev/null || echo 0)"
+if [ "$provider_total" -gt "$previous_total" ]; then provider_failure=1; else provider_failure=0; fi
+printf '%s\n' "$provider_total" > "$provider_state"
+write_metric provider_failure_detected "$provider_failure"
+
+relation_timestamp="$(systemctl show kukuri-relation-analyze.service -p ExecMainExitTimestamp --value 2>/dev/null || true)"
+relation_epoch="$(date -d "$relation_timestamp" +%s 2>/dev/null || echo 0)"
+relation_status="$(systemctl show kukuri-relation-analyze.service -p ExecMainStatus --value 2>/dev/null || echo 1)"
+if [ "$relation_epoch" -gt 0 ] && [ "$relation_status" = "0" ]; then
+  relation_age="$(( $(date +%s) - relation_epoch ))"
+else
+  relation_age=1000000000
+fi
+write_metric relation_last_success_age_seconds "$relation_age"
+%{ endif ~}

--- a/infra/terraform/modules/gcp-vm-compose/templates/startup.sh.tftpl
+++ b/infra/terraform/modules/gcp-vm-compose/templates/startup.sh.tftpl
@@ -115,6 +115,8 @@ echo "${caddyfile_b64}" | base64 -d > "$INSTALL_DIR/Caddyfile"
 echo "${env_runtime_b64}" | base64 -d > "$INSTALL_DIR/community-node.env"
 echo "${renew_script_b64}" | base64 -d > "$INSTALL_DIR/renew-certs.sh"
 chmod +x "$INSTALL_DIR/renew-certs.sh"
+echo "${monitor_script_b64}" | base64 -d > "$INSTALL_DIR/monitor.sh"
+chmod 700 "$INSTALL_DIR/monitor.sh"
 %{ if operator_config_enabled ~}
 # operator-config.yaml を VM に配置する（#380）。compose が cn-user-api に read-only mount し、
 # COMMUNITY_NODE_OPERATOR_CONFIG=${operator_config_path} で public manifest endpoint を有効化する。
@@ -275,8 +277,29 @@ WantedBy=timers.target
 UNIT
 %{ endif ~}
 
+# --- systemd timer: custom Cloud Monitoring metrics ---
+cat > /etc/systemd/system/kukuri-monitor.service <<UNIT
+[Unit]
+Description=kukuri community node health metrics
+[Service]
+Type=oneshot
+ExecStart=/bin/bash $INSTALL_DIR/monitor.sh
+UNIT
+cat > /etc/systemd/system/kukuri-monitor.timer <<UNIT
+[Unit]
+Description=kukuri community node health metrics timer
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30
+Persistent=true
+[Install]
+WantedBy=timers.target
+UNIT
+
 systemctl daemon-reload
 systemctl enable --now kukuri-cert-renew.timer
+systemctl enable --now kukuri-monitor.timer
 %{ if backup_enabled ~}
 systemctl enable --now kukuri-backup.timer
 %{ endif ~}

--- a/xtask/src/cn.rs
+++ b/xtask/src/cn.rs
@@ -69,7 +69,7 @@ pub(crate) fn cn_e2e_arcadedb_url() -> String {
     format!("http://127.0.0.1:{port}")
 }
 
-pub(crate) fn cn_compose_envs() -> [(&'static str, &'static str); 4] {
+pub(crate) fn cn_compose_envs() -> [(&'static str, &'static str); 5] {
     [
         ("CN_POSTGRES_PASSWORD", "cn_password"),
         (
@@ -84,6 +84,7 @@ pub(crate) fn cn_compose_envs() -> [(&'static str, &'static str); 4] {
             "COMMUNITY_NODE_CHANNEL_SECRET_KEY",
             "xtask-channel-secret-key-0123456789abcdef",
         ),
+        ("COMMUNITY_NODE_DEPLOYMENT_REVISION", "xtask-test-v1"),
     ]
 }
 


### PR DESCRIPTION
## Summary

- make indexer readiness depend on successful scope ingest rather than a completed poll alone
- bind read-surface activation to the active profile, operator/provider configuration, deployment revision, expiry, and revocation state
- attribute post/blob moderation risk signals to content authors so authenticated trust reads and appeals use live artifacts
- preserve the indexer persistent disk across feature rollback and add Cloud Monitoring, alert policies, and bounded container logs
- add MIME-unknown and tombstone coverage, strengthen disclosure checks, and align current Phase B runbooks

## Why

The #612 Definition of Done audit found false-positive readiness, a missing content-to-author trust path, activation records reusable across deployment changes, a rollback path that could destroy indexer state, and gaps in operational monitoring and failure-path coverage. This change closes the portions that can be implemented and verified without mutating the live deployment.

## Impact

- index/trust read surfaces fail closed when readiness is stale, revoked, or belongs to another deployment context
- failed scopes no longer refresh indexer success timestamps
- content-derived safety artifacts affect the correct author's trust inputs and follow the normal dispute/clear lifecycle
- disabling the indexer stack leaves its persistent disk intact
- operators receive bounded logs, custom health metrics, alert policies, and updated deployment/recovery guidance

## Validation

- `cargo xtask cn-check`
- `cargo xtask cn-test`
- `cargo xtask cn-e2e`
- `terraform fmt -check -recursive infra/terraform`
- Terraform validation for `infra/terraform/envs/low-cost`
- standard Community Node `docker compose config --quiet`
- `cn-operator check-disclosures`
- `git diff --check`

Refs #612
