### PR TITLE
fix: 参加拒否後に保持したトークンで自己修復経路が再認証を繰り返す問題を止める (#708)

### DIFF
--- a/apps/desktop/src/shell/presentation.test.ts
+++ b/apps/desktop/src/shell/presentation.test.ts
@@ -565,6 +565,18 @@ describe('communityNodeNextStepLabel', () => {
     );
   });
 
+  it('prioritizes an admission rejection even while a local token still looks valid', () => {
+    // #708: 参加拒否後に端末側トークンが残っていても、次の操作は拒否の案内を優先する。
+    expect(
+      communityNodeNextStepLabel(
+        baseStatus({
+          auth_state: { authenticated: true, expires_at: 4102444800 },
+          admission_rejection: { code: 'BANNED', message: 'node-local support denied' },
+        })
+      )
+    ).toBe("Contact this node's operator if needed. Automatic retries are stopped.");
+  });
+
   it('asks to refresh metadata until urls resolve, then reports active', () => {
     expect(communityNodeNextStepLabel(baseStatus())).toBe(
       'refresh metadata if connectivity urls stay unresolved'

--- a/apps/desktop/src/shell/presentation.ts
+++ b/apps/desktop/src/shell/presentation.ts
@@ -373,12 +373,13 @@ export function communityNodeNextStepLabel(status?: CommunityNodeNodeStatus): st
   if (!status) {
     return translate('settings:communityNode.values.saveNodesToBegin');
   }
+  // 参加拒否は認証状態の表示に関わらず利用者の操作待ちなので最優先で案内する(#708)。
+  if (status.admission_rejection) {
+    return translate(
+      `settings:communityNode.admission.nextSteps.${status.admission_rejection.code}`
+    );
+  }
   if (!status.auth_state.authenticated) {
-    if (status.admission_rejection) {
-      return translate(
-        `settings:communityNode.admission.nextSteps.${status.admission_rejection.code}`
-      );
-    }
     return translate('settings:communityNode.values.authenticateThisNode');
   }
   if (status.consent_state && !status.consent_state.all_required_accepted) {

--- a/crates/desktop-runtime/src/community_node/reconnect_support.rs
+++ b/crates/desktop-runtime/src/community_node/reconnect_support.rs
@@ -68,8 +68,10 @@ impl DesktopRuntime {
                 .consent_state
                 .as_ref()
                 .is_some_and(|consent| consent.all_required_accepted);
+            // 参加拒否(AwaitingAdmission)のノードは利用者の操作待ちであり、自己修復の対象にしない(#708)。
             if has_connectivity_inputs
                 && node_status.auth_state.authenticated
+                && node_status.admission_rejection.is_none()
                 && consent_accepted
                 && node_status.last_error.is_none()
             {
@@ -95,7 +97,7 @@ impl DesktopRuntime {
         Ok(())
     }
 
-    async fn ready_community_node_base_urls(&self) -> Result<Vec<String>> {
+    pub(crate) async fn ready_community_node_base_urls(&self) -> Result<Vec<String>> {
         let config = self.community_node_config.lock().await.clone();
         let mut base_urls = Vec::new();
         for node in config.nodes {
@@ -109,8 +111,10 @@ impl DesktopRuntime {
                 .consent_state
                 .as_ref()
                 .is_some_and(|consent| consent.all_required_accepted);
+            // 参加拒否(AwaitingAdmission)のノードは利用者の操作待ちであり、自己修復の対象にしない(#708)。
             if has_connectivity_inputs
                 && node_status.auth_state.authenticated
+                && node_status.admission_rejection.is_none()
                 && consent_accepted
                 && node_status.last_error.is_none()
             {

--- a/crates/desktop-runtime/src/community_node/session_state_support.rs
+++ b/crates/desktop-runtime/src/community_node/session_state_support.rs
@@ -86,6 +86,20 @@ impl DesktopRuntime {
         base_url: &str,
         rejection: CommunityNodeAdmissionRejection,
     ) {
+        // 参加拒否後の既存トークンはサーバ側で 401 になる。端末側に残すと「認証済み」判定が
+        // 続き、自己修復経路が再認証を繰り返すため、拒否と同時に破棄する(#708)。
+        if let Err(error) = crate::identity::delete_optional_secret(
+            &self.db_path,
+            self.identity_mode,
+            COMMUNITY_NODE_TOKEN_PURPOSE,
+            base_url,
+        ) {
+            warn!(
+                error = %error,
+                base_url,
+                "failed to discard community-node token after admission rejection"
+            );
+        }
         {
             let mut sessions = self.community_node_sessions.lock().await;
             let entry = sessions

--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -389,17 +389,32 @@ impl DesktopRuntime {
             CommunityNodeSessionPhase::Refreshing,
         )
         .await;
-        self.refresh_community_node_registration_with_token_if_due(
-            base_url.as_str(),
-            &mut token,
-            node.auto_approve,
-            true,
-        )
-        .await?;
-        self.clear_community_node_retry_state(base_url.as_str())
-            .await;
-        self.set_community_node_session_ready(base_url.as_str(), false)
-            .await;
+        match self
+            .refresh_community_node_registration_with_token_if_due(
+                base_url.as_str(),
+                &mut token,
+                node.auto_approve,
+                true,
+            )
+            .await
+        {
+            Ok(()) => {
+                self.clear_community_node_retry_state(base_url.as_str())
+                    .await;
+                self.set_community_node_session_ready(base_url.as_str(), false)
+                    .await;
+            }
+            Err(error) => {
+                // 心拍 401 → 再認証 → 参加拒否(403)の経路は、定期処理と同じく AwaitingAdmission へ
+                // 落として利用者の操作待ちにする。それ以外の失敗は従来どおり呼び出し元へ返す(#708)。
+                let Some(rejection) = Self::community_node_admission_rejection(&error).cloned()
+                else {
+                    return Err(error);
+                };
+                self.set_community_node_admission_rejection(base_url.as_str(), rejection)
+                    .await;
+            }
+        }
         let refreshed = self.require_community_node(base_url.as_str()).await?;
         self.community_node_status(refreshed, None, None).await
     }

--- a/crates/desktop-runtime/src/tests/community_node/admission.rs
+++ b/crates/desktop-runtime/src/tests/community_node/admission.rs
@@ -11,6 +11,8 @@ struct AdmissionMockState {
     forced_rejection: Arc<Mutex<Option<ApiErrorBody>>>,
     received_invites: Arc<Mutex<Vec<Option<String>>>>,
     verify_hits: Arc<AtomicUsize>,
+    /// 真にすると心拍を 401 で拒否する(参加禁止後の既存トークンをサーバが失効させた状態)。
+    heartbeat_unauthorized: Arc<AtomicBool>,
 }
 
 async fn admission_challenge() -> Json<kukuri_cn_protocol::AuthChallengeResponse> {
@@ -66,10 +68,21 @@ async fn admission_consent_status() -> Json<CommunityNodeConsentStatus> {
     })
 }
 
-async fn admission_heartbeat() -> Json<BootstrapHeartbeatResponse> {
+async fn admission_heartbeat(State(state): State<Arc<AdmissionMockState>>) -> Response {
+    if state.heartbeat_unauthorized.load(Ordering::SeqCst) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ApiErrorBody {
+                code: "AUTH_REQUIRED".into(),
+                message: "subscriber is banned".into(),
+            }),
+        )
+            .into_response();
+    }
     Json(BootstrapHeartbeatResponse {
         expires_at: Utc::now().timestamp() + 300,
     })
+    .into_response()
 }
 
 async fn admission_bootstrap_nodes(
@@ -101,6 +114,7 @@ async fn spawn_admission_mock(
         forced_rejection: Arc::new(Mutex::new(None)),
         received_invites: Arc::new(Mutex::new(Vec::new())),
         verify_hits: Arc::new(AtomicUsize::new(0)),
+        heartbeat_unauthorized: Arc::new(AtomicBool::new(false)),
     });
     let app = Router::new()
         .route("/v1/auth/challenge", post(admission_challenge))
@@ -415,6 +429,96 @@ async fn banned_auto_approve_node_does_not_schedule_retries() {
             .code,
         CommunityNodeAdmissionRejectionCode::Banned
     );
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn banned_member_with_stored_token_stops_self_heal_reauthentication() {
+    // #708: 参加済み利用者が禁止された場合、端末側トークンが未失効でも「認証済み」と扱わず、
+    // 自己修復経路(refresh_community_node_metadata)からも再認証を繰り返さない。
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("admission-banned-member.db");
+    let (base_url, state, server) = spawn_admission_mock(None).await;
+    let runtime = admission_runtime(&db_path, vec![(base_url.clone(), true)]).await;
+
+    // まず正常に認証・接続する。
+    let ready = runtime
+        .authenticate_community_node(CommunityNodeTargetRequest {
+            base_url: base_url.clone(),
+        })
+        .await
+        .expect("authenticate");
+    assert!(ready.auth_state.authenticated);
+    assert_eq!(state.verify_hits.load(Ordering::SeqCst), 1);
+
+    // サーバ側で参加禁止: 既存トークンの心拍は 401、再認証は 403 BANNED。
+    state.heartbeat_unauthorized.store(true, Ordering::SeqCst);
+    *state.forced_rejection.lock().await = Some(ApiErrorBody {
+        code: "BANNED".into(),
+        message: "node-local support denied".into(),
+    });
+
+    // 自己修復経路が呼ぶ metadata 更新: 心拍 401 → 再認証 → 403 で参加拒否に落ちる。
+    let rejected = runtime
+        .refresh_community_node_metadata(CommunityNodeTargetRequest {
+            base_url: base_url.clone(),
+        })
+        .await
+        .expect("rejection is folded into session state, not an error");
+    assert_eq!(state.verify_hits.load(Ordering::SeqCst), 2);
+    assert!(
+        !rejected.auth_state.authenticated,
+        "banned member must not stay authenticated"
+    );
+    assert_eq!(
+        rejected.session_phase,
+        CommunityNodeSessionPhase::AwaitingAdmission
+    );
+    assert_eq!(rejected.retry_after, None);
+    assert_eq!(
+        rejected
+            .admission_rejection
+            .as_ref()
+            .expect("banned rejection")
+            .code,
+        CommunityNodeAdmissionRejectionCode::Banned
+    );
+    assert!(
+        crate::community_node::load_community_node_token(
+            &db_path,
+            IdentityStorageMode::FileOnly,
+            base_url.as_str()
+        )
+        .expect("load token")
+        .is_none(),
+        "stored token must be discarded on admission rejection"
+    );
+
+    // 以後、定期処理でも自己修復判定でも認証要求は増えない。
+    runtime.run_community_node_session_maintenance_once().await;
+    runtime.run_community_node_session_maintenance_once().await;
+    assert_eq!(state.verify_hits.load(Ordering::SeqCst), 2);
+    assert!(
+        runtime
+            .ready_community_node_base_urls()
+            .await
+            .expect("ready base urls")
+            .is_empty(),
+        "rejected node must not be a self-heal target"
+    );
+    let status = runtime
+        .get_community_node_statuses()
+        .await
+        .expect("status")
+        .remove(0);
+    assert_eq!(
+        status.session_phase,
+        CommunityNodeSessionPhase::AwaitingAdmission
+    );
+    assert!(!status.auth_state.authenticated);
 
     runtime.shutdown().await;
     server.abort();

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 
 /// (tests/ からの相対パス, TestResource variant 名, 取得数)。
 const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
-    ("community_node/admission.rs", "CommunityNodeServer", 5),
+    ("community_node/admission.rs", "CommunityNodeServer", 6),
     ("community_node/config.rs", "ProcessEnvironment", 3),
     ("community_node/connectivity.rs", "IrohNetwork", 6),
     ("community_node/index_query.rs", "CommunityNodeServer", 8),
@@ -100,7 +100,7 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 72,
-        "classification total drifted from the Q7 T6 baseline"
+        total, 73,
+        "classification total drifted from the Q7 T6 baseline(#708 で admission 試験を 1 件追加)"
     );
 }


### PR DESCRIPTION
## 概要

Closes #708(親: #670。#667 の完了条件「恒久的な拒否では自動再試行が止まる」の残欠陥)

参加済み利用者が参加禁止(`BANNED`)になっても端末側の未失効トークンが残るため、`auth_state.authenticated` が真のまま自己修復経路が心拍 401 → 再認証 → 403 を退避付きで繰り返し、定期処理側の `AwaitingAdmission` ガードもすり抜けていた。

## 変更点

- `set_community_node_admission_rejection`: 参加拒否時に保存済みトークンを破棄(サーバ側で 401 になるため端末に残す意味がない)
- `reconnect_support`: 自己修復の適用判定と対象列挙で `admission_rejection` のあるノードを除外(二重防御)
- `refresh_community_node_metadata`: 再認証の参加拒否を `AwaitingAdmission` に落として状態を返す(それ以外の失敗は従来どおり `Err`)
- `presentation.ts`: 診断欄の次の操作を `admission_rejection` 優先に
- 試験: admission モックに心拍 401 の切替を追加し、「認証済み → BANNED + 心拍 401 → `refresh_community_node_metadata`」でトークン破棄・`AwaitingAdmission`・`verify_hits` が 1 回だけ増え、以後の定期処理と自己修復対象列挙で増えないことを固定。lock 分類表(`lock_contract.rs`)を +1

## 対象外

- 機能別再認証経路の拒否コード平坦化、未知の 403 の再試行方針、実サーバ(招待モード)結合試験

## 検証

- `cargo xtask rust-check` 成功
- `cargo test -p kukuri-desktop-runtime` 120 件成功(新規 1 件、lock 契約更新後)
- `apps/desktop`: `pnpm lint` / `typecheck` / presentation 試験 40 件成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
