### PR TITLE
fix(cn): mount readiness operator config

### DIFF
--- a/infra/terraform/modules/gcp-vm-compose/main.tf
+++ b/infra/terraform/modules/gcp-vm-compose/main.tf
@@ -358,6 +358,16 @@ resource "google_compute_instance" "vm" {
 
   allow_stopping_for_update = true
 
+  lifecycle {
+    precondition {
+      condition = !local.operator_config_enabled || !var.deploy_indexer_stack || (
+        strcontains(base64decode(local.compose_b64), "./operator-config.yaml:${local.operator_config_path}:ro") &&
+        strcontains(base64decode(local.compose_b64), "[\"readiness\", \"--config\", \"${local.operator_config_path}\"]")
+      )
+      error_message = "cn-readiness must mount the generated operator-config.yaml file at the configured container path."
+    }
+  }
+
   # secret accessor binding と logging 権限が VM 起動前に存在することを保証する。
   depends_on = [
     google_secret_manager_secret_iam_member.accessor,

--- a/infra/terraform/modules/gcp-vm-compose/templates/docker-compose.yml.tftpl
+++ b/infra/terraform/modules/gcp-vm-compose/templates/docker-compose.yml.tftpl
@@ -203,8 +203,8 @@ services:
       PROJECT_ARACHNID_API_PASSWORD: $${PROJECT_ARACHNID_API_PASSWORD:-}
       COMMUNITY_NODE_VLM_API_KEY: $${COMMUNITY_NODE_VLM_API_KEY:-}
     volumes:
-      - ${operator_config_path}:/work/operator-config.yaml:ro
-    command: ["readiness", "--config", "/work/operator-config.yaml"]
+      - ./operator-config.yaml:${operator_config_path}:ro
+    command: ["readiness", "--config", "${operator_config_path}"]
     restart: "no"
 %{ endif ~}
 %{ endif ~}


### PR DESCRIPTION
## Summary
- mount the generated operator config file into the readiness container from the install directory
- use the configured in-container path consistently
- add a Terraform precondition so this mount contract cannot silently regress

## Evidence
- reproduced on the live VM: readiness failed because /work/operator-config.yaml was a directory
- precondition failed against the old rendered compose definition
- terraform validate passes after the fix
- terraform plan reaches the expected startup-script-only replacement diff (not applied)

Follow-up for #612 and #616.