### PR TITLE
fix: 異議申し立て審査の入力値を保存前に検証する (#700)

### DIFF
--- a/crates/cn-core/src/appeal_reviews.rs
+++ b/crates/cn-core/src/appeal_reviews.rs
@@ -9,7 +9,10 @@ use sqlx::postgres::{PgPool, PgRow};
 use uuid::Uuid;
 
 use crate::operator_actions::OperatorAction;
-use crate::safety_appeals::{RiskSignalCorrection, RiskSignalMetadataEdit};
+use crate::safety_appeals::{
+    RiskSignalCorrection, RiskSignalMetadataEdit, validate_optional_confidence,
+    validate_optional_expires_at,
+};
 use crate::safety_events::to_db_enum;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -416,6 +419,8 @@ fn validate_edit(edit: &RiskSignalMetadataEdit) -> Result<()> {
     {
         bail!("no detection metadata fields to edit");
     }
+    validate_optional_confidence(edit.confidence)?;
+    validate_optional_expires_at(edit.expires_at.as_deref())?;
     Ok(())
 }
 
@@ -427,6 +432,7 @@ fn validate_correction(correction: &RiskSignalCorrection) -> Result<()> {
     {
         bail!("no correction fields to reissue");
     }
+    validate_optional_confidence(correction.confidence)?;
     Ok(())
 }
 

--- a/crates/cn-core/src/lib.rs
+++ b/crates/cn-core/src/lib.rs
@@ -114,7 +114,7 @@ pub use rollout::{ensure_default_auth_rollout, load_auth_rollout, store_auth_rol
 pub use safety_appeals::{
     RiskSignalCorrection, RiskSignalMetadataEdit, dispute_risk_signal,
     edit_risk_signal_detection_metadata, reissue_corrected_risk_signal,
-    update_risk_signal_appeal_status,
+    update_risk_signal_appeal_status, validate_optional_confidence, validate_optional_expires_at,
 };
 pub use safety_events::{
     DistributionAudience, StoredModerationEvent, StoredRiskSignal, get_risk_signal,

--- a/crates/cn-core/src/safety_appeals.rs
+++ b/crates/cn-core/src/safety_appeals.rs
@@ -16,6 +16,7 @@
 //!   失効させる（ADR 0028 §2.8 の第 3 の是正手段）。
 
 use anyhow::{Context, Result, bail};
+use chrono::DateTime;
 use sqlx::postgres::PgPool;
 
 use kukuri_cn_safety::{AppealStatus, SafetyCategory, SafetyRiskSignal, Severity, Visibility};
@@ -82,6 +83,32 @@ pub async fn dispute_risk_signal(pool: &PgPool, id: &str) -> Result<StoredRiskSi
     }
 }
 
+/// operator レビュー入力の共通検証: confidence は 0-100 のみ受理する（#700）。
+///
+/// 審査（調整・訂正再発行）・個別編集・`cn-cli` の全経路で共有し、範囲外の値が
+/// どの経路からも保存されないようにする（多層防御）。
+pub fn validate_optional_confidence(confidence: Option<u8>) -> Result<()> {
+    if let Some(confidence) = confidence
+        && confidence > 100
+    {
+        bail!("confidence must be between 0 and 100 (got {confidence})");
+    }
+    Ok(())
+}
+
+/// operator レビュー入力の共通検証: expires_at は RFC 3339 のみ受理する（#700）。
+///
+/// 過去時刻は単独失効の正規手段なので受理する。不正な形式を保存すると trust 入力の
+/// 組み立て（`trust_risk_inputs_from`）や配布クエリの時刻変換が失敗するため、
+/// 保存前にここで拒否する。
+pub fn validate_optional_expires_at(expires_at: Option<&str>) -> Result<()> {
+    if let Some(expires_at) = expires_at {
+        DateTime::parse_from_rfc3339(expires_at)
+            .with_context(|| format!("invalid expires_at `{expires_at}` (expected RFC3339)"))?;
+    }
+    Ok(())
+}
+
 /// operator レビューによる検知メタデータの編集内容。`None` のフィールドは変更しない。
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RiskSignalMetadataEdit {
@@ -122,11 +149,8 @@ pub async fn edit_risk_signal_detection_metadata(
     if edit.is_empty() {
         bail!("no detection metadata fields to edit");
     }
-    if let Some(confidence) = edit.confidence
-        && confidence > 100
-    {
-        bail!("confidence must be between 0 and 100 (got {confidence})");
-    }
+    validate_optional_confidence(edit.confidence)?;
+    validate_optional_expires_at(edit.expires_at.as_deref())?;
     let stored = get_risk_signal(pool, id)
         .await?
         .with_context(|| format!("risk signal `{id}` not found"))?;
@@ -181,11 +205,7 @@ pub async fn reissue_corrected_risk_signal(
              (set safety.moderation.operator_review / COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW)"
         );
     }
-    if let Some(confidence) = correction.confidence
-        && confidence > 100
-    {
-        bail!("confidence must be between 0 and 100 (got {confidence})");
-    }
+    validate_optional_confidence(correction.confidence)?;
     let stored = get_risk_signal(pool, id)
         .await?
         .with_context(|| format!("risk signal `{id}` not found"))?;
@@ -209,4 +229,44 @@ pub async fn reissue_corrected_risk_signal(
         appeal_status: Some(AppealStatus::None),
     };
     persist_risk_signal(pool, &stored.issuer_node_id, &corrected).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- #700: operator レビュー入力の共通検証（保存前検証の contract） ---
+
+    #[test]
+    fn confidence_within_0_to_100_is_accepted() {
+        assert!(validate_optional_confidence(None).is_ok());
+        assert!(validate_optional_confidence(Some(0)).is_ok());
+        assert!(validate_optional_confidence(Some(100)).is_ok());
+    }
+
+    #[test]
+    fn confidence_above_100_is_rejected() {
+        for confidence in [101, 255] {
+            let error = validate_optional_confidence(Some(confidence)).unwrap_err();
+            assert!(error.to_string().contains("between 0 and 100"), "{error}");
+        }
+    }
+
+    #[test]
+    fn expires_at_accepts_rfc3339_including_offsets_and_past() {
+        assert!(validate_optional_expires_at(None).is_ok());
+        assert!(validate_optional_expires_at(Some("2026-07-30T09:00:00Z")).is_ok());
+        // 時差付き表記も RFC 3339 として妥当。
+        assert!(validate_optional_expires_at(Some("2026-07-30T18:00:00+09:00")).is_ok());
+        // 過去時刻は単独失効の正規手段なので受理する。
+        assert!(validate_optional_expires_at(Some("2000-01-01T00:00:00Z")).is_ok());
+    }
+
+    #[test]
+    fn expires_at_rejects_non_rfc3339() {
+        for invalid in ["not-a-timestamp", "", "2026-07-30", "2026/07/30 09:00"] {
+            let error = validate_optional_expires_at(Some(invalid)).unwrap_err();
+            assert!(error.to_string().contains("RFC3339"), "{invalid}: {error}");
+        }
+    }
 }

--- a/crates/cn-core/src/trust_inputs.rs
+++ b/crates/cn-core/src/trust_inputs.rs
@@ -42,7 +42,9 @@ use crate::safety_events::{
 ///   `Disputed`（= pending）は寄与据え置きで含む。
 /// - category は [`trust_component_for`] で絶対 / 相対へ振り分ける。
 ///
-/// 不正な RFC3339（`now_rfc3339` / `expires_at`）は Err（黙って含めたり落としたりしない）。
+/// 不正な RFC3339 の扱い（#700）: `now_rfc3339` はサーバ生成値なので不正なら Err。
+/// signal 側の `expires_at` は保存前検証で新規流入を防いだうえで、既存の不正値は
+/// 警告ログを残して該当 signal だけを除外する（不正値 1 件で read 全体を失敗させない）。
 pub fn trust_risk_inputs_from(
     signals: &[StoredRiskSignal],
     now_rfc3339: &str,
@@ -55,12 +57,14 @@ pub fn trust_risk_inputs_from(
         let signal = &stored.signal;
 
         if let Some(expires_at) = signal.expires_at.as_deref() {
-            let expires = DateTime::parse_from_rfc3339(expires_at).with_context(|| {
-                format!(
-                    "risk signal `{}` has invalid expires_at `{expires_at}` (expected RFC3339)",
-                    stored.id
-                )
-            })?;
+            let Ok(expires) = DateTime::parse_from_rfc3339(expires_at) else {
+                tracing::warn!(
+                    signal_id = %stored.id,
+                    expires_at,
+                    "risk signal の expires_at が RFC3339 として解析できないため trust 入力から除外します"
+                );
+                continue;
+            };
             if expires <= now {
                 continue;
             }

--- a/crates/cn-core/tests/appeal_reviews.rs
+++ b/crates/cn-core/tests/appeal_reviews.rs
@@ -315,3 +315,115 @@ async fn operator_review_revalidates_and_commits_state_reports_and_audit_togethe
     database.cleanup().await?;
     result
 }
+
+/// #700: 中核処理へ不正な入力値(RFC 3339 でない有効期限・範囲外の確信度)を直接渡すと
+/// 保存前に拒否され、`risk_signals` / `reports` / `operator_actions` が一切変化しない。
+#[tokio::test]
+async fn invalid_review_inputs_are_rejected_without_state_change() -> Result<()> {
+    let Some(admin_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping appeal review integration test");
+        return Ok(());
+    };
+    let database = TestDatabase::create(admin_url.as_str(), "cn_appeal_invalid_700").await?;
+    let pool = connect_postgres(database.database_url.as_str()).await?;
+    let result = async {
+        initialize_database(&pool).await?;
+        let stored =
+            persist_risk_signal(&pool, ISSUER, &signal("dave", AppealStatus::None)).await?;
+        let appeal_report = insert_community_node_appeal(
+            &pool,
+            ISSUER,
+            &stored.id,
+            &report("dave", "不正入力の対象"),
+        )
+        .await?;
+        let expected = get_appeal_review(&pool, &stored.id)
+            .await?
+            .expect("review")
+            .version();
+        let before_signal = get_risk_signal(&pool, &stored.id).await?.expect("signal");
+        let before_signal_ids =
+            sqlx::query_scalar::<_, String>("SELECT id FROM cn_safety.risk_signals ORDER BY id")
+                .fetch_all(&pool)
+                .await?;
+
+        let invalid_operations = vec![
+            AppealReviewOperation::Edit {
+                expected: expected.clone(),
+                edit: RiskSignalMetadataEdit {
+                    expires_at: Some("not-a-timestamp".to_string()),
+                    ..RiskSignalMetadataEdit::default()
+                },
+            },
+            AppealReviewOperation::Edit {
+                expected: expected.clone(),
+                edit: RiskSignalMetadataEdit {
+                    confidence: Some(101),
+                    ..RiskSignalMetadataEdit::default()
+                },
+            },
+            AppealReviewOperation::Edit {
+                expected: expected.clone(),
+                edit: RiskSignalMetadataEdit {
+                    confidence: Some(255),
+                    ..RiskSignalMetadataEdit::default()
+                },
+            },
+            AppealReviewOperation::Reissue {
+                expected: expected.clone(),
+                correction: RiskSignalCorrection {
+                    confidence: Some(101),
+                    ..RiskSignalCorrection::default()
+                },
+            },
+        ];
+        for operation in &invalid_operations {
+            assert!(
+                apply_appeal_review_action(&pool, "ops@kukuri.app", &stored.id, operation, true)
+                    .await
+                    .is_err(),
+                "不正な入力値は拒否されるべき: {operation:?}"
+            );
+        }
+
+        // 拒否された操作でデータベースが一切変化していないこと。
+        let after_signal = get_risk_signal(&pool, &stored.id).await?.expect("signal");
+        assert_eq!(after_signal.signal, before_signal.signal);
+        let after_signal_ids =
+            sqlx::query_scalar::<_, String>("SELECT id FROM cn_safety.risk_signals ORDER BY id")
+                .fetch_all(&pool)
+                .await?;
+        assert_eq!(
+            after_signal_ids, before_signal_ids,
+            "再発行の新規行が残ってはならない"
+        );
+        assert_eq!(
+            get_community_node_report(&pool, &appeal_report.id)
+                .await?
+                .expect("report")
+                .status,
+            "received"
+        );
+        assert!(list_operator_actions(&pool, 50, 0).await?.is_empty());
+
+        // 妥当な入力(過去時刻を含む RFC 3339)は従来どおり適用できる。
+        apply_appeal_review_action(
+            &pool,
+            "ops@kukuri.app",
+            &stored.id,
+            &AppealReviewOperation::Edit {
+                expected,
+                edit: RiskSignalMetadataEdit {
+                    expires_at: Some("2000-01-01T00:00:00Z".to_string()),
+                    ..RiskSignalMetadataEdit::default()
+                },
+            },
+            true,
+        )
+        .await?;
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+    database.cleanup().await?;
+    result
+}

--- a/crates/cn-core/tests/safety_appeals.rs
+++ b/crates/cn-core/tests/safety_appeals.rs
@@ -206,6 +206,31 @@ async fn operator_review_can_edit_detection_metadata() -> Result<()> {
         assert_eq!(edited.signal.severity, Severity::Low);
         assert_eq!(edited.signal.confidence, Some(20));
 
+        // #700: 個別編集経路(cn-cli もここを通る)でも不正値は保存前に拒否される。
+        let invalid_expiry = RiskSignalMetadataEdit {
+            expires_at: Some("not-a-timestamp".to_string()),
+            ..RiskSignalMetadataEdit::default()
+        };
+        assert!(
+            edit_risk_signal_detection_metadata(&pool, &stored.id, &invalid_expiry, true)
+                .await
+                .is_err(),
+            "RFC 3339 でない有効期限は拒否する"
+        );
+        let invalid_confidence = RiskSignalCorrection {
+            confidence: Some(255),
+            ..RiskSignalCorrection::default()
+        };
+        assert!(
+            reissue_corrected_risk_signal(&pool, &stored.id, &invalid_confidence, NOW, true)
+                .await
+                .is_err(),
+            "範囲外の確信度は拒否する"
+        );
+        let unchanged = get_risk_signal(&pool, &stored.id).await?.expect("exists");
+        assert_eq!(unchanged.signal.expires_at, None);
+        assert_eq!(unchanged.signal.confidence, Some(20));
+
         // 訂正 signal の再発行: 旧 signal は失効し、訂正版が同じ issuer で新規発行される。
         let correction = RiskSignalCorrection {
             category: Some(SafetyCategory::Spam),

--- a/crates/cn-core/tests/trust_inputs.rs
+++ b/crates/cn-core/tests/trust_inputs.rs
@@ -163,16 +163,38 @@ fn expired_signal_is_excluded_from_trust_inputs() {
 }
 
 #[test]
-fn invalid_expires_at_is_an_error() {
-    // 不正な RFC3339 は黙って含めたり落としたりせず Err にする。
-    let signals = vec![stored_signal(
-        "sig-broken",
-        SafetyCategory::Csam,
-        Some("not-a-timestamp"),
-        None,
-    )];
-    let error = trust_risk_inputs_from(&signals, NOW).unwrap_err();
-    assert!(error.to_string().contains("invalid expires_at"), "{error}");
+fn invalid_expires_at_signal_is_ignored_and_read_succeeds() {
+    // #700: 保存済みの不正な expires_at は移行せず「無視」する決定。該当判定だけを
+    // 寄与から除外して読み取りは成功させ、他の判定には影響させない
+    // （不正値 1 件で trust read 全体が 500 にならない）。
+    let signals = vec![
+        stored_signal(
+            "sig-broken",
+            SafetyCategory::Csam,
+            Some("not-a-timestamp"),
+            None,
+        ),
+        stored_signal("sig-valid", SafetyCategory::Csam, None, None),
+    ];
+    let inputs = trust_risk_inputs_from(&signals, NOW).unwrap();
+    let ids: Vec<&str> = inputs
+        .absolute
+        .iter()
+        .map(|input| input.signal_id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["sig-valid"]);
+    assert!(inputs.relative.is_empty());
+}
+
+#[test]
+fn invalid_now_timestamp_is_still_an_error() {
+    // now はサーバ生成値なので、不正なら従来どおり Err にする（設定・呼び出し側の欠陥検出）。
+    let signals = vec![stored_signal("sig-1", SafetyCategory::Csam, None, None)];
+    let error = trust_risk_inputs_from(&signals, "not-a-timestamp").unwrap_err();
+    assert!(
+        error.to_string().contains("invalid now timestamp"),
+        "{error}"
+    );
 }
 
 // --- appeal 反映（ADR 0026 §6.2。Disputed = pending / Cleared = accepted） ---

--- a/crates/cn-user-api/src/admin.rs
+++ b/crates/cn-user-api/src/admin.rs
@@ -14,7 +14,8 @@ use kukuri_cn_core::{
     OperatorReportStatus, RiskSignalCorrection, RiskSignalMetadataEdit, apply_appeal_review_action,
     apply_operator_action, get_appeal_review, latest_readiness_activation, list_appeal_reviews,
     list_community_node_reports, list_operator_actions, list_supported_topics,
-    load_admission_config, parse_bool_env, validate_admin_operation,
+    load_admission_config, parse_bool_env, validate_admin_operation, validate_optional_confidence,
+    validate_optional_expires_at,
 };
 use serde::Deserialize;
 use tower_http::trace::TraceLayer;
@@ -257,7 +258,7 @@ fn appeal_operation_from_form(
                 category: parse_optional_enum("category", &form.category)?,
                 severity: parse_optional_enum("severity", &form.severity)?,
                 confidence: parse_optional_confidence(&form.confidence)?,
-                expires_at: optional_text(&form.expires_at),
+                expires_at: parse_optional_expires_at(&form.expires_at)?,
             },
         }),
         "appeal.reissue" => Ok(AppealReviewOperation::Reissue {
@@ -291,11 +292,25 @@ fn parse_optional_confidence(value: &str) -> anyhow::Result<Option<u8>> {
     if value.is_empty() {
         return Ok(None);
     }
-    let confidence = value.parse::<u8>().context("invalid confidence")?;
-    if confidence > 100 {
-        bail!("confidence must be between 0 and 100");
+    let Ok(confidence) = value.parse::<u8>() else {
+        bail!("確信度は 0 から 100 の整数で入力してください。");
+    };
+    if validate_optional_confidence(Some(confidence)).is_err() {
+        bail!("確信度は 0 から 100 の整数で入力してください。");
     }
     Ok(Some(confidence))
+}
+
+fn parse_optional_expires_at(value: &str) -> anyhow::Result<Option<String>> {
+    let Some(value) = optional_text(value) else {
+        return Ok(None);
+    };
+    if validate_optional_expires_at(Some(value.as_str())).is_err() {
+        bail!(
+            "有効期限は RFC 3339 形式（例: 2026-08-20T09:00:00+09:00）で入力してください。過去時刻は失効として受理されます。"
+        );
+    }
+    Ok(Some(value))
 }
 
 fn optional_text(value: &str) -> Option<String> {
@@ -918,5 +933,68 @@ mod tests {
         let mut unsupported = form;
         unsupported.category = "not-a-category".to_string();
         assert!(appeal_operation_from_form(&unsupported, expected).is_err());
+    }
+
+    #[test]
+    fn appeal_form_rejects_invalid_expires_at_with_japanese_message() {
+        // #700: RFC 3339 でない有効期限は解析段階（確認・適用の両方が通る経路）で拒否する。
+        let expected = AppealReviewVersion {
+            appeal_status: "disputed".to_string(),
+            category: "nsfw".to_string(),
+            severity: "high".to_string(),
+            confidence: Some(90),
+            visibility: "local".to_string(),
+            expires_at: None,
+            reports: vec![("report-1".to_string(), "received".to_string())],
+        };
+        let mut form = AdminActionForm {
+            action: "appeal.edit".to_string(),
+            target_id: "signal-1".to_string(),
+            expires_at: "not-a-timestamp".to_string(),
+            ..AdminActionForm::default()
+        };
+        let error = appeal_operation_from_form(&form, expected.clone()).unwrap_err();
+        assert!(error.to_string().contains("RFC 3339"), "{error}");
+        assert!(error.to_string().contains("有効期限"), "{error}");
+
+        // 妥当な RFC 3339（時差付き・過去を含む）は受理される。
+        for valid in [
+            "2026-08-20T09:00:00Z",
+            "2026-08-20T18:00:00+09:00",
+            "2000-01-01T00:00:00Z",
+        ] {
+            form.expires_at = valid.to_string();
+            assert!(
+                appeal_operation_from_form(&form, expected.clone()).is_ok(),
+                "{valid} は受理されるべき"
+            );
+        }
+    }
+
+    #[test]
+    fn appeal_form_rejects_out_of_range_confidence_with_japanese_message() {
+        let expected = AppealReviewVersion {
+            appeal_status: "disputed".to_string(),
+            category: "nsfw".to_string(),
+            severity: "high".to_string(),
+            confidence: Some(90),
+            visibility: "local".to_string(),
+            expires_at: None,
+            reports: vec![("report-1".to_string(), "received".to_string())],
+        };
+        // 再発行（適用時にも同じ解析を通る）でも範囲外・数値以外は拒否される。
+        for invalid in ["101", "255", "abc", "-1"] {
+            let form = AdminActionForm {
+                action: "appeal.reissue".to_string(),
+                target_id: "signal-1".to_string(),
+                confidence: invalid.to_string(),
+                ..AdminActionForm::default()
+            };
+            let error = appeal_operation_from_form(&form, expected.clone()).unwrap_err();
+            assert!(
+                error.to_string().contains("0 から 100"),
+                "{invalid}: {error}"
+            );
+        }
     }
 }

--- a/crates/cn-user-api/src/admin.rs
+++ b/crates/cn-user-api/src/admin.rs
@@ -907,9 +907,8 @@ mod tests {
         assert!(html.contains("kukuri:topic:&lt;script&gt;"));
     }
 
-    #[test]
-    fn appeal_form_maps_only_supported_review_operations() {
-        let expected = AppealReviewVersion {
+    fn disputed_appeal_version() -> AppealReviewVersion {
+        AppealReviewVersion {
             appeal_status: "disputed".to_string(),
             category: "nsfw".to_string(),
             severity: "high".to_string(),
@@ -917,7 +916,12 @@ mod tests {
             visibility: "local".to_string(),
             expires_at: None,
             reports: vec![("report-1".to_string(), "received".to_string())],
-        };
+        }
+    }
+
+    #[test]
+    fn appeal_form_maps_only_supported_review_operations() {
+        let expected = disputed_appeal_version();
         let form = AdminActionForm {
             action: "appeal.edit".to_string(),
             target_id: "signal-1".to_string(),
@@ -938,15 +942,7 @@ mod tests {
     #[test]
     fn appeal_form_rejects_invalid_expires_at_with_japanese_message() {
         // #700: RFC 3339 でない有効期限は解析段階（確認・適用の両方が通る経路）で拒否する。
-        let expected = AppealReviewVersion {
-            appeal_status: "disputed".to_string(),
-            category: "nsfw".to_string(),
-            severity: "high".to_string(),
-            confidence: Some(90),
-            visibility: "local".to_string(),
-            expires_at: None,
-            reports: vec![("report-1".to_string(), "received".to_string())],
-        };
+        let expected = disputed_appeal_version();
         let mut form = AdminActionForm {
             action: "appeal.edit".to_string(),
             target_id: "signal-1".to_string(),
@@ -973,15 +969,7 @@ mod tests {
 
     #[test]
     fn appeal_form_rejects_out_of_range_confidence_with_japanese_message() {
-        let expected = AppealReviewVersion {
-            appeal_status: "disputed".to_string(),
-            category: "nsfw".to_string(),
-            severity: "high".to_string(),
-            confidence: Some(90),
-            visibility: "local".to_string(),
-            expires_at: None,
-            reports: vec![("report-1".to_string(), "received".to_string())],
-        };
+        let expected = disputed_appeal_version();
         // 再発行（適用時にも同じ解析を通る）でも範囲外・数値以外は拒否される。
         for invalid in ["101", "255", "abc", "-1"] {
             let form = AdminActionForm {


### PR DESCRIPTION
## 概要

Closes #700

運営者審査(調整・訂正再発行)と個別編集の入力値(`expires_at` / `confidence`)を保存前に共通関数で検証し、不正値が保存されて信頼評価の読み取りが `500 INTERNAL_ERROR` になる経路を塞ぎます。

## 変更内容

- **共通検証関数の追加**(`crates/cn-core/src/safety_appeals.rs`)
  - `validate_optional_confidence`: 確信度を 0 から 100 に制限
  - `validate_optional_expires_at`: 有効期限を RFC 3339 として解析し、妥当な値だけを受理(過去時刻は単独失効の正規手段として受理。時差付き表記も受理)
- **中核処理への組み込み**: 審査の `validate_edit` / `validate_correction`、個別編集 `edit_risk_signal_detection_metadata`、再発行 `reissue_corrected_risk_signal` が同じ検証関数を共有。`cn-cli` は中核関数経由のため自動適用
- **管理画面の入力解析**(`crates/cn-user-api/src/admin.rs`): 不正な有効期限・確信度を日本語の説明つき 400 で拒否(確認・適用の両方が同じ解析を通る)。日本語化は画面層で行い、中核のエラー文は既存流儀(英語)のまま
- **読み取り耐性**(`crates/cn-core/src/trust_inputs.rs`): 保存済みの不正な `expires_at` は移行せず、警告ログを残して該当判定だけを寄与から除外(不正値 1 件で trust read 全体を失敗させない)

## 試験

- 共通検証関数の単体試験(有効期限: 空欄・妥当・時差付き・過去・無効形式 / 確信度: 0・100・101・255・数値以外・未入力)
- 中核処理へ不正値を直接渡すと拒否され `risk_signals` / `reports` / `operator_actions` が不変であることを結合試験で固定
- 個別編集・再発行経路の拒否を既存結合試験に追加
- 管理画面の解析層で日本語の説明つき拒否を単体試験で固定
- trust 入力組み立ての新契約(不正値は除外して継続、`now` 不正は従来どおり Err)を契約試験で固定

## 検証結果

- `cargo xtask check`: 成功
- `cargo test -p kukuri-cn-core`(実 DB 結合試験込み): 全て成功
- `cargo test -p kukuri-cn-user-api`(実 DB / valkey 結合試験込み): 全て成功

## 補足

- 既に保存されている不正な有効期限は移行せず無視する方針(利用者決定)。本番は #709 未配線のため運営者編集経路が存在せず、既存の不正値はない前提
- 配布クエリ `list_distributable_risk_signals` の SQL 側キャスト耐性は対象外(書き込み検証で新規流入を防止)

🤖 Generated with [Claude Code](https://claude.com/claude-code)