### PR TITLE
fix: 異議申し立て審査の確認画面に変更前後の値を表示する (#701)

### DIFF
--- a/crates/cn-user-api/src/admin.rs
+++ b/crates/cn-user-api/src/admin.rs
@@ -21,7 +21,7 @@ use serde::Deserialize;
 use tower_http::trace::TraceLayer;
 use uuid::Uuid;
 
-use crate::admin_appeal_render::render_appeal_reviews;
+use crate::admin_appeal_render::{render_appeal_preview, render_appeal_reviews};
 use crate::state::UserApiState;
 
 pub(crate) fn admin_router(state: UserApiState) -> Router {
@@ -198,16 +198,18 @@ async fn preview_appeal_action(
             return render_action_error(StatusCode::BAD_REQUEST, format!("{error:#}").as_str());
         }
     };
-    let expected = review.version();
-    if let Err(error) = appeal_operation_from_form(form, expected.clone()) {
-        return render_action_error(StatusCode::BAD_REQUEST, format!("{error:#}").as_str());
-    }
+    // 表示値と適用値の出所を一致させるため、解析済み操作をそのまま描画へ渡す(#701)。
+    let operation = match appeal_operation_from_form(form, review.version()) {
+        Ok(operation) => operation,
+        Err(error) => {
+            return render_action_error(StatusCode::BAD_REQUEST, format!("{error:#}").as_str());
+        }
+    };
     Html(render_appeal_preview(
         state.csrf_token.as_str(),
         actor,
-        form,
+        &operation,
         &review,
-        &expected,
     ))
     .into_response()
 }
@@ -658,67 +660,6 @@ fn render_preview(
     render_simple_page("運営操作の確認", body.as_str())
 }
 
-fn render_appeal_preview(
-    csrf_token: &str,
-    actor: &str,
-    form: &AdminActionForm,
-    review: &AppealReview,
-    expected: &AppealReviewVersion,
-) -> String {
-    let (title, impact) = match form.action.as_str() {
-        "appeal.accept" => (
-            "異議申し立てを認容しますか",
-            "このリスク判定を Cleared にし、関連通報を処理済みにします。次回の信頼評価から、この判定の寄与は除外されます。",
-        ),
-        "appeal.reject" => (
-            "異議申し立てを棄却しますか",
-            "このリスク判定を None に戻し、関連通報を棄却済みにします。信頼評価への寄与は残ります。",
-        ),
-        "appeal.edit" => (
-            "検知情報を調整しますか",
-            "署名済みモデレーション事象と利用者の正本状態は変更せず、このノードのリスク判定だけを調整します。異議申し立ては審査中のままです。",
-        ),
-        "appeal.reissue" => (
-            "訂正版を再発行しますか",
-            "現在のリスク判定を失効させ、指定した検知情報と公開範囲で新しいリスク判定を発行します。異議申し立ては審査中のままです。",
-        ),
-        _ => ("操作を確認しますか", "指定した審査操作を適用します。"),
-    };
-    let expected_state = serde_json::to_string(expected).expect("appeal review version serializes");
-    let fields = [
-        ("category", form.category.as_str()),
-        ("severity", form.severity.as_str()),
-        ("confidence", form.confidence.as_str()),
-        ("expires_at", form.expires_at.as_str()),
-        ("visibility", form.visibility.as_str()),
-    ]
-    .into_iter()
-    .map(|(name, value)| {
-        format!(
-            "<input type=\"hidden\" name=\"{}\" value=\"{}\">",
-            name,
-            escape_html(value)
-        )
-    })
-    .collect::<String>();
-    let body = format!(
-        r#"<div class="dialog"><p class="meta">適用前の確認</p><h1>{}</h1><dl><dt>運営者</dt><dd><code>{}</code></dd><dt>リスク判定</dt><dd><code>{}</code></dd><dt>対象</dt><dd><code>{}/{}</code></dd><dt>現在の状態</dt><dd>{}</dd><dt>影響</dt><dd>{}</dd></dl><p class="boundary">適用時に現在値をもう一度取得し、確認後に変更されていた場合は拒否します。リスク判定、関連通報、操作記録は一つの取引で確定します。</p><form method="post" action="/actions/apply"><input type="hidden" name="csrf_token" value="{}"><input type="hidden" name="action" value="{}"><input type="hidden" name="target_id" value="{}"><input type="hidden" name="expected_state" value="{}">{}<button type="submit">確認して適用</button> <a href="/">取り消す</a></form></div>"#,
-        escape_html(title),
-        escape_html(actor),
-        escape_html(&review.risk_signal_id),
-        escape_html(&review.target),
-        escape_html(&review.target_id),
-        escape_html(&review.appeal_status),
-        escape_html(impact),
-        escape_html(csrf_token),
-        escape_html(&form.action),
-        escape_html(&form.target_id),
-        escape_html(&expected_state),
-        fields,
-    );
-    render_simple_page("異議申し立て審査の確認", body.as_str())
-}
-
 fn operation_summary(operation: &AdminOperation) -> (&'static str, String, String) {
     match operation {
         AdminOperation::SetAdmissionMode { mode } => (
@@ -778,7 +719,7 @@ fn render_action_error(status: StatusCode, message: &str) -> Response {
         .into_response()
 }
 
-fn render_simple_page(title: &str, body: &str) -> String {
+pub(crate) fn render_simple_page(title: &str, body: &str) -> String {
     format!(
         r#"<!doctype html><html lang="ja"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>{}</title><style>:root{{color-scheme:dark light;font-family:system-ui,sans-serif}}body{{max-width:760px;margin:0 auto;padding:24px;line-height:1.5}}.dialog{{border:1px solid currentColor;border-radius:18px;padding:20px}}code{{overflow-wrap:anywhere}}.meta{{opacity:.72}}.boundary{{border-left:4px solid #d59b16;padding-left:12px}}button{{min-height:44px;border:0;border-radius:999px;padding:10px 16px;font-weight:700}}dt{{font-weight:700;margin-top:10px}}dd{{margin-left:0}}</style></head><body>{}</body></html>"#,
         escape_html(title),

--- a/crates/cn-user-api/src/admin_appeal_render.rs
+++ b/crates/cn-user-api/src/admin_appeal_render.rs
@@ -1,8 +1,10 @@
-//! 異議申し立て審査一覧の表示。
+//! 異議申し立て審査の一覧と確認画面の表示。
 
-use kukuri_cn_core::AppealReview;
+use kukuri_cn_core::{
+    AppealReview, AppealReviewOperation, RiskSignalCorrection, RiskSignalMetadataEdit,
+};
 
-use crate::admin::{escape_html, option};
+use crate::admin::{escape_html, option, render_simple_page};
 
 pub(crate) fn render_appeal_reviews(
     reviews: &[AppealReview],
@@ -110,4 +112,402 @@ fn enum_options(values: &[&str], current: &str) -> String {
         .iter()
         .map(|value| option(value, value, *value == current))
         .collect()
+}
+
+/// 審査操作の確認画面(#680 / #701)。
+///
+/// 表示値と隠し入力を同じ解析済み操作から生成し、確認画面に見えた値と適用時に
+/// 再解析される値の出所を一致させる(ADR 0029 の「変更前後・影響・実行者を表示」)。
+pub(crate) fn render_appeal_preview(
+    csrf_token: &str,
+    actor: &str,
+    operation: &AppealReviewOperation,
+    review: &AppealReview,
+) -> String {
+    let (action, title, impact, changes) = match operation {
+        AppealReviewOperation::Accept { .. } => (
+            "appeal.accept",
+            "異議申し立てを認容しますか",
+            "このリスク判定を Cleared にし、関連通報を処理済みにします。次回の信頼評価から、この判定の寄与は除外されます。",
+            None,
+        ),
+        AppealReviewOperation::Reject { .. } => (
+            "appeal.reject",
+            "異議申し立てを棄却しますか",
+            "このリスク判定を None に戻し、関連通報を棄却済みにします。信頼評価への寄与は残ります。",
+            None,
+        ),
+        AppealReviewOperation::Edit { edit, .. } => (
+            "appeal.edit",
+            "検知情報を調整しますか",
+            "署名済みモデレーション事象と利用者の正本状態は変更せず、このノードのリスク判定だけを調整します。異議申し立ては審査中のままです。",
+            Some(render_change_list(&edit_changes(edit, review))),
+        ),
+        AppealReviewOperation::Reissue { correction, .. } => (
+            "appeal.reissue",
+            "訂正版を再発行しますか",
+            "現在のリスク判定を失効させ、指定した検知情報と公開範囲で新しいリスク判定を発行します。新しいリスク判定の失効時刻は未設定になります。異議申し立ては審査中のままです。",
+            Some(render_change_list(&reissue_changes(correction, review))),
+        ),
+    };
+    let expected = match operation {
+        AppealReviewOperation::Accept { expected }
+        | AppealReviewOperation::Reject { expected }
+        | AppealReviewOperation::Edit { expected, .. }
+        | AppealReviewOperation::Reissue { expected, .. } => expected,
+    };
+    let expected_state = serde_json::to_string(expected).expect("appeal review version serializes");
+    let body = format!(
+        r#"<div class="dialog"><p class="meta">適用前の確認</p><h1>{}</h1><dl><dt>運営者</dt><dd><code>{}</code></dd><dt>リスク判定</dt><dd><code>{}</code></dd><dt>対象</dt><dd><code>{}/{}</code></dd><dt>現在の状態</dt><dd>{}</dd>{}<dt>影響</dt><dd>{}</dd></dl><p class="boundary">適用時に現在値をもう一度取得し、確認後に変更されていた場合は拒否します。リスク判定、関連通報、操作記録は一つの取引で確定します。</p><form method="post" action="/actions/apply"><input type="hidden" name="csrf_token" value="{}"><input type="hidden" name="action" value="{}"><input type="hidden" name="target_id" value="{}"><input type="hidden" name="expected_state" value="{}">{}<button type="submit">確認して適用</button> <a href="/">取り消す</a></form></div>"#,
+        escape_html(title),
+        escape_html(actor),
+        escape_html(&review.risk_signal_id),
+        escape_html(&review.target),
+        escape_html(&review.target_id),
+        escape_html(&review.appeal_status),
+        changes.unwrap_or_default(),
+        escape_html(impact),
+        escape_html(csrf_token),
+        escape_html(action),
+        escape_html(&review.risk_signal_id),
+        escape_html(&expected_state),
+        hidden_metadata_fields(operation),
+    );
+    render_simple_page("異議申し立て審査の確認", body.as_str())
+}
+
+/// 変更前後表示の 1 項目。`after` が `None`(未入力)の項目は現在値を維持する。
+struct FieldChange {
+    label: &'static str,
+    before: String,
+    after: Option<String>,
+}
+
+fn edit_changes(edit: &RiskSignalMetadataEdit, review: &AppealReview) -> Vec<FieldChange> {
+    vec![
+        FieldChange {
+            label: "分類",
+            before: review.category.clone(),
+            after: edit.category.map(|value| enum_text(&value)),
+        },
+        FieldChange {
+            label: "深刻度",
+            before: review.severity.clone(),
+            after: edit.severity.map(|value| enum_text(&value)),
+        },
+        FieldChange {
+            label: "確信度",
+            before: optional_number_text(review.confidence),
+            after: edit.confidence.map(|value| value.to_string()),
+        },
+        FieldChange {
+            label: "失効時刻",
+            before: optional_text(review.expires_at.as_deref()),
+            after: edit.expires_at.clone(),
+        },
+    ]
+}
+
+fn reissue_changes(correction: &RiskSignalCorrection, review: &AppealReview) -> Vec<FieldChange> {
+    vec![
+        FieldChange {
+            label: "分類",
+            before: review.category.clone(),
+            after: correction.category.map(|value| enum_text(&value)),
+        },
+        FieldChange {
+            label: "深刻度",
+            before: review.severity.clone(),
+            after: correction.severity.map(|value| enum_text(&value)),
+        },
+        FieldChange {
+            label: "確信度",
+            before: optional_number_text(review.confidence),
+            after: correction.confidence.map(|value| value.to_string()),
+        },
+        FieldChange {
+            label: "公開範囲",
+            before: review.visibility.clone(),
+            after: correction.visibility.map(|value| enum_text(&value)),
+        },
+    ]
+}
+
+/// 変更前後の一覧。調整フォームは現在値で事前入力されるため、入力があっても
+/// 確認時点の現在値と同じなら「維持」と表示する(#701)。
+fn render_change_list(changes: &[FieldChange]) -> String {
+    let items = changes
+        .iter()
+        .map(|change| {
+            match change
+                .after
+                .as_deref()
+                .filter(|after| *after != change.before)
+            {
+                Some(after) => format!(
+                    "<li>{}: <code>{}</code> → <code>{}</code></li>",
+                    change.label,
+                    escape_html(&change.before),
+                    escape_html(after),
+                ),
+                None => format!(
+                    "<li>{}: <code>{}</code>(維持)</li>",
+                    change.label,
+                    escape_html(&change.before),
+                ),
+            }
+        })
+        .collect::<String>();
+    format!("<dt>変更内容(変更前は確認時点の審査情報)</dt><dd><ul>{items}</ul></dd>")
+}
+
+/// 適用フォームへ写す検知情報の隠し入力。解析済み操作から生成し、未変更(None)は
+/// 空欄として写す(適用時の再解析で None に戻る)。
+fn hidden_metadata_fields(operation: &AppealReviewOperation) -> String {
+    let (category, severity, confidence, expires_at, visibility) = match operation {
+        AppealReviewOperation::Edit { edit, .. } => (
+            edit.category.map(|value| enum_text(&value)),
+            edit.severity.map(|value| enum_text(&value)),
+            edit.confidence.map(|value| value.to_string()),
+            edit.expires_at.clone(),
+            None,
+        ),
+        AppealReviewOperation::Reissue { correction, .. } => (
+            correction.category.map(|value| enum_text(&value)),
+            correction.severity.map(|value| enum_text(&value)),
+            correction.confidence.map(|value| value.to_string()),
+            None,
+            correction.visibility.map(|value| enum_text(&value)),
+        ),
+        AppealReviewOperation::Accept { .. } | AppealReviewOperation::Reject { .. } => {
+            (None, None, None, None, None)
+        }
+    };
+    [
+        ("category", category),
+        ("severity", severity),
+        ("confidence", confidence),
+        ("expires_at", expires_at),
+        ("visibility", visibility),
+    ]
+    .into_iter()
+    .map(|(name, value)| {
+        format!(
+            "<input type=\"hidden\" name=\"{}\" value=\"{}\">",
+            name,
+            escape_html(value.as_deref().unwrap_or_default()),
+        )
+    })
+    .collect()
+}
+
+/// snake_case enum の wire 表現(解析側 `parse_optional_enum` と対称の serde 経由)。
+fn enum_text<T: serde::Serialize>(value: &T) -> String {
+    match serde_json::to_value(value) {
+        Ok(serde_json::Value::String(text)) => text,
+        _ => String::new(),
+    }
+}
+
+fn optional_number_text(value: Option<u8>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "なし".to_string())
+}
+
+fn optional_text(value: Option<&str>) -> String {
+    value.unwrap_or("なし").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use kukuri_cn_core::{
+        AppealReviewOperation, AppealReviewReport, RiskSignalCorrection, RiskSignalMetadataEdit,
+    };
+    use kukuri_cn_safety::{SafetyCategory, Severity, Visibility};
+
+    fn review_fixture() -> AppealReview {
+        AppealReview {
+            risk_signal_id: "signal-1".to_string(),
+            issuer_node_id: "issuer-node".to_string(),
+            target: "post_id".to_string(),
+            target_id: "post-1".to_string(),
+            category: "nsfw".to_string(),
+            severity: "high".to_string(),
+            basis: "classifier_score".to_string(),
+            confidence: Some(90),
+            visibility: "local".to_string(),
+            expires_at: None,
+            appeal_status: "disputed".to_string(),
+            reports: vec![AppealReviewReport {
+                id: "report-1".to_string(),
+                details: Some("説明".to_string()),
+                status: "received".to_string(),
+                created_at: "2026-08-15T00:00:00Z".parse().expect("timestamp"),
+            }],
+        }
+    }
+
+    // --- #701: 確認画面に変更前後の値を表示する契約 ---
+
+    #[test]
+    fn edit_preview_shows_before_and_after_from_parsed_operation() {
+        let review = review_fixture();
+        let operation = AppealReviewOperation::Edit {
+            expected: review.version(),
+            edit: RiskSignalMetadataEdit {
+                category: Some(SafetyCategory::Spam),
+                // 調整フォームは現在値で事前入力されるため、現在値と同じ入力は「維持」と表示する。
+                severity: Some(Severity::High),
+                confidence: Some(20),
+                expires_at: None,
+            },
+        };
+        let html = render_appeal_preview("csrf", "ops@kukuri.app", &operation, &review);
+
+        // 変更前の出典を明示する。
+        assert!(html.contains("確認時点の審査情報"), "{html}");
+        // 変更する項目は変更前 → 変更後を表示する。
+        assert!(
+            html.contains("<li>分類: <code>nsfw</code> → <code>spam</code></li>"),
+            "{html}"
+        );
+        assert!(
+            html.contains("<li>確信度: <code>90</code> → <code>20</code></li>"),
+            "{html}"
+        );
+        // 値を維持する項目は「維持」と区別して表示する(現在値と同じ入力・未入力の両方)。
+        assert!(
+            html.contains("<li>深刻度: <code>high</code>(維持)</li>"),
+            "{html}"
+        );
+        assert!(
+            html.contains("<li>失効時刻: <code>なし</code>(維持)</li>"),
+            "{html}"
+        );
+
+        // 隠し入力は解析済み操作から生成する(表示値と適用値の出所を一致させる)。
+        assert!(
+            html.contains(r#"<input type="hidden" name="category" value="spam">"#),
+            "{html}"
+        );
+        assert!(
+            html.contains(r#"<input type="hidden" name="severity" value="high">"#),
+            "{html}"
+        );
+        assert!(
+            html.contains(r#"<input type="hidden" name="confidence" value="20">"#),
+            "{html}"
+        );
+        assert!(
+            html.contains(r#"<input type="hidden" name="expires_at" value="">"#),
+            "{html}"
+        );
+        assert!(html.contains(r#"name="expected_state""#), "{html}");
+        // 実行者・対象・競合時の拒否方針は既存どおり表示する。
+        assert!(html.contains("ops@kukuri.app"), "{html}");
+        assert!(html.contains("signal-1"), "{html}");
+        assert!(
+            html.contains("確認後に変更されていた場合は拒否します"),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn reissue_preview_shows_before_after_and_notes_empty_expiry() {
+        let review = review_fixture();
+        let operation = AppealReviewOperation::Reissue {
+            expected: review.version(),
+            correction: RiskSignalCorrection {
+                category: None,
+                severity: None,
+                confidence: None,
+                visibility: Some(Visibility::Public),
+            },
+        };
+        let html = render_appeal_preview("csrf", "ops@kukuri.app", &operation, &review);
+
+        assert!(
+            html.contains("<li>公開範囲: <code>local</code> → <code>public</code></li>"),
+            "{html}"
+        );
+        // 未入力(None)の項目は現在値の維持として表示する。
+        assert!(
+            html.contains("<li>分類: <code>nsfw</code>(維持)</li>"),
+            "{html}"
+        );
+        assert!(
+            html.contains("<li>深刻度: <code>high</code>(維持)</li>"),
+            "{html}"
+        );
+        assert!(
+            html.contains("<li>確信度: <code>90</code>(維持)</li>"),
+            "{html}"
+        );
+        // 新しいリスク判定の失効時刻が未設定になる点を影響文で説明する。
+        assert!(
+            html.contains("新しいリスク判定の失効時刻は未設定になります"),
+            "{html}"
+        );
+        assert!(
+            html.contains(r#"<input type="hidden" name="visibility" value="public">"#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn accept_and_reject_previews_keep_transition_summary() {
+        let review = review_fixture();
+        let accept = render_appeal_preview(
+            "csrf",
+            "ops@kukuri.app",
+            &AppealReviewOperation::Accept {
+                expected: review.version(),
+            },
+            &review,
+        );
+        assert!(accept.contains("異議申し立てを認容しますか"), "{accept}");
+        assert!(accept.contains("Cleared"), "{accept}");
+        assert!(
+            accept.contains("確認後に変更されていた場合は拒否します"),
+            "{accept}"
+        );
+
+        let reject = render_appeal_preview(
+            "csrf",
+            "ops@kukuri.app",
+            &AppealReviewOperation::Reject {
+                expected: review.version(),
+            },
+            &review,
+        );
+        assert!(reject.contains("異議申し立てを棄却しますか"), "{reject}");
+        assert!(reject.contains("None に戻し"), "{reject}");
+    }
+
+    #[test]
+    fn preview_escapes_untrusted_values() {
+        let mut review = review_fixture();
+        review.category = "<script>alert(1)</script>".to_string();
+        review.risk_signal_id = "signal-<script>".to_string();
+        let operation = AppealReviewOperation::Edit {
+            expected: review.version(),
+            edit: RiskSignalMetadataEdit {
+                category: Some(SafetyCategory::Spam),
+                severity: None,
+                confidence: None,
+                expires_at: None,
+            },
+        };
+        let html = render_appeal_preview("csrf", "ops<script>@kukuri.app", &operation, &review);
+        assert!(!html.contains("<script>alert(1)</script>"), "{html}");
+        assert!(
+            html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"),
+            "{html}"
+        );
+        assert!(!html.contains("signal-<script>"), "{html}");
+        assert!(!html.contains("ops<script>"), "{html}");
+    }
 }


### PR DESCRIPTION
## 概要

Closes #701

設計判断文書 0029 が定める「運営操作の確認画面に変更前後の値・影響・実行者を表示する」契約を、異議申し立て審査の確認画面(調整・訂正再発行)で満たします。

## 変更内容

- **表示値と隠し入力の出所を統一**: `preview_appeal_action` が `appeal_operation_from_form` の解析結果を捨てずに描画へ渡し、確認画面の表示値と適用フォームの隠し入力を同じ解析済み操作(`AppealReviewOperation`)から生成。確認画面に見えた値と実際に保存される値が一致します
- **調整の変更前後表示**: 分類・深刻度・確信度・失効時刻の変更前 → 変更後を表示。変更前の出典(確認時点の審査情報)を明示
- **再発行の変更前後表示**: 分類・深刻度・確信度・公開範囲の変更前後を表示し、影響文に「新しいリスク判定の失効時刻は未設定になります」を追記
- **維持と変更の区別**: 調整フォームは現在値で事前入力されるため、入力があっても確認時点の現在値と同じなら「維持」と表示(未入力も同様)。値を消す操作は現在存在しないため対象外
- **既存表示の維持**: 実行者・対象・現在の状態・影響・競合時の拒否方針(確認後に変更されていた場合は拒否)は既存どおり
- **配置**: `render_appeal_preview` を描画責務の `admin_appeal_render.rs` へ移設(`admin.rs` が 1000 行 ratchet 目前のため。移設後 929 行)

## 試験

- `render_appeal_preview` の単体試験を追加(認容・棄却・調整・再発行の 4 操作):
  - 調整・再発行で変更前後が可視部分に含まれ、維持項目と変更項目が区別される
  - 隠し入力が解析済み操作から生成される(category/severity/confidence/expires_at/visibility)
  - 悪意ある値が無害化される
  - 認容・棄却の状態遷移説明と競合拒否文言が維持される

## 検証結果

- `cargo xtask check`: 成功
- `cargo test -p kukuri-cn-core -p kukuri-cn-user-api`(実 DB / valkey 結合試験込み): 全て成功
- `cargo xtask oversized-files`: 違反なし(admin.rs 929 行 / admin_appeal_render.rs 513 行)

## 分担

- 入力値の妥当性検証(適用時の再検証を含む)は #700(マージ済み PR #726)

🤖 Generated with [Claude Code](https://claude.com/claude-code)