### PR TITLE
chore: bump preview version to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-e2e"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-indexer"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-iroh-relay"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "iroh-relay",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-operator"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "kukuri-core",
@@ -3107,14 +3107,14 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-runtime-support"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-arachnid"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-runtime"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-vlm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-trust"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-user-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-harness"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-test-support"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7571,7 +7571,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "kukuri-harness",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.3"
+version = "0.1.4"
 
 [workspace.dependencies]
 anyhow = "1.0.102"

--- a/README.ja.md
+++ b/README.ja.md
@@ -118,7 +118,7 @@ cargo xtask doctor
 cargo xtask check
 cargo xtask test
 cargo xtask e2e-smoke
-cargo xtask release-check v0.1.3-preview.1
+cargo xtask release-check v0.1.4-preview.1
 
 cd apps/desktop
 npx pnpm@10.16.1 install

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cargo xtask doctor
 cargo xtask check
 cargo xtask test
 cargo xtask e2e-smoke
-cargo xtask release-check v0.1.3-preview.1
+cargo xtask release-check v0.1.4-preview.1
 
 cd apps/desktop
 npx pnpm@10.16.1 install

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kukuri-desktop",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "kukuri-core",
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-tauri"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3733,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kukuri-desktop-tauri"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 default-run = "kukuri-desktop-tauri"
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kukuri",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "app.kukuri.desktop",
   "build": {
     "beforeDevCommand": "npx pnpm@10.16.1 vite --host 127.0.0.1 --port 5173 --strictPort",

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -28,7 +28,7 @@ Windows code signing certificates are optional for the first preview. If code si
 ## Local Gates
 
 ```bash
-cargo xtask release-check v0.1.3-preview.1
+cargo xtask release-check v0.1.4-preview.1
 cargo xtask check
 cargo xtask test
 cargo xtask e2e-smoke
@@ -108,7 +108,7 @@ The repository keeps a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)-
 To preview the generated section locally before tagging (no commit, branch, or PR is created):
 
 ```powershell
-./scripts/release/update-changelog.ps1 -Tag v0.1.3-preview.1 -Repository KingYoSun/kukuri -PreviousTag v0.1.2-preview.1
+./scripts/release/update-changelog.ps1 -Tag v0.1.4-preview.1 -Repository KingYoSun/kukuri -PreviousTag v0.1.3-preview.1
 ```
 
 The `changelog` job needs `contents: write` and `pull-requests: write` permissions (already set in the workflow) to push the branch and open the PR.
@@ -174,7 +174,7 @@ if (-not $manifest.platforms.'windows-x86_64'.signature) {
 network access が必要。
 
 ```powershell
-./scripts/release/test-published-updater-signature.ps1 -Tag v0.1.3-preview.1
+./scripts/release/test-published-updater-signature.ps1 -Tag v0.1.4-preview.1
 ```
 
 assetを差し替えた場合は `SHA256SUMS.txt` も必ず更新する。GitHub/CDNの切替後に上記の短いURLを


### PR DESCRIPTION
## What changed

- bump workspace, desktop package, Tauri package/config, and both Cargo lockfiles to 0.1.4
- update current README and release runbook examples to v0.1.4-preview.1
- keep historical v0.1.3 records and test fixtures unchanged

## Why

The next packaged client must include the Settings -> Release resources merged in #656 and remain updater-visible to installed 0.1.3 clients.

## Validation

- cargo xtask release-check v0.1.4-preview.1
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets
- cargo xtask check
- cargo xtask e2e-smoke
- cargo xtask desktop-test (75 files, 623 tests)
- scripts/release/generate-third-party-notices.ps1 -Check

`cargo xtask test` reached 482 passing tests before two Windows-local relay tests timed out. Both use `iroh::test_utils::run_relay_server`, reproduce individually on this host, and are explicitly skipped under `GITHUB_ACTIONS`; no release-version code is involved. CI remains the authoritative full gate.