### PR TITLE
非公開チャンネルのランデブー鍵を世代秘密から派生

### DIFF
--- a/crates/app-api/src/lib.rs
+++ b/crates/app-api/src/lib.rs
@@ -20,6 +20,7 @@ mod live;
 mod media;
 mod notifications;
 mod private_channel_indexing;
+mod private_channel_rendezvous;
 mod private_channels;
 mod reactions;
 mod service;

--- a/crates/app-api/src/private_channel_rendezvous.rs
+++ b/crates/app-api/src/private_channel_rendezvous.rs
@@ -1,0 +1,38 @@
+use crate::service::*;
+
+impl AppService {
+    /// 現在参加している非公開チャンネルについて、通信層が実際に購読する
+    /// `hint/private/<channel_id>` と現在世代の秘密からランデブー鍵を派生する。
+    /// 秘密そのものを実行層の境界へ渡さず、不正な秘密は公開用の派生へ落とさない。
+    pub async fn private_channel_rendezvous_keys(&self) -> BTreeMap<String, String> {
+        let states = self
+            .joined_private_channels
+            .lock()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut keys = BTreeMap::new();
+        for state in states {
+            let rendezvous_topic = kukuri_core::wire::hint_topic_id(&private_channel_hint_topic(
+                state.channel_id.as_str(),
+            ));
+            match kukuri_core::private_topic_rendezvous_key_hex_secret(
+                state.current_epoch_secret_hex.as_str(),
+                &rendezvous_topic,
+            ) {
+                Ok(key) => {
+                    keys.insert(rendezvous_topic.as_str().to_string(), key);
+                }
+                Err(error) => {
+                    warn!(
+                        channel_id = state.channel_id.as_str(),
+                        error = %error,
+                        "非公開チャンネルのランデブー鍵を派生できなかったため除外しました"
+                    );
+                }
+            }
+        }
+        keys
+    }
+}

--- a/crates/app-api/src/private_channels.rs
+++ b/crates/app-api/src/private_channels.rs
@@ -1,6 +1,41 @@
 use crate::service::*;
 use DocFetchPolicy::LocalThenRemote;
 impl AppService {
+    /// 現在参加している非公開チャンネルについて、通信層が実際に購読する
+    /// `hint/private/<channel_id>` と現在世代の秘密からランデブー鍵を派生する。
+    /// 秘密そのものを実行層の境界へ渡さず、不正な秘密は公開用の派生へ落とさない。
+    pub async fn private_channel_rendezvous_keys(&self) -> BTreeMap<String, String> {
+        let states = self
+            .joined_private_channels
+            .lock()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut keys = BTreeMap::new();
+        for state in states {
+            let rendezvous_topic = kukuri_core::wire::hint_topic_id(&private_channel_hint_topic(
+                state.channel_id.as_str(),
+            ));
+            match kukuri_core::private_topic_rendezvous_key_hex_secret(
+                state.current_epoch_secret_hex.as_str(),
+                &rendezvous_topic,
+            ) {
+                Ok(key) => {
+                    keys.insert(rendezvous_topic.as_str().to_string(), key);
+                }
+                Err(error) => {
+                    warn!(
+                        channel_id = state.channel_id.as_str(),
+                        error = %error,
+                        "非公開チャンネルのランデブー鍵を派生できなかったため除外しました"
+                    );
+                }
+            }
+        }
+        keys
+    }
+
     pub async fn create_private_channel(
         &self,
         input: CreatePrivateChannelInput,

--- a/crates/app-api/src/private_channels.rs
+++ b/crates/app-api/src/private_channels.rs
@@ -1,41 +1,6 @@
 use crate::service::*;
 use DocFetchPolicy::LocalThenRemote;
 impl AppService {
-    /// 現在参加している非公開チャンネルについて、通信層が実際に購読する
-    /// `hint/private/<channel_id>` と現在世代の秘密からランデブー鍵を派生する。
-    /// 秘密そのものを実行層の境界へ渡さず、不正な秘密は公開用の派生へ落とさない。
-    pub async fn private_channel_rendezvous_keys(&self) -> BTreeMap<String, String> {
-        let states = self
-            .joined_private_channels
-            .lock()
-            .await
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        let mut keys = BTreeMap::new();
-        for state in states {
-            let rendezvous_topic = kukuri_core::wire::hint_topic_id(&private_channel_hint_topic(
-                state.channel_id.as_str(),
-            ));
-            match kukuri_core::private_topic_rendezvous_key_hex_secret(
-                state.current_epoch_secret_hex.as_str(),
-                &rendezvous_topic,
-            ) {
-                Ok(key) => {
-                    keys.insert(rendezvous_topic.as_str().to_string(), key);
-                }
-                Err(error) => {
-                    warn!(
-                        channel_id = state.channel_id.as_str(),
-                        error = %error,
-                        "非公開チャンネルのランデブー鍵を派生できなかったため除外しました"
-                    );
-                }
-            }
-        }
-        keys
-    }
-
     pub async fn create_private_channel(
         &self,
         input: CreatePrivateChannelInput,

--- a/crates/app-api/src/tests/private_channels/persist_callback.rs
+++ b/crates/app-api/src/tests/private_channels/persist_callback.rs
@@ -4,6 +4,65 @@ use std::sync::Mutex as StdMutex;
 use std::sync::atomic::AtomicUsize;
 
 use crate::PrivateChannelCapability;
+use kukuri_core::{private_topic_rendezvous_key_hex_secret, wire::hint_topic_id};
+use kukuri_docs_sync::private_channel_hint_topic;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn private_channel_rendezvous_keys_follow_the_current_epoch_secret() {
+    let store = Arc::new(MemoryStore::default());
+    let transport = Arc::new(FakeTransport::new("self", FakeNetwork::default()));
+    let app = AppService::new(store, transport);
+    let topic = "kukuri:topic:private-rendezvous";
+    let _ = app.list_timeline(topic, None, 20).await;
+
+    let channel = app
+        .create_private_channel(CreatePrivateChannelInput {
+            topic_id: TopicId::new(topic),
+            label: "非公開ランデブー".into(),
+            audience_kind: ChannelAudienceKind::InviteOnly,
+        })
+        .await
+        .expect("非公開チャンネルを作成できる");
+    let capability = app
+        .get_private_channel_capability(topic, channel.channel_id.as_str())
+        .await
+        .expect("非公開チャンネルの権限を読み出せる")
+        .expect("非公開チャンネルの権限がある");
+    let rendezvous_topic = hint_topic_id(&private_channel_hint_topic(channel.channel_id.as_str()));
+    let expected_before = private_topic_rendezvous_key_hex_secret(
+        capability.current_epoch_secret_hex.as_str(),
+        &rendezvous_topic,
+    )
+    .expect("世代切替前の非公開ランデブー鍵を派生できる");
+
+    let keys_before = app.private_channel_rendezvous_keys().await;
+    assert_eq!(
+        keys_before.get(rendezvous_topic.as_str()),
+        Some(&expected_before)
+    );
+
+    app.rotate_private_channel(topic, channel.channel_id.as_str())
+        .await
+        .expect("非公開チャンネルの世代を切り替えられる");
+    let rotated_capability = app
+        .get_private_channel_capability(topic, channel.channel_id.as_str())
+        .await
+        .expect("世代切替後の非公開チャンネル権限を読み出せる")
+        .expect("世代切替後の非公開チャンネル権限がある");
+    let expected_after = private_topic_rendezvous_key_hex_secret(
+        rotated_capability.current_epoch_secret_hex.as_str(),
+        &rendezvous_topic,
+    )
+    .expect("世代切替後の非公開ランデブー鍵を派生できる");
+    let keys_after = app.private_channel_rendezvous_keys().await;
+
+    assert_ne!(expected_before, expected_after);
+    assert_eq!(
+        keys_after.get(rendezvous_topic.as_str()),
+        Some(&expected_after)
+    );
+    assert!(!keys_after.values().any(|key| key == &expected_before));
+}
 
 /// capability registry の write-through callback が変異経路(register/remove)で
 /// 発火し、state-only スナップショット(diagnostics 既定値)を受け取ることを固定する。

--- a/crates/core/src/tests/derivation_golden.rs
+++ b/crates/core/src/tests/derivation_golden.rs
@@ -24,12 +24,13 @@ fn private_topic_rendezvous_key_matches_golden() {
     // HMAC-SHA256(namespace_secret, "kukuri:rendezvous:private-topic:v1" || 0x00 || topic)
     let key = private_topic_rendezvous_key_hex_secret(
         "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
-        &TopicId::new("kukuri:topic:golden"),
+        // `subscribed_topics` に入る、`hint/` 付与後の通信形式の文字列を固定する。
+        &TopicId::new("hint/private/channel-golden"),
     )
-    .expect("private rendezvous key");
+    .expect("非公開ランデブー鍵を派生できる");
     assert_eq!(
         key,
-        "72d34635686d4a3f177b033941879fa4dfc01c3c881abd92fe3eeb18561e63f7"
+        "abd813b33010433f3ce2032f67c55e1ec94062ee422a123bf430143d5df5241a"
     );
 }
 

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -12,7 +12,10 @@ use kukuri_cn_protocol::{
     TOPIC_RENDEZVOUS_HEARTBEAT_PATH, TopicRendezvousHeartbeat, build_auth_envelope_json,
     normalize_http_url,
 };
-use kukuri_core::{TopicId, public_topic_rendezvous_key};
+use kukuri_core::{
+    TopicId, public_topic_rendezvous_key,
+    wire::{HINT_TOPIC_PREFIX, PRIVATE_CHANNEL_TOPIC_PREFIX},
+};
 use kukuri_transport::{SeedPeer, Transport, TransportRelayConfig, parse_seed_peer};
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};

--- a/crates/desktop-runtime/src/community_node/requests_support.rs
+++ b/crates/desktop-runtime/src/community_node/requests_support.rs
@@ -378,13 +378,30 @@ impl DesktopRuntime {
             .peers()
             .await
             .map_err(CommunityNodeRequestError::Other)?;
-        let topic_keys = snapshot
-            .subscribed_topics
-            .iter()
-            .map(|topic| public_topic_rendezvous_key(&TopicId::new(topic.clone())))
-            .collect::<std::collections::BTreeSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>();
+        let private_topic_keys = self.app_service.private_channel_rendezvous_keys().await;
+        let mut topic_keys = std::collections::BTreeSet::new();
+        let mut skipped_private_topics = 0usize;
+        for topic in &snapshot.subscribed_topics {
+            let is_private_channel_hint = topic
+                .strip_prefix(HINT_TOPIC_PREFIX)
+                .is_some_and(|topic| topic.starts_with(PRIVATE_CHANNEL_TOPIC_PREFIX));
+            if is_private_channel_hint {
+                if let Some(key) = private_topic_keys.get(topic) {
+                    topic_keys.insert(key.clone());
+                } else {
+                    skipped_private_topics += 1;
+                }
+                continue;
+            }
+            topic_keys.insert(public_topic_rendezvous_key(&TopicId::new(topic.clone())));
+        }
+        if skipped_private_topics > 0 {
+            warn!(
+                skipped_private_topics,
+                "現在世代の秘密がない非公開チャンネルのランデブー話題を除外しました"
+            );
+        }
+        let topic_keys = topic_keys.into_iter().collect::<Vec<_>>();
         if topic_keys.is_empty() {
             return Ok(());
         }

--- a/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
+++ b/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
@@ -126,9 +126,14 @@ impl DesktopRuntime {
         &self,
         request: RotatePrivateChannelRequest,
     ) -> Result<JoinedPrivateChannelView> {
-        self.app_service
+        let rotated = self
+            .app_service
             .rotate_private_channel(request.topic.as_str(), request.channel_id.as_str())
-            .await
+            .await?;
+        for session in self.community_node_sessions.lock().await.values_mut() {
+            session.rendezvous_refresh_deadline = 0;
+        }
+        Ok(rotated)
     }
 
     pub async fn leave_private_channel(&self, request: LeavePrivateChannelRequest) -> Result<()> {

--- a/crates/desktop-runtime/src/tests/community_node/scheduler.rs
+++ b/crates/desktop-runtime/src/tests/community_node/scheduler.rs
@@ -359,6 +359,7 @@ async fn topic_rendezvous_refresh_fires_between_bootstrap_heartbeats() {
         heartbeat_hits: Arc::new(AtomicUsize::new(0)),
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
         rendezvous_hits: Arc::new(AtomicUsize::new(0)),
+        rendezvous_requests: Arc::new(Mutex::new(Vec::new())),
     });
     let app = Router::new()
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
@@ -420,6 +421,205 @@ async fn topic_rendezvous_refresh_fires_between_bootstrap_heartbeats() {
         state.rendezvous_hits.load(Ordering::SeqCst) > baseline,
         "rendezvous presence must be refreshed between bootstrap heartbeats \
          (hits stayed at {baseline}; presence would expire against the 45s server TTL)"
+    );
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn private_channel_rendezvous_refresh_uses_only_the_current_epoch_secret() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let dir = tempdir().expect("一時ディレクトリを作成できる");
+    let db_path = dir.path().join("community-private-rendezvous.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("実行環境を作成できる");
+    let topic = "kukuri:topic:private-rendezvous";
+    runtime
+        .list_timeline(ListTimelineRequest {
+            topic: topic.into(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await
+        .expect("公開話題を購読できる");
+    let channel = runtime
+        .create_private_channel(CreatePrivateChannelRequest {
+            topic: topic.into(),
+            label: "非公開ランデブー".into(),
+            audience_kind: ChannelAudienceKind::InviteOnly,
+        })
+        .await
+        .expect("非公開チャンネルを作成できる");
+    let invite = runtime
+        .export_private_channel_invite(ExportPrivateChannelInviteRequest {
+            topic: topic.into(),
+            channel_id: channel.channel_id.clone(),
+            expires_at: None,
+        })
+        .await
+        .expect("現在の招待を出力できる");
+    let preview = kukuri_core::parse_private_channel_invite_token(invite.as_str())
+        .expect("現在の招待を解析できる");
+    let private_topic = kukuri_core::wire::hint_topic_id(
+        &kukuri_docs_sync::private_channel_hint_topic(channel.channel_id.as_str()),
+    );
+    let expected_private = kukuri_core::private_topic_rendezvous_key_hex_secret(
+        preview.namespace_secret_hex.as_str(),
+        &private_topic,
+    )
+    .expect("現在の非公開ランデブー鍵を派生できる");
+    let forbidden_public_private = kukuri_core::public_topic_rendezvous_key(&private_topic);
+    let public_hint_topic = kukuri_core::wire::hint_topic_id(&kukuri_core::TopicId::new(topic));
+    let expected_public = kukuri_core::public_topic_rendezvous_key(&public_hint_topic);
+    let missing_private_base = kukuri_docs_sync::private_channel_hint_topic("missing-secret");
+    let missing_private_topic = kukuri_core::wire::hint_topic_id(&missing_private_base);
+    let forbidden_missing_private =
+        kukuri_core::public_topic_rendezvous_key(&missing_private_topic);
+    let _missing_private_stream = kukuri_transport::HintTransport::subscribe_hints(
+        runtime.iroh_stack.transport.as_ref(),
+        &missing_private_base,
+    )
+    .await
+    .expect("現在の秘密を持たない非公開話題を購読できる");
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("待受先を確保できる");
+    let base_url = format!(
+        "http://{}",
+        listener.local_addr().expect("待受先を取得できる")
+    );
+    let state = Arc::new(MockRendezvousCommunityNodeState {
+        base_url: base_url.clone(),
+        seed_peers: vec![
+            CommunityNodeSeedPeer::new("2".repeat(64), None).expect("初期接続先を作成できる"),
+        ],
+        heartbeat_hits: Arc::new(AtomicUsize::new(0)),
+        bootstrap_hits: Arc::new(AtomicUsize::new(0)),
+        rendezvous_hits: Arc::new(AtomicUsize::new(0)),
+        rendezvous_requests: Arc::new(Mutex::new(Vec::new())),
+    });
+    let app = Router::new()
+        .route("/v1/consents/status", get(mock_bootstrap_consent_status))
+        .route(
+            "/v1/bootstrap/heartbeat",
+            post(mock_rendezvous_bootstrap_heartbeat),
+        )
+        .route("/v1/bootstrap/nodes", get(mock_rendezvous_bootstrap_nodes))
+        .route(
+            "/v1/rendezvous/topics/heartbeat",
+            post(mock_rendezvous_topics_heartbeat),
+        )
+        .with_state(state.clone());
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    persist_community_node_token(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        base_url.as_str(),
+        &StoredCommunityNodeToken {
+            access_token: "fake-token".to_string(),
+            expires_at: Utc::now().timestamp() + 3600,
+        },
+    )
+    .expect("コミュニティノードの認証情報を保存できる");
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.clone(),
+            auto_approve: false,
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
+                    .expect("接続先を解決できる"),
+            ),
+        }],
+    };
+
+    runtime.run_community_node_session_maintenance_once().await;
+    runtime.run_community_node_session_maintenance_once().await;
+    let requests = state.rendezvous_requests.lock().await.clone();
+    assert!(!requests.is_empty(), "ランデブー更新が送信される");
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.refreshes.contains(&expected_private)),
+        "現在の非公開ランデブー鍵が更新される"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.refreshes.contains(&expected_public)),
+        "公開話題のランデブー鍵は変わらない"
+    );
+    assert!(requests.iter().all(|request| {
+        !request.refreshes.contains(&forbidden_public_private)
+            && !request.refreshes.contains(&forbidden_missing_private)
+            && !request
+                .refreshes
+                .iter()
+                .any(|key| key == private_topic.as_str())
+            && !request
+                .refreshes
+                .iter()
+                .any(|key| key == missing_private_topic.as_str())
+    }));
+
+    state.rendezvous_requests.lock().await.clear();
+    let old_private = expected_private;
+    runtime
+        .rotate_private_channel(RotatePrivateChannelRequest {
+            topic: topic.into(),
+            channel_id: channel.channel_id.clone(),
+        })
+        .await
+        .expect("非公開チャンネルの世代を切り替えられる");
+    assert_eq!(
+        runtime
+            .community_node_sessions
+            .lock()
+            .await
+            .get(base_url.as_str())
+            .expect("コミュニティノードの接続状態がある")
+            .rendezvous_refresh_deadline,
+        0,
+        "世代切替後はランデブー更新を直ちに実行する"
+    );
+    let fresh_invite = runtime
+        .export_private_channel_invite(ExportPrivateChannelInviteRequest {
+            topic: topic.into(),
+            channel_id: channel.channel_id.clone(),
+            expires_at: None,
+        })
+        .await
+        .expect("新しい招待を出力できる");
+    let fresh_preview = kukuri_core::parse_private_channel_invite_token(fresh_invite.as_str())
+        .expect("新しい招待を解析できる");
+    let current_private = kukuri_core::private_topic_rendezvous_key_hex_secret(
+        fresh_preview.namespace_secret_hex.as_str(),
+        &private_topic,
+    )
+    .expect("切替後の非公開ランデブー鍵を派生できる");
+    assert_ne!(old_private, current_private);
+
+    runtime.run_community_node_session_maintenance_once().await;
+    let rotated_requests = state.rendezvous_requests.lock().await.clone();
+    assert!(
+        rotated_requests
+            .iter()
+            .any(|request| request.refreshes.contains(&current_private)),
+        "切替後の非公開ランデブー鍵が更新される"
+    );
+    assert!(
+        rotated_requests
+            .iter()
+            .all(|request| !request.refreshes.contains(&old_private))
     );
 
     runtime.shutdown().await;

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -19,7 +19,7 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     ("community_node/connectivity.rs", "IrohNetwork", 6),
     ("community_node/index_query.rs", "CommunityNodeServer", 8),
     ("community_node/metadata.rs", "CommunityNodeServer", 9),
-    ("community_node/scheduler.rs", "CommunityNodeServer", 4),
+    ("community_node/scheduler.rs", "CommunityNodeServer", 5),
     ("community_node/session.rs", "CommunityNodeServer", 6),
     ("community_node/trust_relation.rs", "CommunityNodeServer", 2),
     ("identity_restart.rs", "IdentityStorage", 2),
@@ -95,7 +95,7 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 69,
+        total, 70,
         "classification total drifted from the Q7 T6 baseline"
     );
 }

--- a/crates/desktop-runtime/src/tests/support/mock_cn.rs
+++ b/crates/desktop-runtime/src/tests/support/mock_cn.rs
@@ -133,6 +133,7 @@ pub(crate) struct MockRendezvousCommunityNodeState {
     pub(crate) heartbeat_hits: Arc<AtomicUsize>,
     pub(crate) bootstrap_hits: Arc<AtomicUsize>,
     pub(crate) rendezvous_hits: Arc<AtomicUsize>,
+    pub(crate) rendezvous_requests: Arc<Mutex<Vec<kukuri_cn_protocol::TopicRendezvousHeartbeat>>>,
 }
 
 pub(crate) async fn mock_rendezvous_bootstrap_heartbeat(
@@ -171,6 +172,7 @@ pub(crate) async fn mock_rendezvous_topics_heartbeat(
         "rendezvous heartbeat without topics"
     );
     state.rendezvous_hits.fetch_add(1, Ordering::SeqCst);
+    state.rendezvous_requests.lock().await.push(request);
     // expires_in_seconds はクライアントのマージン(20 秒)より小さくし、deadline が
     // 毎 maintenance pass で即時 due になるようにする(wall-clock 待ちなしの決定的テスト用)。
     Json(kukuri_cn_protocol::TopicRendezvousHeartbeatResponse {

--- a/docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md
+++ b/docs/adr/0018-channel-first-sidebar-and-unified-epoch-lifecycle.md
@@ -69,6 +69,14 @@ Accepted
 - upgrade 後に legacy `invite_only` participant が継続参加するには fresh invite が必要とする。
 - 新規作成される `invite_only` channel は常に epoch-aware 初期 epoch を持つ。
 
+### 7. 非公開チャンネルのランデブー鍵を現在の世代秘密へ結び付ける
+- 非公開チャンネルの通知用話題は、通信層が実際に購読する `hint/private/<channel_id>` を派生入力にする。`hint/` を付ける前の `private/<channel_id>` は使わない。
+- `hint/private/<channel_id>` のランデブー鍵は、現在の世代の `current_epoch_secret_hex` を `private_topic_rendezvous_key_hex_secret` に渡して作る。
+- 現在の世代秘密が見つからない非公開通知用話題は送信対象から除外し、`public_topic_rendezvous_key` へ後退させない。
+- 世代切替後は旧鍵の更新を止め、新鍵だけを送る。旧鍵はコミュニティノードの有効期限により最大45秒で失効する。
+- 旧方式の公開情報由来の鍵と新方式の鍵は併送しない。併送すると失効済み参加者が旧鍵で在席情報を追跡できるためである。
+- 新旧クライアントが混在する間は、同じ非公開チャンネルの参加者でもコミュニティノード経由の発見が成立しない場合がある。参加者のクライアント更新を移行条件とし、サーバー側の別名解決は設けない。
+
 ## Implementation Contract
 
 ### Desktop shell
@@ -90,6 +98,11 @@ Accepted
 - `invite_only` を含む private audience はすべて `channel-policy` と `channel-participant` に参加する。
 - auto rotate は handoff grant の配布までを 1 operation として扱う。
 - participant redeem は read path から呼べる idempotent operation とする。
+
+### 非公開チャンネルのランデブー
+- `AppService` は参加中チャンネルの現在世代から派生済みランデブー鍵だけを実行時へ渡し、世代秘密そのものをコミュニティノード更新処理へ渡さない。
+- 定期更新処理は公開話題だけを `public_topic_rendezvous_key` へ渡し、`hint/private/` で始まる話題には現在世代から派生済みの鍵だけを使う。
+- 明示的な世代切替が成功した場合、接続中のコミュニティノードセッションは次のランデブー更新を直ちに実行対象へ戻す。
 
 ## Consequences
 - channel を workspace と見なす実装は以後の正本ではなくなる。`Channels` tab や route を前提にした UI は削除対象になる。


### PR DESCRIPTION
## 変更内容

- 非公開チャンネルのランデブー鍵を、通信層が実際に購読する `hint/private/<channel_id>` と現在世代の秘密から派生するようにしました。
- 現在世代の秘密がない非公開話題は公開用の派生へ後退させず、送信対象から除外します。
- 世代切替後は旧鍵の更新を止め、新鍵の更新を直ちに予定します。
- 公開話題のランデブー鍵とコミュニティノード側の通信契約は変更していません。
- 新旧方式の鍵を併送しない移行方針と、旧鍵が最大45秒で失効する前提を設計判断記録へ追記しました。
- 大規模ファイルの基準を維持するため、ランデブー鍵の派生処理を専用モジュールへ分離しました。外部挙動は変えていません。

## 影響

旧方式のクライアントと新方式のクライアントが混在する間は、同じ非公開チャンネルでもコミュニティノード経由の相互発見が成立しない場合があります。失効済み参加者による追跡を防ぐため、旧方式の鍵は併送しません。

## 検証

- `cargo xtask check`
- `GITHUB_ACTIONS=true cargo xtask test`
- `cargo xtask cn-test`
- `cargo xtask scenario private_channel_invite_connectivity`
- `cargo xtask oversized-files`
- 追加した鍵派生・世代切替・公開鍵維持・秘密欠落時除外の契約試験

通常のローカル全体試験では、継続的統合環境で除外される既存の中継サーバー試験2件が時間切れになったため、全体試験は継続的統合環境と同じ条件で完走させました。

Closes #668