### PR TITLE
fix: 通報送信時に受付先を構成済みノードと同一オリジンへ限定し転送を追跡しない (#703)

### DIFF
--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -263,11 +263,12 @@ export type RelationOptoutResponse = { pubkey: string, opted_out: boolean, opted
 
 export type SubmitCommunityNodeReportRequest = { 
 /**
- * 通報先 node の base url（記録・表示用）。
+ * 通報先 node の base url。構成済みノードでなければ送信しない(#703)。
  */
 node_base_url: string, 
 /**
  * node manifest が公開する通報受付 endpoint（絶対 http(s) URL）。
+ * `node_base_url` と同一オリジンでなければ送信しない(#703)。
  */
 report_endpoint: string, 
 /**

--- a/crates/desktop-runtime/src/community_node/http_client_support.rs
+++ b/crates/desktop-runtime/src/community_node/http_client_support.rs
@@ -6,6 +6,17 @@ pub(crate) fn community_node_http_client() -> Result<Client> {
         .context("failed to build community-node http client")
 }
 
+/// 通報送信専用の HTTP クライアント(#703)。
+///
+/// 通報本文(詳細・連絡先)が転送応答で別ホストへ再送されないよう、転送を追跡しない。
+/// 3xx は呼び出し側で `REPORT_REDIRECT_REJECTED` として扱う。
+pub(crate) fn community_node_report_http_client() -> Result<Client> {
+    Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .context("failed to build community-node report http client")
+}
+
 #[derive(Debug)]
 pub(crate) enum CommunityNodeRequestError {
     AuthRequired,

--- a/crates/desktop-runtime/src/community_node/report_routing_support.rs
+++ b/crates/desktop-runtime/src/community_node/report_routing_support.rs
@@ -8,14 +8,19 @@ use std::fmt;
 /// client 側（provenance + manifest）で通報先を解決し、その `report_endpoint` を
 /// この request に載せて渡す。endpoint が無い node は client 側で `abuse_contact`
 /// 案内に切り替えるため、この command には到達しない。
+///
+/// 実行時層は画面側の判定を信頼せず、`node_base_url` が構成済みノードであることと、
+/// `report_endpoint` のオリジンが `node_base_url` と一致することを送信前に強制する(#703)。
+/// 提供中能力・責任範囲の照合は画面側(`reportRouting.ts`、#702)が正であり、ここでは行わない。
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 #[serde(rename_all = "snake_case")]
 pub struct SubmitCommunityNodeReportRequest {
-    /// 通報先 node の base url（記録・表示用）。
+    /// 通報先 node の base url。構成済みノードでなければ送信しない(#703)。
     pub node_base_url: String,
     /// node manifest が公開する通報受付 endpoint（絶対 http(s) URL）。
+    /// `node_base_url` と同一オリジンでなければ送信しない(#703)。
     pub report_endpoint: String,
     /// 通報対象の種別（post / profile / media / search_result / recommendation 等）。
     pub subject_kind: String,
@@ -119,6 +124,29 @@ pub(crate) fn validate_report_endpoint(endpoint: &str) -> Result<&str> {
     Ok(trimmed)
 }
 
+/// `report_endpoint` のオリジン(scheme / host / port)が、正規化済みの `node_base_url` と
+/// 一致することを確認する(#703)。実運用の公開ノード情報は受付先を基底アドレスと同一オリジンの
+/// `/v1/report` に置くため、別オリジンの受付先は画面側の不具合か改変された呼び出しとみなす。
+pub(crate) fn ensure_report_endpoint_origin(
+    normalized_base_url: &str,
+    endpoint: &str,
+) -> Result<()> {
+    let base = url::Url::parse(normalized_base_url)
+        .with_context(|| format!("invalid community node base url `{normalized_base_url}`"))?;
+    let target = url::Url::parse(endpoint)
+        .with_context(|| format!("invalid report endpoint `{endpoint}`"))?;
+    let same_origin = base.scheme() == target.scheme()
+        && base.host_str().map(str::to_ascii_lowercase)
+            == target.host_str().map(str::to_ascii_lowercase)
+        && base.port_or_known_default() == target.port_or_known_default();
+    if !same_origin {
+        return Err(anyhow!(
+            "report endpoint `{endpoint}` is not on the same origin as community node `{normalized_base_url}`"
+        ));
+    }
+    Ok(())
+}
+
 impl DesktopRuntime {
     /// 解決済みの通報先 node の report endpoint へ通報を POST する（#310）。
     ///
@@ -132,7 +160,19 @@ impl DesktopRuntime {
         let endpoint = validate_report_endpoint(&request.report_endpoint).map_err(|error| {
             CommunityNodeReportError::new("INVALID_REPORT_ENDPOINT", error.to_string())
         })?;
-        let client = community_node_http_client().map_err(|error| {
+        // 構成情報にないノード、基底アドレスと異なるオリジンの受付先へは送らない(#703)。
+        let base_url = normalize_http_url(request.node_base_url.as_str()).map_err(|error| {
+            CommunityNodeReportError::new("REPORT_TARGET_NOT_CONFIGURED", error.to_string())
+        })?;
+        self.require_community_node(base_url.as_str())
+            .await
+            .map_err(|error| {
+                CommunityNodeReportError::new("REPORT_TARGET_NOT_CONFIGURED", error.to_string())
+            })?;
+        ensure_report_endpoint_origin(base_url.as_str(), endpoint).map_err(|error| {
+            CommunityNodeReportError::new("REPORT_ENDPOINT_MISMATCH", error.to_string())
+        })?;
+        let client = community_node_report_http_client().map_err(|error| {
             CommunityNodeReportError::new("REPORT_CLIENT_UNAVAILABLE", error.to_string())
         })?;
         let payload = CommunityNodeReportRequest {
@@ -153,6 +193,14 @@ impl DesktopRuntime {
                 CommunityNodeReportError::new("REPORT_SUBMISSION_FAILED", error.to_string())
             })?;
         let status = response.status();
+        if status.is_redirection() {
+            // 転送は追跡しない。受付先の境界を越えて本文を再送しないために拒否する(#703)。
+            return Err(CommunityNodeReportError {
+                code: "REPORT_REDIRECT_REJECTED".to_string(),
+                message: format!("report endpoint responded with a redirect ({status})"),
+                status: Some(status.as_u16()),
+            });
+        }
         if !status.is_success() {
             let body = response.json::<ApiErrorBody>().await.ok();
             return Err(CommunityNodeReportError::from_response(status, body));
@@ -172,6 +220,46 @@ impl DesktopRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn report_endpoint_must_share_the_node_origin() {
+        assert!(
+            ensure_report_endpoint_origin("https://node.example", "https://node.example/v1/report")
+                .is_ok()
+        );
+        assert!(
+            ensure_report_endpoint_origin(
+                "https://node.example",
+                "https://NODE.example:443/v1/report"
+            )
+            .is_ok()
+        );
+        assert!(
+            ensure_report_endpoint_origin(
+                "http://127.0.0.1:8080",
+                "http://127.0.0.1:8080/v1/report"
+            )
+            .is_ok()
+        );
+        assert!(
+            ensure_report_endpoint_origin(
+                "https://node.example",
+                "https://other.example/v1/report"
+            )
+            .is_err()
+        );
+        assert!(
+            ensure_report_endpoint_origin("https://node.example", "http://node.example/v1/report")
+                .is_err()
+        );
+        assert!(
+            ensure_report_endpoint_origin(
+                "http://127.0.0.1:8080",
+                "http://127.0.0.1:9090/v1/report"
+            )
+            .is_err()
+        );
+    }
 
     #[test]
     fn validates_http_endpoints() {

--- a/crates/desktop-runtime/src/tests/community_node/report_submission.rs
+++ b/crates/desktop-runtime/src/tests/community_node/report_submission.rs
@@ -53,11 +53,32 @@ async fn report_runtime(
     };
     let app = Router::new()
         .route("/v1/report", post(mock_report))
+        .route("/v1/report-moved", post(mock_report_redirect))
         .with_state(state.clone());
     let server = tokio::spawn(async move {
         axum::serve(listener, app).await.expect("server");
     });
+    // #703: 通報先は構成済みノードに限るため、モックノードを構成に登録しておく。
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.clone(),
+            auto_approve: false,
+            resolved_urls: None,
+        }],
+    };
     (runtime, base_url, state, server, dir)
+}
+
+/// 転送応答を返す受付先(転送先は別オリジン)。
+async fn mock_report_redirect() -> Response {
+    (
+        StatusCode::TEMPORARY_REDIRECT,
+        [(
+            axum::http::header::LOCATION,
+            "https://elsewhere.example/v1/report",
+        )],
+    )
+        .into_response()
 }
 
 fn appeal_request(base_url: &str) -> SubmitCommunityNodeReportRequest {
@@ -107,6 +128,64 @@ async fn community_node_report_client_preserves_invalid_appeal_code() {
         .expect_err("invalid appeal");
     assert_eq!(error.code, "INVALID_APPEAL");
     assert_eq!(error.status, Some(400));
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+// #703: 構成情報にないノード、別オリジンの受付先、転送応答へは通報本文を送らない。
+#[tokio::test]
+async fn community_node_report_client_rejects_unconfigured_node_before_http() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, state, server, _dir) = report_runtime(false).await;
+    *runtime.community_node_config.lock().await = CommunityNodeConfig::default();
+
+    let error = runtime
+        .submit_community_node_report(appeal_request(base_url.as_str()))
+        .await
+        .expect_err("unconfigured node must be rejected");
+    assert_eq!(error.code, "REPORT_TARGET_NOT_CONFIGURED");
+    assert!(state.received.lock().await.is_empty());
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn community_node_report_client_rejects_endpoint_on_another_origin() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, state, server, _dir) = report_runtime(false).await;
+
+    let mut request = appeal_request(base_url.as_str());
+    request.report_endpoint = "https://attacker.example/v1/report".to_string();
+    let error = runtime
+        .submit_community_node_report(request)
+        .await
+        .expect_err("foreign origin must be rejected");
+    assert_eq!(error.code, "REPORT_ENDPOINT_MISMATCH");
+    assert!(state.received.lock().await.is_empty());
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn community_node_report_client_does_not_follow_redirects() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, state, server, _dir) = report_runtime(false).await;
+
+    let mut request = appeal_request(base_url.as_str());
+    request.report_endpoint = format!("{base_url}/v1/report-moved");
+    let error = runtime
+        .submit_community_node_report(request)
+        .await
+        .expect_err("redirects must not be followed");
+    assert_eq!(error.code, "REPORT_REDIRECT_REJECTED");
+    assert_eq!(error.status, Some(307));
+    assert!(
+        state.received.lock().await.is_empty(),
+        "the report body must not reach the redirect target"
+    );
 
     runtime.shutdown().await;
     server.abort();

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -22,7 +22,7 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     (
         "community_node/report_submission.rs",
         "CommunityNodeServer",
-        2,
+        5,
     ),
     ("community_node/scheduler.rs", "CommunityNodeServer", 5),
     ("community_node/session.rs", "CommunityNodeServer", 6),
@@ -100,7 +100,7 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 76,
+        total, 79,
         "classification total drifted from the Q7 T6 baseline(#708 で admission 試験を 1 件追加)"
     );
 }

--- a/docs/adr/0030-content-observation-provenance.md
+++ b/docs/adr/0030-content-observation-provenance.md
@@ -63,6 +63,7 @@
   | `media_cache` | `blob_cache` | `media_cached_by_this_node` |
   | `bootstrap_assist` | `bootstrap_assist` | `this_node`(観測記録の生成経路が整うまで) |
   | `relay_assist` | `iroh_relay` または `traffic_relay_fallback` | `this_node`(同上) |
+- 実行時層(`desktop-runtime`)は画面側の判定を信頼せず、送信前に `node_base_url` が構成済みノードであること、`report_endpoint` のオリジンが `node_base_url` と一致することを強制し、通報用の HTTP クライアントは転送を追跡しない(#703)。不一致は `REPORT_TARGET_NOT_CONFIGURED` / `REPORT_ENDPOINT_MISMATCH` / `REPORT_REDIRECT_REJECTED` で拒否する。提供中能力と責任範囲の照合は画面側が正であり、実行時層では重複して行わない。
 
 ## 影響
 - 観測記録は共有文書や他端末へ流れず、利用者の受信経路を新たに公開しない。


### PR DESCRIPTION
## 概要

Closes #703(親: #670。#696 / #702 の多層防御)

実行時層の通報送信は `report_endpoint` が http(s) ならそのまま POST し、`node_base_url` を照合に使わず、HTTP クライアントも転送を既定で追跡していたため、画面側の不具合や改変された呼び出しから任意の受付先へ通報本文を送れた。

## 変更点

- `request_community_node_report_submit`: (1) `normalize_http_url(node_base_url)` → `require_community_node` で構成済みを確認(`REPORT_TARGET_NOT_CONFIGURED`) (2) `ensure_report_endpoint_origin` で受付先のオリジン(scheme / host / port)が基底アドレスと一致することを確認(`REPORT_ENDPOINT_MISMATCH`) (3) 通報専用クライアント(`redirect::Policy::none()`)で送信し 3xx を `REPORT_REDIRECT_REJECTED` で拒否
- 試験: `report_submission.rs` のモックノードを構成済みにして既存 2 件を維持。未構成ノード・別オリジン受付先・転送応答(307)の 3 件を追加し、いずれもモックへ本文が届かないことを確認。オリジン照合の単体試験。lock 分類表 +3
- IPC 型(`types.generated.ts`)の注釈を再生成(構造変更なし)
- ADR 0030 に実行時層の不変条件を補記

## 設計判断

- 提供中能力・責任範囲の照合は #702 で画面層(`reportRouting.ts`)を正と決めたため、実行時層では重複実装しない
- 観測記録との照合は採用しない(観測記録は投稿・プロフィールにしか保存されず、添付・索引結果・推薦の通報に対応記録が無い)。全通報共通の境界として「構成済みノード + 同一オリジン」を使う
- 共用 HTTP クライアント全体の転送方針、IPC 契約からの `report_endpoint` 除去は対象外

## 検証

- `cargo xtask rust-check` / `cargo test -p kukuri-desktop-runtime`(126 件)/ `cargo xtask scenario community_node_report_routing` / `community_node_trust_relation_client` 成功
- `cargo xtask ipc-types --check` 成功、`apps/desktop` typecheck 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
