### PR TITLE
fix: emit updater manifest without BOM

### DIFF
--- a/scripts/release/create-preview-assets.ps1
+++ b/scripts/release/create-preview-assets.ps1
@@ -66,7 +66,13 @@ $manifest = [ordered]@{
 }
 
 $manifestPath = Join-Path $OutputDir "latest-preview.json"
-$manifest | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+$manifestJson = $manifest | ConvertTo-Json -Depth 8
+$utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText(
+  $manifestPath,
+  $manifestJson + [System.Environment]::NewLine,
+  $utf8WithoutBom
+)
 
 $smokePath = Join-Path $OutputDir "manual-smoke-checklist.md"
 @"

--- a/scripts/release/test-create-preview-assets.ps1
+++ b/scripts/release/test-create-preview-assets.ps1
@@ -32,6 +32,15 @@ try {
   $manifestPath = Join-Path $outputDir "latest-preview.json"
   $checksumPath = Join-Path $outputDir "SHA256SUMS.txt"
   $assetListPath = Join-Path $outputDir "release-assets.txt"
+  $manifestBytes = [System.IO.File]::ReadAllBytes($manifestPath)
+  if (
+    $manifestBytes.Length -ge 3 -and
+    $manifestBytes[0] -eq 0xEF -and
+    $manifestBytes[1] -eq 0xBB -and
+    $manifestBytes[2] -eq 0xBF
+  ) {
+    throw "latest-preview.json must be UTF-8 without a byte order mark"
+  }
   $manifest = Get-Content -LiteralPath $manifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
   $platform = $manifest.platforms.'windows-x86_64'
 


### PR DESCRIPTION
## Summary

- write `latest-preview.json` as UTF-8 without a BOM on Windows PowerShell
- add a byte-level regression check to the release asset smoke test

## Root cause

The manually generated v0.1.3-preview.1 manifest was emitted by Windows PowerShell 5.1 `Set-Content -Encoding UTF8`, which prepended `EF BB BF`. The Tauri updater's JSON decoder rejected that response.

## Validation

- failure reproduced by the new regression check before the fix
- `scripts/release/test-create-preview-assets.ps1`
- `scripts/release/test-update-changelog.ps1`
- `scripts/release/test-generate-third-party-notices.ps1`
- `git diff --check`
- live v0.1.3 manifest replaced and verified BOM-free with matching checksums