### PR TITLE
fix: 通報画面で開いた時に取得した最新ノード情報だけを送信先候補にする (#696)

### DIFF
--- a/apps/desktop/src/components/core/AuthorDetailCard.stories.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.stories.tsx
@@ -13,6 +13,13 @@ import { createDesktopMockApi } from '@/mocks/desktopApiMock';
 const authorDetailView = createStoryAuthorDetailView();
 const advisoryApi = {
   ...createDesktopMockApi(),
+  // 異議申し立てを開いた時に取得する発行元ノードの最新 manifest(#696)。
+  async fetchCommunityNodeManifest(baseUrl: string) {
+    const manifest = advisoryManifests[baseUrl as keyof typeof advisoryManifests];
+    return manifest
+      ? { status: 'ok' as const, manifest }
+      : { status: 'absent' as const, manifest: null };
+  },
   async readCommunityNodeTrustUser(request: { target_pubkey: string }) {
     return {
       viewer_pubkey: 'story-viewer',
@@ -133,7 +140,6 @@ export const CommunityNodeAdvisory: Story = {
         api={advisoryApi}
         targetPubkey={authorDetailView.author?.author_pubkey ?? 'a'.repeat(64)}
         nodeBaseUrls={['https://community.example.com']}
-        communityNodeManifests={advisoryManifests}
       />
     ),
   },
@@ -152,7 +158,6 @@ export const CommunityNodeClearedPostAdvisory: Story = {
         api={clearedPostAdvisoryApi}
         targetPubkey={authorDetailView.author?.author_pubkey ?? 'a'.repeat(64)}
         nodeBaseUrls={['https://community.example.com']}
-        communityNodeManifests={advisoryManifests}
       />
     ),
   },

--- a/apps/desktop/src/components/core/AuthorDetailCard.test.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
@@ -78,4 +78,106 @@ test('author report does not fetch a manifest or create a candidate without prov
   expect(screen.getByText('Cannot determine a report target')).toBeInTheDocument();
   expect(screen.getByText(/block, mute, or hide this locally/i)).toBeInTheDocument();
   expect(screen.queryByRole('button', { name: 'Send report' })).not.toBeInTheDocument();
+});
+
+// #696: 著者詳細の通報も、開いた時に取得成功した最新 manifest だけから候補を作る。
+function authorReportManifest(nodeId: string) {
+  return {
+    node_id: nodeId,
+    node_name: nodeId,
+    node_role: 'community-node',
+    server_name: nodeId,
+    manifest_version: 'v1',
+    capability_scope: { available_enabled: ['community_index'], planned_enabled: [] },
+    authority_scope: { applies_to: ['this_node'], does_not_apply_to: [] },
+    p2p_boundary: {
+      identity_authority: false,
+      profile_canonical_store: false,
+      social_graph_canonical_store: false,
+      content_truth_source: false,
+      network_wide_authority: false,
+    },
+    abuse_contact: '',
+    report_endpoint: `https://${nodeId}/v1/report`,
+    terms_url: '',
+    privacy_url: '',
+    moderation_policy_url: '',
+  };
+}
+
+const OBSERVED_AUTHOR_VIEW = {
+  ...STORY_AUTHOR_DETAIL_VIEW,
+  author: {
+    ...STORY_AUTHOR_DETAIL_VIEW.author!,
+    provenance: {
+      canonical_source: 'author_docs',
+      observed_via: [
+        { node_base_url: 'https://node.example', capability: 'community_index', observed_at: 1 },
+      ],
+    },
+  },
+};
+
+test('author report fetches the observed node manifest on open and submits a profile report', async () => {
+  const user = userEvent.setup();
+  const onFetchReportManifest = vi
+    .fn()
+    .mockResolvedValue({ status: 'ok', manifest: authorReportManifest('node.example') });
+  const onSubmitReport = vi.fn().mockResolvedValue({ status: 'submitted', reference_id: 'r-1' });
+
+  render(
+    <AuthorDetailCard
+      view={OBSERVED_AUTHOR_VIEW}
+      localAuthorPubkey={'f'.repeat(64)}
+      onToggleRelationship={vi.fn()}
+      onToggleMute={vi.fn()}
+      onSubmitReport={onSubmitReport}
+      onFetchReportManifest={onFetchReportManifest}
+    />
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+  await waitFor(() => expect(onFetchReportManifest).toHaveBeenCalledWith('https://node.example'));
+  expect(await screen.findByText('node.example')).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: 'Send report' }));
+  await waitFor(() => expect(onSubmitReport).toHaveBeenCalledTimes(1));
+  expect(onSubmitReport).toHaveBeenCalledWith(
+    expect.objectContaining({
+      node_base_url: 'https://node.example',
+      subject_kind: 'profile',
+      subject_id: STORY_AUTHOR_DETAIL_VIEW.author!.author_pubkey,
+    })
+  );
+});
+
+test('author report does not reuse a previously fetched target after the latest fetch fails', async () => {
+  const user = userEvent.setup();
+  const onFetchReportManifest = vi
+    .fn()
+    .mockResolvedValueOnce({ status: 'ok', manifest: authorReportManifest('node.example') })
+    .mockResolvedValueOnce({ status: 'absent', manifest: null });
+  const onSubmitReport = vi.fn();
+
+  render(
+    <AuthorDetailCard
+      view={OBSERVED_AUTHOR_VIEW}
+      localAuthorPubkey={'f'.repeat(64)}
+      onToggleRelationship={vi.fn()}
+      onToggleMute={vi.fn()}
+      onSubmitReport={onSubmitReport}
+      onFetchReportManifest={onFetchReportManifest}
+    />
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+  expect(await screen.findByText('node.example')).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: 'Cancel' }));
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+  await waitFor(() => expect(onFetchReportManifest).toHaveBeenCalledTimes(2));
+  expect(await screen.findByText(/Could not refresh report targets/)).toBeInTheDocument();
+  expect(screen.queryByText('node.example')).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Send report' })).not.toBeInTheDocument();
+  expect(onSubmitReport).not.toHaveBeenCalled();
 });

--- a/apps/desktop/src/components/core/AuthorDetailCard.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.tsx
@@ -1,11 +1,10 @@
-import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flag } from 'lucide-react';
 
 import { Card, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import type {
-  CommunityNodeManifest,
   CommunityNodeManifestFetch,
   SubmitCommunityNodeReportRequest,
   SubmitCommunityNodeReportResult,
@@ -16,9 +15,8 @@ import { planReportRouting } from '@/lib/api/reportRouting';
 import { AuthorAvatar } from './AuthorAvatar';
 import { RelationshipBadge } from './RelationshipBadge';
 import { ReportRoutingDialog, type ReportSubmitInput } from './ReportRoutingDialog';
+import { useReportManifests } from './useReportManifests';
 import { type AuthorDetailView } from './types';
-
-const EMPTY_COMMUNITY_NODE_MANIFESTS: Record<string, CommunityNodeManifest> = {};
 
 type AuthorDetailCardProps = {
   view: AuthorDetailView;
@@ -27,7 +25,6 @@ type AuthorDetailCardProps = {
   onToggleMute: (authorPubkey: string, muted: boolean) => void;
   onOpenDirectMessage?: (authorPubkey: string) => void;
   communityNodeAdvisory?: ReactNode;
-  communityNodeManifests?: Record<string, CommunityNodeManifest>;
   onSubmitReport?: (
     request: SubmitCommunityNodeReportRequest
   ) => Promise<SubmitCommunityNodeReportResult>;
@@ -42,7 +39,6 @@ export function AuthorDetailCard({
   onToggleMute,
   onOpenDirectMessage,
   communityNodeAdvisory,
-  communityNodeManifests = EMPTY_COMMUNITY_NODE_MANIFESTS,
   onSubmitReport,
   onCopyReportContact,
   onFetchReportManifest,
@@ -59,67 +55,24 @@ export function AuthorDetailCard({
   );
   const showMuteAction = Boolean(author && author.author_pubkey !== localAuthorPubkey);
   const [reportOpen, setReportOpen] = useState(false);
-  const [reportManifests, setReportManifests] = useState(communityNodeManifests);
-  const fetchedReportManifestUrls = useRef(new Set<string>());
-  const [reportResolving, setReportResolving] = useState(false);
-  const [reportResolveError, setReportResolveError] = useState<string | null>(null);
   const provenance = useMemo(
     () => contentProvenanceFromView(author?.provenance),
     [author?.provenance]
   );
+  // 通報画面を開いた時に取得成功した最新 manifest だけを候補源にする(#696)。
+  const {
+    manifests: reportManifests,
+    resolving: reportResolving,
+    resolveError: reportResolveError,
+  } = useReportManifests({
+    open: reportOpen,
+    provenance,
+    fetchManifest: onFetchReportManifest,
+  });
   const reportPlan = useMemo(
     () => planReportRouting(provenance, reportManifests),
     [provenance, reportManifests]
   );
-
-  useEffect(() => setReportManifests(communityNodeManifests), [communityNodeManifests]);
-  useEffect(() => {
-    if (!reportOpen) {
-      fetchedReportManifestUrls.current.clear();
-      setReportResolveError(null);
-    }
-  }, [reportOpen]);
-  useEffect(() => {
-    if (!reportOpen || !onFetchReportManifest || !provenance) return;
-    const baseUrls = [...new Set(provenance.observedVia.map((item) => item.nodeBaseUrl))]
-      .filter((baseUrl) => !fetchedReportManifestUrls.current.has(baseUrl));
-    if (baseUrls.length === 0) return;
-    baseUrls.forEach((baseUrl) => fetchedReportManifestUrls.current.add(baseUrl));
-    let active = true;
-    setReportResolving(true);
-    setReportResolveError(null);
-    Promise.all(
-      baseUrls.map(async (baseUrl) => ({
-        baseUrl,
-        response: await onFetchReportManifest(baseUrl),
-      }))
-    )
-      .then((responses) => {
-        if (!active) return;
-        setReportManifests((current) => {
-          let next = current;
-          for (const { baseUrl, response } of responses) {
-            if (response.status === 'ok' && response.manifest) {
-              if (next === current) next = { ...current };
-              next[baseUrl] = response.manifest;
-            }
-          }
-          return next;
-        });
-        if (responses.some(({ response }) => response.status !== 'ok' || !response.manifest)) {
-          setReportResolveError('community node manifest is unavailable');
-        }
-      })
-      .catch((cause) => {
-        if (active) setReportResolveError(cause instanceof Error ? cause.message : String(cause));
-      })
-      .finally(() => {
-        if (active) setReportResolving(false);
-      });
-    return () => {
-      active = false;
-    };
-  }, [onFetchReportManifest, provenance, reportOpen]);
 
   const submitReport = async (input: ReportSubmitInput) => {
     if (!author || !onSubmitReport) throw new Error('report submission is not available');

--- a/apps/desktop/src/components/core/CommunityNodeAdvisoryPanel.test.tsx
+++ b/apps/desktop/src/components/core/CommunityNodeAdvisoryPanel.test.tsx
@@ -71,6 +71,10 @@ function api(
 ) {
   let appealStatus: 'none' | 'disputed' | 'cleared' = initialAppealStatus;
   return {
+    fetchCommunityNodeManifest: vi.fn(async (baseUrl: string) => ({
+      status: 'ok' as const,
+      manifest: communityNodeManifests[baseUrl as keyof typeof communityNodeManifests] ?? null,
+    })),
     readCommunityNodeTrustUser: vi.fn(async () => ({
       viewer_pubkey: 'viewer',
       target_id: targetPubkey,
@@ -174,7 +178,6 @@ describe('CommunityNodeAdvisoryPanel', () => {
         api={client}
         targetPubkey={targetPubkey}
         nodeBaseUrls={['https://node.example']}
-        communityNodeManifests={communityNodeManifests}
       />
     );
 
@@ -197,7 +200,6 @@ describe('CommunityNodeAdvisoryPanel', () => {
         api={client}
         targetPubkey={targetPubkey}
         nodeBaseUrls={['https://node.example']}
-        communityNodeManifests={communityNodeManifests}
       />
     );
 
@@ -214,7 +216,6 @@ describe('CommunityNodeAdvisoryPanel', () => {
         api={client}
         targetPubkey={targetPubkey}
         nodeBaseUrls={['https://node.example']}
-        communityNodeManifests={communityNodeManifests}
       />
     );
 
@@ -225,7 +226,7 @@ describe('CommunityNodeAdvisoryPanel', () => {
     );
 
     expect(screen.queryByLabelText(/contact|連絡先/i)).not.toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button', { name: '異議を申し立てる' }));
+    await userEvent.click(await screen.findByRole('button', { name: '異議を申し立てる' }));
 
     expect(client.submitCommunityNodeReport).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -250,7 +251,6 @@ describe('CommunityNodeAdvisoryPanel', () => {
         api={client}
         targetPubkey={targetPubkey}
         nodeBaseUrls={['https://node.example']}
-        communityNodeManifests={communityNodeManifests}
       />
     );
 
@@ -259,7 +259,7 @@ describe('CommunityNodeAdvisoryPanel', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'このリスク判定に異議を申し立てる' })
     );
-    await userEvent.click(screen.getByRole('button', { name: '異議を申し立てる' }));
+    await userEvent.click(await screen.findByRole('button', { name: '異議を申し立てる' }));
 
     expect(client.submitCommunityNodeReport).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -277,7 +277,6 @@ describe('CommunityNodeAdvisoryPanel', () => {
         api={client}
         targetPubkey={targetPubkey}
         nodeBaseUrls={['https://node.example']}
-        communityNodeManifests={communityNodeManifests}
       />
     );
 
@@ -299,7 +298,6 @@ describe('CommunityNodeAdvisoryPanel', () => {
         api={client}
         targetPubkey={targetPubkey}
         nodeBaseUrls={[nodeA]}
-        communityNodeManifests={communityNodeManifests}
       />
     );
 
@@ -315,7 +313,6 @@ describe('CommunityNodeAdvisoryPanel', () => {
         api={client}
         targetPubkey={otherTargetPubkey}
         nodeBaseUrls={[nodeA]}
-        communityNodeManifests={communityNodeManifests}
       />
     );
 
@@ -330,7 +327,6 @@ describe('CommunityNodeAdvisoryPanel', () => {
         api={client}
         targetPubkey={targetPubkey}
         nodeBaseUrls={[nodeA, nodeB]}
-        communityNodeManifests={communityNodeManifests}
       />
     );
 
@@ -354,13 +350,13 @@ describe('CommunityNodeAdvisoryPanel', () => {
       readCommunityNodeRelationUser: vi.fn(() => pendingRelation.promise),
       listCommunityNodeRelationNeighbors: vi.fn(() => pendingNeighbors.promise),
       submitCommunityNodeReport: vi.fn(),
+      fetchCommunityNodeManifest: vi.fn(),
     };
     const { rerender } = render(
       <CommunityNodeAdvisoryPanel
         api={client}
         targetPubkey={targetPubkey}
         nodeBaseUrls={[nodeA]}
-        communityNodeManifests={communityNodeManifests}
       />
     );
 
@@ -370,7 +366,6 @@ describe('CommunityNodeAdvisoryPanel', () => {
         api={client}
         targetPubkey={otherTargetPubkey}
         nodeBaseUrls={[nodeA]}
-        communityNodeManifests={communityNodeManifests}
       />
     );
     pendingTrust.resolve(trustResponse(targetPubkey, 'stale-node-a'));
@@ -401,13 +396,13 @@ describe('CommunityNodeAdvisoryPanel', () => {
         .mockImplementationOnce(() => neighborsA.promise)
         .mockImplementationOnce(() => neighborsB.promise),
       submitCommunityNodeReport: vi.fn(),
+      fetchCommunityNodeManifest: vi.fn(),
     };
     const { rerender } = render(
       <CommunityNodeAdvisoryPanel
         api={client}
         targetPubkey={targetPubkey}
         nodeBaseUrls={[nodeA]}
-        communityNodeManifests={communityNodeManifests}
       />
     );
 
@@ -417,7 +412,6 @@ describe('CommunityNodeAdvisoryPanel', () => {
         api={client}
         targetPubkey={otherTargetPubkey}
         nodeBaseUrls={[nodeA]}
-        communityNodeManifests={communityNodeManifests}
       />
     );
     await userEvent.click(screen.getByRole('button', { name: /Load advisory|情報を読み込む/ }));
@@ -435,5 +429,96 @@ describe('CommunityNodeAdvisoryPanel', () => {
     expect(screen.queryByText(/stale-node-a/)).not.toBeInTheDocument();
     expect(screen.getByText(/current-node-b/)).toBeInTheDocument();
     expect(screen.getByText('e'.repeat(64))).toBeInTheDocument();
+  });
+  // #696: 異議申し立ては開いた時に選択中ノードの最新 manifest を取得し、その結果だけから受付先を決める。
+  test('fetches the selected node manifest when an appeal opens and blocks sending until it arrives', async () => {
+    const pending = deferred<{ status: 'ok'; manifest: (typeof communityNodeManifests)[typeof nodeA] }>();
+    const client = { ...api(), fetchCommunityNodeManifest: vi.fn(() => pending.promise) };
+    render(<CommunityNodeAdvisoryPanel api={client} targetPubkey={targetPubkey} nodeBaseUrls={[nodeA]} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Load advisory|情報を読み込む/ }));
+    await userEvent.click(await screen.findByText(/node-a/));
+    expect(client.fetchCommunityNodeManifest).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', { name: 'このリスク判定に異議を申し立てる' }));
+
+    await waitFor(() => expect(client.fetchCommunityNodeManifest).toHaveBeenCalledTimes(1));
+    expect(client.fetchCommunityNodeManifest).toHaveBeenCalledWith(nodeA);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '異議を申し立てる' })).not.toBeInTheDocument();
+    expect(client.submitCommunityNodeReport).not.toHaveBeenCalled();
+
+    pending.resolve({ status: 'ok', manifest: communityNodeManifests[nodeA] });
+    await userEvent.click(await screen.findByRole('button', { name: '異議を申し立てる' }));
+    expect(client.submitCommunityNodeReport).toHaveBeenCalledWith(
+      expect.objectContaining({ node_base_url: nodeA, appeal: { risk_signal_id: 'signal-1' } })
+    );
+  });
+
+  test('offers no appeal target when the latest manifest fetch fails', async () => {
+    const client = {
+      ...api(),
+      fetchCommunityNodeManifest: vi.fn(async () => ({ status: 'absent' as const, manifest: null })),
+    };
+    render(<CommunityNodeAdvisoryPanel api={client} targetPubkey={targetPubkey} nodeBaseUrls={[nodeA]} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Load advisory|情報を読み込む/ }));
+    await userEvent.click(await screen.findByText(/node-a/));
+    await userEvent.click(screen.getByRole('button', { name: 'このリスク判定に異議を申し立てる' }));
+
+    await waitFor(() => expect(client.fetchCommunityNodeManifest).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/Could not refresh report targets/)).toBeInTheDocument();
+    expect(screen.getByText('発行元の送信先を確認できません')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '異議を申し立てる' })).not.toBeInTheDocument();
+    expect(client.submitCommunityNodeReport).not.toHaveBeenCalled();
+  });
+
+  test('offers no appeal target when the fetched manifest belongs to a different issuer', async () => {
+    const client = {
+      ...api(),
+      fetchCommunityNodeManifest: vi.fn(async () => ({
+        status: 'ok' as const,
+        manifest: communityNodeManifests[nodeB],
+      })),
+    };
+    render(<CommunityNodeAdvisoryPanel api={client} targetPubkey={targetPubkey} nodeBaseUrls={[nodeA]} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Load advisory|情報を読み込む/ }));
+    await userEvent.click(await screen.findByText(/node-a/));
+    await userEvent.click(screen.getByRole('button', { name: 'このリスク判定に異議を申し立てる' }));
+
+    await waitFor(() => expect(client.fetchCommunityNodeManifest).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: '異議を申し立てる' })).not.toBeInTheDocument()
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(client.submitCommunityNodeReport).not.toHaveBeenCalled();
+  });
+
+  test('ignores a manifest response that arrives after the appeal was closed and reopened', async () => {
+    const first = deferred<{ status: 'ok'; manifest: (typeof communityNodeManifests)[typeof nodeA] }>();
+    const second = deferred<{ status: 'ok'; manifest: (typeof communityNodeManifests)[typeof nodeA] }>();
+    const client = {
+      ...api(),
+      fetchCommunityNodeManifest: vi
+        .fn()
+        .mockReturnValueOnce(first.promise)
+        .mockReturnValueOnce(second.promise),
+    };
+    render(<CommunityNodeAdvisoryPanel api={client} targetPubkey={targetPubkey} nodeBaseUrls={[nodeA]} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Load advisory|情報を読み込む/ }));
+    await userEvent.click(await screen.findByText(/node-a/));
+    await userEvent.click(screen.getByRole('button', { name: 'このリスク判定に異議を申し立てる' }));
+    await waitFor(() => expect(client.fetchCommunityNodeManifest).toHaveBeenCalledTimes(1));
+    await userEvent.click(screen.getByRole('button', { name: /キャンセル|Cancel/ }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'このリスク判定に異議を申し立てる' }));
+    await waitFor(() => expect(client.fetchCommunityNodeManifest).toHaveBeenCalledTimes(2));
+    first.resolve({ status: 'ok', manifest: communityNodeManifests[nodeA] });
+    await new Promise((done) => setTimeout(done, 0));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '異議を申し立てる' })).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/components/core/CommunityNodeAdvisoryPanel.tsx
+++ b/apps/desktop/src/components/core/CommunityNodeAdvisoryPanel.tsx
@@ -96,22 +96,25 @@ export type CommunityNodeAdvisoryPanelProps = {
     | 'readCommunityNodeRelationUser'
     | 'listCommunityNodeRelationNeighbors'
     | 'submitCommunityNodeReport'
+    | 'fetchCommunityNodeManifest'
   >;
   targetPubkey: string;
   nodeBaseUrls: string[];
-  communityNodeManifests: Readonly<Record<string, CommunityNodeManifest>>;
 };
 
 export function CommunityNodeAdvisoryPanel({
   api,
   targetPubkey,
   nodeBaseUrls,
-  communityNodeManifests,
 }: CommunityNodeAdvisoryPanelProps) {
   const { t } = useTranslation(['profile', 'common']);
   const [baseUrl, setBaseUrl] = useState(nodeBaseUrls[0] ?? '');
   const [advisoryState, setAdvisoryState] = useState<AdvisoryState>(IDLE_ADVISORY_STATE);
   const [appealSelection, setAppealSelection] = useState<AppealSelection | null>(null);
+  // 異議申し立てを開いた時に取得した発行元ノードの最新 manifest(#696)。
+  const [appealManifest, setAppealManifest] = useState<CommunityNodeManifest | null>(null);
+  const [appealResolving, setAppealResolving] = useState(false);
+  const [appealResolveError, setAppealResolveError] = useState<string | null>(null);
   const requestGeneration = useRef(0);
 
   const selectedBaseUrl = nodeBaseUrls.includes(baseUrl) ? baseUrl : (nodeBaseUrls[0] ?? '');
@@ -135,12 +138,50 @@ export function CommunityNodeAdvisoryPanel({
     setAppealSelection(null);
   }, []);
 
+  // 異議申し立ての受付先は、信頼評価を取得した選択中ノードから開いた時に取得した
+  // 最新 manifest だけから決める。取得中・失敗・発行元不一致では候補を作らない(#696)。
+  const appealFetchKey = activeAppealSelection
+    ? `${activeAppealSelection.context.key}\u0000${activeAppealSelection.basis.signal_id}`
+    : null;
+  const appealBaseUrl = activeAppealSelection?.context.baseUrl ?? null;
+  useEffect(() => {
+    setAppealManifest(null);
+    setAppealResolveError(null);
+    if (!appealFetchKey || !appealBaseUrl) {
+      setAppealResolving(false);
+      return;
+    }
+    let active = true;
+    setAppealResolving(true);
+    api
+      .fetchCommunityNodeManifest(appealBaseUrl)
+      .then((response) => {
+        if (!active) return;
+        if (response.status === 'ok' && response.manifest) {
+          setAppealManifest(response.manifest);
+        } else {
+          setAppealResolveError('community node manifest is unavailable');
+        }
+      })
+      .catch((cause) => {
+        if (active) setAppealResolveError(cause instanceof Error ? cause.message : String(cause));
+      })
+      .finally(() => {
+        if (active) setAppealResolving(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [api, appealBaseUrl, appealFetchKey]);
   const appealPlan = useMemo(
     () =>
-      appealBasis
-        ? planAppealReportRouting(appealBasis.issuer_node_id, communityNodeManifests)
+      appealBasis && appealBaseUrl
+        ? planAppealReportRouting(
+            appealBasis.issuer_node_id,
+            appealManifest ? { [appealBaseUrl]: appealManifest } : {},
+          )
         : null,
-    [appealBasis, communityNodeManifests],
+    [appealBasis, appealBaseUrl, appealManifest],
   );
 
   useEffect(() => {
@@ -386,6 +427,8 @@ export function CommunityNodeAdvisoryPanel({
             issuerNodeId: appealBasis.issuer_node_id,
           }}
           onSubmit={submitAppeal}
+          resolving={appealResolving}
+          resolveError={appealResolveError}
           onSubmitted={async () => {
             await loadAdvisory({ preserveAppeal: true });
           }}

--- a/apps/desktop/src/components/core/PostCard.test.tsx
+++ b/apps/desktop/src/components/core/PostCard.test.tsx
@@ -752,3 +752,170 @@ test('attachment report resolves the selected blob provenance instead of the pos
     })
   );
 });
+
+// #696: 通報先は開いた時に取得成功した最新 manifest だけから作る。
+function reportManifest(nodeId: string, overrides: Partial<CommunityNodeManifest> = {}): CommunityNodeManifest {
+  return {
+    node_id: nodeId,
+    node_name: nodeId,
+    node_role: 'community-node',
+    server_name: nodeId,
+    manifest_version: 'v1',
+    capability_scope: { available_enabled: ['community_index'], planned_enabled: [] },
+    authority_scope: { applies_to: ['this_node'], does_not_apply_to: [] },
+    p2p_boundary: {
+      identity_authority: false,
+      profile_canonical_store: false,
+      social_graph_canonical_store: false,
+      content_truth_source: false,
+      network_wide_authority: false,
+    },
+    abuse_contact: 'abuse@node.example',
+    report_endpoint: `https://${nodeId}/v1/report`,
+    terms_url: '',
+    privacy_url: '',
+    moderation_policy_url: '',
+    ...overrides,
+  };
+}
+
+function observedView() {
+  return createView({
+    provenance: {
+      canonicalSource: 'author_docs',
+      observedVia: [{ nodeBaseUrl: 'https://node.example', capability: 'community_index' }],
+      responsibleReportTargets: [],
+    },
+  });
+}
+
+const OBSERVED_UNRESOLVED_TITLE = 'No reachable report target';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+test('report dialog offers no target and no send action while the latest manifest is resolving', async () => {
+  const user = userEvent.setup();
+  const pending = deferred<{ status: 'ok'; manifest: CommunityNodeManifest }>();
+  const onFetchReportManifest = vi.fn().mockReturnValue(pending.promise);
+  const onSubmitReport = vi.fn();
+
+  render(
+    <PostCard
+      view={observedView()}
+      onOpenAuthor={() => undefined}
+      onOpenThread={() => undefined}
+      onReply={() => undefined}
+      onSubmitReport={onSubmitReport}
+      onFetchReportManifest={onFetchReportManifest}
+    />
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+  await waitFor(() => expect(onFetchReportManifest).toHaveBeenCalledTimes(1));
+  expect(screen.getByText('Checking the latest report targets…')).toBeInTheDocument();
+  expect(screen.queryByText('node.example')).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Send report' })).not.toBeInTheDocument();
+
+  pending.resolve({ status: 'ok', manifest: reportManifest('node.example') });
+  expect(await screen.findByText('node.example')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Send report' })).toBeEnabled();
+  expect(onSubmitReport).not.toHaveBeenCalled();
+});
+
+test('a failed latest manifest fetch does not fall back to a target fetched by a previous open', async () => {
+  const user = userEvent.setup();
+  const onFetchReportManifest = vi
+    .fn()
+    .mockResolvedValueOnce({ status: 'ok', manifest: reportManifest('node.example') })
+    .mockResolvedValueOnce({ status: 'absent', manifest: null });
+  const onSubmitReport = vi.fn();
+
+  render(
+    <PostCard
+      view={observedView()}
+      onOpenAuthor={() => undefined}
+      onOpenThread={() => undefined}
+      onReply={() => undefined}
+      onSubmitReport={onSubmitReport}
+      onFetchReportManifest={onFetchReportManifest}
+    />
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+  expect(await screen.findByText('node.example')).toBeInTheDocument();
+  await user.click(screen.getByRole('button', { name: 'Cancel' }));
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+  await waitFor(() => expect(onFetchReportManifest).toHaveBeenCalledTimes(2));
+  expect(await screen.findByText(/Could not refresh report targets/)).toBeInTheDocument();
+  expect(screen.queryByText('node.example')).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Send report' })).not.toBeInTheDocument();
+  expect(onSubmitReport).not.toHaveBeenCalled();
+});
+
+test('a node that withdrew its report endpoint and contact is not offered as a target', async () => {
+  const user = userEvent.setup();
+  const onFetchReportManifest = vi.fn().mockResolvedValue({
+    status: 'ok',
+    manifest: reportManifest('node.example', { report_endpoint: '', abuse_contact: '' }),
+  });
+
+  render(
+    <PostCard
+      view={observedView()}
+      onOpenAuthor={() => undefined}
+      onOpenThread={() => undefined}
+      onReply={() => undefined}
+      onSubmitReport={vi.fn()}
+      onFetchReportManifest={onFetchReportManifest}
+    />
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+  await waitFor(() => expect(onFetchReportManifest).toHaveBeenCalledTimes(1));
+  expect(await screen.findByText(OBSERVED_UNRESOLVED_TITLE)).toBeInTheDocument();
+  expect(screen.queryByText('node.example')).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Send report' })).not.toBeInTheDocument();
+});
+
+test('a manifest response that arrives after the dialog was closed does not seed the next open', async () => {
+  const user = userEvent.setup();
+  const first = deferred<{ status: 'ok'; manifest: CommunityNodeManifest }>();
+  const second = deferred<{ status: 'ok'; manifest: CommunityNodeManifest }>();
+  const onFetchReportManifest = vi
+    .fn()
+    .mockReturnValueOnce(first.promise)
+    .mockReturnValueOnce(second.promise);
+
+  render(
+    <PostCard
+      view={observedView()}
+      onOpenAuthor={() => undefined}
+      onOpenThread={() => undefined}
+      onReply={() => undefined}
+      onSubmitReport={vi.fn()}
+      onFetchReportManifest={onFetchReportManifest}
+    />
+  );
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+  await waitFor(() => expect(onFetchReportManifest).toHaveBeenCalledTimes(1));
+  await user.click(screen.getByRole('button', { name: 'Cancel' }));
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+  await user.click(screen.getByRole('button', { name: 'Report' }));
+  await waitFor(() => expect(onFetchReportManifest).toHaveBeenCalledTimes(2));
+  first.resolve({ status: 'ok', manifest: reportManifest('node.example') });
+  await new Promise((r) => setTimeout(r, 0));
+
+  expect(screen.getByText('Checking the latest report targets…')).toBeInTheDocument();
+  expect(screen.queryByText('node.example')).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Send report' })).not.toBeInTheDocument();
+});

--- a/apps/desktop/src/components/core/PostCard.tsx
+++ b/apps/desktop/src/components/core/PostCard.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Bookmark, Flag, Link2, Reply, Repeat2 } from 'lucide-react';
 
 import { formatLocalizedTime } from '@/i18n/format';
 import type {
   BookmarkedCustomReactionView,
-  CommunityNodeManifest,
   CommunityNodeManifestFetch,
   ContentProvenance,
   CustomReactionAssetView,
@@ -16,6 +15,7 @@ import type {
   SubmitCommunityNodeReportResult,
 } from '@/lib/api';
 import { planReportRouting } from '@/lib/api/reportRouting';
+import { useReportManifests } from './useReportManifests';
 import { copyTextToClipboard } from '@/lib/utils';
 import {
   buildPostLink,
@@ -39,8 +39,6 @@ import type { ReportRoutingSubject } from './ReportRoutingDialog';
 import { RelationshipBadge } from './RelationshipBadge';
 import { SmartReferenceText } from './SmartReferenceText';
 import { type PostCardView } from './types';
-
-const EMPTY_COMMUNITY_NODE_MANIFESTS: Record<string, CommunityNodeManifest> = {};
 
 function sourceAuthorLabel(view: PostCardView['post']['repost_of']): string | null {
   if (!view) {
@@ -79,15 +77,13 @@ type PostCardProps = {
   onActivateReference?: (reference: InternalSmartReference) => void;
   onCopyLink?: (link: string) => void;
   isFocused?: boolean;
-  // 分散通報ルーティング（#310）。取得済み community node manifest（ok のみ）。
-  // 通報先は post の provenance（観測経路）と突き合わせて解決する。
-  communityNodeManifests?: Record<string, CommunityNodeManifest>;
   // 解決済みの通報先 node へ通報を送信する。未指定なら通報導線を表示しない。
   onSubmitReport?: (
     request: SubmitCommunityNodeReportRequest
   ) => Promise<SubmitCommunityNodeReportResult>;
   // abuse contact（endpoint 無し node）の案内用コピー。
   onCopyReportContact?: (value: string) => void;
+  // 通報画面を開いた時に観測元ノードの最新 manifest を取得する。未指定なら候補は作らない(#696)。
   onFetchReportManifest?: (baseUrl: string) => Promise<CommunityNodeManifestFetch>;
   onMuteReportAuthor?: (authorPubkey: string) => Promise<void> | void;
 };
@@ -128,7 +124,6 @@ export function PostCard({
   onActivateReference,
   onCopyLink,
   isFocused = false,
-  communityNodeManifests = EMPTY_COMMUNITY_NODE_MANIFESTS,
   onSubmitReport,
   onCopyReportContact,
   onFetchReportManifest,
@@ -146,10 +141,6 @@ export function PostCard({
   const [reportProvenance, setReportProvenance] = useState<ContentProvenance | undefined>(
     view.provenance
   );
-  const [reportManifests, setReportManifests] = useState(communityNodeManifests);
-  const fetchedReportManifestUrls = useRef(new Set<string>());
-  const [reportResolving, setReportResolving] = useState(false);
-  const [reportResolveError, setReportResolveError] = useState<string | null>(null);
   const [mediaViewerOpen, setMediaViewerOpen] = useState(false);
   const [mediaViewerIndex, setMediaViewerIndex] = useState(view.media.currentImageIndex ?? 0);
   const [reactionMenuPosition, setReactionMenuPosition] = useState<ContextActionMenuPosition | null>(
@@ -211,70 +202,23 @@ export function PostCard({
     onOpenThread(view.threadTargetId);
   };
 
-  // 通報先は現在選択中の対象の provenance（観測経路）と取得済み manifest から解決する。
-  // provenance 不明 / 通報先未解決でも dialog は開き、local action のみ案内する。
+  // 通報先は現在選択中の対象の provenance（観測経路）と、通報画面を開いた時に取得成功した
+  // 最新 manifest だけから解決する(#696)。provenance 不明 / 通報先未解決でも dialog は開き、
+  // local action のみ案内する。
+  const {
+    manifests: reportManifests,
+    resolving: reportResolving,
+    resolveError: reportResolveError,
+  } = useReportManifests({
+    open: reportDialogOpen,
+    provenance: reportProvenance,
+    fetchManifest: onFetchReportManifest,
+  });
   const reportPlan = useMemo(
     () => planReportRouting(reportProvenance, reportManifests),
     [reportProvenance, reportManifests]
   );
   const showReportAction = Boolean(onSubmitReport);
-
-  useEffect(() => {
-    setReportManifests(communityNodeManifests);
-  }, [communityNodeManifests]);
-
-  useEffect(() => {
-    if (!reportDialogOpen) {
-      fetchedReportManifestUrls.current.clear();
-      setReportResolveError(null);
-    }
-  }, [reportDialogOpen]);
-
-  useEffect(() => {
-    if (!reportDialogOpen || !onFetchReportManifest || !reportProvenance) {
-      return;
-    }
-    const baseUrls = [...new Set(reportProvenance.observedVia.map((item) => item.nodeBaseUrl))]
-      .filter((baseUrl) => !fetchedReportManifestUrls.current.has(baseUrl));
-    if (baseUrls.length === 0) {
-      return;
-    }
-    baseUrls.forEach((baseUrl) => fetchedReportManifestUrls.current.add(baseUrl));
-    let active = true;
-    setReportResolving(true);
-    setReportResolveError(null);
-    Promise.all(
-      baseUrls.map(async (baseUrl) => ({
-        baseUrl,
-        response: await onFetchReportManifest(baseUrl),
-      }))
-    )
-      .then((responses) => {
-        if (!active) return;
-        setReportManifests((current) => {
-          let next = current;
-          for (const { baseUrl, response } of responses) {
-            if (response.status === 'ok' && response.manifest) {
-              if (next === current) next = { ...current };
-              next[baseUrl] = response.manifest;
-            }
-          }
-          return next;
-        });
-        if (responses.some(({ response }) => response.status !== 'ok' || !response.manifest)) {
-          setReportResolveError('community node manifest is unavailable');
-        }
-      })
-      .catch((cause) => {
-        if (active) setReportResolveError(cause instanceof Error ? cause.message : String(cause));
-      })
-      .finally(() => {
-        if (active) setReportResolving(false);
-      });
-    return () => {
-      active = false;
-    };
-  }, [onFetchReportManifest, reportDialogOpen, reportProvenance]);
 
   const handleSubmitReport = async (
     input: ReportSubmitInput

--- a/apps/desktop/src/components/core/ReportRoutingDialog.test.tsx
+++ b/apps/desktop/src/components/core/ReportRoutingDialog.test.tsx
@@ -158,3 +158,91 @@ test('shows a stable Japanese message for an invalid appeal', async () => {
   ).toBeInTheDocument();
   expect(screen.queryByText('unknown')).not.toBeInTheDocument();
 });
+
+// #696: 最新 manifest の取得中は送信も連絡先の複写もしない。
+test('disables sending and contact copy while the latest report targets are resolving', () => {
+  const onSubmit = vi.fn();
+  const onCopyContact = vi.fn();
+  const contactPlan: ReportRoutingPlan = {
+    ...endpointPlan,
+    candidates: [
+      {
+        target: { ...endpointPlan.candidates[0].target, reportEndpoint: undefined },
+        contact: { kind: 'contact', value: 'abuse@index.example' },
+      },
+    ],
+  };
+  const { rerender } = render(
+    <ReportRoutingDialog
+      open
+      onOpenChange={vi.fn()}
+      subject={subject}
+      plan={endpointPlan}
+      onSubmit={onSubmit}
+      resolving
+    />,
+  );
+  expect(screen.getByText(/Checking the latest report targets/)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Send report' })).toBeDisabled();
+  fireEvent.click(screen.getByRole('button', { name: 'Send report' }));
+  expect(onSubmit).not.toHaveBeenCalled();
+
+  rerender(
+    <ReportRoutingDialog
+      open
+      onOpenChange={vi.fn()}
+      subject={subject}
+      plan={contactPlan}
+      onSubmit={onSubmit}
+      onCopyContact={onCopyContact}
+      resolving
+    />,
+  );
+  const copyButton = screen.getByRole('button', { name: 'Send report' });
+  expect(copyButton).toHaveTextContent('Copy abuse contact');
+  expect(copyButton).toBeDisabled();
+  fireEvent.click(copyButton);
+  expect(onCopyContact).not.toHaveBeenCalled();
+});
+
+// #696: 候補が後から届いても、入力途中の詳細と選択候補は保たれる。
+test('keeps typed details and the selected candidate when the candidate list is refreshed', () => {
+  const { rerender } = render(
+    <ReportRoutingDialog
+      open
+      onOpenChange={vi.fn()}
+      subject={subject}
+      plan={endpointPlan}
+      onSubmit={vi.fn()}
+    />,
+  );
+  const details = screen.getByPlaceholderText(/Describe the problem/);
+  fireEvent.change(details, { target: { value: 'typed while refreshing' } });
+
+  const refreshedPlan: ReportRoutingPlan = {
+    ...endpointPlan,
+    candidates: [
+      {
+        target: {
+          nodeBaseUrl: 'https://media.example',
+          capability: 'media_cache',
+          reportEndpoint: 'https://media.example/v1/report',
+          authorityScope: ['this_node'],
+        },
+        contact: { kind: 'endpoint', value: 'https://media.example/v1/report' },
+      },
+      { ...endpointPlan.candidates[0] },
+    ],
+  };
+  rerender(
+    <ReportRoutingDialog
+      open
+      onOpenChange={vi.fn()}
+      subject={subject}
+      plan={refreshedPlan}
+      onSubmit={vi.fn()}
+    />,
+  );
+  expect(screen.getByDisplayValue('typed while refreshing')).toBeInTheDocument();
+  expect(screen.getByRole('radio', { name: /index\.example/ })).toBeChecked();
+});

--- a/apps/desktop/src/components/core/ReportRoutingDialog.tsx
+++ b/apps/desktop/src/components/core/ReportRoutingDialog.tsx
@@ -104,10 +104,10 @@ export function ReportRoutingDialog({
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<SubmitCommunityNodeReportResult | null>(null);
 
-  // ダイアログを開くたびに入力状態を初期化する。
+  // ダイアログを開くたびに入力状態を初期化する。候補は取得完了後に届くため、
+  // 候補の変化では入力を消さず、選択候補だけを追随させる(#696)。
   useEffect(() => {
     if (open) {
-      setSelectedKey(candidates.length > 0 ? candidateKey(candidates[0]) : null);
       setReason(isAppeal ? 'other' : 'spam');
       setDetails('');
       setReporterContact('');
@@ -115,7 +115,18 @@ export function ReportRoutingDialog({
       setError(null);
       setResult(null);
     }
-  }, [open, candidates, appealRiskSignalId, isAppeal]);
+  }, [open, appealRiskSignalId, isAppeal]);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedKey((current) =>
+      current && candidates.some((candidate) => candidateKey(candidate) === current)
+        ? current
+        : candidates.length > 0
+          ? candidateKey(candidates[0])
+          : null,
+    );
+  }, [open, candidates]);
 
   const selectedCandidate = useMemo(
     () => candidates.find((candidate) => candidateKey(candidate) === selectedKey) ?? null,
@@ -125,7 +136,8 @@ export function ReportRoutingDialog({
   const isCriticalSafety = isCriticalSafetyReason(reason);
 
   const handleSubmit = async () => {
-    if (!selectedCandidate) {
+    // 最新の manifest を取得し終えるまで、古い候補への送信も連絡先の複写もしない(#696)。
+    if (!selectedCandidate || resolving) {
       return;
     }
     const contact = selectedCandidate.contact;
@@ -393,7 +405,7 @@ export function ReportRoutingDialog({
           {!result && canRoute && selectedCandidate ? (
             <Button
               type='button'
-              disabled={submitting}
+              disabled={submitting || resolving}
               onClick={handleSubmit}
               aria-label={
                 appeal ? t('profile:communityNodeAdvisory.appeal.submit') : t('report.submit')

--- a/apps/desktop/src/components/core/ThreadPanel.tsx
+++ b/apps/desktop/src/components/core/ThreadPanel.tsx
@@ -1,6 +1,5 @@
 import type {
   BookmarkedCustomReactionView,
-  CommunityNodeManifest,
   CommunityNodeManifestFetch,
   CustomReactionAssetView,
   ReactionKeyInput,
@@ -38,7 +37,6 @@ type ThreadPanelProps = {
   hasMore?: boolean;
   loadingMore?: boolean;
   onLoadMore?: () => void;
-  communityNodeManifests?: Record<string, CommunityNodeManifest>;
   onSubmitReport?: (
     request: SubmitCommunityNodeReportRequest
   ) => Promise<SubmitCommunityNodeReportResult>;
@@ -72,7 +70,6 @@ export function ThreadPanel({
   hasMore = false,
   loadingMore = false,
   onLoadMore,
-  communityNodeManifests,
   onSubmitReport,
   onCopyReportContact,
   onFetchReportManifest,
@@ -105,7 +102,6 @@ export function ThreadPanel({
         hasMore={hasMore}
         loadingMore={loadingMore}
         onLoadMore={onLoadMore}
-        communityNodeManifests={communityNodeManifests}
         onSubmitReport={onSubmitReport}
         onCopyReportContact={onCopyReportContact}
         onFetchReportManifest={onFetchReportManifest}

--- a/apps/desktop/src/components/core/ThreadTree.tsx
+++ b/apps/desktop/src/components/core/ThreadTree.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 
 import type {
   BookmarkedCustomReactionView,
-  CommunityNodeManifest,
   CommunityNodeManifestFetch,
   CustomReactionAssetView,
   ReactionKeyInput,
@@ -46,7 +45,6 @@ type ThreadTreeProps = {
   hasMore?: boolean;
   loadingMore?: boolean;
   onLoadMore?: () => void;
-  communityNodeManifests?: Record<string, CommunityNodeManifest>;
   onSubmitReport?: (
     request: SubmitCommunityNodeReportRequest
   ) => Promise<SubmitCommunityNodeReportResult>;
@@ -80,7 +78,6 @@ export function ThreadTree({
   hasMore = false,
   loadingMore = false,
   onLoadMore,
-  communityNodeManifests,
   onSubmitReport,
   onCopyReportContact,
   onFetchReportManifest,
@@ -140,7 +137,6 @@ export function ThreadTree({
               onActivateReference={onActivateReference}
               onCopyLink={onCopyPostLink}
               isFocused={focusedPostObjectId === view.post.object_id}
-              communityNodeManifests={communityNodeManifests}
               onSubmitReport={onSubmitReport}
               onCopyReportContact={onCopyReportContact}
               onFetchReportManifest={onFetchReportManifest}

--- a/apps/desktop/src/components/core/TimelineFeed.tsx
+++ b/apps/desktop/src/components/core/TimelineFeed.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 
 import type {
   BookmarkedCustomReactionView,
-  CommunityNodeManifest,
   CommunityNodeManifestFetch,
   CustomReactionAssetView,
   ReactionKeyInput,
@@ -55,7 +54,6 @@ type TimelineFeedProps = {
   pendingCount?: number;
   onApplyPending?: () => void;
   // 分散通報ルーティング（#310）。取得済み community node manifest（ok のみ）と送信導線。
-  communityNodeManifests?: Record<string, CommunityNodeManifest>;
   onSubmitReport?: (
     request: SubmitCommunityNodeReportRequest
   ) => Promise<SubmitCommunityNodeReportResult>;
@@ -98,7 +96,6 @@ export function TimelineFeed({
   onLoadMore,
   pendingCount = 0,
   onApplyPending,
-  communityNodeManifests,
   onSubmitReport,
   onCopyReportContact,
   onFetchReportManifest,
@@ -208,7 +205,6 @@ export function TimelineFeed({
             onActivateReference={onActivateReference}
             onCopyLink={onCopyPostLink}
             isFocused={focusedPostObjectId === view.post.object_id}
-            communityNodeManifests={communityNodeManifests}
             onSubmitReport={onSubmitReport}
             onCopyReportContact={onCopyReportContact}
             onFetchReportManifest={onFetchReportManifest}

--- a/apps/desktop/src/components/core/useReportManifests.ts
+++ b/apps/desktop/src/components/core/useReportManifests.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type {
+  CommunityNodeManifest,
+  CommunityNodeManifestFetch,
+  ContentProvenance,
+} from '@/lib/api';
+
+const EMPTY_MANIFESTS: Readonly<Record<string, CommunityNodeManifest>> = {};
+
+export type ReportManifestsState = {
+  /// 今回の通報画面で取得に成功したノード情報だけ。開くたびに空へ戻る。
+  manifests: Readonly<Record<string, CommunityNodeManifest>>;
+  resolving: boolean;
+  resolveError: string | null;
+};
+
+/// 通報画面を開くたびに、観測元の基底アドレスから最新の `CommunityNodeManifest` を取得し、
+/// 当該オープンで取得に成功した情報だけを候補源として返す(#666 / #696)。
+///
+/// - 設定画面などで以前取得した store 由来のノード情報は候補源にしない
+/// - 取得失敗・情報なしのノードは候補源に入らない(古い候補へ後退しない)
+/// - 閉じた後、または対象・観測元が変わった後に届いた応答は捨てる
+export function useReportManifests(input: {
+  open: boolean;
+  provenance: ContentProvenance | undefined;
+  fetchManifest?: (baseUrl: string) => Promise<CommunityNodeManifestFetch>;
+}): ReportManifestsState {
+  const { open, provenance, fetchManifest } = input;
+  const [manifests, setManifests] = useState(EMPTY_MANIFESTS);
+  const [resolving, setResolving] = useState(false);
+  const [resolveError, setResolveError] = useState<string | null>(null);
+  // 呼び出し側が毎描画で新しい関数を渡しても再取得を起こさないよう、参照だけを更新する。
+  const fetchManifestRef = useRef(fetchManifest);
+  useEffect(() => {
+    fetchManifestRef.current = fetchManifest;
+  });
+
+  useEffect(() => {
+    const fetchManifest = fetchManifestRef.current;
+    setManifests(EMPTY_MANIFESTS);
+    setResolveError(null);
+    if (!open || !fetchManifest || !provenance) {
+      setResolving(false);
+      return;
+    }
+    const baseUrls = [...new Set(provenance.observedVia.map((item) => item.nodeBaseUrl))];
+    if (baseUrls.length === 0) {
+      setResolving(false);
+      return;
+    }
+    let active = true;
+    setResolving(true);
+    Promise.all(
+      baseUrls.map(async (baseUrl) => ({ baseUrl, response: await fetchManifest(baseUrl) }))
+    )
+      .then((responses) => {
+        if (!active) return;
+        const next: Record<string, CommunityNodeManifest> = {};
+        let failed = false;
+        for (const { baseUrl, response } of responses) {
+          if (response.status === 'ok' && response.manifest) {
+            next[baseUrl] = response.manifest;
+          } else {
+            failed = true;
+          }
+        }
+        setManifests(next);
+        if (failed) setResolveError('community node manifest is unavailable');
+      })
+      .catch((cause) => {
+        if (active) setResolveError(cause instanceof Error ? cause.message : String(cause));
+      })
+      .finally(() => {
+        if (active) setResolving(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [open, provenance]);
+
+  return { manifests, resolving, resolveError };
+}

--- a/apps/desktop/src/shell/page/DesktopShellAuxiliaryPanels.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellAuxiliaryPanels.tsx
@@ -632,7 +632,6 @@ export function DesktopShellDetailPaneStack({
     activeTopic,
     bookmarkedReactionAssets,
     communityNodeConfig,
-    communityNodeManifests,
     focusedObjectId,
     mediaObjectUrls,
     ownedReactionAssets,
@@ -648,7 +647,6 @@ export function DesktopShellDetailPaneStack({
       activeTopic: s.activeTopic,
       bookmarkedReactionAssets: s.bookmarkedReactionAssets,
       communityNodeConfig: s.communityNodeConfig,
-      communityNodeManifests: s.communityNodeManifests,
       focusedObjectId: s.focusedObjectId,
       mediaObjectUrls: s.mediaObjectUrls,
       ownedReactionAssets: s.ownedReactionAssets,
@@ -665,13 +663,6 @@ export function DesktopShellDetailPaneStack({
   const selectedThreadLoadingMore = selectedThread
     ? (threadLoadingMoreById[selectedThread] ?? false)
     : false;
-  const reportableManifests = useMemo(() => {
-    const manifests: Record<string, import('@/lib/api').CommunityNodeManifest> = {};
-    for (const [baseUrl, entry] of Object.entries(communityNodeManifests)) {
-      if (entry.status === 'ok') manifests[baseUrl] = entry.manifest;
-    }
-    return manifests;
-  }, [communityNodeManifests]);
   const fetchReportManifest = (baseUrl: string) =>
     api.fetchCommunityNodeManifest(baseUrl);
   const submitReport = (request: import('@/lib/api').SubmitCommunityNodeReportRequest) =>
@@ -718,7 +709,6 @@ export function DesktopShellDetailPaneStack({
             onActivateReference={(reference) => void handleActivateReference(reference)}
             onCopyPostLink={handleCopyPostLink}
             focusedPostObjectId={focusedObjectId}
-            communityNodeManifests={reportableManifests}
             onSubmitReport={submitReport}
             onCopyReportContact={(value) => void copyTextToClipboard(value)}
             onFetchReportManifest={fetchReportManifest}
@@ -748,7 +738,6 @@ export function DesktopShellDetailPaneStack({
               }
               onToggleMute={(authorPubkey, muted) => void handleMuteAction(authorPubkey, muted)}
               onOpenDirectMessage={(authorPubkey) => void openDirectMessagePane(authorPubkey)}
-              communityNodeManifests={reportableManifests}
               onSubmitReport={submitReport}
               onCopyReportContact={(value) => void copyTextToClipboard(value)}
               onFetchReportManifest={fetchReportManifest}
@@ -757,7 +746,6 @@ export function DesktopShellDetailPaneStack({
                   api={api}
                   targetPubkey={selectedAuthorPubkey}
                   nodeBaseUrls={communityNodeConfig.nodes.map((node) => node.base_url)}
-                  communityNodeManifests={reportableManifests}
                 />
               }
             />
@@ -773,7 +761,6 @@ export function DesktopShellDetailPaneStack({
                 onOpenOriginalTopic={(topicId) => void handleOpenOriginalTopic(topicId)}
                 onActivateReference={(reference) => void handleActivateReference(reference)}
                 onCopyPostLink={handleCopyPostLink}
-                communityNodeManifests={reportableManifests}
                 onSubmitReport={submitReport}
                 onCopyReportContact={(value) => void copyTextToClipboard(value)}
                 onFetchReportManifest={fetchReportManifest}

--- a/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
@@ -25,10 +25,7 @@ import type { SupportedLocale } from '@/i18n';
 import { buildLiveLink, type InternalSmartReference } from '@/lib/internalLinks';
 import { copyTextToClipboard } from '@/lib/utils';
 import { eligibleCommunityIndexNodes } from '@/lib/api/communityIndex';
-import type {
-  CommunityNodeManifest,
-  SubmitCommunityNodeReportRequest,
-} from '@/lib/api';
+import type { SubmitCommunityNodeReportRequest } from '@/lib/api';
 import {
   timelineScopeStorageKey,
   type GameEditorDraft,
@@ -231,17 +228,6 @@ export function DesktopShellPrimaryWorkspace({
     () => new Set(bookmarkedPosts.map((item) => item.post.object_id)),
     [bookmarkedPosts]
   );
-  // 分散通報ルーティング（#310）。取得済み（ok）の manifest だけを base_url で引けるようにする。
-  // 通報先は post の provenance（観測経路）と突き合わせて解決する。
-  const reportableManifests = useMemo(() => {
-    const out: Record<string, CommunityNodeManifest> = {};
-    for (const [baseUrl, entry] of Object.entries(communityNodeManifests)) {
-      if (entry.status === 'ok') {
-        out[baseUrl] = entry.manifest;
-      }
-    }
-    return out;
-  }, [communityNodeManifests]);
   const submitReport = (request: SubmitCommunityNodeReportRequest) =>
     api.submitCommunityNodeReport(request);
   const fetchReportManifest = (baseUrl: string) =>
@@ -397,7 +383,6 @@ export function DesktopShellPrimaryWorkspace({
                   onLoadMore={() => void loadMoreTimeline(activeTopic)}
                   pendingCount={activeTimelinePendingCount}
                   onApplyPending={() => void refreshTimelineFeed(activeTopic, selectedThread)}
-                  communityNodeManifests={reportableManifests}
                   onSubmitReport={submitReport}
                   onCopyReportContact={copyReportContact}
                   onFetchReportManifest={fetchReportManifest}
@@ -428,7 +413,6 @@ export function DesktopShellPrimaryWorkspace({
                   onToggleBookmark={(post) => void handleToggleBookmarkedPost(post)}
                   onActivateReference={(reference) => void handleActivateReference(reference)}
                   onCopyPostLink={handleCopyInternalLink}
-                  communityNodeManifests={reportableManifests}
                   onSubmitReport={submitReport}
                   onCopyReportContact={copyReportContact}
                   onFetchReportManifest={fetchReportManifest}


### PR DESCRIPTION
## 概要

Closes #696(親: #670)

通報(投稿・著者・画像添付)と異議申し立てで、画面を開いた時に取得成功した最新の `CommunityNodeManifest` だけを候補源にし、取得中・取得失敗・候補なしでは古い受付先へ送信も連絡先複写もできないようにする。#690 で索引結果の通報に採った方式(開くたびに空にし、当該取得の成功結果だけを候補源にする)への追随。

## 変更点

- `useReportManifests` を新設し、`PostCard` / `AuthorDetailCard` の通報用ノード情報取得を寄せる。store 由来の `communityNodeManifests` は候補源にせず、取得失敗・情報なしのノードや閉じた後に届いた応答は反映しない
- `ReportRoutingDialog`: 取得中(`resolving`)は送信と連絡先複写を無効化。入力の初期化を `open` 時だけにし、候補が後から届いても入力を保持
- `CommunityNodeAdvisoryPanel`: 異議申し立てを開いた時に選択中ノードの最新 manifest を取得し、その結果だけから `planAppealReportRouting` を評価(取得中・失敗・`node_id` 不一致では送信不可)
- `communityNodeManifests` prop を `PostCard` / `AuthorDetailCard` / `CommunityNodeAdvisoryPanel` と呼び出し鎖(`TimelineFeed` / `ThreadTree` / `ThreadPanel` / shell page の `reportableManifests`)から除去
- 画面試験: 取得中の送信・複写不可、取得失敗時に前回の候補へ後退しない、受付先撤回で候補なし、閉じて開き直した後の遅延応答の非反映、著者詳細の正常系(`profile` 送信)、異議申し立ての取得・失敗・発行元不一致・遅延応答

## 分担(本 PR で扱わないもの)

- 候補判定(提供中能力・責任範囲)の厳密化 → #702
- 実行時層での受付先照合・転送拒否 → #703
- `manifest.node_id` と署名鍵由来 `issuer_node_id` の一致 → #706

## 検証

- `apps/desktop`: `pnpm lint` / `pnpm typecheck` / `pnpm test`(82 ファイル 687 件)成功
- Rust 側と試験場面(harness)は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
