### PR TITLE
fix(terraform): report deployed indexer stack

### DIFF
--- a/infra/terraform/envs/low-cost/outputs.tf
+++ b/infra/terraform/envs/low-cost/outputs.tf
@@ -34,7 +34,7 @@ output "deployment_profile_summary" {
     backup                 = var.backup_enabled ? "pg_dump -> GCS (retention ${var.backup_retention_days}d)" : "disabled"
     managed_db             = "not used (extension point: envs/managed-db)"
     managed_cache          = "not used (extension point: envs/managed-db)"
-    index_moderation_trust = "not provisioned (Phase B; kept out of low-cost DB)"
+    index_moderation_trust = var.deploy_indexer_stack ? "provisioned (cn-indexer + ArcadeDB + relation analysis)" : "not provisioned"
   }
 }
 

--- a/infra/terraform/envs/low-cost/tests/deployment_summary.tftest.hcl
+++ b/infra/terraform/envs/low-cost/tests/deployment_summary.tftest.hcl
@@ -1,0 +1,40 @@
+mock_provider "google" {}
+
+variables {
+  project_id                  = "test-project"
+  api_domain                  = "api.example.com"
+  relay_domain                = "relay.example.com"
+  acme_email                  = "ops@example.com"
+  cn_user_api_image           = "example/user-api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  cn_iroh_relay_image         = "example/relay@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  cn_cli_image                = "example/cli@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  jwt_secret_id               = "test-jwt-secret"
+  postgres_password_secret_id = "test-postgres-secret"
+  backup_enabled              = false
+}
+
+run "indexer_stack_enabled_summary" {
+  command = plan
+
+  variables {
+    deploy_indexer_stack = true
+  }
+
+  assert {
+    condition     = output.deployment_profile_summary.index_moderation_trust == "provisioned (cn-indexer + ArcadeDB + relation analysis)"
+    error_message = "deployment summary must report the enabled indexer stack as provisioned"
+  }
+}
+
+run "indexer_stack_disabled_summary" {
+  command = plan
+
+  variables {
+    deploy_indexer_stack = false
+  }
+
+  assert {
+    condition     = output.deployment_profile_summary.index_moderation_trust == "not provisioned"
+    error_message = "deployment summary must report a disabled indexer stack as not provisioned"
+  }
+}


### PR DESCRIPTION
## 概要

#612 のGCP apply確認中に、`deploy_indexer_stack=true` で実際にindexer stackが稼働していても、Terraform outputが `not provisioned` と固定表示するstaleな運用表示を発見したため修正します。

- `deployment_profile_summary.index_moderation_trust` を `deploy_indexer_stack` と連動
- Terraform native testでenabled/disabled両方を固定

## 検証

- 修正前 `terraform test -no-color`: 0 passed / 2 failed（stale表示を再現）
- 修正後 `terraform test -no-color`: 2 passed / 0 failed
- `terraform validate -no-color`
- live stateに対する `terraform plan -no-color`: resource変更0、outputのみ更新
- `git diff --check`