### PR TITLE
test: 通報画面試験で送信ボタンの出現を待ち合わせる (#696 追補)

### DIFF
--- a/apps/desktop/src/components/core/AuthorDetailCard.test.tsx
+++ b/apps/desktop/src/components/core/AuthorDetailCard.test.tsx
@@ -139,7 +139,7 @@ test('author report fetches the observed node manifest on open and submits a pro
   await user.click(screen.getByRole('button', { name: 'Report' }));
   await waitFor(() => expect(onFetchReportManifest).toHaveBeenCalledWith('https://node.example'));
   expect(await screen.findByText('node.example')).toBeInTheDocument();
-  await user.click(screen.getByRole('button', { name: 'Send report' }));
+  await user.click(await screen.findByRole('button', { name: 'Send report' }));
   await waitFor(() => expect(onSubmitReport).toHaveBeenCalledTimes(1));
   expect(onSubmitReport).toHaveBeenCalledWith(
     expect.objectContaining({

--- a/apps/desktop/src/components/core/PostCard.test.tsx
+++ b/apps/desktop/src/components/core/PostCard.test.tsx
@@ -824,7 +824,7 @@ test('report dialog offers no target and no send action while the latest manifes
 
   pending.resolve({ status: 'ok', manifest: reportManifest('node.example') });
   expect(await screen.findByText('node.example')).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Send report' })).toBeEnabled();
+  expect(await screen.findByRole('button', { name: 'Send report' })).toBeEnabled();
   expect(onSubmitReport).not.toHaveBeenCalled();
 });
 


### PR DESCRIPTION
## 概要

#714 で追加した \`PostCard\` / \`AuthorDetailCard\` の画面試験が、候補到着直後に同期で送信ボタンを探しており \`linux-desktop-ui\` で不安定だった(main の実行で 1 件失敗)。\`findByRole\` で出現を待つように修正する。

関連: #696 / #714

## 検証

- 対象 2 ファイルを 3 回連続実行して 24 件成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)