### PR TITLE
fix: 非公開チャンネルの索引申請確認を送信ごとに固定

### DIFF
--- a/apps/desktop/src/components/core/CommunityIndexingRequestDialog.test.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexingRequestDialog.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { expect, test, vi } from 'vitest';
 
 import type { DesktopApi } from '@/lib/api';
@@ -72,4 +72,190 @@ test('private channel request stays disabled until explicit disclosure confirmat
       confirm_private_channel_secret_disclosure: true,
     })
   );
+  expect(screen.getByRole('checkbox')).not.toBeChecked();
+  expect(submit).toBeDisabled();
+});
+
+test('private confirmation and status reset when the selected node changes', async () => {
+  const submitCommunityNodeIndexingRequest = vi.fn().mockResolvedValue({
+    request_id: 'request-3',
+    status: 'pending',
+  });
+  render(
+    <CommunityIndexingRequestDialog
+      api={{ submitCommunityNodeIndexingRequest } as unknown as DesktopApi}
+      target={{
+        kind: 'private_channel',
+        topicId: 'kukuri:topic:demo',
+        channelId: 'channel-1',
+        channelLabel: 'Core',
+      }}
+      eligibleNodeBaseUrls={['https://index-a.example', 'https://index-b.example']}
+      onOpenChange={vi.fn()}
+      onOpenCommunityNodeSettings={vi.fn()}
+    />
+  );
+
+  const confirmation = screen.getByRole('checkbox');
+  const submit = screen.getByRole('button', { name: 'Submit request' });
+  fireEvent.click(confirmation);
+  fireEvent.click(submit);
+
+  expect(await screen.findByText('The request is pending review.')).toBeInTheDocument();
+  expect(confirmation).not.toBeChecked();
+  expect(submit).toBeDisabled();
+
+  fireEvent.click(confirmation);
+  fireEvent.change(screen.getByLabelText('Community Node'), {
+    target: { value: 'https://index-b.example' },
+  });
+
+  expect(confirmation).not.toBeChecked();
+  expect(submit).toBeDisabled();
+  expect(screen.queryByText('The request is pending review.')).not.toBeInTheDocument();
+
+  fireEvent.click(confirmation);
+  fireEvent.click(submit);
+  await waitFor(() => expect(submitCommunityNodeIndexingRequest).toHaveBeenCalledTimes(2));
+  expect(submitCommunityNodeIndexingRequest).toHaveBeenLastCalledWith(
+    expect.objectContaining({ base_url: 'https://index-b.example' })
+  );
+});
+
+test('failed private request consumes confirmation and node change clears the error', async () => {
+  const submitCommunityNodeIndexingRequest = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('request failed'))
+    .mockResolvedValueOnce({ request_id: 'request-4', status: 'approved' });
+  render(
+    <CommunityIndexingRequestDialog
+      api={{ submitCommunityNodeIndexingRequest } as unknown as DesktopApi}
+      target={{
+        kind: 'private_channel',
+        topicId: 'kukuri:topic:demo',
+        channelId: 'channel-1',
+        channelLabel: 'Core',
+      }}
+      eligibleNodeBaseUrls={['https://index-a.example', 'https://index-b.example']}
+      onOpenChange={vi.fn()}
+      onOpenCommunityNodeSettings={vi.fn()}
+    />
+  );
+
+  const confirmation = screen.getByRole('checkbox');
+  const submit = screen.getByRole('button', { name: 'Submit request' });
+  fireEvent.click(confirmation);
+  fireEvent.click(submit);
+
+  expect(await screen.findByText('The indexing request failed. Please try again later.')).toBeInTheDocument();
+  expect(confirmation).not.toBeChecked();
+  expect(submit).toBeDisabled();
+
+  fireEvent.click(confirmation);
+  fireEvent.change(screen.getByLabelText('Community Node'), {
+    target: { value: 'https://index-b.example' },
+  });
+  expect(confirmation).not.toBeChecked();
+  expect(submit).toBeDisabled();
+  expect(
+    screen.queryByText('The indexing request failed. Please try again later.')
+  ).not.toBeInTheDocument();
+});
+
+test('private confirmation and status reset when the request target changes', async () => {
+  const submitCommunityNodeIndexingRequest = vi.fn().mockResolvedValue({
+    request_id: 'request-5',
+    status: 'approved',
+  });
+  const eligibleNodeBaseUrls = ['https://index.example'];
+  const props = {
+    api: { submitCommunityNodeIndexingRequest } as unknown as DesktopApi,
+    eligibleNodeBaseUrls,
+    onOpenChange: vi.fn(),
+    onOpenCommunityNodeSettings: vi.fn(),
+  };
+  const { rerender } = render(
+    <CommunityIndexingRequestDialog
+      {...props}
+      target={{
+        kind: 'private_channel',
+        topicId: 'kukuri:topic:demo',
+        channelId: 'channel-1',
+        channelLabel: 'Core',
+      }}
+    />
+  );
+
+  const confirmation = screen.getByRole('checkbox');
+  fireEvent.click(confirmation);
+  fireEvent.click(screen.getByRole('button', { name: 'Submit request' }));
+  expect(await screen.findByText('Indexing is approved.')).toBeInTheDocument();
+  fireEvent.click(confirmation);
+
+  rerender(
+    <CommunityIndexingRequestDialog
+      {...props}
+      target={{
+        kind: 'private_channel',
+        topicId: 'kukuri:topic:demo',
+        channelId: 'channel-2',
+        channelLabel: 'Review',
+      }}
+    />
+  );
+
+  expect(screen.getByRole('checkbox')).not.toBeChecked();
+  expect(screen.getByRole('button', { name: 'Submit request' })).toBeDisabled();
+  expect(screen.queryByText('Indexing is approved.')).not.toBeInTheDocument();
+});
+
+test('stale private request result does not overwrite a changed target', async () => {
+  let resolveRequest:
+    | ((value: { request_id: string; status: 'approved' }) => void)
+    | undefined;
+  const response = new Promise<{ request_id: string; status: 'approved' }>((resolve) => {
+    resolveRequest = resolve;
+  });
+  const submitCommunityNodeIndexingRequest = vi.fn().mockReturnValue(response);
+  const eligibleNodeBaseUrls = ['https://index.example'];
+  const props = {
+    api: { submitCommunityNodeIndexingRequest } as unknown as DesktopApi,
+    eligibleNodeBaseUrls,
+    onOpenChange: vi.fn(),
+    onOpenCommunityNodeSettings: vi.fn(),
+  };
+  const { rerender } = render(
+    <CommunityIndexingRequestDialog
+      {...props}
+      target={{
+        kind: 'private_channel',
+        topicId: 'kukuri:topic:demo',
+        channelId: 'channel-1',
+        channelLabel: 'Core',
+      }}
+    />
+  );
+
+  fireEvent.click(screen.getByRole('checkbox'));
+  fireEvent.click(screen.getByRole('button', { name: 'Submit request' }));
+  rerender(
+    <CommunityIndexingRequestDialog
+      {...props}
+      target={{
+        kind: 'private_channel',
+        topicId: 'kukuri:topic:demo',
+        channelId: 'channel-2',
+        channelLabel: 'Review',
+      }}
+    />
+  );
+
+  await act(async () => {
+    resolveRequest?.({ request_id: 'request-6', status: 'approved' });
+    await response;
+  });
+
+  expect(screen.getByText('Target: Review')).toBeInTheDocument();
+  expect(screen.queryByText('Indexing is approved.')).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Submit request' })).toBeDisabled();
 });

--- a/apps/desktop/src/components/core/CommunityIndexingRequestDialog.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexingRequestDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { DesktopApi, IndexingRequestStatus } from '@/lib/api';
@@ -52,8 +52,10 @@ export function CommunityIndexingRequestDialog({
   const [pending, setPending] = useState(false);
   const [status, setStatus] = useState<IndexingRequestStatus | null>(null);
   const [errorKey, setErrorKey] = useState<string | null>(null);
+  const requestVersionRef = useRef(0);
 
   useEffect(() => {
+    requestVersionRef.current += 1;
     setSelectedNode(eligibleNodeBaseUrls[0] ?? '');
     setConfirmed(false);
     setPending(false);
@@ -68,9 +70,21 @@ export function CommunityIndexingRequestDialog({
       : topicDisplayName(target.topicId)
     : '';
 
+  function selectNode(baseUrl: string) {
+    requestVersionRef.current += 1;
+    setSelectedNode(baseUrl);
+    setConfirmed(false);
+    setStatus(null);
+    setErrorKey(null);
+  }
+
   async function submit() {
     if (!target || !selectedNode || (privateTarget && !confirmed)) return;
+    const requestVersion = requestVersionRef.current + 1;
+    requestVersionRef.current = requestVersion;
+    if (privateTarget) setConfirmed(false);
     setPending(true);
+    setStatus(null);
     setErrorKey(null);
     try {
       const response = await api.submitCommunityNodeIndexingRequest({
@@ -80,11 +94,13 @@ export function CommunityIndexingRequestDialog({
         channel_id: privateTarget ? target.channelId : null,
         confirm_private_channel_secret_disclosure: privateTarget && confirmed,
       });
+      if (requestVersionRef.current !== requestVersion) return;
       setStatus(response.status);
     } catch (error) {
+      if (requestVersionRef.current !== requestVersion) return;
       setErrorKey(requestErrorKey(error));
     } finally {
-      setPending(false);
+      if (requestVersionRef.current === requestVersion) setPending(false);
     }
   }
 
@@ -109,7 +125,11 @@ export function CommunityIndexingRequestDialog({
             ) : (
               <Label>
                 <span>{t('shell:indexingRequest.nodeLabel')}</span>
-                <Select value={selectedNode} onChange={(event) => setSelectedNode(event.target.value)}>
+                <Select
+                  value={selectedNode}
+                  disabled={pending}
+                  onChange={(event) => selectNode(event.target.value)}
+                >
                   {eligibleNodeBaseUrls.map((baseUrl) => (
                     <option key={baseUrl} value={baseUrl}>{baseUrl}</option>
                   ))}
@@ -124,6 +144,7 @@ export function CommunityIndexingRequestDialog({
                     type='checkbox'
                     className='mt-1 size-4 shrink-0'
                     checked={confirmed}
+                    disabled={pending}
                     onChange={(event) => setConfirmed(event.target.checked)}
                   />
                   <span className='min-w-0'>{t('shell:indexingRequest.privateConfirmation')}</span>

--- a/apps/desktop/tests/playwright/community-index.spec.ts
+++ b/apps/desktop/tests/playwright/community-index.spec.ts
@@ -52,11 +52,21 @@ test('public and private indexing requests expose status and require private dis
   await settingsDialog.getByRole('button', { name: 'Request indexing' }).click();
   requestDialog = page.getByRole('dialog', { name: 'Request Community Node indexing' });
   const submit = requestDialog.getByRole('button', { name: 'Submit request' });
+  const confirmation = requestDialog.getByRole('checkbox', {
+    name: /I agree to disclose this channel's read capability/,
+  });
   await expect(submit).toBeDisabled();
-  await requestDialog
-    .getByRole('checkbox', { name: /I agree to disclose this channel's read capability/ })
-    .check();
+  await confirmation.check();
   await expect(submit).toBeEnabled();
   await submit.click();
   await expect(requestDialog.getByText('The request is pending review.')).toBeVisible();
+  await expect(confirmation).not.toBeChecked();
+  await expect(submit).toBeDisabled();
+
+  await confirmation.check();
+  await expect(submit).toBeEnabled();
+  await submit.click();
+  await expect(requestDialog.getByText('The request is pending review.')).toBeVisible();
+  await expect(confirmation).not.toBeChecked();
+  await expect(submit).toBeDisabled();
 });


### PR DESCRIPTION
## 変更内容

- 非公開チャンネルの索引申請で、送信開始時に秘密値の開示確認を消費
- ノードまたは申請対象の変更時に、確認、申請結果、エラーを解除
- 対象変更後に完了した古い要求が、現在の画面状態を上書きしないように修正
- 送信中はノード選択と確認欄を操作不能にし、成功・失敗後の再送には再確認を要求

## 原因

確認状態が単一の `boolean` として保持され、ノード変更時と送信完了時に解除されていなかった。そのため、別ノードへの送信や同じ申請の再送で、以前の確認を使い回せた。

## 利用者への影響

非公開チャンネルの秘密値は、利用者が選択中のノードに対して確認した1回の申請でだけ送信される。公開トピックの申請動作は変わらない。

## 操作の流れ

1. 非公開チャンネルと送信先ノードを確認する。
2. 秘密値の開示確認を選択して申請する。
3. 送信開始時に確認が解除され、結果が表示される。
4. 状態照会または再送を行う場合は、もう一度開示確認を選択する。
5. ノードまたは申請対象を変えると、以前の確認と結果は破棄される。

## 画面確認

見た目と文言は変更していないため、#664 で承認済みの[非公開チャンネル申請画面](https://github.com/KingYoSun/kukuri/blob/main/docs/ui-reviews/assets/2026-08-13-issue-664/community-indexing-request-private.png?raw=1)を継続して適用する。今回の状態遷移は部品試験と画面試験で確認した。

## 8つの黄金律の確認

- 一貫性: 公開・非公開の申請結果表示は維持し、秘密値を送る場合だけ毎回確認する。
- 熟練者向けの近道: 再送手順は同じダイアログ内で完結する。
- 有益な反応: 送信中、結果、エラー、再確認が必要な状態を明確に表示する。
- 対話の完結: 送信結果を表示し、次の送信には再確認が必要であることをボタン状態で示す。
- 誤操作の防止: 確認の使い回しと送信中のノード変更を防ぐ。
- 容易な回復: 失敗後も再確認して再送できる。
- 利用者による制御: 自動送信は行わず、各送信を利用者の操作に限定する。
- 短期記憶への負担軽減: 対象、送信先、確認、結果を同じダイアログ内に置く。

## 確認

- 対象の `Vitest`: 6件成功
- `cargo xtask desktop-test`: 656件成功
- `cargo xtask desktop-browser-test`: 13件成功
- `cargo xtask check`: 成功
- `cargo xtask desktop-ui-check`: 部品試験656件、画面試験13件、視覚到達試験14件、物語表示の構築が成功
- `git diff --check`: 成功

Closes #683
