### PR TITLE
[codex][fix] active peerをmedia fetchへ反映する

### DIFF
--- a/crates/cn-indexer/src/participant.rs
+++ b/crates/cn-indexer/src/participant.rs
@@ -15,6 +15,7 @@ use anyhow::Result;
 use sqlx::postgres::PgPool;
 use tracing::{info, warn};
 
+use kukuri_blob_service::BlobService;
 use kukuri_cn_core::{
     ChannelSecretCipher, IndexEntryStore, IndexScopeKind, list_channel_secrets,
     list_supported_topics, load_bootstrap_seed_peers,
@@ -25,6 +26,18 @@ use kukuri_transport::SeedPeer;
 
 use crate::ingest::{IngestPipeline, IngestSummary};
 use crate::projection::IndexProjection;
+
+async fn apply_seed_peers(
+    docs_sync: &dyn DocsSync,
+    blob_service: Option<&dyn BlobService>,
+    peers: Vec<SeedPeer>,
+) -> Result<()> {
+    docs_sync.set_seed_peers(peers.clone()).await?;
+    if let Some(blob_service) = blob_service {
+        blob_service.set_seed_peers(peers).await?;
+    }
+    Ok(())
+}
 
 /// scope（種別 + id）と、それが指す共有 replica id。
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -61,6 +74,7 @@ pub struct IndexerParticipant {
     pipeline: IngestPipeline,
     channel_secret_cipher: ChannelSecretCipher,
     configured_seed_peers: Option<Vec<SeedPeer>>,
+    blob_service: Option<Arc<dyn BlobService>>,
 }
 
 impl IndexerParticipant {
@@ -80,6 +94,7 @@ impl IndexerParticipant {
             pipeline,
             channel_secret_cipher,
             configured_seed_peers: None,
+            blob_service: None,
         }
     }
 
@@ -88,7 +103,12 @@ impl IndexerParticipant {
         self
     }
 
-    /// desktop heartbeat が Postgres に保持する active peer を docs sync へ反映する。
+    pub fn with_blob_service(mut self, blob_service: Arc<dyn BlobService>) -> Self {
+        self.blob_service = Some(blob_service);
+        self
+    }
+
+    /// desktop heartbeat が Postgres に保持する active peer を docs sync と media fetch へ反映する。
     /// operator 指定 seed は残し、同じ endpoint の fresh addr_hint は heartbeat 側で更新する。
     async fn refresh_seed_peers(&self) -> Result<()> {
         let Some(configured) = self.configured_seed_peers.as_deref() else {
@@ -103,12 +123,18 @@ impl IndexerParticipant {
             })
             .collect::<Vec<_>>();
         let peers = merge_seed_peers(configured, &active);
-        self.docs_sync.set_seed_peers(peers.clone()).await?;
+        apply_seed_peers(
+            self.docs_sync.as_ref(),
+            self.blob_service.as_deref(),
+            peers.clone(),
+        )
+        .await?;
         info!(
             configured = configured.len(),
             active = active.len(),
             applied = peers.len(),
-            "refreshed docs sync seed peers from active bootstrap registrations"
+            media_fetch = self.blob_service.is_some(),
+            "refreshed docs sync and media fetch seed peers from active bootstrap registrations"
         );
         Ok(())
     }
@@ -270,6 +296,68 @@ fn merge_seed_peers(configured: &[SeedPeer], active: &[SeedPeer]) -> Vec<SeedPee
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use kukuri_blob_service::{BlobStatus, StoredBlob};
+    use kukuri_core::BlobHash;
+    use kukuri_docs_sync::MemoryDocsSync;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingBlobService {
+        seed_peers: Mutex<Vec<SeedPeer>>,
+    }
+
+    #[async_trait]
+    impl BlobService for RecordingBlobService {
+        async fn put_blob(&self, _data: Vec<u8>, _mime: &str) -> Result<StoredBlob> {
+            unreachable!("not used by this contract test")
+        }
+
+        async fn fetch_blob(&self, _hash: &BlobHash) -> Result<Option<Vec<u8>>> {
+            unreachable!("not used by this contract test")
+        }
+
+        async fn pin_blob(&self, _hash: &BlobHash) -> Result<()> {
+            unreachable!("not used by this contract test")
+        }
+
+        async fn blob_status(&self, _hash: &BlobHash) -> Result<BlobStatus> {
+            unreachable!("not used by this contract test")
+        }
+
+        async fn import_peer_ticket(&self, _ticket: &str) -> Result<()> {
+            unreachable!("not used by this contract test")
+        }
+
+        async fn set_seed_peers(&self, peers: Vec<SeedPeer>) -> Result<()> {
+            *self.seed_peers.lock().expect("seed peer mutex poisoned") = peers;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn seed_refresh_applies_active_peers_to_media_fetcher() {
+        let endpoint_id = "1".repeat(64);
+        let peer = SeedPeer {
+            endpoint_id: endpoint_id.clone(),
+            addr_hint: Some("192.0.2.10:4433".to_string()),
+        };
+        let docs_sync = MemoryDocsSync::default();
+        let blob_service = RecordingBlobService::default();
+
+        apply_seed_peers(&docs_sync, Some(&blob_service), vec![peer.clone()])
+            .await
+            .expect("seed refresh succeeds");
+
+        assert_eq!(
+            *blob_service
+                .seed_peers
+                .lock()
+                .expect("seed peer mutex poisoned"),
+            vec![peer],
+            "media fetcher must receive the same active peers as docs sync"
+        );
+    }
 
     #[test]
     fn public_topic_scope_maps_to_topic_replica() {

--- a/crates/cn-indexer/src/runtime.rs
+++ b/crates/cn-indexer/src/runtime.rs
@@ -13,7 +13,8 @@
 //! media scan 用の一時 fetch（#609）と docs replica sync（#613 T1）は、同じ persistent iroh node
 //! （`data_dir` 配下）を共有する。provider が構成されている場合のみ node を立ち上げ、
 //! `IrohBlobService` + `BlobMediaFetcher`（media fetch）と `IrohDocsSync`（docs participant）の
-//! 双方へ渡す。シードピア（`COMMUNITY_NODE_INDEXER_SEED_PEERS`）は docs 同期へ適用する。
+//! 双方へ渡す。シードピア（`COMMUNITY_NODE_INDEXER_SEED_PEERS` と active bootstrap registration）は
+//! docs 同期と media の一時 fetch の両方へ適用する。
 
 use std::sync::Arc;
 
@@ -21,7 +22,7 @@ use anyhow::{Context, Result};
 use sqlx::postgres::PgPool;
 use tracing::{info, warn};
 
-use kukuri_blob_service::IrohBlobService;
+use kukuri_blob_service::{BlobService, IrohBlobService};
 use kukuri_cn_core::{ChannelSecretCipher, PgIndexEntryStore, PgSafetyArtifactStore};
 use kukuri_cn_safety::provider::MediaFetcher;
 use kukuri_cn_safety_runtime::SafetyScanService;
@@ -146,15 +147,17 @@ async fn run(config: IndexerConfig) -> Result<()> {
     };
 
     // media scan 用の一時 fetch（#609）。共有 node の blob 経路から組み、provider 解決へ注入する。
-    let media_fetcher: Option<Arc<dyn MediaFetcher>> = node.as_ref().map(|node| {
-        let blob_service = Arc::new(IrohBlobService::new(Arc::clone(node)));
+    let blob_service: Option<Arc<dyn BlobService>> = node
+        .as_ref()
+        .map(|node| Arc::new(IrohBlobService::new(Arc::clone(node))) as Arc<dyn BlobService>);
+    let media_fetcher: Option<Arc<dyn MediaFetcher>> = blob_service.as_ref().map(|blob_service| {
         info!(
             max_bytes = config.media_fetch.max_bytes,
             timeout_secs = config.media_fetch.timeout.as_secs(),
             "media fetcher constructed (ephemeral blob fetch; no permanent blob storage)"
         );
         Arc::new(
-            BlobMediaFetcher::new(blob_service, config.media_fetch.clone())
+            BlobMediaFetcher::new(Arc::clone(blob_service), config.media_fetch.clone())
                 .with_metrics(Arc::clone(&state)),
         ) as Arc<dyn MediaFetcher>
     });
@@ -169,8 +172,8 @@ async fn run(config: IndexerConfig) -> Result<()> {
         safety_providers,
         Arc::new(PgSafetyArtifactStore::new(pool.clone())),
     )?;
-    match (safety, node) {
-        (Some(service), Some(node)) => {
+    match (safety, node, blob_service) {
+        (Some(service), Some(node), Some(blob_service)) => {
             info!(
                 issuer_node_id = %service.issuer_node_id(),
                 "safety scan service constructed"
@@ -181,6 +184,7 @@ async fn run(config: IndexerConfig) -> Result<()> {
                 cipher,
                 service,
                 Arc::clone(&node),
+                blob_service,
                 Arc::clone(&state),
             )
             .await?;
@@ -259,7 +263,8 @@ async fn wait_for_shutdown_signal() {
 
 /// ingest 経路の本番依存を組み立てる（#613 T1）。
 ///
-/// - 共有 iroh node から `IrohDocsSync` を作り、シードピアを適用する。
+/// - 共有 iroh node から `IrohDocsSync` を作り、シードピアを docs sync と blob fetch の双方へ
+///   適用できるよう participant へ渡す。
 /// - ArcadeDB 投影は起動時に schema 準備（`ensure_schema`）を行い、接続できなければ起動失敗に
 ///   する（fail-closed。投影へ書けない構成で取り込みを始めない）。
 /// - 索引の真実源は Postgres（`PgIndexEntryStore`）。
@@ -269,6 +274,7 @@ async fn compose_ingest_stack(
     cipher: ChannelSecretCipher,
     safety: SafetyScanService,
     node: Arc<IrohDocsNode>,
+    blob_service: Arc<dyn BlobService>,
     state: Arc<IndexerRuntimeState>,
 ) -> Result<(IndexerParticipant, Arc<IrohDocsSync>)> {
     let docs_sync = Arc::new(IrohDocsSync::new(node));
@@ -307,7 +313,8 @@ async fn compose_ingest_stack(
         pipeline,
         cipher,
     )
-    .with_configured_seed_peers(config.seed_peers.clone());
+    .with_configured_seed_peers(config.seed_peers.clone())
+    .with_blob_service(blob_service);
     Ok((participant, docs_sync))
 }
 


### PR DESCRIPTION
## 概要

#612 のbenign image live確認で、postは検出されたもののmedia fetchが `ProviderUnavailable` になる不具合を修正します。

## 種別

fix

## 原因

active bootstrap registration由来のpeerは `IrohDocsSync` にだけ反映され、同じpersistent Iroh nodeを使う `IrohBlobService` の独立peer台帳には反映されていませんでした。そのためdocs replicaは同期できても、mediaのephemeral fetch候補が空になっていました。

## 変更

- merged seed peersをdocs syncとblob fetchの双方へ適用
- runtimeがmedia fetcherとparticipantで同じ `IrohBlobService` を共有
- active peerがmedia fetcherにも渡るcontract testを追加

## 再現

修正前の追加test:

`participant::tests::seed_refresh_applies_active_peers_to_media_fetcher`

- left: `[]`
- right: active `SeedPeer`

## 検証

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo xtask cn-check`
- `cargo xtask cn-test`
- `cargo xtask cn-e2e`

すべて成功。

## Public API / protocol / storage

変更なし。media bytesを恒久保存しない既存のephemeral fetch経路は維持します。

Closes no issue; follow-up for #612.