### PR TITLE
fix: 観測記録の90日保持を時刻経過でも強制

### DIFF
--- a/apps/desktop/src/components/core/AuthorDetailCard.test.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
 import { STORY_AUTHOR_DETAIL_VIEW } from '@/components/storyFixtures';
@@ -47,4 +48,34 @@ test('author detail marks long unbroken values as wrappable content', () => {
     screen.getByText('bob')
   );
   expect(screen.getByText('mutual').closest('.author-detail-actions')).toBeNull();
+});
+
+test('author report does not fetch a manifest or create a candidate without provenance', async () => {
+  const user = userEvent.setup();
+  const onFetchReportManifest = vi.fn();
+
+  render(
+    <AuthorDetailCard
+      view={{
+        ...STORY_AUTHOR_DETAIL_VIEW,
+        author: {
+          ...STORY_AUTHOR_DETAIL_VIEW.author!,
+          provenance: null,
+        },
+      }}
+      localAuthorPubkey={'f'.repeat(64)}
+      onToggleRelationship={vi.fn()}
+      onToggleMute={vi.fn()}
+      onSubmitReport={vi.fn()}
+      onFetchReportManifest={onFetchReportManifest}
+    />
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  expect(onFetchReportManifest).not.toHaveBeenCalled();
+  expect(screen.getByText('Cannot determine a report target')).toBeInTheDocument();
+  expect(screen.getByText(/block, mute, or hide this locally/i)).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Send report' })).not.toBeInTheDocument();
 });

--- a/apps/desktop/src/components/core/PostCard.test.tsx
+++ b/apps/desktop/src/components/core/PostCard.test.tsx
@@ -640,6 +640,30 @@ test('report action refreshes the observed node manifest when the dialog opens',
   expect(await screen.findByText('node.example')).toBeInTheDocument();
 });
 
+test('report action does not fetch a manifest or create a candidate without provenance', async () => {
+  const user = userEvent.setup();
+  const onFetchReportManifest = vi.fn();
+
+  render(
+    <PostCard
+      view={createView()}
+      onOpenAuthor={() => undefined}
+      onOpenThread={() => undefined}
+      onReply={() => undefined}
+      onSubmitReport={vi.fn()}
+      onFetchReportManifest={onFetchReportManifest}
+    />
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  expect(onFetchReportManifest).not.toHaveBeenCalled();
+  expect(screen.getByText('Cannot determine a report target')).toBeInTheDocument();
+  expect(screen.getByText(/block, mute, or hide this locally/i)).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Send report' })).not.toBeInTheDocument();
+});
+
 test('attachment report resolves the selected blob provenance instead of the post provenance', async () => {
   const user = userEvent.setup();
   const manifest = (nodeId: string): CommunityNodeManifest => ({

--- a/crates/app-api/src/tests/mod.rs
+++ b/crates/app-api/src/tests/mod.rs
@@ -15,8 +15,9 @@ use kukuri_docs_sync::IrohDocsSync;
 #[cfg(feature = "iroh-integration-tests")]
 use kukuri_iroh_node::IrohDocsNode;
 use kukuri_store::{
-    BookmarkedCustomReactionRow, DirectMessageStore, LiveGameProjectionStore, MemoryStore,
-    ReactionBookmarkStore, SocialProjectionStore, SqliteStore,
+    BookmarkedCustomReactionRow, ContentObservationRow, ContentObservationStore,
+    DirectMessageStore, LiveGameProjectionStore, MemoryStore, ReactionBookmarkStore,
+    SocialProjectionStore, SqliteStore,
 };
 #[cfg(feature = "iroh-integration-tests")]
 use kukuri_transport::{DhtDiscoveryOptions, IrohGossipTransport, TransportRelayConfig};

--- a/crates/app-api/src/tests/timeline/profile.rs
+++ b/crates/app-api/src/tests/timeline/profile.rs
@@ -54,6 +54,86 @@ async fn create_public_post_persists_profile_post_doc_and_lists_profile_timeline
 }
 
 #[tokio::test]
+async fn expired_content_observations_do_not_reach_post_profile_or_attachment_views() {
+    let (app, store, _docs_sync, _blob_service) = local_app_with_memory_services();
+    let profile = app
+        .set_my_profile(ProfileInput {
+            name: Some("retention-owner".into()),
+            display_name: Some("保持期限の確認用".into()),
+            about: None,
+            picture: None,
+            picture_upload: None,
+            clear_picture: false,
+        })
+        .await
+        .expect("set profile");
+    let topic = "kukuri:topic:observation-retention";
+    let object_id = app
+        .create_post_with_attachments(
+            topic,
+            "retention body",
+            None,
+            vec![pending_image_attachment(
+                "image/png",
+                tiny_png_bytes().as_slice(),
+            )],
+        )
+        .await
+        .expect("create observed post");
+
+    for (subject_kind, subject_id) in [
+        ("post", object_id.as_str()),
+        ("profile", profile.pubkey.as_str()),
+    ] {
+        assert!(
+            store
+                .put_content_observation(ContentObservationRow {
+                    subject_kind: subject_kind.to_string(),
+                    subject_id: subject_id.to_string(),
+                    node_base_url: "https://expired-observer.example".to_string(),
+                    capability: "community_index".to_string(),
+                    observed_at: 1,
+                })
+                .await
+                .expect("store expired observation")
+        );
+    }
+
+    let timeline = app
+        .list_timeline(topic, None, 20)
+        .await
+        .expect("list timeline");
+    let post = timeline
+        .items
+        .iter()
+        .find(|post| post.object_id == object_id)
+        .expect("observed post");
+    assert_eq!(post.provenance, None);
+    assert_eq!(post.attachments.len(), 1);
+    assert_eq!(post.attachments[0].provenance, None);
+
+    let author = app
+        .build_author_social_view(profile.pubkey.as_str())
+        .await
+        .expect("build author view");
+    assert_eq!(author.provenance, None);
+    assert!(
+        store
+            .list_content_observations("post", object_id.as_str())
+            .await
+            .expect("list post observations")
+            .is_empty()
+    );
+    assert!(
+        store
+            .list_content_observations("profile", profile.pubkey.as_str())
+            .await
+            .expect("list profile observations")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn public_reply_is_indexed_in_profile_timeline() {
     let store = Arc::new(MemoryStore::default());
     let transport = Arc::new(StaticTransport::new(PeerSnapshot::default()));

--- a/crates/store/src/memory/observations.rs
+++ b/crates/store/src/memory/observations.rs
@@ -1,7 +1,7 @@
 use super::*;
+use crate::traits::CONTENT_OBSERVATION_RETENTION_MS;
 
 const MAX_CONTENT_OBSERVATIONS: usize = 2048;
-const CONTENT_OBSERVATION_RETENTION_MS: i64 = 90 * 24 * 60 * 60 * 1000;
 
 #[async_trait]
 impl ContentObservationStore for MemoryStore {
@@ -56,15 +56,16 @@ impl ContentObservationStore for MemoryStore {
         Ok(true)
     }
 
-    async fn list_content_observations(
+    async fn list_content_observations_at(
         &self,
         subject_kind: &str,
         subject_id: &str,
+        now_millis: i64,
     ) -> Result<Vec<ContentObservationRow>> {
-        let mut rows = self
-            .content_observation_rows
-            .read()
-            .await
+        let cutoff = now_millis.saturating_sub(CONTENT_OBSERVATION_RETENTION_MS);
+        let mut observations = self.content_observation_rows.write().await;
+        observations.retain(|_, observation| observation.observed_at >= cutoff);
+        let mut rows = observations
             .values()
             .filter(|row| row.subject_kind == subject_kind && row.subject_id == subject_id)
             .cloned()

--- a/crates/store/src/sqlite/observations.rs
+++ b/crates/store/src/sqlite/observations.rs
@@ -1,7 +1,7 @@
 use super::*;
+use crate::traits::CONTENT_OBSERVATION_RETENTION_MS;
 
 const MAX_CONTENT_OBSERVATIONS: i64 = 2048;
-const CONTENT_OBSERVATION_RETENTION_MS: i64 = 90 * 24 * 60 * 60 * 1000;
 
 #[async_trait]
 impl ContentObservationStore for SqliteStore {
@@ -73,11 +73,18 @@ impl ContentObservationStore for SqliteStore {
         Ok(true)
     }
 
-    async fn list_content_observations(
+    async fn list_content_observations_at(
         &self,
         subject_kind: &str,
         subject_id: &str,
+        now_millis: i64,
     ) -> Result<Vec<ContentObservationRow>> {
+        let cutoff = now_millis.saturating_sub(CONTENT_OBSERVATION_RETENTION_MS);
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM content_observations WHERE observed_at < ?1")
+            .bind(cutoff)
+            .execute(&mut *tx)
+            .await?;
         let rows = sqlx::query(
             r#"
             SELECT subject_kind, subject_id, node_base_url, capability, observed_at
@@ -88,8 +95,9 @@ impl ContentObservationStore for SqliteStore {
         )
         .bind(subject_kind)
         .bind(subject_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *tx)
         .await?;
+        tx.commit().await?;
         rows.into_iter()
             .map(|row| {
                 Ok(ContentObservationRow {

--- a/crates/store/src/tests/content_observations.rs
+++ b/crates/store/src/tests/content_observations.rs
@@ -48,7 +48,7 @@ where
     );
     assert!(
         store
-            .list_content_observations("post", object_id.as_str())
+            .list_content_observations_at("post", object_id.as_str(), observation.observed_at)
             .await
             .unwrap()
             .is_empty()
@@ -75,7 +75,7 @@ where
     );
     assert_eq!(
         store
-            .list_content_observations("post", object_id.as_str())
+            .list_content_observations_at("post", object_id.as_str(), refreshed.observed_at)
             .await
             .unwrap(),
         vec![refreshed]
@@ -84,7 +84,7 @@ where
     store.rebuild_object_projections(Vec::new()).await.unwrap();
     assert!(
         store
-            .list_content_observations("post", object_id.as_str())
+            .list_content_observations_at("post", object_id.as_str(), 20)
             .await
             .unwrap()
             .is_empty()
@@ -121,7 +121,7 @@ where
         );
     }
     let rows = store
-        .list_content_observations("post", object_id.as_str())
+        .list_content_observations_at("post", object_id.as_str(), now)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2);
@@ -159,7 +159,7 @@ where
         );
     }
     let rows = store
-        .list_content_observations("post", object_id.as_str())
+        .list_content_observations_at("post", object_id.as_str(), 2048)
         .await
         .unwrap();
     assert_eq!(rows.len(), 2048);
@@ -170,6 +170,59 @@ where
     assert!(
         rows.iter()
             .any(|row| row.node_base_url == "https://node-2048.example")
+    );
+}
+
+async fn content_observation_expires_without_another_write_scenario<S>(store: &S)
+where
+    S: ContentObservationStore + ObjectProjectionStore,
+{
+    const DAY_MS: i64 = 24 * 60 * 60 * 1000;
+    let object_id = EnvelopeId::from("time-only-expiring-post");
+    let observed_at = 10;
+    let observation = ContentObservationRow {
+        subject_kind: "post".to_string(),
+        subject_id: object_id.as_str().to_string(),
+        node_base_url: "https://time-only.example".to_string(),
+        capability: "community_index".to_string(),
+        observed_at,
+    };
+    store
+        .put_object_projection(observation_projection_row(object_id.as_str()))
+        .await
+        .unwrap();
+    assert!(
+        store
+            .put_content_observation(observation.clone())
+            .await
+            .unwrap()
+    );
+
+    assert_eq!(
+        store
+            .list_content_observations_at("post", object_id.as_str(), observed_at + 90 * DAY_MS,)
+            .await
+            .unwrap(),
+        vec![observation]
+    );
+    assert!(
+        store
+            .list_content_observations_at(
+                "post",
+                object_id.as_str(),
+                observed_at + 90 * DAY_MS + 1,
+            )
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        store
+            .list_content_observations_at("post", object_id.as_str(), observed_at)
+            .await
+            .unwrap()
+            .is_empty(),
+        "期限切れ記録は読み取り時に物理削除される"
     );
 }
 
@@ -189,4 +242,13 @@ async fn content_observation_removes_rows_older_than_ninety_days() {
 async fn content_observation_keeps_only_the_newest_2048_rows() {
     content_observation_limit_scenario(&MemoryStore::default()).await;
     content_observation_limit_scenario(&SqliteStore::connect_memory().await.unwrap()).await;
+}
+
+#[tokio::test]
+async fn content_observation_expires_after_time_passes_without_another_write() {
+    content_observation_expires_without_another_write_scenario(&MemoryStore::default()).await;
+    content_observation_expires_without_another_write_scenario(
+        &SqliteStore::connect_memory().await.unwrap(),
+    )
+    .await;
 }

--- a/crates/store/src/traits.rs
+++ b/crates/store/src/traits.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeSet, HashMap};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -11,6 +12,8 @@ use crate::models::{
     GameRoomProjectionRow, LiveSessionProjectionRow, MutedAuthorRow, NotificationRow,
     ObjectProjectionRow, Page, ReactionProjectionRow, TimelineCursor,
 };
+
+pub(crate) const CONTENT_OBSERVATION_RETENTION_MS: i64 = 90 * 24 * 60 * 60 * 1000;
 
 #[async_trait]
 pub trait Store: Send + Sync {
@@ -119,6 +122,17 @@ pub trait ContentObservationStore: Send + Sync {
         &self,
         subject_kind: &str,
         subject_id: &str,
+    ) -> Result<Vec<ContentObservationRow>> {
+        let now_millis = i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis())?;
+        self.list_content_observations_at(subject_kind, subject_id, now_millis)
+            .await
+    }
+    /// 保持期間の契約試験で基準時刻を固定するための読み取り境界。
+    async fn list_content_observations_at(
+        &self,
+        subject_kind: &str,
+        subject_id: &str,
+        now_millis: i64,
     ) -> Result<Vec<ContentObservationRow>>;
 }
 

--- a/docs/adr/0030-content-observation-provenance.md
+++ b/docs/adr/0030-content-observation-provenance.md
@@ -10,6 +10,8 @@
 - #310
 - #612
 - #666
+- #684
+- #692
 - `docs/adr/0002-feature-data-classification-template.md`
 - `docs/adr/0027-deterministic-moderation-critical-safety.md`
 - `docs/architecture/p2p-first-community-node-responsibility-boundary.md`
@@ -28,7 +30,9 @@
   - `content_observation_requires_local_subject`
   - `content_observation_upsert_refreshes_timestamp`
   - `content_observation_restores_after_restart`
+  - `content_observation_expires_after_time_passes_without_another_write`
   - `post_view_exposes_content_provenance`
+  - `expired_content_observations_do_not_reach_post_profile_or_attachment_views`
   - `unknown_provenance_has_no_report_candidate`
   - `report_manifest_loads_without_settings_visit`
 - `必須 scenario`:
@@ -42,7 +46,9 @@
 - 手動接続、`DHT`、直接接続、単なる待ち合わせ参加からコミュニティノード由来を推測しない。
 - 索引応答を受けても、対象の投稿またはプロフィールが端末内に存在しない場合は永続化しない。
 - 同じ対象、ノード、能力を再観測した場合は最終観測時刻だけを更新する。
-- 保持期間は最終観測から90日、総数は2048件を上限とし、古い記録から削除する。
+- 保持期間は最終観測から90日、総数は2048件を上限とする。ちょうど90日の記録は残し、90日を超えた記録を期限切れとする。
+- 期限切れ記録は書き込み時の整理に加え、観測記録の読み取り時にも現在時刻で判定する。読み取りでは期限切れの物理削除と対象記録の取得を同じ取引または排他範囲で行い、削除対象を返さない。これにより、新しい観測がない端末でも保持期間を強制する。
+- 2048件の上限を超えた場合は、引き続き最終観測時刻が古い記録から削除する。
 - 投稿の端末内射影が削除された場合、その投稿の観測記録も削除する。プロフィールは端末内プロフィールが存在する間だけ記録できる。
 - 添付は親投稿の観測元を表示時に引き継ぎ、正本を `blob` とする。添付単位の観測記録は保存しない。
 - 通報先は保存せず、通報を開いた時に観測元の基底アドレスから最新の `CommunityNodeManifest` を取得して求める。


### PR DESCRIPTION
## 概要

- 内容観測記録の読み取り時に、最終観測から90日を超えた記録を物理削除します。
- `MemoryStore` と `SqliteStore` で同じ保持境界を使い、削除と取得を同じ排他範囲または取引内で行います。
- 期限切れ記録が投稿・プロフィール・添付の観測元表示や通報先候補へ届かないことを固定します。
- 設計判断記録0030へ、90日の境界と読み取り時削除を追記します。

## 原因

従来は `put_content_observation` を実行した時だけ期限切れ記録を削除していました。そのため、新しい観測が90日を超えて発生しない端末では、古い記録が読み取り結果へ残り続けていました。

## 確認

- `cargo xtask check`
- `cargo test -p kukuri-store`
- `cargo test -p kukuri-app-api`
- `cargo nextest run -p kukuri-desktop-runtime`
- `cargo nextest run -p kukuri-harness -j 1`
- `cargo xtask scenario community_node_report_routing`
- `npx pnpm@10.16.1 test`（82ファイル、675件成功）
- `git diff --check`

`cargo xtask test` は今回の変更に関係する504件が成功した後、既知の中継同期試験2件が制限時間を超過し、残り68件が打ち切られました。打ち切られたうちデスクトップ実行時層119件と試験基盤18件は個別実行ですべて成功しています。

Closes #692