### PR TITLE
test(cn): cover replica query failure end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,6 +3006,7 @@ name = "kukuri-cn-e2e"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "chrono",
  "kukuri-blob-service",

--- a/crates/cn-e2e/Cargo.toml
+++ b/crates/cn-e2e/Cargo.toml
@@ -13,6 +13,7 @@ cn-lane = true
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 axum.workspace = true
 chrono.workspace = true
 serde_json.workspace = true

--- a/crates/cn-e2e/src/lib.rs
+++ b/crates/cn-e2e/src/lib.rs
@@ -13,9 +13,11 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use chrono::Utc;
 use reqwest::Client;
 use tempfile::TempDir;
@@ -53,12 +55,17 @@ use kukuri_cn_safety_vlm::{
 use kukuri_cn_user_api::{UserApiConfig, app_router, build_state};
 use kukuri_core::{
     AssetRef, AssetRole, BlobHash, KukuriKeys, KukuriMediaManifestV1, MediaManifestItem,
-    ObjectVisibility, PayloadRef, TopicId, build_media_manifest_envelope,
+    ObjectVisibility, PayloadRef, ReplicaId, TopicId, build_media_manifest_envelope,
     build_post_envelope_with_payload, generate_keys,
 };
-use kukuri_docs_sync::{DocOp, DocsSync, IrohDocsSync, stable_key, topic_replica_id};
+use kukuri_docs_sync::{
+    DocEventStream, DocFetchPolicy, DocOp, DocQuery, DocRecord, DocsSync, IrohDocsSync, stable_key,
+    topic_replica_id,
+};
 use kukuri_iroh_node::IrohDocsNode;
-use kukuri_transport::{DhtDiscoveryOptions, TransportNetworkConfig, TransportRelayConfig};
+use kukuri_transport::{
+    DhtDiscoveryOptions, SeedPeer, TransportNetworkConfig, TransportRelayConfig,
+};
 
 /// 判定イベント署名鍵（テスト固定値。既知の有効な secp256k1 secret）。
 const TEST_SIGNER_SECRET: &str = "0000000000000000000000000000000000000000000000000000000000000001";
@@ -107,6 +114,78 @@ pub struct AuthorNode {
     _data_dir: TempDir,
 }
 
+/// 実 `IrohDocsSync` の query 境界だけを可逆に失敗させるE2E専用ラッパー。
+///
+/// production runtimeに障害注入用envやendpointを持ち込まず、残りの同期・Postgres・ArcadeDB・
+/// user-apiは本物の構成のままreplica query failureを再現する。
+struct FaultInjectingDocsSync {
+    inner: Arc<IrohDocsSync>,
+    fail_queries: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl DocsSync for FaultInjectingDocsSync {
+    async fn open_replica(&self, replica_id: &ReplicaId) -> Result<()> {
+        self.inner.open_replica(replica_id).await
+    }
+
+    async fn register_private_replica_secret(
+        &self,
+        replica_id: &ReplicaId,
+        namespace_secret_hex: &str,
+    ) -> Result<()> {
+        self.inner
+            .register_private_replica_secret(replica_id, namespace_secret_hex)
+            .await
+    }
+
+    async fn remove_private_replica_secret(&self, replica_id: &ReplicaId) -> Result<()> {
+        self.inner.remove_private_replica_secret(replica_id).await
+    }
+
+    async fn apply_doc_op(&self, replica_id: &ReplicaId, op: DocOp) -> Result<()> {
+        self.inner.apply_doc_op(replica_id, op).await
+    }
+
+    async fn query_replica_with_policy(
+        &self,
+        replica_id: &ReplicaId,
+        query: DocQuery,
+        policy: DocFetchPolicy,
+    ) -> Result<Vec<DocRecord>> {
+        if self.fail_queries.load(Ordering::SeqCst) {
+            anyhow::bail!("injected replica query failure for {}", replica_id.as_str());
+        }
+        self.inner
+            .query_replica_with_policy(replica_id, query, policy)
+            .await
+    }
+
+    async fn subscribe_replica(&self, replica_id: &ReplicaId) -> Result<DocEventStream> {
+        self.inner.subscribe_replica(replica_id).await
+    }
+
+    async fn import_peer_ticket(&self, ticket: &str) -> Result<()> {
+        self.inner.import_peer_ticket(ticket).await
+    }
+
+    async fn learn_peer(&self, endpoint_id: &str) -> Result<()> {
+        self.inner.learn_peer(endpoint_id).await
+    }
+
+    async fn restart_replica_sync(&self, replica_id: &ReplicaId) -> Result<()> {
+        self.inner.restart_replica_sync(replica_id).await
+    }
+
+    async fn set_seed_peers(&self, peers: Vec<SeedPeer>) -> Result<()> {
+        self.inner.set_seed_peers(peers).await
+    }
+
+    async fn assist_peer_ids(&self) -> Result<Vec<String>> {
+        self.inner.assist_peer_ids().await
+    }
+}
+
 /// 全構成 E2E の稼働一式。`boot` で本番相当の順序（migration → 投影 schema →
 /// 対象範囲の登録 → 常駐ワーカー → 有効化記録 → API 公開）で立ち上がる。
 pub struct E2eStack {
@@ -127,6 +206,8 @@ pub struct E2eStack {
     pub api_base_url: String,
     arachnid_auth: SyntheticBasicAuth,
     participant: Arc<IndexerParticipant>,
+    worker_docs: Arc<dyn DocsSync>,
+    replica_query_failure: Arc<AtomicBool>,
     worker: Option<WorkerHandle>,
     api_task: tokio::task::JoinHandle<()>,
     _relay: SpawnedIrohRelay,
@@ -302,6 +383,11 @@ impl E2eStack {
             _data_dir: author_dir,
         };
         let indexer_docs = Arc::new(IrohDocsSync::new(Arc::clone(&indexer_node)));
+        let replica_query_failure = Arc::new(AtomicBool::new(false));
+        let worker_docs: Arc<dyn DocsSync> = Arc::new(FaultInjectingDocsSync {
+            inner: Arc::clone(&indexer_docs),
+            fail_queries: Arc::clone(&replica_query_failure),
+        });
         let indexer_blobs = Arc::new(IrohBlobService::new(Arc::clone(&indexer_node)));
         let indexer_blob_service: Arc<dyn BlobService> = indexer_blobs.clone();
         let ticket = loopback_ticket(&author.node)?;
@@ -355,7 +441,7 @@ impl E2eStack {
 
         // 7. 常駐ワーカー（本番と同じ participant / pipeline 構成）。
         let pipeline = IngestPipeline::new(
-            indexer_docs.clone(),
+            Arc::clone(&worker_docs),
             Arc::new(safety),
             entries.clone(),
             projection.clone(),
@@ -363,7 +449,7 @@ impl E2eStack {
         .with_metrics(Arc::clone(&runtime_state));
         let participant = Arc::new(IndexerParticipant::new(
             pool.clone(),
-            indexer_docs.clone(),
+            Arc::clone(&worker_docs),
             entries.clone(),
             projection.clone(),
             pipeline,
@@ -373,7 +459,7 @@ impl E2eStack {
         ));
         let worker = IndexerWorker::new(
             Arc::clone(&participant),
-            indexer_docs.clone(),
+            Arc::clone(&worker_docs),
             Arc::clone(&runtime_state),
             WorkerConfig {
                 poll_interval: Duration::from_millis(300),
@@ -459,6 +545,8 @@ impl E2eStack {
             api_base_url,
             arachnid_auth,
             participant,
+            worker_docs,
+            replica_query_failure,
             worker: Some(worker),
             api_task,
             _relay: relay,
@@ -787,7 +875,7 @@ impl E2eStack {
         }
         let worker = IndexerWorker::new(
             Arc::clone(&self.participant),
-            self.indexer_docs.clone(),
+            Arc::clone(&self.worker_docs),
             Arc::clone(&self.runtime_state),
             WorkerConfig {
                 poll_interval: Duration::from_millis(300),
@@ -798,6 +886,11 @@ impl E2eStack {
         );
         self.worker = Some(worker.spawn());
         Ok(())
+    }
+
+    /// E2E内のdocs replica query障害を有効化・解除する。
+    pub fn set_replica_query_failure(&self, enabled: bool) {
+        self.replica_query_failure.store(enabled, Ordering::SeqCst);
     }
 
     /// 既定の許可応答を両プロバイダ模擬へ載せ直す（`MockServer::reset` 後の復旧用）。

--- a/crates/cn-e2e/tests/failure_paths.rs
+++ b/crates/cn-e2e/tests/failure_paths.rs
@@ -16,6 +16,7 @@ use kukuri_cn_core::{IndexScopeKind, inspect_index_integrity};
 use kukuri_cn_e2e::{E2eOptions, E2eStack};
 use kukuri_cn_indexer::config::MediaFetchConfig;
 use kukuri_cn_indexer::projection::IndexProjection;
+use reqwest::{Client, StatusCode};
 
 const TINY_PNG: &[u8] = &[
     0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
@@ -168,5 +169,99 @@ async fn oversize_media_holds_posts() -> Result<()> {
         "scan must hold when the media exceeds the fetch limit"
     );
     assert_held(&stack, object_id.as_str()).await?;
+    stack.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn replica_query_failure_keeps_new_posts_out_of_surfaces_until_recovery() -> Result<()> {
+    let Some(stack) = E2eStack::boot("replicaqueryfail").await? else {
+        return Ok(());
+    };
+
+    // 障害前に許可済みの投稿を1件作り、通常経路が成立していることを先に固定する。
+    let baseline = stack.publish_text_post("replica failure baseline").await?;
+    assert!(
+        stack
+            .wait_for_projection(baseline.as_str(), HOLD_TIMEOUT)
+            .await?,
+        "baseline post did not reach the projection"
+    );
+
+    let client = Client::new();
+    let token = stack.authenticate(&client).await?;
+
+    // 実IrohDocsSyncの直前で、この走行のreplica queryだけを失敗させる。
+    stack.set_replica_query_failure(true);
+    assert!(
+        stack
+            .wait_for_state(
+                |state| {
+                    state.last_error_scope.as_deref()
+                        == Some(format!("topic::{}", stack.topic_id).as_str())
+                },
+                HOLD_TIMEOUT,
+            )
+            .await?,
+        "replica query failure must be observable on the worker"
+    );
+
+    let blocked = stack
+        .publish_text_post("replica-failure-marker must stay hidden")
+        .await?;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    assert!(
+        !stack
+            .projection
+            .contains_object(
+                IndexScopeKind::PublicTopic,
+                stack.topic_id.as_str(),
+                blocked.as_str(),
+            )
+            .await?,
+        "a post published while replica queries fail must not reach ArcadeDB"
+    );
+    let findings = inspect_index_integrity(&stack.pool).await?;
+    assert_eq!(
+        findings.index_entries_total, 1,
+        "the failed replica query must not add a truth entry: {findings:?}"
+    );
+
+    let search_url = format!(
+        "{}/v1/index/search?scope_kind=public_topic&scope_id={}&q=replica-failure-marker",
+        stack.api_base_url, stack.topic_id,
+    );
+    let response = client
+        .get(&search_url)
+        .bearer_auth(token.as_str())
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.json::<serde_json::Value>().await?;
+    assert!(
+        !E2eStack::entry_ids(&body).contains(&blocked),
+        "the failed replica query must not expose the new post: {body}"
+    );
+
+    // 障害を解除すると同じ常駐workerが再試行し、未処理投稿を安全に取り込む。
+    stack.set_replica_query_failure(false);
+    assert!(
+        stack
+            .wait_for_projection(blocked.as_str(), HOLD_TIMEOUT)
+            .await?,
+        "the post did not reach the projection after replica query recovery"
+    );
+    let response = client
+        .get(&search_url)
+        .bearer_auth(token.as_str())
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.json::<serde_json::Value>().await?;
+    assert!(
+        E2eStack::entry_ids(&body).contains(&blocked),
+        "the recovered replica query must make the post searchable: {body}"
+    );
+
     stack.shutdown().await
 }


### PR DESCRIPTION
## 概要

#612 で唯一未完了だった docs replica query failure の full-stack 障害注入E2Eを追加します。

- production runtimeに障害注入用env/endpointを追加せず、E2E harness内だけで実 `IrohDocsSync` の query境界を可逆に失敗させる
- 実Postgres・実ArcadeDB・実Iroh・HTTP user-apiを通し、障害中の新規投稿がtruth/projection/searchへ出ないことを確認する
- 障害解除後、同じresident workerの再試行で投稿が取り込まれ検索可能になることを確認する

## 検証

- `cargo xtask cn-e2e`
- `cargo clippy -p kukuri-cn-e2e --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes the remaining automated verification item in #612; the live benign-image check remains a manual-device task.