### PR TITLE
fix: 索引ノードの利用可否変更時に古い選択・結果・索引申請を失効させる (#698)

### DIFF
--- a/apps/desktop/src/components/core/CommunityIndexWorkspace.test.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexWorkspace.test.tsx
@@ -274,3 +274,32 @@ test.each([
 
   expect(await screen.findByText(expected)).toBeInTheDocument();
 });
+
+// #698: 選択値が適格一覧から外れている間は古いノードへ要求を送らない。
+test('a selected node that is no longer eligible does not receive queries until it is eligible again', async () => {
+  const searchCommunityNodeIndex = vi.fn().mockResolvedValue({ entries: [] });
+  const api = { searchCommunityNodeIndex } as unknown as DesktopApi;
+  const { rerender } = render(
+    <CommunityIndexWorkspace
+      {...workspaceProps(api, { eligibleNodeBaseUrls: [NODE_B], selectedNodeBaseUrl: NODE_A })}
+    />
+  );
+
+  // 適格一覧 [B] と古い選択値 A が同時に渡っても、A へ検索語を送らない。
+  const runButton = screen.queryByRole('button', { name: 'Run' });
+  if (runButton) fireEvent.click(runButton);
+  await new Promise((done) => setTimeout(done, 0));
+  expect(searchCommunityNodeIndex).not.toHaveBeenCalled();
+
+  // 再調整で選択が適格ノードになれば送れる。
+  rerender(
+    <CommunityIndexWorkspace
+      {...workspaceProps(api, { eligibleNodeBaseUrls: [NODE_B], selectedNodeBaseUrl: NODE_B })}
+    />
+  );
+  runSearch('hello');
+  await waitFor(() => expect(searchCommunityNodeIndex).toHaveBeenCalledTimes(1));
+  expect(searchCommunityNodeIndex).toHaveBeenCalledWith(
+    expect.objectContaining({ base_url: NODE_B, query: 'hello' })
+  );
+});

--- a/apps/desktop/src/components/core/CommunityIndexWorkspace.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexWorkspace.tsx
@@ -164,10 +164,16 @@ export function CommunityIndexWorkspace({
 
   const effectiveOperation: IndexOperation = mode === 'topic' ? 'search' : operation;
   const isAllJoined = mode === 'topic' && activeTimelineScope.kind === 'all_joined';
-  const disabled = selectedNodeBaseUrl === null || isAllJoined;
+  // 選択値が適格一覧(認証・同意・通信・提供中能力)に含まれない間は、再調整が追いつくまで
+  // 古いノードへ要求を送らない(#698)。文脈も無効化するので古い結果・通報対象は失効する。
+  const activeNodeBaseUrl =
+    selectedNodeBaseUrl !== null && eligibleNodeBaseUrls.includes(selectedNodeBaseUrl)
+      ? selectedNodeBaseUrl
+      : null;
+  const disabled = activeNodeBaseUrl === null || isAllJoined;
   const currentContext = useMemo(
-    () => indexContext(mode, effectiveOperation, selectedNodeBaseUrl, activeTopic, activeTimelineScope),
-    [activeTimelineScope, activeTopic, effectiveOperation, mode, selectedNodeBaseUrl]
+    () => indexContext(mode, effectiveOperation, activeNodeBaseUrl, activeTopic, activeTimelineScope),
+    [activeNodeBaseUrl, activeTimelineScope, activeTopic, effectiveOperation, mode]
   );
   const currentContextKey = currentContext?.key ?? null;
   const currentContextKeyRef = useRef(currentContextKey);
@@ -299,7 +305,7 @@ export function CommunityIndexWorkspace({
             <span className='font-medium'>{t('shell:communityIndex.nodeLabel')}</span>
             <select
               className='rounded-lg border border-[var(--border-subtle)] bg-background px-3 py-2'
-              value={selectedNodeBaseUrl ?? ''}
+              value={activeNodeBaseUrl ?? ''}
               onChange={(event) => {
                 invalidateResults();
                 onSelectNode(event.currentTarget.value);

--- a/apps/desktop/src/components/core/CommunityIndexingRequestDialog.test.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexingRequestDialog.test.tsx
@@ -259,3 +259,80 @@ test('stale private request result does not overwrite a changed target', async (
   expect(screen.queryByText('Indexing is approved.')).not.toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Submit request' })).toBeDisabled();
 });
+
+// #698: 適格一覧の参照が変わるだけ(内容不変)では確認状態を消さない。
+test('an equal eligible list rendered as a new array keeps the private confirmation', async () => {
+  const submitCommunityNodeIndexingRequest = vi.fn().mockResolvedValue({
+    request_id: 'request-1',
+    status: 'pending',
+  });
+  const api = { submitCommunityNodeIndexingRequest } as unknown as DesktopApi;
+  const target = { kind: 'private_channel' as const, topicId: 'kukuri:topic:demo', channelId: 'ch-1', channelLabel: 'demo' };
+  const { rerender } = render(
+    <CommunityIndexingRequestDialog
+      api={api}
+      target={target}
+      eligibleNodeBaseUrls={['https://index.example']}
+      onOpenChange={vi.fn()}
+      onOpenCommunityNodeSettings={vi.fn()}
+    />
+  );
+  fireEvent.click(screen.getByRole('checkbox'));
+  expect(screen.getByRole('checkbox')).toBeChecked();
+
+  rerender(
+    <CommunityIndexingRequestDialog
+      api={api}
+      target={target}
+      eligibleNodeBaseUrls={['https://index.example']}
+      onOpenChange={vi.fn()}
+      onOpenCommunityNodeSettings={vi.fn()}
+    />
+  );
+  expect(screen.getByRole('checkbox')).toBeChecked();
+  expect(screen.getByRole('button', { name: 'Submit request' })).toBeEnabled();
+});
+
+// #698: 選択ノードが適格一覧から外れると、確認済みでも申請(秘密値)を送らない。
+test('a selected node dropped from the eligible list cannot receive a private request', async () => {
+  const submitCommunityNodeIndexingRequest = vi.fn().mockResolvedValue({
+    request_id: 'request-1',
+    status: 'pending',
+  });
+  const api = { submitCommunityNodeIndexingRequest } as unknown as DesktopApi;
+  const target = { kind: 'private_channel' as const, topicId: 'kukuri:topic:demo', channelId: 'ch-1', channelLabel: 'demo' };
+  const { rerender } = render(
+    <CommunityIndexingRequestDialog
+      api={api}
+      target={target}
+      eligibleNodeBaseUrls={['https://index-a.example', 'https://index-b.example']}
+      onOpenChange={vi.fn()}
+      onOpenCommunityNodeSettings={vi.fn()}
+    />
+  );
+  fireEvent.click(screen.getByRole('checkbox'));
+  expect(screen.getByRole('button', { name: 'Submit request' })).toBeEnabled();
+
+  // A の同意/能力が失効し、適格一覧が [B] だけになる。
+  rerender(
+    <CommunityIndexingRequestDialog
+      api={api}
+      target={target}
+      eligibleNodeBaseUrls={['https://index-b.example']}
+      onOpenChange={vi.fn()}
+      onOpenCommunityNodeSettings={vi.fn()}
+    />
+  );
+  // 内容が変わったので確認は消え、送信は無効。改めて確認しても送信先は B になる。
+  expect(screen.getByRole('checkbox')).not.toBeChecked();
+  expect(screen.getByRole('button', { name: 'Submit request' })).toBeDisabled();
+  fireEvent.click(screen.getByRole('checkbox'));
+  fireEvent.click(screen.getByRole('button', { name: 'Submit request' }));
+  await waitFor(() => expect(submitCommunityNodeIndexingRequest).toHaveBeenCalledTimes(1));
+  expect(submitCommunityNodeIndexingRequest).toHaveBeenCalledWith(
+    expect.objectContaining({ base_url: 'https://index-b.example' })
+  );
+  expect(submitCommunityNodeIndexingRequest).not.toHaveBeenCalledWith(
+    expect.objectContaining({ base_url: 'https://index-a.example' })
+  );
+});

--- a/apps/desktop/src/components/core/CommunityIndexingRequestDialog.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexingRequestDialog.tsx
@@ -54,14 +54,17 @@ export function CommunityIndexingRequestDialog({
   const [errorKey, setErrorKey] = useState<string | null>(null);
   const requestVersionRef = useRef(0);
 
+  // 適格一覧は定期更新のたびに新しい配列になり得るため、参照ではなく内容の変化で初期化する(#698)。
+  const eligibleKey = JSON.stringify(eligibleNodeBaseUrls);
   useEffect(() => {
     requestVersionRef.current += 1;
-    setSelectedNode(eligibleNodeBaseUrls[0] ?? '');
+    setSelectedNode((JSON.parse(eligibleKey) as string[])[0] ?? '');
     setConfirmed(false);
     setPending(false);
     setStatus(null);
     setErrorKey(null);
-  }, [eligibleNodeBaseUrls, target]);
+  }, [eligibleKey, target]);
+  const selectedNodeEligible = selectedNode !== '' && eligibleNodeBaseUrls.includes(selectedNode);
 
   const privateTarget = target?.kind === 'private_channel';
   const targetLabel = target
@@ -79,7 +82,8 @@ export function CommunityIndexingRequestDialog({
   }
 
   async function submit() {
-    if (!target || !selectedNode || (privateTarget && !confirmed)) return;
+    // 選択ノードが適格一覧から外れた瞬間から申請(非公開チャンネルでは秘密値)を送らない(#698)。
+    if (!target || !selectedNodeEligible || (privateTarget && !confirmed)) return;
     const requestVersion = requestVersionRef.current + 1;
     requestVersionRef.current = requestVersion;
     if (privateTarget) setConfirmed(false);
@@ -169,7 +173,7 @@ export function CommunityIndexingRequestDialog({
               </Button>
               <Button
                 type='button'
-                disabled={pending || !selectedNode || (privateTarget && !confirmed)}
+                disabled={pending || !selectedNodeEligible || (privateTarget && !confirmed)}
                 onClick={() => void submit()}
               >
                 {pending ? t('shell:indexingRequest.submitting') : t('shell:indexingRequest.submit')}

--- a/apps/desktop/src/lib/api/communityIndex.ts
+++ b/apps/desktop/src/lib/api/communityIndex.ts
@@ -39,3 +39,19 @@ export function resolveCommunityIndexNodeBaseUrl(
   }
   return eligibleBaseUrls[0] ?? null;
 }
+
+/// 接続状態の定期更新後などに、現在の構成・接続状態・取得済み構成情報から適格一覧を求め直し、
+/// 選択中の索引ノードを再調整する(#698)。構成情報の再取得は行わず、既存の記録だけを使う。
+export function reconcileCommunityIndexNodeSelection(state: {
+  communityNodeConfig: CommunityNodeConfig;
+  communityNodeStatuses: readonly CommunityNodeNodeStatus[];
+  communityNodeManifests: Readonly<Record<string, CommunityIndexManifestEntry>>;
+  communityIndexNodeBaseUrl: string | null;
+}): string | null {
+  const eligible = eligibleCommunityIndexNodes(
+    state.communityNodeConfig,
+    state.communityNodeStatuses,
+    state.communityNodeManifests
+  );
+  return resolveCommunityIndexNodeBaseUrl(state.communityIndexNodeBaseUrl, eligible);
+}

--- a/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
+++ b/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
@@ -5,6 +5,7 @@ import {
   type MutableRefObject,
 } from 'react';
 
+import { reconcileCommunityIndexNodeSelection } from '@/lib/api/communityIndex';
 import type {
   AttachmentView,
   CommunityNodeNodeStatus,
@@ -218,12 +219,21 @@ export function useDesktopShellDataEffects({
       ? CONNECTIVITY_STATUS_FALLBACK_INTERVAL_MS
       : REFRESH_INTERVAL_MS;
     const intervalId = window.setInterval(() => {
-      void refreshConnectivityStatus();
+      // 接続状態(認証・同意・通信エラー)が変わって適格ノードが入れ替わった場合に備え、
+      // 定期更新の後は既存の構成情報記録で選択中の索引ノードを再調整する(#698)。
+      void refreshConnectivityStatus().then((statuses) => {
+        if (!statuses) return;
+        const state = storeApi.getState();
+        const next = reconcileCommunityIndexNodeSelection(state);
+        if (next !== state.communityIndexNodeBaseUrl) {
+          state.patchState({ communityIndexNodeBaseUrl: next });
+        }
+      });
     }, intervalMs);
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [loadCommunityIndexCapability, refreshConnectivityStatus]);
+  }, [loadCommunityIndexCapability, refreshConnectivityStatus, storeApi]);
 
   useEffect(() => {
     void refreshNotificationStatus();

--- a/apps/desktop/src/shell/useDesktopShellData.test.tsx
+++ b/apps/desktop/src/shell/useDesktopShellData.test.tsx
@@ -321,6 +321,55 @@ describe('useDesktopShellData characterization', () => {
     view.unmount();
   });
 
+  test('periodic connectivity refresh re-resolves the community index node from the eligible list', async () => {
+    // #698: 選択中ノードの同意/接続が落ちて適格一覧が変わったら、次の定期更新で選択を再調整する。
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    const NODE_A = 'https://index-a.example';
+    const NODE_B = 'https://index-b.example';
+    const baseApi = createDesktopMockApi();
+    const nodeStatus = (baseUrl: string, lastError: string | null) => ({
+      base_url: baseUrl,
+      auto_approve: true,
+      auth_state: { authenticated: true, expires_at: null },
+      consent_state: { all_required_accepted: true, items: [] },
+      resolved_urls: null,
+      last_error: lastError,
+      invite_code_saved: false,
+      admission_rejection: null,
+      session_phase: 'ready' as const,
+      retry_after: null,
+      restart_required: false,
+    });
+    let statuses = [nodeStatus(NODE_A, null), nodeStatus(NODE_B, null)];
+    const api: DesktopApi = {
+      ...baseApi,
+      getCommunityNodeConfig: async () => ({
+        nodes: [
+          { base_url: NODE_A, auto_approve: true, resolved_urls: null },
+          { base_url: NODE_B, auto_approve: true, resolved_urls: null },
+        ],
+      }),
+      getCommunityNodeStatuses: async () => statuses,
+    };
+
+    const { harness, view } = renderDataHook(api);
+    await flushAsyncWork();
+    expect(harness.store.getState().communityIndexNodeBaseUrl).toBe(NODE_A);
+
+    // A が通信エラーになり B だけが適格になる。
+    statuses = [nodeStatus(NODE_A, 'connection refused'), nodeStatus(NODE_B, null)];
+    await advanceTimersAsync(CONNECTIVITY_STATUS_FALLBACK_INTERVAL_MS);
+    expect(harness.store.getState().communityIndexNodeBaseUrl).toBe(NODE_B);
+
+    // 適格ノードが無くなれば選択なし。
+    statuses = [nodeStatus(NODE_A, 'connection refused'), nodeStatus(NODE_B, 'connection refused')];
+    await advanceTimersAsync(CONNECTIVITY_STATUS_FALLBACK_INTERVAL_MS);
+    expect(harness.store.getState().communityIndexNodeBaseUrl).toBeNull();
+
+    view.unmount();
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+  });
+
   test('connectivity status uses mount bootstrap and 60 second fallback, not the 3 second refresh', async () => {
     (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
     const baseApi = createDesktopMockApi();

--- a/crates/desktop-runtime/src/community_node/index_query_support.rs
+++ b/crates/desktop-runtime/src/community_node/index_query_support.rs
@@ -147,6 +147,16 @@ impl DesktopRuntime {
                     error.to_string(),
                 )
             })?;
+        // 必須同意が未承認のノードへは検索語を送らない(#698)。
+        if self
+            .community_node_required_consent_is_pending(base_url.as_str())
+            .await
+        {
+            return Err(CommunityNodeIndexQueryError::new(
+                "CONSENT_REQUIRED",
+                "community node required policies must be accepted before index queries",
+            ));
+        }
         let token = load_community_node_token(&self.db_path, self.identity_mode, base_url.as_str())
             .map_err(|error| {
                 CommunityNodeIndexQueryError::new("AUTH_TOKEN_LOAD_FAILED", error.to_string())

--- a/crates/desktop-runtime/src/community_node/indexing_request_support.rs
+++ b/crates/desktop-runtime/src/community_node/indexing_request_support.rs
@@ -101,6 +101,25 @@ impl DesktopRuntime {
                 "topic_id is required",
             ));
         }
+        // セッション確立と同意確認は秘密値を組み立てる前に行う。必須同意が未承認のノードへは
+        // 非公開チャンネルの秘密値を含む申請を送らない(#698)。
+        self.ensure_community_node_session(base_url.as_str())
+            .await
+            .map_err(|error| {
+                CommunityNodeIndexingRequestError::new(
+                    "COMMUNITY_NODE_SESSION_FAILED",
+                    error.to_string(),
+                )
+            })?;
+        if self
+            .community_node_required_consent_is_pending(base_url.as_str())
+            .await
+        {
+            return Err(CommunityNodeIndexingRequestError::new(
+                "CONSENT_REQUIRED",
+                "community node required policies must be accepted before indexing requests",
+            ));
+        }
         let (target_id, channel_secret_hex) = match request.scope_kind {
             IndexScopeKind::PublicTopic => {
                 if request
@@ -147,14 +166,6 @@ impl DesktopRuntime {
             }
         };
 
-        self.ensure_community_node_session(base_url.as_str())
-            .await
-            .map_err(|error| {
-                CommunityNodeIndexingRequestError::new(
-                    "COMMUNITY_NODE_SESSION_FAILED",
-                    error.to_string(),
-                )
-            })?;
         let token = load_community_node_token(&self.db_path, self.identity_mode, base_url.as_str())
             .map_err(|error| {
                 CommunityNodeIndexingRequestError::new("AUTH_TOKEN_LOAD_FAILED", error.to_string())

--- a/crates/desktop-runtime/src/community_node/session_state_support.rs
+++ b/crates/desktop-runtime/src/community_node/session_state_support.rs
@@ -72,6 +72,19 @@ impl DesktopRuntime {
         entry.cached_consent = consent_state;
     }
 
+    /// `ensure_community_node_session` 直後の同意確認(#698 / #705)。
+    ///
+    /// キャッシュ済み同意が「必須同意未承認」なら真を返す。索引参照・索引申請・信頼関係の
+    /// クライアントは、真なら HTTP を送らず `CONSENT_REQUIRED` を返す(サーバの 403 に頼らない)。
+    /// 同意を未取得(`None`)の場合は判定しない(セッション確立が別経路で失敗を返す)。
+    pub(crate) async fn community_node_required_consent_is_pending(&self, base_url: &str) -> bool {
+        let sessions = self.community_node_sessions.lock().await;
+        sessions
+            .get(base_url)
+            .and_then(|session| session.cached_consent.as_ref())
+            .is_some_and(|consent| !consent.all_required_accepted)
+    }
+
     pub(crate) async fn clear_community_node_retry_state(&self, base_url: &str) {
         let mut sessions = self.community_node_sessions.lock().await;
         if let Some(entry) = sessions.get_mut(base_url) {

--- a/crates/desktop-runtime/src/tests/community_node/index_query.rs
+++ b/crates/desktop-runtime/src/tests/community_node/index_query.rs
@@ -602,3 +602,48 @@ async fn community_node_indexing_request_preserves_stable_error() {
     runtime.shutdown().await;
     server.abort();
 }
+
+// #698: 必須同意が未承認のノードへは、検索語も非公開チャンネルの秘密値も送らない。
+#[tokio::test]
+async fn community_node_index_query_stops_before_http_when_consent_is_pending() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, managed, state, server, _dir) = index_runtime(None).await;
+    managed.consent_accepted.store(false, Ordering::SeqCst);
+
+    let error = runtime
+        .search_community_node_index(scoped_request(base_url.as_str()))
+        .await
+        .expect_err("pending consent must stop the query");
+
+    assert_eq!(error.code, "CONSENT_REQUIRED");
+    assert!(
+        state.requests.lock().await.is_empty(),
+        "no index request may reach the node while required consent is pending"
+    );
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn community_node_private_indexing_stops_before_secret_when_consent_is_pending() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, managed, state, server, _dir) = index_runtime(None).await;
+    managed.consent_accepted.store(false, Ordering::SeqCst);
+
+    let error = runtime
+        .submit_community_node_indexing_request(CommunityNodeIndexingRequest {
+            base_url,
+            scope_kind: IndexScopeKind::PrivateChannel,
+            topic_id: "kukuri:topic:indexing-request".to_string(),
+            channel_id: Some("private-channel".to_string()),
+            confirm_private_channel_secret_disclosure: true,
+        })
+        .await
+        .expect_err("pending consent must stop the request");
+
+    // 秘密値の取得(PRIVATE_CHANNEL_CAPABILITY_UNAVAILABLE)より前に同意で止まる。
+    assert_eq!(error.code, "CONSENT_REQUIRED");
+    assert!(state.indexing_requests.lock().await.is_empty());
+    runtime.shutdown().await;
+    server.abort();
+}

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -17,7 +17,7 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     ("community_node/admission.rs", "CommunityNodeServer", 6),
     ("community_node/config.rs", "ProcessEnvironment", 3),
     ("community_node/connectivity.rs", "IrohNetwork", 6),
-    ("community_node/index_query.rs", "CommunityNodeServer", 8),
+    ("community_node/index_query.rs", "CommunityNodeServer", 10),
     ("community_node/metadata.rs", "CommunityNodeServer", 9),
     (
         "community_node/report_submission.rs",
@@ -100,7 +100,7 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 73,
+        total, 75,
         "classification total drifted from the Q7 T6 baseline(#708 で admission 試験を 1 件追加)"
     );
 }


### PR DESCRIPTION
## 概要

Closes #698(親: #670。#663 の縮退目標の延長。信頼・関係側の同型課題は #705)

接続状態の定期更新後に適格ノード一覧が変わっても選択中の索引ノードが再調整されず、画面は選択値が適格一覧に含まれるかを確認せずに検索語(非公開チャンネルでは申請の秘密値)を古いノードへ送れた。実行時層も同意状態を確認していなかった。

## 変更点

- **選択値の再調整**: `reconcileCommunityIndexNodeSelection`(`lib/api/communityIndex.ts`)を追加し、定期更新(`refreshConnectivityStatus`)後に store の構成・接続状態・既存の構成情報記録から `eligibleCommunityIndexNodes` → `resolveCommunityIndexNodeBaseUrl` を再実行。構成情報の再取得はしない
- **画面ガード**: `CommunityIndexWorkspace` は選択値が適格一覧外の間は文脈を無効化(要求を送らず、#690 の文脈キーで結果・通報対象も失効)。`CommunityIndexingRequestDialog` は送信時に適格性を確認し、初期化を適格一覧の内容変化(参照ではなく `JSON.stringify` キー)だけで行う
- **実行時層**: `community_node_required_consent_is_pending` を追加し、索引参照・索引申請で `ensure_community_node_session` 後に必須同意が未承認なら `CONSENT_REQUIRED` を返して HTTP を送らない。索引申請は同意確認を非公開チャンネルの秘密値の組み立て前へ移動
- **試験**: 定期更新後の再調整(A→B、候補なし→null)、選択値が適格一覧外の間は要求を送らない、内容不変の再描画で確認状態維持、失効後は送信不可で B へだけ送れる、同意未承認で索引検索・非公開申請の HTTP 0 件。lock 分類表を +2

## 対象外(監査で過剰と判断)

- 全ノード manifest の定期再取得と取得世代管理、実行時層での能力(manifest)確認、5 面横断試験

## 検証

- `cargo xtask rust-check` / `cargo test -p kukuri-desktop-runtime`(122 件)/ `cargo xtask scenario community_node_index_query_client` 成功
- `apps/desktop`: `pnpm lint` / `typecheck` / `test`(82 ファイル 694 件)成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
