### PR TITLE
fix: 信頼・関係応答の対象識別子を要求対象へ照合する (#699)

### DIFF
--- a/apps/desktop/src/components/core/CommunityNodeAdvisoryPanel.test.tsx
+++ b/apps/desktop/src/components/core/CommunityNodeAdvisoryPanel.test.tsx
@@ -618,4 +618,34 @@ describe('CommunityNodeAdvisoryPanel', () => {
     expect(await screen.findByText(/認証が必要です|Authenticate with the selected/)).toBeInTheDocument();
     expect(screen.queryByText(/required policies must be accepted/)).not.toBeInTheDocument();
   });
+  // #699: 実行時層が対象不一致を返したら、内容を表示せず異議申し立て導線も出さない。
+  test('shows a mismatch notice and no appeal when the runtime rejects a response for another target', async () => {
+    const client = api();
+    client.readCommunityNodeTrustUser.mockRejectedValue(
+      new InvokeError('TRUST_RELATION_RESPONSE_MISMATCH', 'response for another target')
+    );
+    client.readCommunityNodeRelationUser.mockRejectedValue(
+      new InvokeError('TRUST_RELATION_RESPONSE_MISMATCH', 'response for another target')
+    );
+    render(<CommunityNodeAdvisoryPanel api={client} targetPubkey={targetPubkey} nodeBaseUrls={[nodeA]} />);
+    await userEvent.click(screen.getByRole('button', { name: /Load advisory|情報を読み込む/ }));
+
+    expect((await screen.findAllByText(/別の利用者を対象にしていた|answered for a different user/)).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/node-a/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'このリスク判定に異議を申し立てる' })).not.toBeInTheDocument();
+  });
+
+  // #699: 利用者対象の根拠が表示中の利用者と異なる場合は、この画面から申し立てできない。
+  test('does not offer an appeal for a user judgment that targets another user', async () => {
+    const client = api('user_pubkey', otherTargetPubkey);
+    render(<CommunityNodeAdvisoryPanel api={client} targetPubkey={targetPubkey} nodeBaseUrls={[nodeA]} />);
+    await userEvent.click(screen.getByRole('button', { name: /Load advisory|情報を読み込む/ }));
+    await userEvent.click(await screen.findByText(/node-a/));
+
+    expect(screen.queryByRole('button', { name: 'このリスク判定に異議を申し立てる' })).not.toBeInTheDocument();
+    expect(
+      screen.getByText('この種類のリスク判定は、現在の画面から異議申し立てできません。')
+    ).toBeInTheDocument();
+    expect(client.submitCommunityNodeReport).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/components/core/CommunityNodeAdvisoryPanel.tsx
+++ b/apps/desktop/src/components/core/CommunityNodeAdvisoryPanel.tsx
@@ -74,9 +74,15 @@ function resultState<T>(result: PromiseSettledResult<T>): ReadState<T> {
   };
 }
 
-function appealSubjectForBasis(basis: TrustBasisEntry): ReportRoutingSubject | null {
+/// 根拠から異議申し立ての対象を決める。利用者対象の根拠は、表示中の利用者と一致する場合だけ
+/// 対象にする(#699: 別利用者の判定を申し立てない)。投稿・添付対象は #685 / #707 の契約どおり。
+function appealSubjectForBasis(
+  basis: TrustBasisEntry,
+  targetPubkey: string
+): ReportRoutingSubject | null {
   switch (basis.target) {
     case 'user_pubkey':
+      if (basis.target_id.trim().toLowerCase() !== targetPubkey.trim().toLowerCase()) return null;
       return { kind: 'profile', id: basis.target_id };
     case 'post_id':
       return { kind: 'post', id: basis.target_id };
@@ -249,7 +255,7 @@ export function CommunityNodeAdvisoryPanel({
 
   async function submitAppeal(input: ReportSubmitInput) {
     const selection = activeAppealSelection;
-    const subject = selection ? appealSubjectForBasis(selection.basis) : null;
+    const subject = selection ? appealSubjectForBasis(selection.basis, targetPubkey) : null;
     if (
       !selection ||
       selection.context.key !== currentContextKeyRef.current ||
@@ -363,7 +369,7 @@ export function CommunityNodeAdvisoryPanel({
                         <p className='text-xs text-[var(--muted-foreground)]'>
                           {t('profile:communityNodeAdvisory.appeal.noneContribution')}
                         </p>
-                        {appealSubjectForBasis(basis) ? (
+                        {appealSubjectForBasis(basis, targetPubkey) ? (
                           <Button
                             type='button'
                             variant='secondary'
@@ -429,13 +435,13 @@ export function CommunityNodeAdvisoryPanel({
         <Notice>{unavailableCopy(neighbors)}</Notice>
       ) : null}
 
-      {appealBasis && appealPlan && appealSubjectForBasis(appealBasis) ? (
+      {appealBasis && appealPlan && appealSubjectForBasis(appealBasis, targetPubkey) ? (
         <ReportRoutingDialog
           open
           onOpenChange={(open) => {
             if (!open) setAppealSelection(null);
           }}
-          subject={appealSubjectForBasis(appealBasis)!}
+          subject={appealSubjectForBasis(appealBasis, targetPubkey)!}
           plan={appealPlan}
           appeal={{
             riskSignalId: appealBasis.signal_id,

--- a/apps/desktop/src/i18n/locales/en/profile.json
+++ b/apps/desktop/src/i18n/locales/en/profile.json
@@ -67,7 +67,8 @@
       "trust_not_activated": "Trust advisory reads are not active for your current node session.",
       "relation_unavailable": "Relation information is unavailable from this Community Node. The reason is intentionally not disclosed.",
       "auth_required": "Authenticate with the selected Community Node first.",
-      "consent_required": "Accept the required policies of the selected Community Node first."
+      "consent_required": "Accept the required policies of the selected Community Node first.",
+      "response_mismatch": "The node answered for a different user, so the response was not used."
     },
     "trust": {
       "title": "Trust advisory",

--- a/apps/desktop/src/i18n/locales/ja/profile.json
+++ b/apps/desktop/src/i18n/locales/ja/profile.json
@@ -67,7 +67,8 @@
       "trust_not_activated": "現在のノードセッションでは trust 情報が有効になっていません。",
       "relation_unavailable": "この Community Node では relation 情報を利用できません。理由は推測・開示しません。",
       "auth_required": "選択した Community Node への認証が必要です。",
-      "consent_required": "選択した Community Node の必須同意が必要です。"
+      "consent_required": "選択した Community Node の必須同意が必要です。",
+      "response_mismatch": "ノードの応答が別の利用者を対象にしていたため、内容を採用しませんでした。"
     },
     "trust": {
       "title": "Trust advisory",

--- a/apps/desktop/src/i18n/locales/zh-CN/profile.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/profile.json
@@ -67,7 +67,8 @@
       "trust_not_activated": "当前节点会话尚未启用信任提示读取。",
       "relation_unavailable": "该社区节点无法提供关系信息；不会推测或披露具体原因。",
       "auth_required": "请先对所选社区节点完成认证。",
-      "consent_required": "请先接受所选社区节点的必需条款。"
+      "consent_required": "请先接受所选社区节点的必需条款。",
+      "response_mismatch": "节点返回的是其他用户的结果，因此未采用该响应。"
     },
     "trust": {
       "title": "信任提示",

--- a/apps/desktop/src/lib/api/trustRelationPresentation.test.ts
+++ b/apps/desktop/src/lib/api/trustRelationPresentation.test.ts
@@ -11,6 +11,7 @@ describe('trustRelationUnavailableReason', () => {
     // #705: 認証・同意の未達は索引画面と同じ安定理由で案内する。
     ['AUTH_REQUIRED', 'auth_required'],
     ['CONSENT_REQUIRED', 'consent_required'],
+    ['TRUST_RELATION_RESPONSE_MISMATCH', 'response_mismatch'],
     ['SOMETHING_ELSE', 'other'],
   ] as const)('maps %s without inferring an opt-out cause', (code, expected) => {
     expect(trustRelationUnavailableReason(new InvokeError(code, 'server detail'))).toBe(expected);

--- a/apps/desktop/src/lib/api/trustRelationPresentation.ts
+++ b/apps/desktop/src/lib/api/trustRelationPresentation.ts
@@ -6,6 +6,7 @@ export type TrustRelationUnavailableReason =
   | 'relation_unavailable'
   | 'auth_required'
   | 'consent_required'
+  | 'response_mismatch'
   | 'other';
 
 export function trustRelationUnavailableReason(error: unknown): TrustRelationUnavailableReason {
@@ -20,6 +21,9 @@ export function trustRelationUnavailableReason(error: unknown): TrustRelationUna
       return 'trust_not_activated';
     case 'RELATION_NOT_FOUND':
       return 'relation_unavailable';
+    case 'TRUST_RELATION_RESPONSE_MISMATCH':
+      // 応答本文の対象が要求した利用者と一致しない(#699)。内容は採用しない。
+      return 'response_mismatch';
     default:
       return 'other';
   }

--- a/crates/desktop-runtime/src/community_node/trust_relation_support.rs
+++ b/crates/desktop-runtime/src/community_node/trust_relation_support.rs
@@ -71,6 +71,27 @@ impl fmt::Display for CommunityNodeTrustRelationError {
 
 impl std::error::Error for CommunityNodeTrustRelationError {}
 
+/// 応答本文の対象識別子が要求した利用者(正規化済み)と一致することを確認する(#699)。
+///
+/// 規約に従わないノードが別の利用者の評価・関係を返した場合に、その内容を表示したり
+/// 別の判定を異議申し立て対象にしたりしないための実行時層の照合。比較は `normalize_pubkey`
+/// と同じ正規化(前後空白除去・小文字化)で行う。
+pub(crate) fn ensure_trust_relation_target(
+    requested_normalized: &str,
+    response_target: &str,
+) -> Result<(), CommunityNodeTrustRelationError> {
+    let response_target = response_target.trim().to_ascii_lowercase();
+    if response_target == requested_normalized {
+        return Ok(());
+    }
+    Err(CommunityNodeTrustRelationError::new(
+        "TRUST_RELATION_RESPONSE_MISMATCH",
+        format!(
+            "community node returned a response for `{response_target}` while `{requested_normalized}` was requested"
+        ),
+    ))
+}
+
 impl DesktopRuntime {
     pub(crate) async fn request_community_node_trust_user(
         &self,
@@ -79,13 +100,16 @@ impl DesktopRuntime {
         let target = normalize_pubkey(request.target_pubkey.as_str()).map_err(|error| {
             CommunityNodeTrustRelationError::new("INVALID_TRUST_QUERY", error.to_string())
         })?;
-        self.request_community_node_trust_relation(
-            request.base_url.as_str(),
-            Method::GET,
-            format!("{TRUST_USERS_PATH_PREFIX}{target}").as_str(),
-            None,
-        )
-        .await
+        let response: TrustUserReadResponse = self
+            .request_community_node_trust_relation(
+                request.base_url.as_str(),
+                Method::GET,
+                format!("{TRUST_USERS_PATH_PREFIX}{target}").as_str(),
+                None,
+            )
+            .await?;
+        ensure_trust_relation_target(target.as_str(), response.view.target_id.as_str())?;
+        Ok(response)
     }
 
     pub(crate) async fn request_community_node_relation_user(
@@ -95,13 +119,16 @@ impl DesktopRuntime {
         let target = normalize_pubkey(request.target_pubkey.as_str()).map_err(|error| {
             CommunityNodeTrustRelationError::new("INVALID_TRUST_QUERY", error.to_string())
         })?;
-        self.request_community_node_trust_relation(
-            request.base_url.as_str(),
-            Method::GET,
-            format!("{RELATION_USERS_PATH_PREFIX}{target}").as_str(),
-            None,
-        )
-        .await
+        let response: RelationReadResponse = self
+            .request_community_node_trust_relation(
+                request.base_url.as_str(),
+                Method::GET,
+                format!("{RELATION_USERS_PATH_PREFIX}{target}").as_str(),
+                None,
+            )
+            .await?;
+        ensure_trust_relation_target(target.as_str(), response.target_pubkey.as_str())?;
+        Ok(response)
     }
 
     pub(crate) async fn request_community_node_relation_neighbors(

--- a/crates/desktop-runtime/src/tests/community_node/trust_relation.rs
+++ b/crates/desktop-runtime/src/tests/community_node/trust_relation.rs
@@ -13,6 +13,8 @@ struct MockTrustRelationState {
     expected_token: Arc<Mutex<String>>,
     requests: Arc<Mutex<Vec<(Method, String)>>>,
     forced_error: Arc<Mutex<Option<(StatusCode, ApiErrorBody)>>>,
+    /// 設定すると、応答本文の対象識別子を要求対象ではなくこの値にする(規約に従わないノードの再現)。
+    mismatch_target: Arc<Mutex<Option<String>>>,
 }
 
 impl MockTrustRelationState {
@@ -57,6 +59,7 @@ async fn mock_trust_user(
     if let Some(error) = state.authorize_or_error(&headers).await {
         return error;
     }
+    let target = state.mismatch_target.lock().await.clone().unwrap_or(target);
     Json(TrustUserReadResponse {
         viewer_pubkey: "viewer".to_string(),
         view: TrustReadView {
@@ -87,6 +90,7 @@ async fn mock_relation_user(
     if let Some(error) = state.authorize_or_error(&headers).await {
         return error;
     }
+    let target = state.mismatch_target.lock().await.clone().unwrap_or(target);
     Json(RelationReadResponse {
         viewer_pubkey: "viewer".to_string(),
         target_pubkey: target,
@@ -194,6 +198,7 @@ async fn trust_relation_runtime(
         expected_token,
         requests: Arc::new(Mutex::new(Vec::new())),
         forced_error: Arc::new(Mutex::new(forced_error)),
+        mismatch_target: Arc::new(Mutex::new(None)),
     };
     let managed_router = Router::new()
         .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
@@ -369,6 +374,46 @@ async fn community_node_trust_relation_client_stops_before_http_when_consent_is_
         state.requests.lock().await.is_empty(),
         "no trust / relation / opt-out request may reach the node while consent is pending"
     );
+    runtime.shutdown().await;
+    server.abort();
+}
+
+// #699: 応答本文の対象識別子が要求対象と違う応答は採用しない。
+#[tokio::test]
+async fn community_node_trust_relation_client_rejects_responses_for_another_target() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, state, _managed, server, _dir) = trust_relation_runtime(None).await;
+    *state.mismatch_target.lock().await = Some("b".repeat(64));
+
+    let trust_error = runtime
+        .read_community_node_trust_user(CommunityNodeUserAdvisoryRequest {
+            base_url: base_url.clone(),
+            target_pubkey: "A".repeat(64),
+        })
+        .await
+        .expect_err("trust response for another target must be rejected");
+    assert_eq!(trust_error.code, "TRUST_RELATION_RESPONSE_MISMATCH");
+
+    let relation_error = runtime
+        .read_community_node_relation_user(CommunityNodeUserAdvisoryRequest {
+            base_url: base_url.clone(),
+            target_pubkey: "a".repeat(64),
+        })
+        .await
+        .expect_err("relation response for another target must be rejected");
+    assert_eq!(relation_error.code, "TRUST_RELATION_RESPONSE_MISMATCH");
+
+    // 大文字混じりで要求しても、正規化した同じ対象の応答は受理される。
+    *state.mismatch_target.lock().await = Some("a".repeat(64));
+    let trust = runtime
+        .read_community_node_trust_user(CommunityNodeUserAdvisoryRequest {
+            base_url,
+            target_pubkey: "A".repeat(64),
+        })
+        .await
+        .expect("normalized target matches");
+    assert_eq!(trust.view.target_id, "a".repeat(64));
+
     runtime.shutdown().await;
     server.abort();
 }

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -26,7 +26,7 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     ),
     ("community_node/scheduler.rs", "CommunityNodeServer", 5),
     ("community_node/session.rs", "CommunityNodeServer", 6),
-    ("community_node/trust_relation.rs", "CommunityNodeServer", 3),
+    ("community_node/trust_relation.rs", "CommunityNodeServer", 4),
     ("identity_restart.rs", "IdentityStorage", 2),
     ("media_blob_restore.rs", "IrohNetwork", 11),
     ("private_channels/friend_only.rs", "IrohNetwork", 1),
@@ -100,7 +100,7 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 79,
+        total, 80,
         "classification total drifted from the Q7 T6 baseline(#708 で admission 試験を 1 件追加)"
     );
 }


### PR DESCRIPTION
## 概要

Closes #699(親: #670。#691 の文脈固定の延長)

実行時層は信頼評価・関係情報の応答本文をそのまま返し、`target_id` / `target_pubkey` を要求した利用者と照合していなかったため、規約に従わないノードが別利用者の情報を返すと表示や異議申し立て対象になり得た。

## 変更点

- **実行時層**: `ensure_trust_relation_target`(`normalize_pubkey` と同じ正規化で比較)を追加し、`request_community_node_trust_user` / `request_community_node_relation_user` で不一致を `TRUST_RELATION_RESPONSE_MISMATCH` として拒否
- **画面**: `trustRelationPresentation` に `response_mismatch` を追加し 3 言語で案内。`appealSubjectForBasis` は利用者対象(`user_pubkey`)の根拠について `target_id` が表示中の利用者と一致する場合だけ対象にする(投稿・添付は #685 / #707 の契約どおり)
- **試験**: モックに「別利用者の対象識別子を返す」切替を追加し、信頼・関係の 2 経路で拒否、大文字混じりの要求でも正規化一致なら受理。画面試験 2 件(不一致コードの表示と導線なし、別利用者対象の根拠は申し立て不可)、分類試験。lock 分類表 +1

## 対象外(監査で #670 外と判断)

- `viewer_pubkey` / `RelationOptoutResponse.pubkey` の認証利用者照合、近傍一覧の照合、画面層での重複照合

## 検証

- `cargo xtask rust-check` / `cargo test -p kukuri-desktop-runtime`(127 件)/ `cargo xtask scenario community_node_trust_relation_client` 成功
- `apps/desktop`: `pnpm lint` / `typecheck` / `test`(82 ファイル 715 件)成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
