### PR TITLE
fix(cn): publish data retention disclosure

### DIFF
--- a/crates/cn-user-api/src/routes.rs
+++ b/crates/cn-user-api/src/routes.rs
@@ -91,6 +91,7 @@ pub fn manifest_routes(
         .route("/external-transmission", get(external_transmission))
         .route("/moderation-policy", get(moderation_policy))
         .route("/abuse-policy", get(abuse_policy))
+        .route("/data-retention", get(data_retention))
         .with_state(ManifestState {
             manifest,
             public_disclosures,
@@ -115,6 +116,10 @@ async fn moderation_policy(State(state): State<ManifestState>) -> Response {
 
 async fn abuse_policy(State(state): State<ManifestState>) -> Response {
     disclosure_response(&state, "abuse-policy.md")
+}
+
+async fn data_retention(State(state): State<ManifestState>) -> Response {
+    disclosure_response(&state, "data-retention-policy.md")
 }
 
 fn disclosure_response(state: &ManifestState, filename: &str) -> Response {

--- a/crates/cn-user-api/src/state.rs
+++ b/crates/cn-user-api/src/state.rs
@@ -277,6 +277,7 @@ fn load_manifest(path: Option<&std::path::Path>) -> Result<LoadedManifest> {
                     | "external-transmission-notice.md"
                     | "moderation-policy.md"
                     | "abuse-policy.md"
+                    | "data-retention-policy.md"
             )
         })
         .map(|file| (file.filename, file.content))
@@ -286,4 +287,39 @@ fn load_manifest(path: Option<&std::path::Path>) -> Result<LoadedManifest> {
         public_disclosures: Arc::new(public_disclosures),
         operator_config_yaml: bytes,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use anyhow::Result;
+    use tempfile::NamedTempFile;
+
+    use super::load_manifest;
+
+    #[test]
+    fn load_manifest_includes_every_http_disclosure() -> Result<()> {
+        let mut config = NamedTempFile::new()?;
+        write!(
+            config,
+            "server:\n  domain: example-kukuri.net\n  operator_name: Example Operator\n  country: JP\nprofile: relay-enabled\nacknowledge_planned_capabilities: true\n"
+        )?;
+
+        let loaded = load_manifest(Some(config.path()))?;
+        for filename in [
+            "terms.md",
+            "privacy-policy.md",
+            "external-transmission-notice.md",
+            "moderation-policy.md",
+            "abuse-policy.md",
+            "data-retention-policy.md",
+        ] {
+            assert!(
+                loaded.public_disclosures.contains_key(filename),
+                "missing public disclosure: {filename}"
+            );
+        }
+        Ok(())
+    }
 }

--- a/crates/cn-user-api/tests/manifest.rs
+++ b/crates/cn-user-api/tests/manifest.rs
@@ -48,16 +48,27 @@ async fn spawn_manifest_server(
 #[tokio::test]
 async fn disclosure_urls_serve_markdown_from_operator_config_output() -> Result<()> {
     let (base_url, task) = spawn_manifest_server(Some(SAMPLE_YAML)).await?;
-    let response = Client::new()
-        .get(format!("{base_url}/terms"))
-        .send()
-        .await?;
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(
-        response.headers()[reqwest::header::CONTENT_TYPE],
-        "text/markdown; charset=utf-8"
-    );
-    assert!(response.text().await?.contains("Example Operator"));
+    let client = Client::new();
+    for path in [
+        "/terms",
+        "/privacy",
+        "/external-transmission",
+        "/moderation-policy",
+        "/abuse-policy",
+        "/data-retention",
+    ] {
+        let response = client.get(format!("{base_url}{path}")).send().await?;
+        assert_eq!(response.status(), StatusCode::OK, "path {path}");
+        assert_eq!(
+            response.headers()[reqwest::header::CONTENT_TYPE],
+            "text/markdown; charset=utf-8",
+            "path {path}"
+        );
+        assert!(
+            response.text().await?.contains("Example Operator"),
+            "path {path}"
+        );
+    }
     task.abort();
     Ok(())
 }

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -544,8 +544,9 @@ terraform apply
 - これにより `GET /.well-known/kukuri/community-node.json` / `GET /v1/node/manifest` が応答し、
   `report_endpoint` capability を有効化した node では `POST /v1/report` が受理される。
 - manifest に記載される `GET /terms` / `GET /privacy` / `GET /external-transmission` /
-  `GET /moderation-policy` / `GET /abuse-policy` も、同じ operator config から生成した Markdown を
-  応答する。デプロイ後は manifest の各 URL が 200 であり、`Content-Type` が
+  `GET /moderation-policy` / `GET /abuse-policy` と、公開用の `GET /data-retention` も、
+  同じ operator config から生成した Markdown を応答する。デプロイ後は manifest の各 URL が
+  200 であり、`Content-Type` が
   `text/markdown; charset=utf-8` であることを確認する。
 - `operator_config_path` が空（既定）なら manifest endpoint は `404` のまま（従来挙動）。
 - blob cache の on/off は operator-config の `features.blob_cache` が真実源で、tfvars の


### PR DESCRIPTION
## Summary
- serve generated data retention policy at /data-retention`n- include data-retention-policy.md in the production disclosure allowlist
- cover all six public Markdown endpoints and document the deploy check

## Validation
- cargo test -p kukuri-cn-user-api --all-features`n- cargo clippy -p kukuri-cn-user-api --all-targets --all-features -- -D warnings`n- git diff --check`n
Closes the automated disclosure gap tracked by #612 and hands the public URL to #602.