### PR TITLE
fix: 非公開チャンネルの索引参照を所属者に限定する (#711)

### DIFF
--- a/apps/desktop/src/components/core/CommunityIndexWorkspace.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexWorkspace.tsx
@@ -43,6 +43,7 @@ type IndexRequestContext = {
   operation: IndexOperation;
   scopeKind: CommunityNodeIndexQueryRequest['scope_kind'];
   scopeId: CommunityNodeIndexQueryRequest['scope_id'];
+  topicId: CommunityNodeIndexQueryRequest['topic_id'];
 };
 
 type IndexResultState = {
@@ -130,6 +131,8 @@ function indexContext(
     operation,
     scopeKind,
     scopeId,
+    // 非公開チャンネル範囲では所属証明(channel secret)を引くために topic が要る(#711)。
+    topicId: scopeKind === 'private_channel' ? activeTopic : null,
   };
 }
 
@@ -260,6 +263,7 @@ export function CommunityIndexWorkspace({
       query: currentContext.operation === 'search' ? query.trim() : null,
       scope_kind: currentContext.scopeKind,
       scope_id: currentContext.scopeId,
+      topic_id: currentContext.topicId,
       limit: 50,
     };
     const requestContext = currentContext;

--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -191,7 +191,12 @@ export type CommunityNodeManifestFetchStatus = "ok" | "absent";
 
 export type CommunityNodeManifestFetch = { status: CommunityNodeManifestFetchStatus, manifest?: CommunityNodeManifest | null, };
 
-export type CommunityNodeIndexQueryRequest = { base_url: string, query?: string | null, scope_kind?: IndexScopeKind | null, scope_id?: string | null, limit?: number | null, };
+export type CommunityNodeIndexQueryRequest = { base_url: string, query?: string | null, scope_kind?: IndexScopeKind | null, scope_id?: string | null, 
+/**
+ * scope_kind が private_channel のとき必須。所属証明(channel secret)を参加中
+ * チャンネルの capability から引くために使う(#711)。
+ */
+topic_id?: string | null, limit?: number | null, };
 
 export type CommunityNodeIndexQueryError = { code: string, message: string, status?: number | null, retry_after_seconds?: number | null, };
 

--- a/crates/cn-indexer/src/query.rs
+++ b/crates/cn-indexer/src/query.rs
@@ -128,7 +128,7 @@ impl IndexQuery for FailClosedIndexQuery {
 
     async fn search_all(&self, query: &str, limit: usize) -> Result<Vec<IndexedEntry>> {
         let limit = clamp_query_limit(limit);
-        let hits = self.inner.search_all(query, limit).await?;
+        let hits = exclude_private_channel(self.inner.search_all(query, limit).await?);
         self.gate(hits).await
     }
 
@@ -139,6 +139,23 @@ impl IndexQuery for FailClosedIndexQuery {
     ) -> Result<Vec<IndexedEntry>> {
         let limit = clamp_query_limit(limit);
         let hits = self.inner.list_recent(scope, limit).await?;
+        let hits = if scope.is_none() {
+            exclude_private_channel(hits)
+        } else {
+            hits
+        };
         self.gate(hits).await
     }
+}
+
+/// 横断読みから非公開チャンネルの項目を除外する(#711 / ADR 0025 §6.3)。
+///
+/// 非公開チャンネルの索引は参加者に閉じるため、scope 無指定の search / discovery /
+/// recommendation には項目も識別子(`scope_id`)も出さない。所属証明つきの範囲指定読み
+/// (`search_scope` / scope 指定の `list_recent`)だけが読み口になる(所属証明の検証は
+/// cn-user-api の門が担う)。
+fn exclude_private_channel(hits: Vec<IndexedEntry>) -> Vec<IndexedEntry> {
+    hits.into_iter()
+        .filter(|hit| hit.scope_kind != IndexScopeKind::PrivateChannel)
+        .collect()
 }

--- a/crates/cn-indexer/tests/query_contracts.rs
+++ b/crates/cn-indexer/tests/query_contracts.rs
@@ -24,7 +24,9 @@ use kukuri_cn_safety_runtime::id::UuidEventIdGenerator;
 use kukuri_cn_safety_runtime::{MemorySafetyArtifactStore, SafetyArtifactStore, SafetyScanService};
 use kukuri_cn_safety_runtime::{SafetyOrchestrator, Secp256k1ModerationEventSigner};
 use kukuri_core::{KukuriKeys, ReplicaId, TopicId, build_post_envelope};
-use kukuri_docs_sync::{DocOp, DocsSync, MemoryDocsSync, stable_key, topic_replica_id};
+use kukuri_docs_sync::{
+    DocOp, DocsSync, MemoryDocsSync, private_channel_replica_id, stable_key, topic_replica_id,
+};
 
 const TEST_SECRET: &str = "0000000000000000000000000000000000000000000000000000000000000001";
 
@@ -258,6 +260,64 @@ async fn deindexed_scope_disappears_from_all_read_surfaces() -> Result<()> {
 
     assert!(f.query.search_all("unsupported", 10).await?.is_empty());
     assert!(f.query.list_recent(None, 10).await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn cross_scope_reads_exclude_private_channel_entries() -> Result<()> {
+    // #711 / ADR 0025 §6.3: 非公開チャンネルの索引は参加者に閉じる。横断読み
+    // (search_all / list_recent(None)) には private_channel 項目を出さず、範囲指定読みは
+    // 返す(所属証明の検証は cn-user-api の門が担う)。
+    let f = fixture();
+    let topic = TopicId::new("rust");
+    let topic_replica = topic_replica_id("rust");
+    let public_post = persist_post(&f.docs, &topic_replica, &topic, "shared async post").await;
+    let channel_replica = private_channel_replica_id("secret-room");
+    // MemoryDocsSync の非公開 replica は capability 登録後に開ける。
+    f.docs
+        .register_private_replica_secret(
+            &channel_replica,
+            "1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .await?;
+    let private_post = persist_post(&f.docs, &channel_replica, &topic, "hidden async post").await;
+
+    f.pipeline
+        .ingest_scope(IndexScopeKind::PublicTopic, "rust", &topic_replica)
+        .await?;
+    f.pipeline
+        .ingest_scope(
+            IndexScopeKind::PrivateChannel,
+            "secret-room",
+            &channel_replica,
+        )
+        .await?;
+
+    // 横断検索・横断新着には非公開チャンネルの項目も識別子(scope_id)も出ない。
+    let hits = f.query.search_all("async", 10).await?;
+    let ids: Vec<&str> = hits.iter().map(|hit| hit.object_id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec![public_post.as_str()],
+        "search_all は公開 scope のみ"
+    );
+    let recent = f.query.list_recent(None, 10).await?;
+    let ids: Vec<&str> = recent.iter().map(|hit| hit.object_id.as_str()).collect();
+    assert_eq!(ids, vec![public_post.as_str()], "横断新着は公開 scope のみ");
+
+    // 範囲指定読みは従来どおり返す(この層では所属を判定しない)。
+    let scoped = f
+        .query
+        .search_scope(IndexScopeKind::PrivateChannel, "secret-room", "async", 10)
+        .await?;
+    assert_eq!(scoped.len(), 1);
+    assert_eq!(scoped[0].object_id, private_post);
+    let scoped_recent = f
+        .query
+        .list_recent(Some((IndexScopeKind::PrivateChannel, "secret-room")), 10)
+        .await?;
+    assert_eq!(scoped_recent.len(), 1);
+    assert_eq!(scoped_recent[0].object_id, private_post);
     Ok(())
 }
 

--- a/crates/cn-protocol/src/index.rs
+++ b/crates/cn-protocol/src/index.rs
@@ -96,6 +96,19 @@ impl IndexScopeKind {
     }
 }
 
+/// 非公開チャンネル範囲指定読みの所属証明(channel secret hex)を運ぶ HTTP ヘッダ名(#711)。
+///
+/// 秘密値を URL クエリへ載せるとアクセスログに露出するため、専用ヘッダで送る。
+/// 提示された値はサーバが保存済み capability の復号値と照合する(ADR 0025 §6.3
+/// 「秘密値の提示が権限の証明」を read にも適用)。
+pub const CHANNEL_MEMBERSHIP_SECRET_HEADER: &str = "x-kukuri-channel-secret";
+
+/// 非公開チャンネル範囲指定読みで所属証明が満たされないときの安定コード(#711)。
+///
+/// 未提示・不一致・チャンネル未登録・暗号鍵未設定を区別せず同一コード(403)で返し、
+/// 非所属者に索引の存在有無を漏らさない。
+pub const CHANNEL_MEMBERSHIP_REQUIRED_CODE: &str = "CHANNEL_MEMBERSHIP_REQUIRED";
+
 /// Query parameters shared by search, discovery, and recommendations.
 ///
 /// `scope_kind` and `scope_id` must either both be present or both be absent.

--- a/crates/cn-user-api/src/errors.rs
+++ b/crates/cn-user-api/src/errors.rs
@@ -113,6 +113,7 @@ pub(crate) enum IndexingOperation {
     Discovery,
     Recommendations,
     FilterRelationVisibility,
+    VerifyChannelMembership,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/cn-user-api/src/handlers/indexing.rs
+++ b/crates/cn-user-api/src/handlers/indexing.rs
@@ -7,12 +7,13 @@ use axum::Json;
 use axum::extract::{Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use kukuri_cn_core::{
-    ApiError, ApiResult, IndexScopeKind, filter_relation_visible, insert_indexing_request,
-    register_channel_secret, require_bearer_identity, require_consents,
+    ApiError, ApiResult, IndexScopeKind, filter_relation_visible, get_channel_secret,
+    insert_indexing_request, register_channel_secret, require_bearer_identity, require_consents,
 };
 use kukuri_cn_indexer::IndexQuery;
 use kukuri_cn_protocol::{
-    IndexEntryView, IndexQueryParams, IndexQueryResponse, SubmitIndexingRequestRequest,
+    CHANNEL_MEMBERSHIP_REQUIRED_CODE, CHANNEL_MEMBERSHIP_SECRET_HEADER, IndexEntryView,
+    IndexQueryParams, IndexQueryResponse, SubmitIndexingRequestRequest,
     SubmitIndexingRequestResponse,
 };
 
@@ -178,6 +179,63 @@ async fn filter_index_entries(
         .collect())
 }
 
+/// 非公開チャンネル範囲指定読みの所属証明(#711 / ADR 0025 §6.3)。
+///
+/// 提示された channel secret を保存済み capability の復号値と定数時間比較する。
+/// 「秘密値の提示が権限の証明」(申請側と同じ原則)を read にも適用し、新しい権限体系は
+/// 作らない。未提示・不一致・チャンネル未登録・暗号鍵未設定は同一の安定コードで拒否し、
+/// 非所属者に索引の存在有無を漏らさない。提示値・保存値はログへ出さない。
+async fn require_channel_membership(
+    state: &UserApiState,
+    headers: &HeaderMap,
+    channel_id: &str,
+) -> ApiResult<()> {
+    let denied = || {
+        ApiError::new(
+            StatusCode::FORBIDDEN,
+            CHANNEL_MEMBERSHIP_REQUIRED_CODE,
+            "private channel index queries require the channel secret of a participant",
+        )
+    };
+    let presented = headers
+        .get(CHANNEL_MEMBERSHIP_SECRET_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let Some(presented) = presented else {
+        return Err(denied());
+    };
+    let Some(cipher) = state.channel_secret_cipher.as_ref() else {
+        return Err(denied());
+    };
+    let stored = get_channel_secret(&state.pool, cipher, channel_id)
+        .await
+        .map_err(|source| {
+            IndexingError::infrastructure(IndexingOperation::VerifyChannelMembership, source)
+        })
+        .map_err(indexing_error)?;
+    let Some(stored) = stored else {
+        return Err(denied());
+    };
+    if !constant_time_str_eq(stored.namespace_secret_hex.as_str(), presented) {
+        return Err(denied());
+    }
+    Ok(())
+}
+
+fn constant_time_str_eq(expected: &str, supplied: &str) -> bool {
+    if expected.len() != supplied.len() || expected.is_empty() {
+        return false;
+    }
+    expected
+        .bytes()
+        .zip(supplied.bytes())
+        .fold(0_u8, |difference, (left, right)| {
+            difference | (left ^ right)
+        })
+        == 0
+}
+
 /// `scope_kind` / `scope_id` パラメータの組を解釈する。
 ///
 /// 両方指定 = scope 内読み、両方無指定 = 横断。片方のみは 400。
@@ -244,11 +302,18 @@ pub(crate) async fn index_search(
         })?;
     let limit = index_query_limit(&params);
     let entries = match parse_index_scope_params(&params)? {
-        Some((scope_kind, scope_id)) => index_query
-            .search_scope(scope_kind, scope_id.as_str(), query, limit)
-            .await
-            .map_err(|source| IndexingError::infrastructure(IndexingOperation::SearchScope, source))
-            .map_err(indexing_error)?,
+        Some((scope_kind, scope_id)) => {
+            if scope_kind == IndexScopeKind::PrivateChannel {
+                require_channel_membership(&state, &headers, scope_id.as_str()).await?;
+            }
+            index_query
+                .search_scope(scope_kind, scope_id.as_str(), query, limit)
+                .await
+                .map_err(|source| {
+                    IndexingError::infrastructure(IndexingOperation::SearchScope, source)
+                })
+                .map_err(indexing_error)?
+        }
         None => index_query
             .search_all(query, limit)
             .await
@@ -278,6 +343,9 @@ pub(crate) async fn index_discovery(
         require_index_query(&state, &headers).await?;
     let limit = index_query_limit(&params);
     let scope = parse_index_scope_params(&params)?;
+    if let Some((IndexScopeKind::PrivateChannel, scope_id)) = scope.as_ref() {
+        require_channel_membership(&state, &headers, scope_id.as_str()).await?;
+    }
     let entries = index_query
         .list_recent(scope.as_ref().map(|(kind, id)| (*kind, id.as_str())), limit)
         .await

--- a/crates/cn-user-api/tests/index_query.rs
+++ b/crates/cn-user-api/tests/index_query.rs
@@ -14,11 +14,12 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use kukuri_cn_core::{
-    IndexEntryStore, IndexScopeKind, JwtConfig, MemoryIndexEntryStore, NewIndexEntry, TestDatabase,
+    ChannelSecretCipher, IndexEntryStore, IndexScopeKind, JwtConfig, MemoryIndexEntryStore,
+    NewIndexEntry, TestDatabase, connect_postgres, register_channel_secret,
 };
 use kukuri_cn_indexer::projection::{IndexProjection, IndexedEntry, MemoryIndexProjection};
 use kukuri_cn_indexer::query::FailClosedIndexQuery;
-use kukuri_cn_protocol::build_auth_envelope_json;
+use kukuri_cn_protocol::{CHANNEL_MEMBERSHIP_SECRET_HEADER, build_auth_envelope_json};
 use kukuri_cn_safety::provider::SubjectKind;
 use kukuri_cn_safety::{ReasonCode, SafetyAction, SafetyVerdict};
 use kukuri_cn_safety_runtime::{MemorySafetyArtifactStore, SafetyArtifactStore};
@@ -81,6 +82,24 @@ impl MemoryIndex {
         author_pubkey: &str,
         text: &str,
     ) -> Result<()> {
+        self.seed_allow_in(
+            IndexScopeKind::PublicTopic,
+            scope_id,
+            object_id,
+            author_pubkey,
+            text,
+        )
+        .await
+    }
+
+    async fn seed_allow_in(
+        &self,
+        scope_kind: IndexScopeKind,
+        scope_id: &str,
+        object_id: &str,
+        author_pubkey: &str,
+        text: &str,
+    ) -> Result<()> {
         let verdict_id = self
             .store
             .persist_verdict(
@@ -91,7 +110,7 @@ impl MemoryIndex {
             .await?;
         self.entries
             .upsert_entry(&NewIndexEntry {
-                scope_kind: IndexScopeKind::PublicTopic,
+                scope_kind,
                 scope_id: scope_id.to_string(),
                 object_id: object_id.to_string(),
                 author_pubkey: author_pubkey.to_string(),
@@ -104,7 +123,7 @@ impl MemoryIndex {
             .await?;
         self.projection
             .upsert_entry(&IndexedEntry {
-                scope_kind: IndexScopeKind::PublicTopic,
+                scope_kind,
                 scope_id: scope_id.to_string(),
                 object_id: object_id.to_string(),
                 author_pubkey: author_pubkey.to_string(),
@@ -144,6 +163,16 @@ impl TestServer {
         prefix: &str,
         index: Option<Arc<FailClosedIndexQuery>>,
     ) -> Result<Self> {
+        Self::spawn_with_channel_secret_key(admin_database_url, prefix, index, None).await
+    }
+
+    /// channel secret の at-rest 暗号鍵つきで起動する(#711 の所属証明検証用)。
+    async fn spawn_with_channel_secret_key(
+        admin_database_url: &str,
+        prefix: &str,
+        index: Option<Arc<FailClosedIndexQuery>>,
+        channel_secret_key: Option<&str>,
+    ) -> Result<Self> {
         let database = TestDatabase::create(admin_database_url, prefix).await?;
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
@@ -161,7 +190,7 @@ impl TestServer {
             connectivity_urls: vec!["http://127.0.0.1:13340".to_string()],
             jwt_config: JwtConfig::new("kukuri-cn-tests", "test-secret", 3600),
             operator_config_path: None,
-            channel_secret_key: None,
+            channel_secret_key: channel_secret_key.map(str::to_string),
             index_query_enabled: false,
             trust_read_enabled: false,
             relation_distance_optout_min_proximity: None,
@@ -547,6 +576,116 @@ async fn index_query_validates_parameters() -> Result<()> {
         .send()
         .await?;
     assert_eq!(bad_kind.status(), StatusCode::BAD_REQUEST);
+
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn private_channel_reads_are_limited_to_members_with_secret_proof() -> Result<()> {
+    // #711 / ADR 0025 §6.3: 非公開チャンネルの索引は参加者に閉じる。
+    // - 横断読み(search_all / discovery / recommendations)には項目も scope_id も出ない。
+    // - 範囲指定読みは channel secret の提示(所属証明)を検証し、未提示・不一致・未登録は
+    //   同一の安定コード 403 CHANNEL_MEMBERSHIP_REQUIRED で拒否する(存在の秘匿)。
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api index query test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let index = memory_index();
+    let author = generate_keys().public_key_hex();
+    index
+        .seed_allow("rust", "post-public", author.as_str(), "tokio public post")
+        .await?;
+    index
+        .seed_allow_in(
+            IndexScopeKind::PrivateChannel,
+            "secret-room",
+            "post-private",
+            author.as_str(),
+            "tokio private post",
+        )
+        .await?;
+
+    let key_material = "index-membership-test-key-material-0123456789";
+    let server = TestServer::spawn_with_channel_secret_key(
+        admin_database_url.as_str(),
+        "cn_index_query_membership",
+        Some(index.query.clone()),
+        Some(key_material),
+    )
+    .await?;
+    let namespace_secret = "2".repeat(64);
+    {
+        // サーバと同じ鍵 material から cipher を組み、所属者の申請済み capability を再現する。
+        let pool = connect_postgres(server.database.database_url.as_str()).await?;
+        let cipher = ChannelSecretCipher::from_key_material(key_material)?;
+        register_channel_secret(&pool, &cipher, "secret-room", namespace_secret.as_str()).await?;
+    }
+    let client = Client::new();
+    let keys = generate_keys();
+    let token = authenticate_and_consent(&client, &server.base_url, &keys).await?;
+
+    // 横断読みには非公開チャンネルの項目も識別子も出ない。
+    for path in [
+        "/v1/index/search?q=tokio",
+        "/v1/index/discovery",
+        "/v1/index/recommendations",
+    ] {
+        let response = client
+            .get(format!("{}{path}", server.base_url))
+            .bearer_auth(token.as_str())
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+        let body = response.json::<serde_json::Value>().await?;
+        assert_eq!(entry_ids(&body), vec!["post-public".to_string()], "{path}");
+        assert!(
+            !body.to_string().contains("secret-room"),
+            "{path}: 非公開チャンネルの識別子を漏らさない"
+        );
+    }
+
+    // 範囲指定読み: 未提示・不一致・未登録チャンネルは同一コードで拒否する。
+    let scoped_search =
+        "/v1/index/search?scope_kind=private_channel&scope_id=secret-room&q=tokio".to_string();
+    let scoped_discovery =
+        "/v1/index/discovery?scope_kind=private_channel&scope_id=secret-room".to_string();
+    let unregistered =
+        "/v1/index/search?scope_kind=private_channel&scope_id=no-such-room&q=tokio".to_string();
+    let wrong_secret = "3".repeat(64);
+    for (path, secret) in [
+        (scoped_search.as_str(), None),
+        (scoped_search.as_str(), Some(wrong_secret.as_str())),
+        (scoped_discovery.as_str(), None),
+        (unregistered.as_str(), Some(namespace_secret.as_str())),
+    ] {
+        let mut request = client
+            .get(format!("{}{path}", server.base_url))
+            .bearer_auth(token.as_str());
+        if let Some(secret) = secret {
+            request = request.header(CHANNEL_MEMBERSHIP_SECRET_HEADER, secret);
+        }
+        let response = request.send().await?;
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "{path} secret={secret:?}"
+        );
+        let body = response.json::<serde_json::Value>().await?;
+        assert_eq!(body["code"], "CHANNEL_MEMBERSHIP_REQUIRED");
+    }
+
+    // 正しい secret を提示した所属者は従来どおり範囲指定で読める。
+    for path in [scoped_search.as_str(), scoped_discovery.as_str()] {
+        let response = client
+            .get(format!("{}{path}", server.base_url))
+            .bearer_auth(token.as_str())
+            .header(CHANNEL_MEMBERSHIP_SECRET_HEADER, namespace_secret.as_str())
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+        let body = response.json::<serde_json::Value>().await?;
+        assert_eq!(entry_ids(&body), vec!["post-private".to_string()], "{path}");
+    }
 
     server.shutdown().await
 }

--- a/crates/desktop-runtime/src/community_node/index_query_support.rs
+++ b/crates/desktop-runtime/src/community_node/index_query_support.rs
@@ -2,8 +2,9 @@ use std::fmt;
 
 use chrono::Utc;
 use kukuri_cn_protocol::{
-    ApiErrorBody, INDEX_DISCOVERY_PATH, INDEX_RECOMMENDATIONS_PATH, INDEX_SEARCH_PATH,
-    IndexQueryParams, IndexQueryResponse, IndexScopeKind, normalize_http_url,
+    ApiErrorBody, CHANNEL_MEMBERSHIP_SECRET_HEADER, INDEX_DISCOVERY_PATH,
+    INDEX_RECOMMENDATIONS_PATH, INDEX_SEARCH_PATH, IndexQueryParams, IndexQueryResponse,
+    IndexScopeKind, normalize_http_url,
 };
 use kukuri_store::{ContentObservationRow, ContentObservationStore};
 use reqwest::{StatusCode, header::RETRY_AFTER};
@@ -20,6 +21,9 @@ pub struct CommunityNodeIndexQueryRequest {
     pub query: Option<String>,
     pub scope_kind: Option<IndexScopeKind>,
     pub scope_id: Option<String>,
+    /// scope_kind が private_channel のとき必須。所属証明(channel secret)を参加中
+    /// チャンネルの capability から引くために使う(#711)。
+    pub topic_id: Option<String>,
     pub limit: Option<usize>,
 }
 
@@ -157,6 +161,40 @@ impl DesktopRuntime {
                 "community node required policies must be accepted before index queries",
             ));
         }
+        // 非公開チャンネルの範囲指定は所属証明(channel secret)を同伴する(#711)。
+        // 参加中でない(capability が無い)チャンネルへは送信前に拒否する。
+        // 秘密値の組み立ては同意確認の後に行う(#698 と同じ順序)。
+        let channel_secret = if request.scope_kind == Some(IndexScopeKind::PrivateChannel) {
+            let channel_id = request
+                .scope_id
+                .as_deref()
+                .map(str::trim)
+                .unwrap_or_default();
+            let topic_id = request
+                .topic_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    CommunityNodeIndexQueryError::new(
+                        "INVALID_INDEX_QUERY",
+                        "topic_id is required for private channel scoped queries",
+                    )
+                })?;
+            let secret = self
+                .app_service
+                .private_channel_indexing_secret(topic_id, channel_id)
+                .await
+                .map_err(|error| {
+                    CommunityNodeIndexQueryError::new(
+                        "PRIVATE_CHANNEL_CAPABILITY_UNAVAILABLE",
+                        error.to_string(),
+                    )
+                })?;
+            Some(secret)
+        } else {
+            None
+        };
         let token = load_community_node_token(&self.db_path, self.identity_mode, base_url.as_str())
             .map_err(|error| {
                 CommunityNodeIndexQueryError::new("AUTH_TOKEN_LOAD_FAILED", error.to_string())
@@ -182,6 +220,7 @@ impl DesktopRuntime {
                 operation,
                 &params,
                 token.access_token.as_str(),
+                channel_secret.as_deref(),
             )
             .await
         {
@@ -200,6 +239,7 @@ impl DesktopRuntime {
                     operation,
                     &params,
                     refreshed.access_token.as_str(),
+                    channel_secret.as_deref(),
                 )
                 .await
             }
@@ -249,19 +289,23 @@ impl DesktopRuntime {
         operation: IndexOperation,
         params: &IndexQueryParams,
         access_token: &str,
+        channel_secret: Option<&str>,
     ) -> Result<IndexQueryResponse, CommunityNodeIndexQueryError> {
         let client = community_node_http_client().map_err(|error| {
             CommunityNodeIndexQueryError::new("INDEX_HTTP_CLIENT_FAILED", error.to_string())
         })?;
-        let response = client
+        let mut request_builder = client
             .get(format!("{base_url}{}", operation.path()))
             .bearer_auth(access_token)
-            .query(params)
-            .send()
-            .await
-            .map_err(|error| {
-                CommunityNodeIndexQueryError::new("INDEX_QUERY_TRANSPORT_FAILED", error.to_string())
-            })?;
+            .query(params);
+        // 所属証明は URL クエリでなくヘッダで送る(アクセスログへの露出を避ける。#711)。
+        if let Some(channel_secret) = channel_secret {
+            request_builder =
+                request_builder.header(CHANNEL_MEMBERSHIP_SECRET_HEADER, channel_secret);
+        }
+        let response = request_builder.send().await.map_err(|error| {
+            CommunityNodeIndexQueryError::new("INDEX_QUERY_TRANSPORT_FAILED", error.to_string())
+        })?;
         let status = response.status();
         let retry_after_seconds = response
             .headers()

--- a/crates/desktop-runtime/src/tests/community_node/index_query.rs
+++ b/crates/desktop-runtime/src/tests/community_node/index_query.rs
@@ -12,6 +12,7 @@ type ForcedIndexError = (StatusCode, ApiErrorBody, Option<&'static str>);
 struct MockIndexQueryState {
     expected_token: Arc<Mutex<String>>,
     requests: Arc<Mutex<Vec<(String, IndexQueryParams)>>>,
+    channel_secret_headers: Arc<Mutex<Vec<Option<String>>>>,
     indexing_requests: Arc<Mutex<Vec<SubmitIndexingRequestRequest>>>,
     forced_error: Arc<Mutex<Option<ForcedIndexError>>>,
     unauthorized_remaining: Arc<AtomicUsize>,
@@ -78,6 +79,12 @@ async fn mock_index_query(
 
     let path = uri.path().to_string();
     state.requests.lock().await.push((path, params.clone()));
+    state.channel_secret_headers.lock().await.push(
+        headers
+            .get("x-kukuri-channel-secret")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string),
+    );
     let expected = state.expected_token.lock().await.clone();
     let expected_header = format!("Bearer {expected}");
     if headers
@@ -170,6 +177,7 @@ async fn index_runtime(
     let index = MockIndexQueryState {
         expected_token,
         requests: Arc::new(Mutex::new(Vec::new())),
+        channel_secret_headers: Arc::new(Mutex::new(Vec::new())),
         indexing_requests: Arc::new(Mutex::new(Vec::new())),
         forced_error: Arc::new(Mutex::new(forced_error)),
         unauthorized_remaining: Arc::new(AtomicUsize::new(0)),
@@ -231,6 +239,7 @@ fn scoped_request(base_url: &str) -> CommunityNodeIndexQueryRequest {
         query: Some("hello".to_string()),
         scope_kind: Some(IndexScopeKind::PublicTopic),
         scope_id: Some("rust".to_string()),
+        topic_id: None,
         limit: Some(10),
     }
 }
@@ -644,6 +653,76 @@ async fn community_node_private_indexing_stops_before_secret_when_consent_is_pen
     // 秘密値の取得(PRIVATE_CHANNEL_CAPABILITY_UNAVAILABLE)より前に同意で止まる。
     assert_eq!(error.code, "CONSENT_REQUIRED");
     assert!(state.indexing_requests.lock().await.is_empty());
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn community_node_private_scoped_query_attaches_membership_proof() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, _managed, state, server, _dir) = index_runtime(None).await;
+    let topic = "kukuri:topic:private-scope";
+    let channel = runtime
+        .create_private_channel(CreatePrivateChannelRequest {
+            topic: topic.to_string(),
+            label: "searchable private channel".to_string(),
+            audience_kind: ChannelAudienceKind::InviteOnly,
+        })
+        .await
+        .expect("create private channel");
+
+    // #711: topic_id なしの非公開チャンネル範囲指定は HTTP 前に拒否する。
+    let error = runtime
+        .search_community_node_index(CommunityNodeIndexQueryRequest {
+            scope_kind: Some(IndexScopeKind::PrivateChannel),
+            scope_id: Some(channel.channel_id.clone()),
+            ..scoped_request(base_url.as_str())
+        })
+        .await
+        .expect_err("missing topic_id should fail");
+    assert_eq!(error.code, "INVALID_INDEX_QUERY");
+    // 参加していないチャンネルは所属証明を引けないため HTTP 前に拒否する。
+    let error = runtime
+        .search_community_node_index(CommunityNodeIndexQueryRequest {
+            scope_kind: Some(IndexScopeKind::PrivateChannel),
+            scope_id: Some("not-joined-channel".to_string()),
+            topic_id: Some(topic.to_string()),
+            ..scoped_request(base_url.as_str())
+        })
+        .await
+        .expect_err("not joined channel should fail");
+    assert_eq!(error.code, "PRIVATE_CHANNEL_CAPABILITY_UNAVAILABLE");
+    assert!(state.requests.lock().await.is_empty());
+
+    // 参加中チャンネルの範囲指定は所属証明(channel secret)をヘッダで同伴する。
+    runtime
+        .search_community_node_index(CommunityNodeIndexQueryRequest {
+            scope_kind: Some(IndexScopeKind::PrivateChannel),
+            scope_id: Some(channel.channel_id.clone()),
+            topic_id: Some(topic.to_string()),
+            ..scoped_request(base_url.as_str())
+        })
+        .await
+        .expect("private scoped search");
+    let headers = state.channel_secret_headers.lock().await.clone();
+    assert_eq!(headers.len(), 1);
+    assert!(
+        headers[0]
+            .as_deref()
+            .is_some_and(|secret| !secret.is_empty()),
+        "所属証明ヘッダを同伴する"
+    );
+    let requests = state.requests.lock().await.clone();
+    assert_eq!(requests[0].1.scope_kind.as_deref(), Some("private_channel"));
+
+    // 公開範囲の検索には秘密値ヘッダを付けない。
+    runtime
+        .search_community_node_index(scoped_request(base_url.as_str()))
+        .await
+        .expect("public scoped search");
+    let headers = state.channel_secret_headers.lock().await.clone();
+    assert_eq!(headers.len(), 2);
+    assert!(headers[1].is_none());
     runtime.shutdown().await;
     server.abort();
 }

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -17,7 +17,7 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     ("community_node/admission.rs", "CommunityNodeServer", 6),
     ("community_node/config.rs", "ProcessEnvironment", 3),
     ("community_node/connectivity.rs", "IrohNetwork", 6),
-    ("community_node/index_query.rs", "CommunityNodeServer", 10),
+    ("community_node/index_query.rs", "CommunityNodeServer", 11),
     ("community_node/metadata.rs", "CommunityNodeServer", 9),
     (
         "community_node/report_submission.rs",
@@ -100,7 +100,7 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 80,
-        "classification total drifted from the Q7 T6 baseline(#708 で admission 試験を 1 件追加)"
+        total, 81,
+        "classification total drifted from the Q7 T6 baseline(#711 で index_query 試験を 1 件追加)"
     );
 }

--- a/crates/harness/src/scenarios/community_node_index.rs
+++ b/crates/harness/src/scenarios/community_node_index.rs
@@ -160,6 +160,7 @@ fn request(base_url: &str) -> CommunityNodeIndexQueryRequest {
         query: None,
         scope_kind: None,
         scope_id: None,
+        topic_id: None,
         limit: Some(20),
     }
 }

--- a/crates/harness/src/scenarios/community_node_trust_relation.rs
+++ b/crates/harness/src/scenarios/community_node_trust_relation.rs
@@ -519,6 +519,7 @@ pub(crate) async fn run_community_node_trust_relation_client(
                                 other => anyhow::bail!("unsupported scope kind: {other}"),
                             }),
                             scope_id: Some(scope_id.clone()),
+                            topic_id: None,
                             limit: Some(20),
                         })
                         .await?;

--- a/docs/adr/0025-community-node-indexing-foundation.md
+++ b/docs/adr/0025-community-node-indexing-foundation.md
@@ -140,6 +140,7 @@ content が index に入る条件は次の AND とする:
 - 基本 UX は **トピック毎の検索窓**（topic-scoped search）。あるトピックの中で検索するのが既定の体験。
 - **CN ベースのトピック横断検索（cross-topic search）は別画面**として用意する。supported topic set 全体を対象に、node の authority scope 内で横断検索する。
 - どちらの検索面も §2.2 の supported-topic scope と §2.5 の safety ゲートに従う（横断検索でも supported 外 topic / 非 `allow` content は出ない）。
+- **横断検索の対象は supported set のうち公開 scope（public topic）全体**（#711 で明確化）。非公開チャンネルの索引は §6.3 の閲覧境界（チャンネル参加者に閉じる）に従い、横断検索・発見・推薦には項目も識別子も出さない。非公開チャンネルの読み口は所属証明つきの範囲指定読みだけである。「supported set 全体」と「参加者に閉じる」は矛盾しない: 横断面は公開 scope の集合、非公開 scope は範囲指定面、と読み口を分ける。
 
 ## 3. Consequences
 
@@ -191,7 +192,8 @@ index する content（post 本文・media タグ・room メタデータ）を c
 - **解決**: **indexing リクエスト＝secret 送信**とする。リクエスト時に channel secret（capability）を CN に渡し、CN はそれを登録して **Model C と同じ仕組みで `channel::` replica を sync** する。private channel 専用の別 ingestion 経路は新設せず、C に capability を注入するだけで解決する。
 - **リクエスト権限**: indexing をリクエストできる権限は **channel の既存権限モデルをそのまま応用**する（channel の secret にアクセスできる権限者が、その secret を提示して indexing をリクエストできる）。CN は新しい権限体系を作らない。
 - scope / consent: private channel index は channel メンバー + その CN の authority に閉じ、risk signal / visibility は `local` 寄り（trust-semantics）。
-- contract: `index_private_channel_requires_submitted_channel_secret` / `index_private_channel_request_authz_reuses_channel_permission`。
+- **閲覧境界（read 側。#711）**: 「channel メンバーに閉じる」は読み口にも適用する。範囲指定読み（`scope_kind = private_channel` の search / discovery）は、申請と同じ「secret を提示できること自体が権限の証明」の原則で **channel secret の提示を所属証明として要求**し、保存済み capability の復号値と定数時間比較で照合する。秘密値はアクセスログへ露出する URL クエリでなく専用ヘッダ（`x-kukuri-channel-secret`。`cn-protocol` に定数化）で送る。未提示・不一致・チャンネル未登録・暗号鍵未設定は同一の安定コード `CHANNEL_MEMBERSHIP_REQUIRED`（403）で拒否し、非所属者に索引の存在有無を漏らさない。横断読み（scope 無指定）には非公開チャンネルの項目を出さない（§2.7）。
+- contract: `index_private_channel_requires_submitted_channel_secret` / `index_private_channel_request_authz_reuses_channel_permission` / `cross_scope_reads_exclude_private_channel_entries` / `private_channel_reads_are_limited_to_members_with_secret_proof`。
 
 ### 6.4 課題 2 の解決: relay validation（relay 抜き CN）
 


### PR DESCRIPTION
## 概要

Closes #711

認証・同意済みなら誰でも、所属していない非公開チャンネルの索引項目を横断検索・発見・推薦経由で(`scope_id` = チャンネル識別子ごと)閲覧できる問題を修正します。ADR 0025 §6.3「非公開チャンネルの索引はチャンネル参加者とそのノードの責任範囲に閉じる」を読み口にも適用します。

## 設計判断(実装済み)

- **横断読み(scope 無指定の検索・発見・推薦)**: 非公開チャンネルの項目を返さない。唯一のユーザー向け入口 `FailClosedIndexQuery` の単一点で除外し、記憶内・ArcadeDB の両投影に共通で効かせる
- **範囲指定読み(`scope_kind=private_channel`)**: 申請側と同じ「秘密値の提示が権限の証明」を read にも適用。提示された channel secret を保存済み capability の復号値と定数時間比較で照合する。新しい権限体系は作らない
- **秘密値の送り方**: アクセスログへ露出する URL クエリでなく専用ヘッダ `x-kukuri-channel-secret`(`cn-protocol` に定数化)
- **存在の秘匿**: 未提示・不一致・未登録・暗号鍵未設定を同一の安定コード 403 `CHANNEL_MEMBERSHIP_REQUIRED` で拒否し、非所属者に索引の存在有無を漏らさない

## 変更内容

- `crates/cn-indexer/src/query.rs`: 横断読みからの private_channel 除外(単一点)
- `crates/cn-protocol/src/index.rs`: ヘッダ名・安定コードの定数化
- `crates/cn-user-api/src/handlers/indexing.rs`: 範囲指定の検索・発見に所属証明の検証を追加(推薦は横断のみで対象外)
- `crates/desktop-runtime`: 範囲指定要求に `topic_id` を追加し、参加中チャンネルの capability から秘密値をヘッダで同伴。未参加・topic 未指定は送信前に安定コードで拒否
- `apps/desktop`: `CommunityIndexWorkspace` がチャンネル範囲検索時に `topic_id` を同伴(`cargo xtask ipc-types` で生成型を再生成)
- `docs/adr/0025`: §2.7(横断検索は公開 scope 全体)と §6.3(閲覧境界・contract 名)の関係整理を明記

## 試験

- `cross_scope_reads_exclude_private_channel_entries`(cn-indexer 契約): 横断読みに項目が出ず、範囲指定読みは返る(所属検証は上位の門)
- `private_channel_reads_are_limited_to_members_with_secret_proof`(cn-user-api 結合): 横断応答に識別子ごと漏れない / 未提示・不一致・未登録が同一コードで拒否 / 正しい secret の所属者は従来どおり読める
- `community_node_private_scoped_query_attaches_membership_proof`(desktop-runtime): 所属証明ヘッダの同伴・送信前拒否・公開範囲ではヘッダ無し

いずれも赤(失敗)を確認してから実装しています。

## 検証結果

- `cargo xtask check`: 成功
- `cargo test -p kukuri-cn-indexer -p kukuri-cn-user-api -p kukuri-cn-protocol`(実 DB / valkey 結合込み): 25 スイート全て成功
- `cargo test -p kukuri-desktop-runtime --lib`: 129 件成功(試験追加に伴い lock 分類表を 80→81 に更新)
- frontend: `tsc --noEmit` と `CommunityIndexWorkspace.test.tsx`(13 件)成功

## 補足

- 非公開チャンネル索引は本番未解禁(#670 対象外)のため、既存利用者の互換切れはありません
- 投影 SQL 側の絞り込み最適化と、横断検索へ所属チャンネル分を含める拡張は対象外(プラン Out of Scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)