### PR TITLE
ci: run workflows with Rust 1.92

### DIFF
--- a/.github/workflows/kukuri-fast.yml
+++ b/.github/workflows/kukuri-fast.yml
@@ -46,10 +46,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
           components: clippy,rustfmt
 
       - name: Install Linux system dependencies
@@ -110,10 +110,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -159,10 +159,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -225,10 +225,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -306,10 +306,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -355,10 +355,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -401,10 +401,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -455,10 +455,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -512,10 +512,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
           components: clippy,rustfmt
 
       - name: Setup pnpm

--- a/.github/workflows/kukuri-nightly.yml
+++ b/.github/workflows/kukuri-nightly.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -51,10 +51,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -95,10 +95,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
           components: clippy,rustfmt
 
       - name: Install Linux system dependencies
@@ -156,10 +156,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -205,10 +205,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -271,10 +271,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -341,10 +341,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -390,10 +390,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -444,10 +444,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -501,10 +501,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >

--- a/.github/workflows/kukuri-release.yml
+++ b/.github/workflows/kukuri-release.yml
@@ -61,10 +61,10 @@ jobs:
         with:
           ref: refs/tags/${{ steps.release.outputs.release_tag }}
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
 
       - name: Install Linux system dependencies
         run: >
@@ -95,10 +95,10 @@ jobs:
         with:
           ref: refs/tags/${{ needs.validate-release-inputs.outputs.release_tag }}
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
           components: clippy,rustfmt
 
       - name: Install Linux system dependencies
@@ -215,10 +215,10 @@ jobs:
         with:
           ref: refs/tags/${{ needs.validate-release-inputs.outputs.release_tag }}
 
-      - name: Install Rust 1.91
+      - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.91.0
+          toolchain: 1.92.0
           components: clippy,rustfmt
 
       - name: Setup pnpm


### PR DESCRIPTION
## 概要

Rust 1.92 への依存更新を CI と release workflow にも反映します。PR #661 の CI ログ確認で、workflow 内の明示的な 1.91.0 pin が残っていることを検出したための追補です。

## 変更内容

- `kukuri-fast.yml` の Rust toolchain 9か所を 1.92.0 に更新
- `kukuri-nightly.yml` の Rust toolchain 10か所を 1.92.0 に更新
- `kukuri-release.yml` の Rust toolchain 3か所を 1.92.0 に更新
- 各ステップ名を `Install Rust 1.92` に同期

## 検証

- リポジトリ内の Rust 1.91 指定が残っていないことを確認
- `git diff --check`
- 変更が上記3 workflow のバージョン置換だけであることを確認