### PR TITLE
fix: 索引申請の受付で索引参照の構成と有効化を確認する (#713)

### DIFF
--- a/apps/desktop/src/components/core/CommunityIndexingRequestDialog.test.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexingRequestDialog.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { expect, test, vi } from 'vitest';
 
 import type { DesktopApi } from '@/lib/api';
+import { InvokeError } from '@/lib/api/invoke/error';
 
 import { CommunityIndexingRequestDialog } from './CommunityIndexingRequestDialog';
 
@@ -335,4 +336,36 @@ test('a selected node dropped from the eligible list cannot receive a private re
   expect(submitCommunityNodeIndexingRequest).not.toHaveBeenCalledWith(
     expect.objectContaining({ base_url: 'https://index-a.example' })
   );
+});
+
+test('explains the server-side indexing request gate with stable codes', async () => {
+  // #713: 索引未提供・有効化失効のノードは申請を受け付けない。安定コードで案内する。
+  const submitCommunityNodeIndexingRequest = vi
+    .fn()
+    .mockRejectedValueOnce(new InvokeError('INDEXING_REQUEST_NOT_CONFIGURED', 'gate'))
+    .mockRejectedValueOnce(new InvokeError('INDEXING_REQUEST_NOT_ACTIVATED', 'gate'));
+  render(
+    <CommunityIndexingRequestDialog
+      api={{ submitCommunityNodeIndexingRequest } as unknown as DesktopApi}
+      target={{ kind: 'public_topic', topicId: 'kukuri:topic:demo' }}
+      eligibleNodeBaseUrls={['https://index-a.example']}
+      onOpenChange={vi.fn()}
+      onOpenCommunityNodeSettings={vi.fn()}
+    />
+  );
+
+  const submit = screen.getByRole('button', { name: 'Submit request' });
+  fireEvent.click(submit);
+  expect(
+    await screen.findByText(
+      'This Community Node does not provide indexing, so it does not accept requests.'
+    )
+  ).toBeInTheDocument();
+
+  fireEvent.click(submit);
+  expect(
+    await screen.findByText(
+      'Indexing on this Community Node is temporarily unavailable, so it does not accept requests.'
+    )
+  ).toBeInTheDocument();
 });

--- a/apps/desktop/src/components/core/CommunityIndexingRequestDialog.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexingRequestDialog.tsx
@@ -32,6 +32,9 @@ type CommunityIndexingRequestDialogProps = {
 
 function requestErrorKey(error: unknown): string {
   if (!(error instanceof InvokeError)) return 'requestFailed';
+  // #713: 索引を提供しない・停止中のノードは申請を受け付けない(サーバ側の門)。
+  if (error.code === 'INDEXING_REQUEST_NOT_CONFIGURED') return 'requestNotConfigured';
+  if (error.code === 'INDEXING_REQUEST_NOT_ACTIVATED') return 'requestNotActivated';
   if (error.code === 'CHANNEL_INDEXING_NOT_CONFIGURED') return 'notConfigured';
   if (error.code === 'CHANNEL_SECRET_CONFLICT') return 'secretConflict';
   if (error.code === 'AUTH_REQUIRED' || error.status === 401) return 'authRequired';

--- a/apps/desktop/src/i18n/locales/en/shell.json
+++ b/apps/desktop/src/i18n/locales/en/shell.json
@@ -154,6 +154,8 @@
     "submitting": "Submitting…",
     "status": { "pending": "The request is pending review.", "approved": "Indexing is approved.", "rejected": "Indexing was rejected." },
     "errors": {
+      "requestNotConfigured": "This Community Node does not provide indexing, so it does not accept requests.",
+      "requestNotActivated": "Indexing on this Community Node is temporarily unavailable, so it does not accept requests.",
       "notConfigured": "Channel indexing is not configured on this Community Node.",
       "secretConflict": "The channel capability conflicts with the existing registration. Contact the node operator.",
       "authRequired": "Authentication is required for the selected Community Node.",

--- a/apps/desktop/src/i18n/locales/ja/shell.json
+++ b/apps/desktop/src/i18n/locales/ja/shell.json
@@ -158,6 +158,8 @@
       "rejected": "索引登録は却下されています。"
     },
     "errors": {
+      "requestNotConfigured": "この Community Node は索引を提供していないため、申請を受け付けていません。",
+      "requestNotActivated": "この Community Node の索引は一時的に利用できないため、申請を受け付けていません。",
       "notConfigured": "この Community Node ではチャネル索引登録が設定されていません。",
       "secretConflict": "登録済みのチャネル capability と一致しません。管理者へ確認してください。",
       "authRequired": "選択した Community Node への認証が必要です。",

--- a/apps/desktop/src/i18n/locales/zh-CN/shell.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/shell.json
@@ -154,6 +154,8 @@
     "submitting": "提交中…",
     "status": { "pending": "申请正在等待审核。", "approved": "索引已获批准。", "rejected": "索引申请已被拒绝。" },
     "errors": {
+      "requestNotConfigured": "该社区节点不提供索引，因此不接受申请。",
+      "requestNotActivated": "该社区节点的索引暂时不可用，因此不接受申请。",
       "notConfigured": "此 Community Node 未配置频道索引。",
       "secretConflict": "频道 capability 与现有注册冲突，请联系节点运营者。",
       "authRequired": "需要对所选 Community Node 进行认证。",

--- a/crates/cn-protocol/src/error_codes.rs
+++ b/crates/cn-protocol/src/error_codes.rs
@@ -14,6 +14,12 @@ pub const AUTH_REQUIRED_CODE: &str = "AUTH_REQUIRED";
 /// 必須ポリシーへの同意が未完了(403)。
 pub const CONSENT_REQUIRED_CODE: &str = "CONSENT_REQUIRED";
 
+/// このノードは索引を提供しないため索引申請を受け付けない(未構成。404。#713)。
+pub const INDEXING_REQUEST_NOT_CONFIGURED_CODE: &str = "INDEXING_REQUEST_NOT_CONFIGURED";
+
+/// 索引の有効化が失効しているため索引申請を受け付けない(404。#713)。
+pub const INDEXING_REQUEST_NOT_ACTIVATED_CODE: &str = "INDEXING_REQUEST_NOT_ACTIVATED";
+
 /// このノードは索引参照を提供しない(未構成。404)。
 pub const INDEX_QUERY_NOT_CONFIGURED_CODE: &str = "INDEX_QUERY_NOT_CONFIGURED";
 

--- a/crates/cn-user-api/src/handlers/indexing.rs
+++ b/crates/cn-user-api/src/handlers/indexing.rs
@@ -13,7 +13,8 @@ use kukuri_cn_core::{
 use kukuri_cn_indexer::IndexQuery;
 use kukuri_cn_protocol::{
     CHANNEL_MEMBERSHIP_REQUIRED_CODE, CHANNEL_MEMBERSHIP_SECRET_HEADER,
-    INDEX_QUERY_NOT_ACTIVATED_CODE, INDEX_QUERY_NOT_CONFIGURED_CODE, IndexEntryView,
+    INDEX_QUERY_NOT_ACTIVATED_CODE, INDEX_QUERY_NOT_CONFIGURED_CODE,
+    INDEXING_REQUEST_NOT_ACTIVATED_CODE, INDEXING_REQUEST_NOT_CONFIGURED_CODE, IndexEntryView,
     IndexQueryParams, IndexQueryResponse, RELATION_VISIBILITY_NOT_CONFIGURED_CODE,
     SubmitIndexingRequestRequest, SubmitIndexingRequestResponse,
 };
@@ -32,11 +33,27 @@ use crate::state::{RelationVisibilityState, UserApiState};
 ///   権限の証明とみなす(ADR 0025 §6.3。CN は新権限体系を作らない)。secret は at-rest 暗号化して保存し、
 ///   cn-indexer が Model C と同じ機構で `channel::` replica を sync する。channel secret 暗号鍵が未設定の
 ///   node は private channel request を受け付けない(平文保存しないため)。
+/// - 受付の門(#713): 索引参照が未構成・有効化失効のノードは申請を受け付けない。索引を
+///   提供しないノードへ秘密値が保存されるのを防ぐ(検査は read 面と同じ順で認証より先)。
 pub(crate) async fn submit_indexing_request(
     State(state): State<UserApiState>,
     headers: HeaderMap,
     Json(request): Json<SubmitIndexingRequestRequest>,
 ) -> ApiResult<Json<SubmitIndexingRequestResponse>> {
+    if state.index_query.is_none() {
+        return Err(ApiError::new(
+            StatusCode::NOT_FOUND,
+            INDEXING_REQUEST_NOT_CONFIGURED_CODE,
+            "this community node does not provide indexing, so it does not accept indexing requests",
+        ));
+    }
+    if !state.readiness_activation_is_valid().await {
+        return Err(ApiError::new(
+            StatusCode::NOT_FOUND,
+            INDEXING_REQUEST_NOT_ACTIVATED_CODE,
+            "this community node index activation is not current, so it does not accept indexing requests",
+        ));
+    }
     let identity = require_bearer_identity(&state.pool, &state.jwt_config, &headers).await?;
     let _ = require_consents(&state.pool, identity.pubkey.as_str()).await?;
 

--- a/crates/cn-user-api/tests/indexing_requests.rs
+++ b/crates/cn-user-api/tests/indexing_requests.rs
@@ -10,7 +10,12 @@
 use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
-use kukuri_cn_core::{JwtConfig, TestDatabase};
+use chrono::Utc;
+use kukuri_cn_core::{
+    JwtConfig, TestDatabase, connect_postgres, readiness_context_fingerprint,
+    record_readiness_activation,
+};
+use kukuri_cn_operator::READINESS_CHECK_IDS;
 use kukuri_cn_protocol::build_auth_envelope_json;
 use kukuri_cn_user_api::{UserApiConfig, app_router, build_state};
 use kukuri_core::{KukuriKeys, generate_keys};
@@ -27,11 +32,37 @@ struct TestServer {
     base_url: String,
 }
 
+/// 索引参照の提供状態(#713 の受付門)。申請の受付は Activated のときだけ許される。
+#[derive(Clone, Copy, PartialEq)]
+enum IndexGate {
+    /// 索引参照が未構成(このノードは索引を提供しない)。
+    NotConfigured,
+    /// 構成済みだが有効化(準備完了記録)が無い・失効している。
+    Inactive,
+    /// 構成済みかつ有効化済み。
+    Activated,
+}
+
 impl TestServer {
     async fn spawn(
         admin_database_url: &str,
         prefix: &str,
         channel_secret_key: Option<String>,
+    ) -> Result<Self> {
+        Self::spawn_with_index_gate(
+            admin_database_url,
+            prefix,
+            channel_secret_key,
+            IndexGate::Activated,
+        )
+        .await
+    }
+
+    async fn spawn_with_index_gate(
+        admin_database_url: &str,
+        prefix: &str,
+        channel_secret_key: Option<String>,
+        gate: IndexGate,
     ) -> Result<Self> {
         let database = TestDatabase::create(admin_database_url, prefix).await?;
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -50,14 +81,27 @@ impl TestServer {
             jwt_config: JwtConfig::new("kukuri-cn-tests", "test-secret", 3600),
             operator_config_path: None,
             channel_secret_key,
-            index_query_enabled: false,
+            index_query_enabled: gate != IndexGate::NotConfigured,
             trust_read_enabled: false,
-            relation_distance_optout_min_proximity: None,
+            relation_distance_optout_min_proximity: (gate != IndexGate::NotConfigured)
+                .then_some(0.5),
             deployment_revision: "test-deployment-v1".to_string(),
             readiness_activation_max_age_secs: 3600,
             expected_issuer_node_id: None,
         })
         .await?;
+        if gate == IndexGate::Activated {
+            let pool = connect_postgres(database.database_url.as_str()).await?;
+            record_readiness_activation(
+                &pool,
+                Utc::now(),
+                "public-node",
+                &READINESS_CHECK_IDS,
+                &readiness_context_fingerprint("public-node", "test-deployment-v1", b""),
+                &serde_json::json!([]),
+            )
+            .await?;
+        }
         let app = app_router(state);
         let task = tokio::spawn(async move {
             axum::serve(
@@ -356,6 +400,103 @@ async fn invalid_kind_is_rejected() -> Result<()> {
     assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
     let body = rejected.json::<serde_json::Value>().await?;
     assert_eq!(body["code"], "INVALID_INDEXING_REQUEST");
+
+    server.shutdown().await
+}
+
+/// 拒否後にデータベースへ何も残っていないことを確認する(#713: 秘密値の不保存)。
+async fn assert_nothing_stored(server: &TestServer) -> Result<()> {
+    let pool = connect_postgres(server.database.database_url.as_str()).await?;
+    let requests: i64 = sqlx::query_scalar("SELECT count(*) FROM cn_index.indexing_requests")
+        .fetch_one(&pool)
+        .await?;
+    let secrets: i64 = sqlx::query_scalar("SELECT count(*) FROM cn_index.channel_secrets")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(requests, 0, "申請行が保存されてはならない");
+    assert_eq!(secrets, 0, "channel secret が保存されてはならない");
+    Ok(())
+}
+
+#[tokio::test]
+async fn indexing_request_is_rejected_when_index_query_not_configured() -> Result<()> {
+    // #713: 索引参照を提供しないノードは申請を受理・保存しない(サーバ側の門)。
+    // 未提供の面は read 面と同じく認証前でも 404 で存在しない扱いにする。
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api indexing test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn_with_index_gate(
+        admin_database_url.as_str(),
+        "cn_indexing_gate_off",
+        Some(TEST_CHANNEL_SECRET_KEY.to_string()),
+        IndexGate::NotConfigured,
+    )
+    .await?;
+    let client = Client::new();
+
+    let unauthenticated = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .json(&serde_json::json!({ "kind": "public_topic", "target_id": "rust" }))
+        .send()
+        .await?;
+    assert_eq!(unauthenticated.status(), StatusCode::NOT_FOUND);
+    let body = unauthenticated.json::<serde_json::Value>().await?;
+    assert_eq!(body["code"], "INDEXING_REQUEST_NOT_CONFIGURED");
+
+    // 認証・同意済みで秘密値を提示しても、受理も保存もされない。
+    let keys = generate_keys();
+    let token = authenticate_and_consent(&client, &server.base_url, &keys).await?;
+    let rejected = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .bearer_auth(token.as_str())
+        .json(&serde_json::json!({
+            "kind": "private_channel",
+            "target_id": "secret-room",
+            "channel_secret_hex": hex::encode([7u8; 32]),
+        }))
+        .send()
+        .await?;
+    assert_eq!(rejected.status(), StatusCode::NOT_FOUND);
+    let body = rejected.json::<serde_json::Value>().await?;
+    assert_eq!(body["code"], "INDEXING_REQUEST_NOT_CONFIGURED");
+    assert_nothing_stored(&server).await?;
+
+    server.shutdown().await
+}
+
+#[tokio::test]
+async fn indexing_request_is_rejected_when_activation_is_stale() -> Result<()> {
+    // #713: 構成済みでも有効化(準備完了記録)が無い・失効しているノードは申請を受け付けない。
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api indexing test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn_with_index_gate(
+        admin_database_url.as_str(),
+        "cn_indexing_gate_stale",
+        Some(TEST_CHANNEL_SECRET_KEY.to_string()),
+        IndexGate::Inactive,
+    )
+    .await?;
+    let client = Client::new();
+    let keys = generate_keys();
+    let token = authenticate_and_consent(&client, &server.base_url, &keys).await?;
+
+    let rejected = client
+        .post(format!("{}/v1/indexing/requests", server.base_url))
+        .bearer_auth(token.as_str())
+        .json(&serde_json::json!({
+            "kind": "private_channel",
+            "target_id": "secret-room",
+            "channel_secret_hex": hex::encode([7u8; 32]),
+        }))
+        .send()
+        .await?;
+    assert_eq!(rejected.status(), StatusCode::NOT_FOUND);
+    let body = rejected.json::<serde_json::Value>().await?;
+    assert_eq!(body["code"], "INDEXING_REQUEST_NOT_ACTIVATED");
+    assert_nothing_stored(&server).await?;
 
     server.shutdown().await
 }

--- a/docs/adr/0025-community-node-indexing-foundation.md
+++ b/docs/adr/0025-community-node-indexing-foundation.md
@@ -194,6 +194,7 @@ index する content（post 本文・media タグ・room メタデータ）を c
 - scope / consent: private channel index は channel メンバー + その CN の authority に閉じ、risk signal / visibility は `local` 寄り（trust-semantics）。
 - **閲覧境界（read 側。#711）**: 「channel メンバーに閉じる」は読み口にも適用する。範囲指定読み（`scope_kind = private_channel` の search / discovery）は、申請と同じ「secret を提示できること自体が権限の証明」の原則で **channel secret の提示を所属証明として要求**し、保存済み capability の復号値と定数時間比較で照合する。秘密値はアクセスログへ露出する URL クエリでなく専用ヘッダ（`x-kukuri-channel-secret`。`cn-protocol` に定数化）で送る。未提示・不一致・チャンネル未登録・暗号鍵未設定は同一の安定コード `CHANNEL_MEMBERSHIP_REQUIRED`（403）で拒否し、非所属者に索引の存在有無を漏らさない。横断読み（scope 無指定）には非公開チャンネルの項目を出さない（§2.7）。
 - contract: `index_private_channel_requires_submitted_channel_secret` / `index_private_channel_request_authz_reuses_channel_permission` / `cross_scope_reads_exclude_private_channel_entries` / `private_channel_reads_are_limited_to_members_with_secret_proof`。
+- **申請の受付条件（#713）**: indexing request の受付は、そのノードで索引参照が**構成済みかつ有効化（準備完了記録）が有効**であることを必須とする（Decision。「申請だけ受け付けて索引時に判定する」案は不採用）。索引を提供しない・提供が停止中のノードが申請（private channel では channel secret を含む）を受理・保存するのを防ぐ — 「秘密値の提示が権限の証明」は、提示先が索引を実際に提供していることの確認とセットで初めて意味を持つ。未構成は `INDEXING_REQUEST_NOT_CONFIGURED`、有効化失効は `INDEXING_REQUEST_NOT_ACTIVATED`（いずれも 404。検査は read 面と同じ順で認証より先）。拒否時は申請行も channel secret も保存されない。#698 の client 側送信前判定と対になるサーバ側の門。contract: `indexing_request_is_rejected_when_index_query_not_configured` / `indexing_request_is_rejected_when_activation_is_stale`。
 
 ### 6.4 課題 2 の解決: relay validation（relay 抜き CN）
 


### PR DESCRIPTION
## 概要

Closes #713

索引申請の受付(`submit_indexing_request`)は認証・同意・対象種別・秘密値暗号鍵・先着順を確認する一方、索引参照の構成(`state.index_query`)と有効化(`readiness_activation_is_valid`)を確認しないため、索引を提供しない・停止中のノードでも申請(非公開チャンネルでは秘密値を含む)を受理・保存していました。サーバ側の門を追加します。

## 設計判断(実装済み)

- **受付条件は「索引参照の構成と有効化を必須」**(もう一方の「申請だけ受け付けて索引時に判定」案は不採用)。索引を提供しないノードへ channel secret が保存されるのを防ぐ — 「秘密値の提示が権限の証明」(ADR 0025 §6.3)は、提示先が索引を実際に提供していることの確認とセットで初めて意味を持つ、という整合
- 門の順序は read 面(`require_index_query`)と同じ「構成 → 有効化 → 認証 → 同意」(未提供の面は認証前でも 404)
- 申請側の安定コード `INDEXING_REQUEST_NOT_CONFIGURED` / `INDEXING_REQUEST_NOT_ACTIVATED`(404)を #712 の `cn-protocol::error_codes` 基盤に追加
- #698 のクライアント側送信前判定と対になるサーバ側の門

## 変更内容

- `crates/cn-protocol/src/error_codes.rs`: 申請側コード 2 件を追加
- `crates/cn-user-api/src/handlers/indexing.rs`: 受付の門を実装
- `crates/cn-user-api/tests/indexing_requests.rs`: 未構成・有効化失効の拒否契約(拒否時に `indexing_requests` / `channel_secrets` へ何も保存されないことを含む)を追加。既存の受理系契約は有効化記録つき spawn へ更新して維持
- `apps/desktop`: 申請ダイアログの `requestErrorKey` が新コードを判別し、3 言語の文言で案内(画面試験を追加)
- `docs/adr/0025` §6.3: 受付条件の設計判断と契約試験名を明記

## 検証結果

- `cargo test -p kukuri-cn-user-api -p kukuri-cn-protocol`(実 DB / valkey 結合込み): 17 スイート全て成功(新契約試験は門の実装前に赤を確認)
- frontend: `tsc --noEmit` と `CommunityIndexingRequestDialog.test.tsx`(9 件、うち新コード判別 1 件追加)成功
- `cargo xtask check`: 成功

## 補足

- desktop-runtime は `body.code` を透過するため変更なし(#698 の送信前判定はそのまま)
- 公開ノード情報(起動時固定)への有効化状態の反映は対象外(門が実行時状態を直接見るため不要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)