### PR TITLE
fix: 異議申し立ての発行元識別子を公開ノード情報の node_id と一致させる (#706)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,6 +3085,7 @@ dependencies = [
  "kukuri-cn-operator",
  "kukuri-cn-safety",
  "kukuri-cn-safety-arachnid",
+ "kukuri-cn-safety-runtime",
  "kukuri-cn-safety-vlm",
  "reqwest 0.13.4",
  "serde_json",

--- a/crates/cn-cli/Cargo.toml
+++ b/crates/cn-cli/Cargo.toml
@@ -23,6 +23,7 @@ kukuri-cn-core = { path = "../cn-core" }
 kukuri-cn-indexer = { path = "../cn-indexer" }
 kukuri-cn-operator = { path = "../cn-operator" }
 kukuri-cn-safety = { path = "../cn-safety" }
+kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 kukuri-cn-safety-arachnid = { path = "../cn-safety-arachnid" }
 kukuri-cn-safety-vlm = { path = "../cn-safety-vlm" }
 

--- a/crates/cn-cli/src/commands/mod.rs
+++ b/crates/cn-cli/src/commands/mod.rs
@@ -6,7 +6,7 @@ use crate::Command;
 mod admission;
 mod database;
 mod indexing;
-mod moderation;
+pub(crate) mod moderation;
 mod readiness;
 mod readiness_runtime;
 mod relation;

--- a/crates/cn-cli/src/commands/moderation.rs
+++ b/crates/cn-cli/src/commands/moderation.rs
@@ -22,8 +22,27 @@ use crate::{ModerationCliAction, SafetyCategoryArg, SeverityArg, VisibilityArg};
 /// `safety.moderation.operator_review` に対応）。
 pub(crate) const OPERATOR_REVIEW_ENV: &str = "COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW";
 
+/// この配備がリスク判定に載せる発行元識別子を標準出力へ 1 行で表示する(#706)。
+///
+/// 導出は cn-indexer の signer および cn-user-api の起動時検査と同じ
+/// [`kukuri_cn_safety_runtime::expected_issuer_node_id_from_env`] を使う。
+/// 署名鍵は env からしか読まず、出力には公開鍵 hex(または明示識別子)だけを含める。
+pub(crate) fn print_issuer_node_id() -> Result<()> {
+    let issuer = kukuri_cn_safety_runtime::expected_issuer_node_id_from_env()
+        .map_err(|error| anyhow::anyhow!("{error}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "発行元識別子を導出できません。COMMUNITY_NODE_SAFETY_SIGNING_KEY(署名鍵)または \
+                 COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID(署名無効時の明示識別子)を設定してください"
+            )
+        })?;
+    println!("{issuer}");
+    Ok(())
+}
+
 pub(super) async fn run(pool: &PgPool, action: ModerationCliAction) -> Result<()> {
     match action {
+        ModerationCliAction::IssuerNodeId => print_issuer_node_id()?,
         ModerationCliAction::ListSignals { limit, offset } => {
             let signals = list_risk_signals(pool, limit, offset).await?;
             if signals.is_empty() {

--- a/crates/cn-cli/src/main.rs
+++ b/crates/cn-cli/src/main.rs
@@ -11,8 +11,9 @@ mod commands;
 
 #[derive(Debug, Parser)]
 struct Cli {
+    /// PostgreSQL 接続先。`moderation issuer-node-id` 以外の全コマンドで必須。
     #[arg(long, env = "COMMUNITY_NODE_DATABASE_URL")]
-    database_url: String,
+    database_url: Option<String>,
     #[command(subcommand)]
     command: Command,
 }
@@ -107,6 +108,12 @@ enum ModerationCliAction {
         #[arg(long)]
         id: String,
     },
+    /// この配備がリスク判定に載せる発行元識別子(`issuer_node_id`)を表示する(#706)。
+    ///
+    /// env `COMMUNITY_NODE_SAFETY_SIGNING_KEY` があれば署名鍵の公開鍵 hex、無ければ
+    /// `COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID` を出力する。秘密鍵は引数で受け取らず、
+    /// 出力にも含めない。得た値を operator-config の `server.node_id` に記入する。
+    IssuerNodeId,
     /// 申し立てを受理して Disputed にする（None→Disputed。冪等）。
     Dispute {
         #[arg(long)]
@@ -360,6 +367,18 @@ enum AuthModeArg {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    let pool = connect_postgres(cli.database_url.as_str()).await?;
+    if matches!(
+        cli.command,
+        Command::Moderation {
+            action: ModerationCliAction::IssuerNodeId
+        }
+    ) {
+        // DB 接続を伴わない導出専用コマンド。
+        return commands::moderation::print_issuer_node_id();
+    }
+    let database_url = cli.database_url.as_deref().ok_or_else(|| {
+        anyhow::anyhow!("--database-url または COMMUNITY_NODE_DATABASE_URL が必要です")
+    })?;
+    let pool = connect_postgres(database_url).await?;
     commands::dispatch(&pool, cli.command).await
 }

--- a/crates/cn-e2e/src/lib.rs
+++ b/crates/cn-e2e/src/lib.rs
@@ -519,6 +519,7 @@ impl E2eStack {
             relation_distance_optout_min_proximity: Some(0.5),
             deployment_revision: "cn-e2e-v1".to_string(),
             readiness_activation_max_age_secs: 3600,
+            expected_issuer_node_id: None,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-indexer/src/config.rs
+++ b/crates/cn-indexer/src/config.rs
@@ -27,8 +27,8 @@ pub const SAFETY_PROVIDER_UNKNOWN_CSAM_ENV: &str = "COMMUNITY_NODE_SAFETY_PROVID
 /// signed moderation event を発行するか（operator config の
 /// `safety.events.emit_signed_moderation_events` に対応。既定 true）。
 pub const SAFETY_EMIT_SIGNED_EVENTS_ENV: &str = "COMMUNITY_NODE_SAFETY_EMIT_SIGNED_EVENTS";
-/// signed event 無効時に risk signal issuer として使う node id。
-pub const SAFETY_ISSUER_NODE_ID_ENV: &str = "COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID";
+/// signed event 無効時に risk signal issuer として使う node id(定数は cn-safety-runtime と共有)。
+pub use kukuri_cn_safety_runtime::SAFETY_ISSUER_NODE_ID_ENV;
 /// 自前 relay を cn-indexer の iroh runtime へ渡す公開 URL。
 pub const CONNECTIVITY_URLS_ENV: &str = "COMMUNITY_NODE_CONNECTIVITY_URLS";
 /// suspected 判定の classifier スコア閾値（1-100。未設定なら policy 既定 70。ADR 0028 §2.2）。

--- a/crates/cn-operator/src/config.rs
+++ b/crates/cn-operator/src/config.rs
@@ -61,6 +61,9 @@ pub struct ServerConfig {
     /// abuse / 問い合わせ連絡先。未指定なら domain から導出する。
     #[serde(default)]
     pub contact: Option<String>,
+    /// 公開ノード情報の `node_id`。モデレーション事象の発行元識別子(署名鍵の x-only 公開鍵 hex、
+    /// 署名無効時は `COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID`)と一致させる必要がある(#706)。
+    /// `safety` 節があり `features.moderation` が有効な設定では必須。
     #[serde(default)]
     pub node_id: Option<String>,
     #[serde(default)]
@@ -494,6 +497,23 @@ pub fn resolve_and_validate(config: OperatorConfig) -> Result<ResolvedConfig> {
 
     if let Some(safety) = resolved.raw.safety.as_ref() {
         validate_safety_config(safety)?;
+        // 公開ノード情報の node_id は異議申し立ての発行元照合に使われる。モデレーションを提供する
+        // 公開ノードでは、リスク判定の issuer_node_id(署名鍵の公開鍵 hex)と同じ値を必ず記入する(#706)。
+        if resolved.enabled(Capability::Moderation)
+            && resolved
+                .raw
+                .server
+                .node_id
+                .as_deref()
+                .is_none_or(|node_id| node_id.trim().is_empty())
+        {
+            bail!(
+                "server.node_id は必須です(safety 節があり features.moderation が有効な公開ノード)。\
+                 モデレーション事象の発行元識別子(署名鍵の公開鍵 hex。`cn-cli moderation issuer-node-id` で導出)\
+                 と同じ値を記入してください。異議申し立ては公開ノード情報の node_id と \
+                 risk signal の issuer_node_id が一致する場合だけ受理されます"
+            );
+        }
     }
 
     // deploy セクションの検証（指定されている場合のみ。未指定は従来通り通す）。

--- a/crates/cn-operator/src/lib.rs
+++ b/crates/cn-operator/src/lib.rs
@@ -55,6 +55,10 @@ pub const SAMPLE_CONFIG: &str = r#"server:
   cloud_provider: AWS
   region: ap-northeast-1
   contact: abuse@example-kukuri.net
+  # 公開ノード情報の node_id。モデレーションを提供する場合は、モデレーション事象の発行元識別子
+  # (署名鍵の公開鍵 hex。`cn-cli moderation issuer-node-id` で導出)と同じ値を記入する。
+  # 異議申し立ては node_id と risk signal の issuer_node_id が一致する場合だけ受理される。
+  node_id: 0000000000000000000000000000000000000000000000000000000000000000
 
 # profile が features の既定値を与える。個別の features キーで上書きできる。
 profile: relay-enabled

--- a/crates/cn-operator/tests/generate.rs
+++ b/crates/cn-operator/tests/generate.rs
@@ -262,6 +262,7 @@ fn config_with_safety_providers(vlm_hosting_line: &str) -> String {
   domain: example-kukuri.net
   operator_name: Example Operator
   country: JP
+  node_id: 79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
 features:
   moderation: true
 retention:
@@ -681,4 +682,47 @@ fn generated_docs_reflect_authority_scope() {
     assert!(diagram.contains("authority scope"));
     assert!(diagram.contains("does_not_apply_to"));
     assert!(diagram.contains("network-wide authority: false"));
+}
+
+// #706: モデレーションを提供する公開ノードでは、公開ノード情報の node_id を
+// リスク判定の issuer_node_id と一致させるために必須にする。
+#[test]
+fn moderation_public_node_requires_server_node_id() {
+    let yaml = config_with_safety_providers("").replace(
+        "  node_id: 79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798\n",
+        "",
+    );
+    let err = load_and_validate(&yaml).expect_err("node_id missing must fail");
+    let message = err.to_string();
+    assert!(message.contains("server.node_id"), "got: {message}");
+    assert!(message.contains("issuer_node_id"), "got: {message}");
+
+    let blank = config_with_safety_providers("").replace(
+        "  node_id: 79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798\n",
+        "  node_id: \"  \"\n",
+    );
+    assert!(
+        load_and_validate(&blank).is_err(),
+        "blank node_id must fail"
+    );
+}
+
+#[test]
+fn server_node_id_stays_optional_without_safety_or_moderation() {
+    // safety 節が無い設定(開発用・relay 専用など)は従来どおり node_id 無しで通る。
+    let yaml = base_config("  moderation: true\n", false);
+    assert!(
+        load_and_validate(&yaml).is_ok(),
+        "no safety section must stay valid"
+    );
+    // safety 節があってもモデレーションが無効なら node_id は不要。
+    let yaml = config_with_safety_providers("").replace(
+        "  node_id: 79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798\n",
+        "",
+    );
+    let yaml = yaml.replace("  moderation: true\n", "  moderation: false\n");
+    assert!(
+        load_and_validate(&yaml).is_ok(),
+        "moderation disabled must stay valid"
+    );
 }

--- a/crates/cn-safety-runtime/src/lib.rs
+++ b/crates/cn-safety-runtime/src/lib.rs
@@ -45,6 +45,7 @@ pub use service::{
     SafetyScanServiceBuilder, build_safety_scan_service, resolve_safety_policy,
 };
 pub use signer::{
-    SAFETY_SIGNING_KEY_ENV, Secp256k1ModerationEventSigner, SignatureError, SignerKeyError,
+    SAFETY_ISSUER_NODE_ID_ENV, SAFETY_SIGNING_KEY_ENV, Secp256k1ModerationEventSigner,
+    SignatureError, SignerKeyError, expected_issuer_node_id, expected_issuer_node_id_from_env,
     verify_signed_event,
 };

--- a/crates/cn-safety-runtime/src/signer.rs
+++ b/crates/cn-safety-runtime/src/signer.rs
@@ -30,6 +30,38 @@ use thiserror::Error;
 /// Secret Manager の secret（operator-config の `safety.events.signing_key_secret_id` が指す）を
 /// runtime に注入する経路。値は secp256k1 秘密鍵（hex / `nsec` bech32）。
 pub const SAFETY_SIGNING_KEY_ENV: &str = "COMMUNITY_NODE_SAFETY_SIGNING_KEY";
+/// signed event 無効時に risk signal issuer として使う node id を注入する env var。
+pub const SAFETY_ISSUER_NODE_ID_ENV: &str = "COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID";
+
+/// この配備でリスク判定の `issuer_node_id` になる値を、署名鍵(優先)または明示指定から導出する。
+///
+/// - 署名鍵があれば x-only 公開鍵 hex(`Secp256k1ModerationEventSigner` と同一の導出)
+/// - 無ければ明示指定の識別子(前後空白除去)
+/// - どちらも無ければ `None`
+///
+/// cn-indexer が signal を発行する値と、公開ノード情報 `node_id` の一致検査(cn-user-api 起動時)、
+/// 運用者向けの導出コマンド(`cn-cli moderation issuer-node-id`)が同じ関数を共有する(#706)。
+pub fn expected_issuer_node_id(
+    signing_key: Option<&str>,
+    explicit_issuer_node_id: Option<&str>,
+) -> Result<Option<String>, SignerKeyError> {
+    if let Some(secret) = signing_key.map(str::trim).filter(|value| !value.is_empty()) {
+        let signer = Secp256k1ModerationEventSigner::from_secret(secret)?;
+        return Ok(Some(signer.issuer_node_id().to_string()));
+    }
+    Ok(explicit_issuer_node_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string))
+}
+
+/// [`expected_issuer_node_id`] を env var([`SAFETY_SIGNING_KEY_ENV`] / [`SAFETY_ISSUER_NODE_ID_ENV`])
+/// から評価する。
+pub fn expected_issuer_node_id_from_env() -> Result<Option<String>, SignerKeyError> {
+    let signing_key = std::env::var(SAFETY_SIGNING_KEY_ENV).ok();
+    let explicit = std::env::var(SAFETY_ISSUER_NODE_ID_ENV).ok();
+    expected_issuer_node_id(signing_key.as_deref(), explicit.as_deref())
+}
 
 /// 本番 [`ModerationEventSigner`] 実装（secp256k1 schnorr）。
 ///

--- a/crates/cn-safety-runtime/tests/signer.rs
+++ b/crates/cn-safety-runtime/tests/signer.rs
@@ -201,3 +201,29 @@ fn signed_event_fixture_still_verifies_and_reserializes_identically() {
     verify_signed_event(&signed).expect("historically signed event must keep verifying");
     assert_eq!(serde_json::to_string(&signed).expect("serialize"), FIXTURE);
 }
+
+// #706: 公開ノード情報 node_id と突合する発行元識別子は、signer と同じ導出で得られる。
+#[test]
+fn expected_issuer_node_id_prefers_signing_key_and_falls_back_to_explicit_id() {
+    use kukuri_cn_safety_runtime::expected_issuer_node_id;
+
+    let signer = Secp256k1ModerationEventSigner::from_secret(TEST_SECRET_A).unwrap();
+    // 署名鍵があれば公開鍵 hex(明示指定は無視される)。
+    assert_eq!(
+        expected_issuer_node_id(Some(TEST_SECRET_A), Some("explicit-node")).unwrap(),
+        Some(signer.issuer_node_id().to_string())
+    );
+    // 署名鍵が無ければ明示指定(前後空白は除去)。
+    assert_eq!(
+        expected_issuer_node_id(None, Some(" explicit-node ")).unwrap(),
+        Some("explicit-node".to_string())
+    );
+    assert_eq!(
+        expected_issuer_node_id(Some("  "), Some("explicit-node")).unwrap(),
+        Some("explicit-node".to_string())
+    );
+    // どちらも無ければ None。
+    assert_eq!(expected_issuer_node_id(None, None).unwrap(), None);
+    // 不正な署名鍵は明示指定へ後退せずエラー。
+    assert!(expected_issuer_node_id(Some("not-a-key"), Some("explicit-node")).is_err());
+}

--- a/crates/cn-user-api/Cargo.toml
+++ b/crates/cn-user-api/Cargo.toml
@@ -32,11 +32,11 @@ kukuri-cn-operator = { path = "../cn-operator" }
 kukuri-cn-safety = { path = "../cn-safety" }
 kukuri-cn-trust = { path = "../cn-trust" }
 kukuri-cn-runtime-support = { path = "../cn-runtime-support" }
+kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 
 [dev-dependencies]
 kukuri-test-support = { path = "../test-support" }
 kukuri-core = { path = "../core" }
-kukuri-cn-safety-runtime = { path = "../cn-safety-runtime" }
 hex.workspace = true
 reqwest.workspace = true
 redis.workspace = true

--- a/crates/cn-user-api/src/config.rs
+++ b/crates/cn-user-api/src/config.rs
@@ -47,6 +47,10 @@ pub struct UserApiConfig {
     pub deployment_revision: String,
     /// readiness activationを有効とみなす最大経過秒数。
     pub readiness_activation_max_age_secs: u64,
+    /// この配備がリスク判定に載せる `issuer_node_id`(署名鍵の公開鍵 hex、または明示指定)。
+    /// 公開ノード情報の `node_id` と一致しなければ起動を拒否する(#706)。
+    /// 署名鍵も明示指定も無い構成では `None`(検査を省略)。
+    pub expected_issuer_node_id: Option<String>,
 }
 
 impl std::fmt::Debug for UserApiConfig {
@@ -77,6 +81,7 @@ impl std::fmt::Debug for UserApiConfig {
                 "readiness_activation_max_age_secs",
                 &self.readiness_activation_max_age_secs,
             )
+            .field("expected_issuer_node_id", &self.expected_issuer_node_id)
             .finish()
     }
 }
@@ -134,6 +139,10 @@ impl UserApiConfig {
         }
         let readiness_activation_max_age_secs =
             parse_u64_env("COMMUNITY_NODE_READINESS_ACTIVATION_MAX_AGE_SECS", 900)?.max(1);
+        // 署名鍵(または明示識別子)は cn-indexer と同じ env_file で届く。値そのものは保持せず、
+        // 公開鍵 hex(発行元識別子)だけを設定に残す。
+        let expected_issuer_node_id = kukuri_cn_safety_runtime::expected_issuer_node_id_from_env()
+            .context("invalid COMMUNITY_NODE_SAFETY_SIGNING_KEY")?;
         Ok(Self {
             bind_addr,
             database_url,
@@ -150,6 +159,7 @@ impl UserApiConfig {
             relation_distance_optout_min_proximity,
             deployment_revision,
             readiness_activation_max_age_secs,
+            expected_issuer_node_id,
         })
     }
 }

--- a/crates/cn-user-api/src/state.rs
+++ b/crates/cn-user-api/src/state.rs
@@ -159,6 +159,12 @@ async fn build_state_from_pool(config: &UserApiConfig, pool: PgPool) -> Result<U
         public_disclosures,
         operator_config_yaml,
     } = load_manifest(config.operator_config_path.as_deref())?;
+    if let (Some(manifest), Some(expected)) = (
+        manifest.as_deref(),
+        config.expected_issuer_node_id.as_deref(),
+    ) {
+        ensure_manifest_node_id_matches_issuer(manifest.node_id.as_str(), expected)?;
+    }
     let channel_secret_cipher = config
         .channel_secret_key
         .as_deref()
@@ -296,6 +302,30 @@ async fn activation_is_valid(
         }))
 }
 
+/// 公開ノード情報の `node_id` が、この配備がリスク判定に載せる `issuer_node_id`
+/// (署名鍵の公開鍵 hex、または明示指定)と一致することを起動時に強制する(#706)。
+///
+/// 異議申し立てはサーバ(`/v1/report`)もクライアントも `manifest.node_id == issuer_node_id`
+/// を前提にするため、不一致のまま起動すると本番で異議申し立てが端から端まで成立しない。
+/// 運用者設定の誤りを黙って通さず、理由を明示して起動を止める。
+pub(crate) fn ensure_manifest_node_id_matches_issuer(
+    manifest_node_id: &str,
+    expected_issuer_node_id: &str,
+) -> Result<()> {
+    let manifest_node_id = manifest_node_id.trim();
+    let expected = expected_issuer_node_id.trim();
+    if manifest_node_id == expected {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "operator config の server.node_id (`{manifest_node_id}`) が、この配備のモデレーション事象の \
+         発行元識別子 (`{expected}`; COMMUNITY_NODE_SAFETY_SIGNING_KEY の公開鍵 hex、または \
+         COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID) と一致しません。異議申し立てが受理されなくなるため \
+         起動を拒否します。`cn-cli moderation issuer-node-id` で導出した値を server.node_id に \
+         記入してください"
+    );
+}
+
 /// operator config から公開 manifest を構築する。
 ///
 /// config が指定されているのに読込・検証に失敗した場合は起動を失敗させる
@@ -343,6 +373,16 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use super::load_manifest;
+
+    #[test]
+    fn manifest_node_id_must_match_expected_issuer() {
+        assert!(super::ensure_manifest_node_id_matches_issuer("node-a", "node-a").is_ok());
+        assert!(super::ensure_manifest_node_id_matches_issuer(" node-a ", "node-a").is_ok());
+        let err = super::ensure_manifest_node_id_matches_issuer("", "79be66").unwrap_err();
+        assert!(err.to_string().contains("server.node_id"), "{err}");
+        assert!(err.to_string().contains("79be66"), "{err}");
+        assert!(super::ensure_manifest_node_id_matches_issuer("node-a", "node-b").is_err());
+    }
 
     #[test]
     fn load_manifest_includes_every_http_disclosure() -> Result<()> {

--- a/crates/cn-user-api/tests/activation_gate.rs
+++ b/crates/cn-user-api/tests/activation_gate.rs
@@ -59,6 +59,7 @@ async fn spawn_api(
         relation_distance_optout_min_proximity: Some(0.5),
         deployment_revision: "test-deployment-v1".to_string(),
         readiness_activation_max_age_secs: 3600,
+        expected_issuer_node_id: None,
     })
     .await?;
     let app = app_router(state);

--- a/crates/cn-user-api/tests/index_query.rs
+++ b/crates/cn-user-api/tests/index_query.rs
@@ -167,6 +167,7 @@ impl TestServer {
             relation_distance_optout_min_proximity: None,
             deployment_revision: "test-deployment-v1".to_string(),
             readiness_activation_max_age_secs: 3600,
+            expected_issuer_node_id: None,
         })
         .await?;
         if let Some(index) = index {

--- a/crates/cn-user-api/tests/indexing_requests.rs
+++ b/crates/cn-user-api/tests/indexing_requests.rs
@@ -55,6 +55,7 @@ impl TestServer {
             relation_distance_optout_min_proximity: None,
             deployment_revision: "test-deployment-v1".to_string(),
             readiness_activation_max_age_secs: 3600,
+            expected_issuer_node_id: None,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-user-api/tests/reports.rs
+++ b/crates/cn-user-api/tests/reports.rs
@@ -50,7 +50,25 @@ struct TestServer {
 
 impl TestServer {
     async fn spawn(admin_database_url: &str, prefix: &str, operator_yaml: &str) -> Result<Self> {
-        Self::spawn_inner(admin_database_url, prefix, operator_yaml, None).await
+        Self::spawn_inner(admin_database_url, prefix, operator_yaml, None, None).await
+    }
+
+    /// 発行元識別子(署名鍵の公開鍵 hex 等)を与えて起動する。公開ノード情報の node_id と
+    /// 一致しない場合は起動が失敗する(#706)。
+    async fn spawn_with_expected_issuer(
+        admin_database_url: &str,
+        prefix: &str,
+        operator_yaml: &str,
+        expected_issuer_node_id: &str,
+    ) -> Result<Self> {
+        Self::spawn_inner(
+            admin_database_url,
+            prefix,
+            operator_yaml,
+            None,
+            Some(expected_issuer_node_id.to_string()),
+        )
+        .await
     }
 
     async fn spawn_with_trust(
@@ -59,7 +77,7 @@ impl TestServer {
         operator_yaml: &str,
         trust: Arc<TrustReadState>,
     ) -> Result<Self> {
-        Self::spawn_inner(admin_database_url, prefix, operator_yaml, Some(trust)).await
+        Self::spawn_inner(admin_database_url, prefix, operator_yaml, Some(trust), None).await
     }
 
     async fn spawn_inner(
@@ -67,6 +85,7 @@ impl TestServer {
         prefix: &str,
         operator_yaml: &str,
         trust: Option<Arc<TrustReadState>>,
+        expected_issuer_node_id: Option<String>,
     ) -> Result<Self> {
         use std::io::Write;
 
@@ -85,7 +104,7 @@ impl TestServer {
             .context("failed to bind test report listener")?;
         let addr = listener.local_addr()?;
         let base_url = format!("http://{addr}");
-        let mut state = build_state(&UserApiConfig {
+        let state = build_state(&UserApiConfig {
             bind_addr: addr,
             database_url: database.database_url.clone(),
             rendezvous_redis_url: integration_test_rendezvous_redis_url(),
@@ -101,8 +120,16 @@ impl TestServer {
             relation_distance_optout_min_proximity: None,
             deployment_revision: "test-deployment-v1".to_string(),
             readiness_activation_max_age_secs: 3600,
+            expected_issuer_node_id,
         })
-        .await?;
+        .await;
+        let mut state = match state {
+            Ok(state) => state,
+            Err(error) => {
+                database.cleanup().await?;
+                return Err(error);
+            }
+        };
         if let Some(trust) = trust {
             state = state.with_trust_read(trust);
         }
@@ -542,4 +569,94 @@ async fn report_endpoint_rejects_when_capability_disabled() -> Result<()> {
 
     server.shutdown().await?;
     Ok(())
+}
+
+/// テスト専用の決定論的な署名鍵(本番鍵ではない)。
+const TEST_SIGNING_KEY: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+
+#[tokio::test]
+async fn appeal_is_accepted_when_manifest_node_id_matches_signing_key_issuer() -> Result<()> {
+    // #706: リスク判定の issuer_node_id は署名鍵の公開鍵 hex。公開ノード情報の node_id を同じ値に
+    // した構成で異議申し立てが端から端まで通ること、別値の構成では起動時に拒否されることを固定する。
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api report test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let signer =
+        kukuri_cn_safety_runtime::Secp256k1ModerationEventSigner::from_secret(TEST_SIGNING_KEY)?;
+    let issuer = kukuri_cn_safety::ModerationEventSigner::issuer_node_id(&signer).to_string();
+    let matching_yaml =
+        REPORT_ENABLED_YAML.replace("node_id: issuer-node-1", &format!("node_id: {issuer}"));
+
+    // node_id が発行元識別子と一致しない構成(既存 fixture の issuer-node-1)は起動を拒否する。
+    let mismatch = TestServer::spawn_with_expected_issuer(
+        admin_database_url.as_str(),
+        "cn_user_api_issuer_mismatch",
+        REPORT_ENABLED_YAML,
+        issuer.as_str(),
+    )
+    .await;
+    let error = mismatch
+        .err()
+        .expect("mismatched node_id must refuse to start");
+    let message = format!("{error:#}");
+    assert!(message.contains("server.node_id"), "{message}");
+    assert!(message.contains(issuer.as_str()), "{message}");
+
+    // 一致する構成では、署名鍵由来の issuer で保存した判定への異議申し立てが受理される。
+    let server = TestServer::spawn_with_expected_issuer(
+        admin_database_url.as_str(),
+        "cn_user_api_issuer_match",
+        matching_yaml.as_str(),
+        issuer.as_str(),
+    )
+    .await?;
+    let manifest = Client::new()
+        .get(format!("{}/v1/node/manifest", server.base_url))
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+    assert_eq!(manifest["node_id"], issuer);
+
+    let pool = kukuri_cn_core::connect_postgres(server.database.database_url.as_str()).await?;
+    let stored = kukuri_cn_core::persist_risk_signal(
+        &pool,
+        issuer.as_str(),
+        &kukuri_cn_safety::SafetyRiskSignal {
+            target: kukuri_cn_safety::RiskSignalTarget::PostId,
+            target_id: "post-signed-issuer".to_string(),
+            category: kukuri_cn_safety::SafetyCategory::Nsfw,
+            severity: kukuri_cn_safety::Severity::High,
+            basis: kukuri_cn_safety::Basis::ClassifierScore,
+            confidence: Some(90),
+            visibility: kukuri_cn_safety::Visibility::Local,
+            expires_at: None,
+            appeal_status: Some(kukuri_cn_safety::AppealStatus::None),
+        },
+    )
+    .await?;
+    let accepted = Client::new()
+        .post(format!("{}/v1/report", server.base_url))
+        .json(&serde_json::json!({
+            "subject_kind": "post",
+            "subject_id": "post-signed-issuer",
+            "capability": "moderation",
+            "reason": "false_positive",
+            "appeal": { "risk_signal_id": stored.id },
+        }))
+        .send()
+        .await?;
+    assert_eq!(accepted.status(), StatusCode::OK);
+    let body = accepted.json::<serde_json::Value>().await?;
+    assert_eq!(body["disputed_risk_signal_id"], stored.id);
+    let refreshed = kukuri_cn_core::get_risk_signal(&pool, &stored.id)
+        .await?
+        .expect("signal exists");
+    assert_eq!(
+        refreshed.signal.appeal_status,
+        Some(kukuri_cn_safety::AppealStatus::Disputed)
+    );
+
+    server.shutdown().await
 }

--- a/crates/cn-user-api/tests/support/mod.rs
+++ b/crates/cn-user-api/tests/support/mod.rs
@@ -49,6 +49,7 @@ impl TestServer {
             relation_distance_optout_min_proximity: None,
             deployment_revision: "test-deployment-v1".to_string(),
             readiness_activation_max_age_secs: 3600,
+            expected_issuer_node_id: None,
         })
         .await?;
         let app = app_router(state);

--- a/crates/cn-user-api/tests/trust_relation.rs
+++ b/crates/cn-user-api/tests/trust_relation.rs
@@ -69,6 +69,7 @@ impl TestServer {
             relation_distance_optout_min_proximity: None,
             deployment_revision: "test-deployment-v1".to_string(),
             readiness_activation_max_age_secs: 3600,
+            expected_issuer_node_id: None,
         })
         .await?;
         if let Some(trust) = trust {

--- a/crates/harness/src/runtime.rs
+++ b/crates/harness/src/runtime.rs
@@ -107,6 +107,7 @@ impl CommunityNodeStack {
             relation_distance_optout_min_proximity: None,
             deployment_revision: String::new(),
             readiness_activation_max_age_secs: 900,
+            expected_issuer_node_id: None,
         })
         .await
         .context("failed to build community-node user-api state")?;

--- a/docker-compose.community-node.yml
+++ b/docker-compose.community-node.yml
@@ -114,6 +114,10 @@ services:
       COMMUNITY_NODE_RATE_LIMIT_PER_SECOND: ${COMMUNITY_NODE_RATE_LIMIT_PER_SECOND:-10}
       COMMUNITY_NODE_RATE_LIMIT_BURST: ${COMMUNITY_NODE_RATE_LIMIT_BURST:-30}
       COMMUNITY_NODE_RATE_LIMIT_TRUST_FORWARDED_FOR: ${COMMUNITY_NODE_RATE_LIMIT_TRUST_FORWARDED_FOR:-false}
+      # 公開ノード情報の node_id と、cn-indexer がリスク判定に載せる発行元識別子(署名鍵の
+      # 公開鍵 hex、または明示識別子)の一致を起動時に検査する(#706)。cn-indexer と同じ値を渡す。
+      COMMUNITY_NODE_SAFETY_SIGNING_KEY: ${COMMUNITY_NODE_SAFETY_SIGNING_KEY:-}
+      COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID: ${COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID:-}
       # Admin listener is loopback-published below. Browser writes remain disabled unless
       # COMMUNITY_NODE_ADMIN_ACTOR is explicitly configured.
       COMMUNITY_NODE_ADMIN_BIND_ADDR: ${COMMUNITY_NODE_ADMIN_BIND_ADDR:-0.0.0.0:9090}

--- a/docs/adr/0027-deterministic-moderation-critical-safety.md
+++ b/docs/adr/0027-deterministic-moderation-critical-safety.md
@@ -110,6 +110,7 @@ community node の moderation のうち **決定論的 moderation（既知 hash 
 - 永続化（`cn-core` `persist_signed_moderation_event`）は **保存前に `verify_signed_event` で署名検証**し、改竄 / 別鍵 / issuer 詐称を拒否する（配布クエリが常に検証済みを返す保証）。id 冪等（最初の writer が権威）。
 - event の `ModerationAction` は `Exclude` / `Hold` / `Quarantine` / `RiskLabel`。`RiskLabel` は「強制排除等ではなく根拠つき risk label を付す」action であり、その内容は §2.6 の `SafetyRiskSignal`（target / category / basis / severity / confidence / visibility）として表現・配布される（event action ↔ signal payload の対応）。
 - 事象記録・監査は event id / reference id / basis category を使い、有害コンテンツ本体を証拠として再配布しない。
+- **issuer 同一性と公開ノード情報（#706）**: risk signal / event の `issuer_node_id` は署名鍵の x-only 公開鍵 hex（署名無効時は `COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID`）であり、公開ノード情報 `CommunityNodeManifest.node_id`（operator-config `server.node_id`）は **同じ値でなければならない**。異議申し立て（§2.8）はサーバ・クライアントとも `manifest.node_id == issuer_node_id` で発行元を照合するためである。`safety` 節があり moderation を提供する設定では `server.node_id` を必須にし（`validate-config`）、cn-user-api は起動時に env 由来の発行元識別子と `manifest.node_id` を突合して不一致なら起動を拒否する。導出は `cn-cli moderation issuer-node-id`。
 
 ### 2.6 risk signals + visibility
 - `SafetyRiskSignal`（target / category / severity / basis / confidence / visibility / expiry / appeal）は断定ラベルではなく根拠つき advisory。

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -94,6 +94,13 @@ printf '%s' "$(openssl rand -hex 24)" | \
 # moderation event signing key（secp256k1 秘密鍵 hex。issuer node の鍵として公開鍵が event に載る）
 printf '%s' "$(openssl rand -hex 32)" | \
   gcloud secrets create kukuri-cn-safety-signing-key --data-file=-
+# 署名鍵の公開鍵 hex(= risk signal の issuer_node_id)を導出し、operator-config.yaml の
+# server.node_id に記入する(#706)。秘密鍵は同一シェルの環境変数に留め、標準出力には公開鍵だけが出る。
+# 異議申し立ては公開ノード情報の node_id と issuer_node_id が一致する場合だけ受理され、
+# 一致しない構成は validate-config と cn-user-api の起動時検査で拒否される。
+COMMUNITY_NODE_SAFETY_SIGNING_KEY="$(gcloud secrets versions access latest \
+  --secret=kukuri-cn-safety-signing-key --project=YOUR_PROJECT)" \
+  cargo run -q -p kukuri-cn-cli -- moderation issuer-node-id
 # Project Arachnid Shield credentials（operator 自身が https://projectarachnid.com で取得）
 printf '%s' 'YOUR_ARACHNID_USERNAME' | \
   gcloud secrets create kukuri-cn-arachnid-username --data-file=-

--- a/docs/runbooks/community-node-production-rollout.md
+++ b/docs/runbooks/community-node-production-rollout.md
@@ -89,7 +89,13 @@ job成功後のregistry manifestである。VMからも `docker manifest inspect
 
 ### 2.1 検証とbackup
 
+`operator-config.yaml` の `server.node_id` が、Secret Manager の署名鍵から導出した発行元識別子
+(`cn-cli moderation issuer-node-id`。導出手順は `community-node-gcp-terraform.md`)と一致することを
+先に確認する(#706)。不一致のままだと cn-user-api は起動を拒否し、異議申し立ても受理されない。
+署名鍵を差し替えた場合は node_id も更新し、生成文書を再生成する。
+
 ```bash
+cargo run -q -p kukuri-cn-operator -- validate-config --config operator-config.yaml
 cargo xtask cn-check
 cargo xtask cn-test
 cargo xtask cn-e2e
@@ -339,7 +345,9 @@ curl -fsS "https://<api-domain>/v1/node/manifest"
 ```
 
 manifestが示すterms / privacy / external-transmission / moderation-policy / abuse-policy /
-data-retentionもHTTP 200と `text/markdown; charset=utf-8` を確認する。index / trust surfaceは、
+data-retentionもHTTP 200と `text/markdown; charset=utf-8` を確認する。manifest の `node_id` が
+`cn-cli moderation issuer-node-id` の出力(署名鍵の公開鍵 hex)と一致することも確認する
+(異議申し立ての発行元照合に使われる。#706)。index / trust surfaceは、
 有効時に未認証401または入力不備400となり、構成未完了を示す404へ戻っていないことを確認する。
 
 ### 5.4 monitoring通知とlog / secret監査


### PR DESCRIPTION
## 概要

Closes #706(親: #670。#669 / #696 の前提)

リスク判定の `issuer_node_id`(cn-indexer の署名鍵の x-only 公開鍵 hex)と、公開ノード情報 `manifest.node_id`(operator-config `server.node_id`)が独立に決まっており、本番の `operator-config.yaml` には `node_id` が無かったため、異議申し立てがサーバ(`INVALID_APPEAL`)・クライアント(候補 0 件)とも成立しなかった。正本を `server.node_id` に置き、設定検証と起動時検査で一致を強制する。

## 変更点

- **cn-operator**: `safety` 節があり `features.moderation` が有効な設定で `server.node_id` を必須化(`validate-config`)。`SAMPLE_CONFIG` と fixture に追加。必須化・非該当の試験を追加
- **cn-safety-runtime**: `expected_issuer_node_id(signing_key, explicit)` / `_from_env` を追加(署名鍵優先 → 明示識別子 → None)。`SAFETY_ISSUER_NODE_ID_ENV` を cn-indexer と共有
- **cn-user-api**: `UserApiConfig.expected_issuer_node_id` を env(`COMMUNITY_NODE_SAFETY_SIGNING_KEY` / `COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID`)から導出し、公開ノード情報がある場合に `node_id` と突合。不一致は理由付きで起動拒否、env なしは省略。本番は `community-node.env` 経由で cn-user-api にも署名鍵が届くため追加配線不要。ローカル compose の cn-user-api には両 env を追加
- **cn-cli**: `moderation issuer-node-id`(env の署名鍵から公開鍵 hex を 1 行出力。DB 接続不要。秘密鍵は引数で受けず出力もしない)。`--database-url` はこのコマンドだけ省略可
- **結合試験**(`cn-user-api/tests/reports.rs`): 試験鍵の signer 由来 issuer でリスク判定を保存 → 同値 `node_id` の設定で `/v1/report` appeal が 200・`disputed`。別値の設定は state 構築が失敗
- **本番 `operator-config.yaml`**: Secret Manager の署名鍵から同一シェル内で導出した公開鍵 hex を `server.node_id` に記入(秘密鍵は標準出力・会話・リポジトリに出していない)。`validate-config` 緑、`generate-docs` 12 文書、`check-disclosures` drift なし、生成 manifest に `node_id` 反映
- **文書**: runbook(GCP terraform: 導出コマンドと記入手順 / 本番展開: apply 前 gate と public surface 確認)、ADR 0027 §2.5 に issuer 同一性と検査箇所を追記

## 検証

- `cargo xtask rust-check` / `cargo xtask cn-check` 成功
- `cargo xtask cn-test`(実 Postgres)成功。新規結合試験 `appeal_is_accepted_when_manifest_node_id_matches_signing_key_issuer` を含む
- `cargo test -p kukuri-cn-cli -p kukuri-cn-operator -p kukuri-cn-safety-runtime -p kukuri-cn-indexer` 成功
- `cn-cli moderation issuer-node-id` を試験鍵で確認(`79be66…` = 既存 e2e の署名 issuer と一致)

## 運用上の注意

- 次回の `terraform apply` 後、cn-user-api は起動時に `node_id` を検査する。署名鍵を差し替えた場合は `node_id` も更新すること(runbook に記載)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
