### PR TITLE
fix(cn): sync live peers and serve disclosures

### DIFF
--- a/crates/cn-indexer/src/config.rs
+++ b/crates/cn-indexer/src/config.rs
@@ -29,6 +29,8 @@ pub const SAFETY_PROVIDER_UNKNOWN_CSAM_ENV: &str = "COMMUNITY_NODE_SAFETY_PROVID
 pub const SAFETY_EMIT_SIGNED_EVENTS_ENV: &str = "COMMUNITY_NODE_SAFETY_EMIT_SIGNED_EVENTS";
 /// signed event 無効時に risk signal issuer として使う node id。
 pub const SAFETY_ISSUER_NODE_ID_ENV: &str = "COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID";
+/// 自前 relay を cn-indexer の iroh runtime へ渡す公開 URL。
+pub const CONNECTIVITY_URLS_ENV: &str = "COMMUNITY_NODE_CONNECTIVITY_URLS";
 /// suspected 判定の classifier スコア閾値（1-100。未設定なら policy 既定 70。ADR 0028 §2.2）。
 pub const SAFETY_SUSPECTED_THRESHOLD_ENV: &str = "COMMUNITY_NODE_SAFETY_SUSPECTED_THRESHOLD";
 /// suspected advisory の配布 visibility（`local` / `subscribed_nodes` / `public`。
@@ -54,6 +56,7 @@ pub enum RelayValidation {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RelayConfig {
     pub has_own_relay: bool,
+    pub own_relay_urls: Vec<String>,
     pub external_relay_urls: Vec<String>,
 }
 
@@ -61,8 +64,25 @@ impl RelayConfig {
     pub fn new(has_own_relay: bool, external_relay_urls: Vec<String>) -> Self {
         Self {
             has_own_relay,
+            own_relay_urls: Vec::new(),
             external_relay_urls: normalize_relay_urls(external_relay_urls),
         }
+    }
+
+    pub fn with_own_relay_urls(mut self, own_relay_urls: Vec<String>) -> Self {
+        self.own_relay_urls = normalize_relay_urls(own_relay_urls);
+        self
+    }
+
+    /// iroh node へ実際に渡す relay URL。自前 / 外部を区別せず重複排除する。
+    pub fn runtime_relay_urls(&self) -> Vec<String> {
+        normalize_relay_urls(
+            self.own_relay_urls
+                .iter()
+                .chain(self.external_relay_urls.iter())
+                .cloned()
+                .collect(),
+        )
     }
 
     /// indexing 起動の relay validation gate（ADR 0025 §6.4）。
@@ -70,14 +90,16 @@ impl RelayConfig {
     /// 自前 relay も外部 relay も無ければ `Err`（indexing を起動しない）。どちらかが有れば
     /// どの経路で成立したかを返す。
     pub fn validate_for_startup(&self) -> Result<RelayValidation> {
+        let has_own = self.has_own_relay && !self.own_relay_urls.is_empty();
         let has_external = !self.external_relay_urls.is_empty();
-        match (self.has_own_relay, has_external) {
+        match (has_own, has_external) {
             (true, true) => Ok(RelayValidation::OwnAndExternalRelay),
             (true, false) => Ok(RelayValidation::OwnRelay),
             (false, true) => Ok(RelayValidation::ExternalRelay),
             (false, false) => bail!(
                 "cn-indexer requires a validated relay to start indexing: enable the node's own \
-                 iroh_relay capability or configure COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS"
+                 iroh_relay capability with COMMUNITY_NODE_CONNECTIVITY_URLS or configure \
+                 COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS"
             ),
         }
     }
@@ -269,6 +291,11 @@ impl IndexerConfig {
             .into();
         let has_own_relay =
             kukuri_cn_core::parse_bool_env("COMMUNITY_NODE_INDEXER_OWN_RELAY", false)?;
+        let own_relay_urls = if has_own_relay {
+            kukuri_cn_core::parse_csv_env(CONNECTIVITY_URLS_ENV)
+        } else {
+            Vec::new()
+        };
         let external_relay_urls =
             kukuri_cn_core::parse_csv_env("COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS");
         let channel_secret_key = std::env::var("COMMUNITY_NODE_CHANNEL_SECRET_KEY")
@@ -310,7 +337,8 @@ impl IndexerConfig {
         Ok(Self {
             database_url,
             data_dir,
-            relay: RelayConfig::new(has_own_relay, external_relay_urls),
+            relay: RelayConfig::new(has_own_relay, external_relay_urls)
+                .with_own_relay_urls(own_relay_urls),
             channel_secret_key,
             arcadedb,
             safety,
@@ -437,6 +465,7 @@ mod tests {
         "COMMUNITY_NODE_DATABASE_URL",
         "COMMUNITY_NODE_INDEXER_DATA_DIR",
         "COMMUNITY_NODE_INDEXER_OWN_RELAY",
+        CONNECTIVITY_URLS_ENV,
         "COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS",
         "COMMUNITY_NODE_CHANNEL_SECRET_KEY",
         "COMMUNITY_NODE_ARCADEDB_URL",
@@ -505,11 +534,32 @@ mod tests {
 
     #[test]
     fn startup_succeeds_with_own_relay() {
-        let config = RelayConfig::new(true, vec![]);
+        let config = RelayConfig::new(true, vec![])
+            .with_own_relay_urls(vec!["https://relay.example.net".to_string()]);
         assert_eq!(
             config.validate_for_startup().unwrap(),
             RelayValidation::OwnRelay
         );
+    }
+
+    #[test]
+    fn own_relay_env_supplies_runtime_relay_url() {
+        with_clean_indexer_env(|| {
+            set_minimal_indexer_env();
+            unsafe {
+                std::env::set_var("COMMUNITY_NODE_INDEXER_OWN_RELAY", "true");
+                std::env::set_var(
+                    "COMMUNITY_NODE_CONNECTIVITY_URLS",
+                    "https://iroh-relay.example.net",
+                );
+            }
+
+            let config = IndexerConfig::from_env().unwrap();
+            assert_eq!(
+                config.relay.own_relay_urls,
+                vec!["https://iroh-relay.example.net"]
+            );
+        });
     }
 
     #[test]
@@ -523,7 +573,8 @@ mod tests {
 
     #[test]
     fn startup_reports_both_when_own_and_external_present() {
-        let config = RelayConfig::new(true, vec!["https://relay.example.net".to_string()]);
+        let config = RelayConfig::new(true, vec!["https://external-relay.example.net".to_string()])
+            .with_own_relay_urls(vec!["https://own-relay.example.net".to_string()]);
         assert_eq!(
             config.validate_for_startup().unwrap(),
             RelayValidation::OwnAndExternalRelay
@@ -548,6 +599,15 @@ mod tests {
             ],
         );
         assert_eq!(config.external_relay_urls.len(), 1);
+    }
+
+    #[test]
+    fn own_relay_without_connectivity_url_fails_closed() {
+        assert!(
+            RelayConfig::new(true, vec![])
+                .validate_for_startup()
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/cn-indexer/src/participant.rs
+++ b/crates/cn-indexer/src/participant.rs
@@ -17,10 +17,11 @@ use tracing::{info, warn};
 
 use kukuri_cn_core::{
     ChannelSecretCipher, IndexEntryStore, IndexScopeKind, list_channel_secrets,
-    list_supported_topics,
+    list_supported_topics, load_bootstrap_seed_peers,
 };
 use kukuri_core::ReplicaId;
 use kukuri_docs_sync::{DocsSync, private_channel_replica_id, topic_replica_id};
+use kukuri_transport::SeedPeer;
 
 use crate::ingest::{IngestPipeline, IngestSummary};
 use crate::projection::IndexProjection;
@@ -59,6 +60,7 @@ pub struct IndexerParticipant {
     projection: Arc<dyn IndexProjection>,
     pipeline: IngestPipeline,
     channel_secret_cipher: ChannelSecretCipher,
+    configured_seed_peers: Option<Vec<SeedPeer>>,
 }
 
 impl IndexerParticipant {
@@ -77,7 +79,38 @@ impl IndexerParticipant {
             projection,
             pipeline,
             channel_secret_cipher,
+            configured_seed_peers: None,
         }
+    }
+
+    pub fn with_configured_seed_peers(mut self, peers: Vec<SeedPeer>) -> Self {
+        self.configured_seed_peers = Some(peers);
+        self
+    }
+
+    /// desktop heartbeat が Postgres に保持する active peer を docs sync へ反映する。
+    /// operator 指定 seed は残し、同じ endpoint の fresh addr_hint は heartbeat 側で更新する。
+    async fn refresh_seed_peers(&self) -> Result<()> {
+        let Some(configured) = self.configured_seed_peers.as_deref() else {
+            return Ok(());
+        };
+        let active = load_bootstrap_seed_peers(&self.pool, None, None)
+            .await?
+            .into_iter()
+            .map(|peer| SeedPeer {
+                endpoint_id: peer.endpoint_id,
+                addr_hint: peer.addr_hint,
+            })
+            .collect::<Vec<_>>();
+        let peers = merge_seed_peers(configured, &active);
+        self.docs_sync.set_seed_peers(peers.clone()).await?;
+        info!(
+            configured = configured.len(),
+            active = active.len(),
+            applied = peers.len(),
+            "refreshed docs sync seed peers from active bootstrap registrations"
+        );
+        Ok(())
     }
 
     /// いま index 対象であるべき scope を返す（#613 T2。読み取りのみ、副作用なし）。
@@ -112,6 +145,8 @@ impl IndexerParticipant {
     /// capability（channel secret）を docs へ登録してから open する。secret 未登録の private channel は
     /// open せず warn する（secret 無しでは index しない）。
     pub async fn restore_scopes(&self) -> Result<Vec<ScopeReplica>> {
+        self.refresh_seed_peers().await?;
+
         // private channel の capability を先に docs へ登録する。
         let secrets = list_channel_secrets(&self.pool, &self.channel_secret_cipher).await?;
         for secret in &secrets {
@@ -217,6 +252,21 @@ impl IndexerParticipant {
     }
 }
 
+fn merge_seed_peers(configured: &[SeedPeer], active: &[SeedPeer]) -> Vec<SeedPeer> {
+    let mut peers = std::collections::BTreeMap::new();
+    for peer in configured.iter().chain(active.iter()) {
+        peers
+            .entry(peer.endpoint_id.clone())
+            .and_modify(|existing: &mut SeedPeer| {
+                if peer.addr_hint.is_some() {
+                    existing.addr_hint.clone_from(&peer.addr_hint);
+                }
+            })
+            .or_insert_with(|| peer.clone());
+    }
+    peers.into_values().collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -231,5 +281,23 @@ mod tests {
     fn private_channel_scope_maps_to_channel_replica() {
         let scope = ScopeReplica::from_scope(IndexScopeKind::PrivateChannel, "secret-room");
         assert_eq!(scope.replica_id.as_str(), "channel::secret-room");
+    }
+
+    #[test]
+    fn active_bootstrap_peer_refreshes_configured_addr_hint() {
+        let endpoint_id = "1".repeat(64);
+        let peers = merge_seed_peers(
+            &[SeedPeer {
+                endpoint_id: endpoint_id.clone(),
+                addr_hint: None,
+            }],
+            &[SeedPeer {
+                endpoint_id: endpoint_id.clone(),
+                addr_hint: Some("192.0.2.10:4433".to_string()),
+            }],
+        );
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].endpoint_id, endpoint_id);
+        assert_eq!(peers[0].addr_hint.as_deref(), Some("192.0.2.10:4433"));
     }
 }

--- a/crates/cn-indexer/src/runtime.rs
+++ b/crates/cn-indexer/src/runtime.rs
@@ -136,7 +136,7 @@ async fn run(config: IndexerConfig) -> Result<()> {
                 TransportNetworkConfig::from_env()?,
                 DhtDiscoveryOptions::disabled(),
                 TransportRelayConfig {
-                    iroh_relay_urls: config.relay.external_relay_urls.clone(),
+                    iroh_relay_urls: config.relay.runtime_relay_urls(),
                 }
                 .normalized(),
             )
@@ -306,7 +306,8 @@ async fn compose_ingest_stack(
         projection,
         pipeline,
         cipher,
-    );
+    )
+    .with_configured_seed_peers(config.seed_peers.clone());
     Ok((participant, docs_sync))
 }
 

--- a/crates/cn-indexer/tests/ingestion_contracts.rs
+++ b/crates/cn-indexer/tests/ingestion_contracts.rs
@@ -714,11 +714,17 @@ async fn indexing_startup_requires_validated_relay() -> Result<()> {
             .validate_for_startup()
             .is_err()
     );
-    // 自前 relay 有り、または外部 relay 有りで起動できる。
+    // 自前 relay は runtime が接続に使える公開 URL も必要。外部 relay URL でも起動できる。
+    assert!(
+        RelayConfig::new(true, vec![])
+            .with_own_relay_urls(vec!["https://own-relay.example.net".to_string()])
+            .validate_for_startup()
+            .is_ok()
+    );
     assert!(
         RelayConfig::new(true, vec![])
             .validate_for_startup()
-            .is_ok()
+            .is_err()
     );
     assert!(
         RelayConfig::new(false, vec!["https://relay.example.net".to_string()])

--- a/crates/cn-user-api/src/routes.rs
+++ b/crates/cn-user-api/src/routes.rs
@@ -1,6 +1,7 @@
 //! route 定義と起動(serve / tracing)。desktop 対向のパスは kukuri-cn-protocol の
 //! 定数を参照する(パス変更が client / server 両側にコンパイルエラーとして届く)。
 
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -37,7 +38,10 @@ use crate::rate_limit::apply_rate_limit;
 use crate::state::{ManifestState, UserApiState, build_runtime_state};
 
 pub fn app_router(state: UserApiState) -> Router {
-    let manifest = manifest_routes(state.manifest.clone());
+    let manifest = manifest_routes(
+        state.manifest.clone(),
+        Arc::clone(&state.public_disclosures),
+    );
     let api = Router::new()
         .route("/healthz", get(healthz))
         .route(AUTH_CHALLENGE_PATH, post(auth_challenge))
@@ -72,14 +76,68 @@ pub fn app_router(state: UserApiState) -> Router {
 /// `GET /.well-known/kukuri/community-node.json` と `GET /v1/node/manifest` の
 /// 両方を同じ handler で提供する。manifest 単独でテスト・配信できるよう、DB を
 /// 必要としない最小 state を持つ独立 router にしている。
-pub fn manifest_routes(manifest: Option<Arc<CommunityNodeManifest>>) -> Router {
+pub fn manifest_routes(
+    manifest: Option<Arc<CommunityNodeManifest>>,
+    public_disclosures: Arc<BTreeMap<String, String>>,
+) -> Router {
     Router::new()
         .route(
             "/.well-known/kukuri/community-node.json",
             get(node_manifest),
         )
         .route(NODE_MANIFEST_PATH, get(node_manifest))
-        .with_state(ManifestState { manifest })
+        .route("/terms", get(terms))
+        .route("/privacy", get(privacy))
+        .route("/external-transmission", get(external_transmission))
+        .route("/moderation-policy", get(moderation_policy))
+        .route("/abuse-policy", get(abuse_policy))
+        .with_state(ManifestState {
+            manifest,
+            public_disclosures,
+        })
+}
+
+async fn terms(State(state): State<ManifestState>) -> Response {
+    disclosure_response(&state, "terms.md")
+}
+
+async fn privacy(State(state): State<ManifestState>) -> Response {
+    disclosure_response(&state, "privacy-policy.md")
+}
+
+async fn external_transmission(State(state): State<ManifestState>) -> Response {
+    disclosure_response(&state, "external-transmission-notice.md")
+}
+
+async fn moderation_policy(State(state): State<ManifestState>) -> Response {
+    disclosure_response(&state, "moderation-policy.md")
+}
+
+async fn abuse_policy(State(state): State<ManifestState>) -> Response {
+    disclosure_response(&state, "abuse-policy.md")
+}
+
+fn disclosure_response(state: &ManifestState, filename: &str) -> Response {
+    let Some(content) = state.public_disclosures.get(filename) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "error": "disclosure_not_configured",
+                "message": "this community node does not publish this disclosure"
+            })),
+        )
+            .into_response();
+    };
+    let mut response = content.clone().into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/markdown; charset=utf-8"),
+    );
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("public, max-age=300"),
+    );
+    response
 }
 
 /// public manifest を返す。設定されていなければ 404(client は別経路へ fallback)。

--- a/crates/cn-user-api/src/state.rs
+++ b/crates/cn-user-api/src/state.rs
@@ -1,5 +1,6 @@
 //! user-api の実行時 state(DI)と構築。
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -12,7 +13,7 @@ use kukuri_cn_indexer::{
     ArcadeDbConfig, ArcadeDbProjection, ArcadeDbRelationGraph, FailClosedIndexQuery, IndexQuery,
 };
 use kukuri_cn_operator::{
-    CommunityNodeManifest, READINESS_CHECK_IDS, build_manifest, load_and_validate,
+    CommunityNodeManifest, READINESS_CHECK_IDS, build_manifest, generate_all, load_and_validate,
 };
 use kukuri_cn_protocol::{CommunityNodeBootstrapNode, CommunityNodeResolvedUrls};
 use kukuri_cn_trust::{RelationStore, TrustParams};
@@ -28,6 +29,8 @@ pub struct UserApiState {
     pub(crate) self_node: CommunityNodeBootstrapNode,
     /// 公開する manifest(operator config が設定されている場合のみ)。
     pub(crate) manifest: Option<Arc<CommunityNodeManifest>>,
+    /// manifest が指す公開開示文書。operator config と同じ入力から決定論的に生成する。
+    pub(crate) public_disclosures: Arc<BTreeMap<String, String>>,
     /// private channel の indexing request で受け取る channel secret を at-rest 暗号化する cipher。
     /// 鍵 material(`COMMUNITY_NODE_CHANNEL_SECRET_KEY`)が未設定なら None で、private channel の
     /// indexing request は受け付けない(secret を平文保存しないため)。
@@ -98,6 +101,13 @@ impl UserApiState {
 #[derive(Clone)]
 pub(crate) struct ManifestState {
     pub(crate) manifest: Option<Arc<CommunityNodeManifest>>,
+    pub(crate) public_disclosures: Arc<BTreeMap<String, String>>,
+}
+
+struct LoadedManifest {
+    manifest: Option<Arc<CommunityNodeManifest>>,
+    public_disclosures: Arc<BTreeMap<String, String>>,
+    operator_config_yaml: Vec<u8>,
 }
 
 pub async fn build_state(config: &UserApiConfig) -> Result<UserApiState> {
@@ -117,7 +127,11 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
         config.rendezvous_redis_url.as_str(),
         config.rendezvous_key_prefix.as_str(),
     )?;
-    let (manifest, operator_config_yaml) = load_manifest(config.operator_config_path.as_deref())?;
+    let LoadedManifest {
+        manifest,
+        public_disclosures,
+        operator_config_yaml,
+    } = load_manifest(config.operator_config_path.as_deref())?;
     let channel_secret_cipher = config
         .channel_secret_key
         .as_deref()
@@ -221,6 +235,7 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
             )?,
         },
         manifest,
+        public_disclosures,
         channel_secret_cipher,
         index_query,
         trust_read,
@@ -249,16 +264,36 @@ async fn activation_is_valid(
 ///
 /// config が指定されているのに読込・検証に失敗した場合は起動を失敗させる
 /// (運営者の設定ミスを黙って無視せず、明示的に止める)。
-fn load_manifest(
-    path: Option<&std::path::Path>,
-) -> Result<(Option<Arc<CommunityNodeManifest>>, Vec<u8>)> {
+fn load_manifest(path: Option<&std::path::Path>) -> Result<LoadedManifest> {
     let Some(path) = path else {
-        return Ok((None, Vec::new()));
+        return Ok(LoadedManifest {
+            manifest: None,
+            public_disclosures: Arc::new(BTreeMap::new()),
+            operator_config_yaml: Vec::new(),
+        });
     };
     let yaml = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read operator config at {}", path.display()))?;
     let resolved = load_and_validate(&yaml)
         .with_context(|| format!("invalid operator config at {}", path.display()))?;
     let bytes = yaml.as_bytes().to_vec();
-    Ok((Some(Arc::new(build_manifest(&resolved))), bytes))
+    let public_disclosures = generate_all(&resolved)
+        .into_iter()
+        .filter(|file| {
+            matches!(
+                file.filename.as_str(),
+                "terms.md"
+                    | "privacy-policy.md"
+                    | "external-transmission-notice.md"
+                    | "moderation-policy.md"
+                    | "abuse-policy.md"
+            )
+        })
+        .map(|file| (file.filename, file.content))
+        .collect();
+    Ok(LoadedManifest {
+        manifest: Some(Arc::new(build_manifest(&resolved))),
+        public_disclosures: Arc::new(public_disclosures),
+        operator_config_yaml: bytes,
+    })
 }

--- a/crates/cn-user-api/tests/manifest.rs
+++ b/crates/cn-user-api/tests/manifest.rs
@@ -2,30 +2,38 @@
 //!
 //! manifest endpoint は DB を必要としないため、`manifest_routes` を単独でサーブして検証する。
 
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use kukuri_cn_operator::{build_manifest, load_and_validate};
+use kukuri_cn_operator::{build_manifest, generate_all, load_and_validate};
 use kukuri_cn_user_api::manifest_routes;
 use reqwest::{Client, StatusCode};
 
 async fn spawn_manifest_server(
     yaml: Option<&str>,
 ) -> Result<(String, tokio::task::JoinHandle<()>)> {
-    let manifest = match yaml {
+    let (manifest, disclosures) = match yaml {
         Some(yaml) => {
             let resolved = load_and_validate(yaml).context("config must validate")?;
-            Some(Arc::new(build_manifest(&resolved)))
+            let disclosures = generate_all(&resolved)
+                .into_iter()
+                .map(|file| (file.filename, file.content))
+                .collect();
+            (
+                Some(Arc::new(build_manifest(&resolved))),
+                Arc::new(disclosures),
+            )
         }
-        None => None,
+        None => (None, Arc::new(BTreeMap::new())),
     };
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .context("bind manifest test listener")?;
     let addr = listener.local_addr()?;
     let base_url = format!("http://{addr}");
-    let app = manifest_routes(manifest);
+    let app = manifest_routes(manifest, disclosures);
     let task = tokio::spawn(async move {
         axum::serve(
             listener,
@@ -35,6 +43,23 @@ async fn spawn_manifest_server(
         .expect("manifest server");
     });
     Ok((base_url, task))
+}
+
+#[tokio::test]
+async fn disclosure_urls_serve_markdown_from_operator_config_output() -> Result<()> {
+    let (base_url, task) = spawn_manifest_server(Some(SAMPLE_YAML)).await?;
+    let response = Client::new()
+        .get(format!("{base_url}/terms"))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()[reqwest::header::CONTENT_TYPE],
+        "text/markdown; charset=utf-8"
+    );
+    assert!(response.text().await?.contains("Example Operator"));
+    task.abort();
+    Ok(())
 }
 
 const SAMPLE_YAML: &str = r#"server:

--- a/docs/progress/2026-08-03-613-cn-indexer-resident-worker.md
+++ b/docs/progress/2026-08-03-613-cn-indexer-resident-worker.md
@@ -56,6 +56,13 @@ private channel だけを `restore_scopes()` が開く（鍵が無ければ索�
 `COMMUNITY_NODE_CHANNEL_SECRET_KEY` / `COMMUNITY_NODE_ARCADEDB_*` /
 `COMMUNITY_NODE_SAFETY_*` / `COMMUNITY_NODE_MEDIA_FETCH_*` は変更なし。
 
+`COMMUNITY_NODE_INDEXER_OWN_RELAY=true` の場合、実際の iroh 接続先は
+`COMMUNITY_NODE_CONNECTIVITY_URLS` から解決する。フラグだけが設定され URL が空なら起動を
+fail-closed する。`COMMUNITY_NODE_INDEXER_EXTERNAL_RELAY_URLS` と併用した場合は両方を重複除去して使う。
+また resident worker は固定の `COMMUNITY_NODE_INDEXER_SEED_PEERS` に加え、Valkey の active
+bootstrap 登録を各 restore / 全件見直しで再取得する。これにより稼働中 client の endpoint と
+`addr_hint` を再起動なしで docs 同期へ反映する。
+
 ## テスト
 
 - **ループ契約（`tests/worker_contracts.rs`、`KUKURI_CN_RUN_INTEGRATION_TESTS=1`）**: 起動時

--- a/docs/progress/2026-08-06-616-activation.md
+++ b/docs/progress/2026-08-06-616-activation.md
@@ -86,14 +86,26 @@ cn-indexer 常駐ワーカー・cn-iroh-relay + 実 iroh ノード 2 台 + wirem
 
 ## 運用メモ
 
-- VM 上での readiness 実行は `cn-relation-analyze` サービス（cn-cli image）を流用するが、
-  プロバイダ資格情報の env はサービス定義に含まれないため、project `.env` を source して
-  `-e` で転送する（runbook に追記済み）。
+- VM 上では専用の `cn-readiness` ops serviceを `kukuri-readiness.timer` が5分ごとに起動する。
+  project `.env` のproduction資格情報とoperator configを渡し、15分のactivation有効期限より前に
+  再判定する。失敗時は旧activationをrevokeし、user-apiのread-time gateが即時に面を閉じる。
 - readiness の疎通確認結果は 15 分 TTL で `cn_admin.readiness_probe_cache` に保存され、
   `--force-probe` で強制再実行できる。
 
+## 2026-08-07 継続稼働の再検証
+
+- 2ユーザーの実投稿を同期し、Postgres truth=2 / ArcadeDB projection=2 / relation edge=1、
+  認証付きdiscovery=2件を確認した。
+- activationの有効期限が900秒なのに定期readiness経路がなく、時間経過後に実際の公開面が
+  `INDEX_QUERY_NOT_ACTIVATED`へ戻る不足を検出した。この記録の `cn-readiness` service / timerで
+  継続更新する。
+- ArcadeDBを実停止すると、activationがまだ有効な直後でもdiscoveryは500かつ0件で
+  unsafeな結果を返さなかった。readinessはprojection / truth整合の2項目がFailして旧activationを
+  revokeし、公開面は404へ閉じた。ArcadeDB再起動・relation再解析後は全項目Pass、
+  discovery 200 / 2件へ復旧した。
+
 ## 残作業（後続 Issue）
 
-- 実運用の投稿が索引へ入った後の実測値の見直し（現時点で対象 4 トピックは投稿 0 件）。
+- benign imageの一時取得・非残留を含む実投稿の追加確認。
 - 届出受領前の拘束条件（#612 / #617 に記載: DNS の停止か招待制への切替）の適用判断。
 - プライベートチャンネル索引の本番解禁（申請ベース。#612 側の後続）。

--- a/docs/progress/2026-08-06-617-capability-disclosure-sync.md
+++ b/docs/progress/2026-08-06-617-capability-disclosure-sync.md
@@ -52,7 +52,10 @@ PR: [#640](https://github.com/KingYoSun/kukuri/pull/640)（T1 昇格）·
 
 ## 残作業・持ち越し
 
-- 実機（GCP VM）の public manifest への反映は、新 image の digest 更新 + apply が必要。
+- public manifest が指す `GET /terms` / `GET /privacy` / `GET /external-transmission` /
+  `GET /moderation-policy` / `GET /abuse-policy` は、operator config から生成した同一の開示文書を
+  `cn-user-api` が Markdown として配信する。operator config 未設定時は manifest と同様に 404。
+- 実機（GCP VM）の public manifest と開示 URL への反映は、新 image の digest 更新 + apply が必要。
   現在は届出受領前の拘束条件により DNS 閉鎖中のため、再公開時（届出受領後）に
   image 更新とあわせて行う（`docs/progress/2026-08-06-616-activation.md` の再公開手順参照）。
 - kukuri.app サイト側（#602）の公開物更新は再公開時に接続する。

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -367,6 +367,8 @@ docker volume rm community-node_cn-arcadedb-data   # volume 名は docker volume
 
 - cn-indexer / ArcadeDB / relation timer が構成から外れ、公開 surface は従来どおり
   API / relay のみになる（flag が既定 false のため index / trust API はもともと 404）。
+- startupは `docker-compose up -d --remove-orphans` とoptional systemd unitのcleanupを行うため、
+  旧構成のcn-indexer / ArcadeDB containerやrelation / readiness timerは再起動後に残らない。
 - Postgres の永続 data（verdict / moderation artifact / index 真実源）は残る。
 - `indexer_data_disk_gb > 0` の PD は Terraform 管理のため、変数を 0 にしない限り残る
   （再有効化時に endpoint 同一性を保てる）。

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -288,8 +288,13 @@ journalctl -u kukuri-relation-analyze.service -n 50
 読み取り面（索引 query / 信頼 read）は、環境変数（`COMMUNITY_NODE_INDEX_QUERY_ENABLED` /
 `COMMUNITY_NODE_TRUST_READ_ENABLED`）が真でも、`cn-cli readiness` の全項目合格記録
 （`cn_admin.readiness_activations`）が無ければ公開されない（有効化の関門）。
-全項目合格すると記録は自動で書かれる。反映には cn-user-api の再起動が必要
-（関門は起動時に評価される）。
+全項目合格すると記録は自動で書かれる。user-api は各read時に最新activationを再検査するため、
+記録の更新・失効に再起動は不要。
+
+GCP構成では `kukuri-readiness.timer` が5分ごとに同じ判定を実行する（activationの既定有効期限は
+15分）。`systemctl status kukuri-readiness.timer` / `systemctl status kukuri-readiness.service` /
+`journalctl -u kukuri-readiness.service -n 100` で、最終成功・失敗と次回実行を確認する。判定失敗時は
+CLIが旧activationをrevokeし、read-time gateがindex / trust surfaceを閉じる。timerは次回再試行する。
 
 `cn-relation-analyze` サービス（cn-cli image）を流用して実行するが、プロバイダ資格情報の
 env はサービス定義に含まれないため、project `.env` を source して `-e` で転送する:
@@ -303,8 +308,7 @@ sudo bash -c 'set -a; . ./.env; set +a; \
     -e COMMUNITY_NODE_VLM_API_KEY \
     -v /var/lib/kukuri/community-node/operator-config.yaml:/work/operator-config.yaml:ro \
     cn-relation-analyze readiness --config /work/operator-config.yaml'
-# 全項目合格 → 有効化記録が書かれる → cn-user-api を再起動して反映:
-sudo /var/lib/toolbox/kukuri/bin/docker-compose restart cn-user-api
+# 全項目合格 → 有効化記録が書かれ、次のreadから反映される。
 ```
 
 - 疎通確認（Arachnid への合成ハッシュ送信 / VLM への無害な 1 リクエスト）の結果は

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -537,6 +537,10 @@ terraform apply
   `cn-user-api` が `COMMUNITY_NODE_OPERATOR_CONFIG` で読み込む。
 - これにより `GET /.well-known/kukuri/community-node.json` / `GET /v1/node/manifest` が応答し、
   `report_endpoint` capability を有効化した node では `POST /v1/report` が受理される。
+- manifest に記載される `GET /terms` / `GET /privacy` / `GET /external-transmission` /
+  `GET /moderation-policy` / `GET /abuse-policy` も、同じ operator config から生成した Markdown を
+  応答する。デプロイ後は manifest の各 URL が 200 であり、`Content-Type` が
+  `text/markdown; charset=utf-8` であることを確認する。
 - `operator_config_path` が空（既定）なら manifest endpoint は `404` のまま（従来挙動）。
 - blob cache の on/off は operator-config の `features.blob_cache` が真実源で、tfvars の
   `blob_cache_enabled` はそこから導出される。`features.blob_cache: false` なのに

--- a/infra/terraform/modules/gcp-vm-compose/templates/docker-compose.yml.tftpl
+++ b/infra/terraform/modules/gcp-vm-compose/templates/docker-compose.yml.tftpl
@@ -185,6 +185,28 @@ services:
       COMMUNITY_NODE_ARCADEDB_PASSWORD: $${CN_ARCADEDB_ROOT_PASSWORD:?set CN_ARCADEDB_ROOT_PASSWORD}
     command: ["relation", "analyze"]
     restart: "no"
+%{ if operator_config_enabled ~}
+
+  # readiness activation は短命（既定15分）のため、systemd timer が5分ごとに
+  # production credential probeを含む全判定を再実行する。失敗時はCLIが旧activationを
+  # revokeし、user-apiのread-time gateが直ちにsurfaceを閉じる。
+  cn-readiness:
+    logging: *cn-logging
+    image: ${cn_cli_image}
+    profiles: ["ops"]
+    env_file:
+      - ./community-node.env
+    environment:
+      COMMUNITY_NODE_DATABASE_URL: $${COMMUNITY_NODE_DATABASE_URL:?set COMMUNITY_NODE_DATABASE_URL}
+      COMMUNITY_NODE_ARCADEDB_PASSWORD: $${CN_ARCADEDB_ROOT_PASSWORD:?set CN_ARCADEDB_ROOT_PASSWORD}
+      PROJECT_ARACHNID_API_USERNAME: $${PROJECT_ARACHNID_API_USERNAME:-}
+      PROJECT_ARACHNID_API_PASSWORD: $${PROJECT_ARACHNID_API_PASSWORD:-}
+      COMMUNITY_NODE_VLM_API_KEY: $${COMMUNITY_NODE_VLM_API_KEY:-}
+    volumes:
+      - ${operator_config_path}:/work/operator-config.yaml:ro
+    command: ["readiness", "--config", "/work/operator-config.yaml"]
+    restart: "no"
+%{ endif ~}
 %{ endif ~}
 
   caddy:

--- a/infra/terraform/modules/gcp-vm-compose/templates/startup.sh.tftpl
+++ b/infra/terraform/modules/gcp-vm-compose/templates/startup.sh.tftpl
@@ -252,6 +252,32 @@ RandomizedDelaySec=60
 [Install]
 WantedBy=timers.target
 UNIT
+%{ if operator_config_enabled ~}
+# --- systemd timer: public read surface readiness activation（#616 / #612） ---
+# activationの有効期限（既定15分）より短い5分間隔で再判定する。oneshotの失敗時も
+# timerは次回再試行し、CLIが旧activationをrevokeするためunsafeなsurfaceは残らない。
+cat > /etc/systemd/system/kukuri-readiness.service <<UNIT
+[Unit]
+Description=kukuri community node public readiness activation
+After=docker.service
+Requires=docker.service
+[Service]
+Type=oneshot
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$COMPOSE_BIN run --rm cn-readiness
+UNIT
+cat > /etc/systemd/system/kukuri-readiness.timer <<UNIT
+[Unit]
+Description=kukuri community node public readiness activation timer
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30
+Persistent=true
+[Install]
+WantedBy=timers.target
+UNIT
+%{ endif ~}
 %{ endif ~}
 
 %{ if backup_enabled ~}
@@ -305,6 +331,9 @@ systemctl enable --now kukuri-backup.timer
 %{ endif ~}
 %{ if deploy_indexer_stack ~}
 systemctl enable --now kukuri-relation-analyze.timer
+%{ if operator_config_enabled ~}
+systemctl enable --now kukuri-readiness.timer
+%{ endif ~}
 %{ endif ~}
 
 log "bootstrap complete"

--- a/infra/terraform/modules/gcp-vm-compose/templates/startup.sh.tftpl
+++ b/infra/terraform/modules/gcp-vm-compose/templates/startup.sh.tftpl
@@ -205,9 +205,23 @@ fi
 
 # --- start the stack ---
 cd "$INSTALL_DIR"
+# 前回bootの構成で作られたoptional timerを先に片付ける。現在も有効なunitはこの後で
+# 再生成・再enableする。serviceの実行中にflagを切り替える場合も次回bootで収束する。
+systemctl disable --now kukuri-relation-analyze.timer 2>/dev/null || true
+systemctl disable --now kukuri-readiness.timer 2>/dev/null || true
+systemctl disable --now kukuri-backup.timer 2>/dev/null || true
+rm -f /etc/systemd/system/kukuri-relation-analyze.service \
+  /etc/systemd/system/kukuri-relation-analyze.timer \
+  /etc/systemd/system/kukuri-readiness.service \
+  /etc/systemd/system/kukuri-readiness.timer \
+  /etc/systemd/system/kukuri-backup.service \
+  /etc/systemd/system/kukuri-backup.timer
+
 "$COMPOSE_BIN" pull
 "$COMPOSE_BIN" run --rm cn-migrate
-"$COMPOSE_BIN" up -d
+# feature flag rollbackで旧composeのindexer / ArcadeDB containerを残さない。
+# named volumeと別PDは削除しないため、再有効化時のprojection再構築・endpoint同一性は維持される。
+"$COMPOSE_BIN" up -d --remove-orphans
 
 # --- systemd timer: certificate renewal ---
 cat > /etc/systemd/system/kukuri-cert-renew.service <<UNIT


### PR DESCRIPTION
## Summary
- resolve the node's own relay URLs from COMMUNITY_NODE_CONNECTIVITY_URLS and refresh docs-sync seeds from active bootstrap registrations
- serve manifest-referenced disclosure documents directly from cn-user-api
- renew the short-lived public readiness activation every 5 minutes and revoke surfaces on failed checks
- make deploy_indexer_stack rollback converge with orphan-container and stale-timer cleanup while preserving persistent disks

## Live evidence
- two desktop clients published to kukuri:topic:demo; truth=2 / projection=2 / discovery=2 / relation edge=1
- public-node readiness passes all checks with production credential probes
- ArcadeDB stop: discovery 500 with zero surfaced entries, readiness 2 failures and activation revoke, surface 404; restart restored 200 / 2 entries
- isolated restore drill recovered index truth, moderation artifacts, activations, and relation runs from the latest GCS dump
- VLM boundary: VM + API key=200, no key=401, valid key outside source allowlist=connection rejected

## Validation
- cargo fmt --all -- --check
- cargo xtask cn-check
- cargo xtask cn-test
- terraform fmt -check -recursive infra/terraform
- terraform -chdir=infra/terraform/envs/low-cost validate

Refs #612
Refs #613
Refs #615
Refs #616
Refs #617