### PR TITLE
test: stabilize docs sync relay tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3417,6 +3417,7 @@ dependencies = [
  "iroh-blobs",
  "iroh-docs",
  "iroh-gossip",
+ "kukuri-cn-iroh-relay",
  "kukuri-core",
  "kukuri-iroh-node",
  "kukuri-transport",

--- a/crates/docs-sync/Cargo.toml
+++ b/crates/docs-sync/Cargo.toml
@@ -24,8 +24,8 @@ kukuri-transport = { path = "../transport" }
 kukuri-iroh-node = { path = "../iroh-node" }
 
 [dev-dependencies]
-iroh = { workspace = true, features = ["test-utils"] }
 tempfile.workspace = true
+kukuri-cn-iroh-relay = { path = "../cn-iroh-relay" }
 
 [lints]
 workspace = true

--- a/crates/docs-sync/src/tests/relay.rs
+++ b/crates/docs-sync/src/tests/relay.rs
@@ -6,6 +6,7 @@ use iroh::RelayUrl;
 use tempfile::tempdir;
 use tokio::time::{sleep, timeout};
 
+use kukuri_cn_iroh_relay::{IrohRelayConfig, SpawnedIrohRelay, spawn_server};
 use kukuri_iroh_node::IrohDocsNode;
 
 use crate::{DocOp, DocQuery, DocsSync, IrohDocsSync, stable_key, topic_replica_id};
@@ -26,6 +27,17 @@ fn external_relay_url() -> Option<String> {
         .ok()
         .map(|value| value.trim().trim_end_matches('/').to_string())
         .filter(|value| !value.is_empty())
+}
+
+async fn spawn_local_test_relay() -> Result<(String, SpawnedIrohRelay)> {
+    let relay = spawn_server(IrohRelayConfig {
+        http_bind_addr: "127.0.0.1:0".parse()?,
+        tls: None,
+        client_rx_limit: None,
+    })
+    .await?;
+    let relay_url = format!("http://{}", relay.http_addr());
+    Ok((relay_url, relay))
 }
 
 async fn wait_for_relay_seeded_replica_row(
@@ -181,12 +193,9 @@ async fn apply_relay_config_tolerates_relay_activation_timeout() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn public_replica_syncs_over_custom_relay_seed_peers() -> Result<()> {
-    if std::env::var_os("GITHUB_ACTIONS").is_some() {
-        return Ok(());
-    }
-    let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server().await?;
+    let (relay_url, _relay) = spawn_local_test_relay().await?;
     let relay_config = TransportRelayConfig {
-        iroh_relay_urls: vec![relay_url.to_string()],
+        iroh_relay_urls: vec![relay_url],
     }
     .normalized();
     let dir = tempdir()?;
@@ -302,12 +311,9 @@ async fn public_replica_syncs_over_external_relay_when_configured() -> Result<()
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn learned_peer_recovers_relay_backfilled_doc_entry_after_seed_peers_are_cleared()
 -> Result<()> {
-    if std::env::var_os("GITHUB_ACTIONS").is_some() {
-        return Ok(());
-    }
-    let (_relay_map, relay_url, _guard) = iroh::test_utils::run_relay_server().await?;
+    let (relay_url, _relay) = spawn_local_test_relay().await?;
     let relay_config = TransportRelayConfig {
-        iroh_relay_urls: vec![relay_url.to_string()],
+        iroh_relay_urls: vec![relay_url],
     }
     .normalized();
     let dir = tempdir()?;


### PR DESCRIPTION
## Summary
- replace self-signed HTTPS relay fixtures with the repository's local HTTP relay server
- keep relay integration tests enabled on GitHub Actions
- avoid weakening production TLS verification

## Validation
- `cargo xtask test`
  - Rust workspace: 584 passed, 3 skipped
  - harness: 18 passed
  - desktop Vitest: 721 passed across 83 files
- `cargo xtask check`