### PR TITLE
fix: do not treat clean classifier as detection

### DIFF
--- a/crates/cn-safety/src/policy.rs
+++ b/crates/cn-safety/src/policy.rs
@@ -246,10 +246,11 @@ fn suspected_action(policy: &SafetyPolicy) -> SafetyAction {
 
 /// result が critical safety（CSAM / CSE / grooming）の検知か。
 ///
-/// capability か、いずれかのラベル category のどちらかが critical safety なら true。
-/// score の有無に依存しない（categorical な検知でも取りこぼさないため）。
+/// critical label があれば categorical な検知として扱う。label を持たない provider との互換性の
+/// ため、critical capability と score の組み合わせも検知として扱うが、capability だけでは検知と
+/// みなさない。`Completed` + label/score なしは classifier の clean 応答だからである。
 fn is_critical_detection(result: &ProviderScanResult) -> bool {
-    result.capability.is_critical_safety()
+    (result.capability.is_critical_safety() && result.score.is_some())
         || result
             .labels
             .iter()

--- a/crates/cn-safety/tests/derived_tags.rs
+++ b/crates/cn-safety/tests/derived_tags.rs
@@ -78,10 +78,14 @@ fn derived_tags_exclude_critical_and_match_data() {
         tagged_general_result(&["harbor"]),
         critical_tagged,
     ];
-    // critical 検知（Completed + critical capability）が混ざると verdict は fail-closed。
+    // capability は provider の機能を表すだけなので、label/score の無い clean 結果は検知では
+    // ない。一方、critical capability 由来のタグは多層防御として引き続き収集しない。
     let verdict = route(&outcomes, &policy, SCANNED_AT);
-    assert!(!verdict.is_indexable());
-    assert!(derived_tags_for_index(&verdict, &outcomes).is_empty());
+    assert!(verdict.is_indexable());
+    assert_eq!(
+        derived_tags_for_index(&verdict, &outcomes),
+        vec!["harbor".to_string()]
+    );
 
     // Match Data（known_hash_match=true）の結果からもタグを流さない。
     let mut match_data =

--- a/crates/cn-safety/tests/policy_router.rs
+++ b/crates/cn-safety/tests/policy_router.rs
@@ -146,6 +146,25 @@ fn critical_detection_with_no_score_fails_closed() {
 }
 
 #[test]
+fn clean_critical_classifier_capability_is_not_itself_a_detection() {
+    let policy = SafetyPolicy::public_node_default();
+    let clean_unknown_csam = ProviderScanResult::completed(
+        "unknown-csam-classifier",
+        SafetyProviderCapability::NovelCsamImageClassifier,
+    );
+
+    let verdict = route(
+        &[no_known_match_result(), clean_unknown_csam],
+        &policy,
+        SCANNED_AT,
+    );
+
+    assert_eq!(verdict.action, SafetyAction::Allow);
+    assert_eq!(verdict.reason_code, ReasonCode::NoKnownMatch);
+    assert!(!verdict.critical);
+}
+
+#[test]
 fn critical_label_confidence_drives_suspected_when_score_absent() {
     // result.score が無くても label.confidence>=threshold なら suspected として扱う。
     let policy = SafetyPolicy::public_node_default();


### PR DESCRIPTION
## What changed
- distinguish a critical-safety provider capability from an actual detection
- keep score-only and critical-label detections fail-closed
- retain derived-tag suppression for critical-capability providers
- add a regression test for a clean `unknown_csam` classifier result

## Root cause
A completed `unknown_csam` scan with no labels or score still carries the `NovelCsamImageClassifier` capability. The router treated that capability alone as a CSAM detection, so clean images were quarantined with `csam_suspected` and no confidence.

## Impact
Clean image scans can now reach the normal allow/index path after required providers complete, while real critical labels, score-only detections, low-confidence detections, and provider failures remain fail-closed.

## Validation
- `cargo test -p kukuri-cn-safety`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo xtask cn-check`
- `cargo xtask cn-test`
- `cargo xtask cn-e2e`

Follow-up for #612.