### PR TITLE
chore: bump preview version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-e2e"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-indexer"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-iroh-relay"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "iroh-relay",
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-operator"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "kukuri-cn-safety",
@@ -3234,14 +3234,14 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-runtime-support"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-arachnid"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-runtime"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-vlm"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-trust"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-user-api"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-harness"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-test-support"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "thiserror 2.0.20",
@@ -3500,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "kukuri-harness",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.4"
+version = "0.1.5"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/README.ja.md
+++ b/README.ja.md
@@ -118,7 +118,7 @@ cargo xtask doctor
 cargo xtask check
 cargo xtask test
 cargo xtask e2e-smoke
-cargo xtask release-check v0.1.4-preview.1
+cargo xtask release-check v0.1.5-preview.1
 
 cd apps/desktop
 npx pnpm@10.16.1 install

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cargo xtask doctor
 cargo xtask check
 cargo xtask test
 cargo xtask e2e-smoke
-cargo xtask release-check v0.1.4-preview.1
+cargo xtask release-check v0.1.5-preview.1
 
 cd apps/desktop
 npx pnpm@10.16.1 install

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kukuri-desktop",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "kukuri-cn-safety",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-trait",
  "serde",
@@ -3762,7 +3762,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-tauri"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kukuri-desktop-tauri"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 default-run = "kukuri-desktop-tauri"
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kukuri",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "app.kukuri.desktop",
   "build": {
     "beforeDevCommand": "npx pnpm@10.16.1 vite --host 127.0.0.1 --port 5173 --strictPort",

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -28,7 +28,7 @@ Windows code signing certificates are optional for the first preview. If code si
 ## Local Gates
 
 ```bash
-cargo xtask release-check v0.1.4-preview.1
+cargo xtask release-check v0.1.5-preview.1
 cargo xtask check
 cargo xtask test
 cargo xtask e2e-smoke
@@ -108,7 +108,7 @@ The repository keeps a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)-
 To preview the generated section locally before tagging (no commit, branch, or PR is created):
 
 ```powershell
-./scripts/release/update-changelog.ps1 -Tag v0.1.4-preview.1 -Repository KingYoSun/kukuri -PreviousTag v0.1.3-preview.1
+./scripts/release/update-changelog.ps1 -Tag v0.1.5-preview.1 -Repository KingYoSun/kukuri -PreviousTag v0.1.4-preview.1
 ```
 
 The `changelog` job needs `contents: write` and `pull-requests: write` permissions (already set in the workflow) to push the branch and open the PR.
@@ -174,7 +174,7 @@ if (-not $manifest.platforms.'windows-x86_64'.signature) {
 network access が必要。
 
 ```powershell
-./scripts/release/test-published-updater-signature.ps1 -Tag v0.1.4-preview.1
+./scripts/release/test-published-updater-signature.ps1 -Tag v0.1.5-preview.1
 ```
 
 assetを差し替えた場合は `SHA256SUMS.txt` も必ず更新する。GitHub/CDNの切替後に上記の短いURLを


### PR DESCRIPTION
## 変更内容

- workspace、desktop package、Tauri package/config、両 Cargo lockfile を 0.1.5 へ更新
- README と release runbook の現行例を v0.1.5-preview.1 へ更新
- 過去の changelog と dependency version は変更しない

## 検証

- cargo xtask release-check v0.1.5-preview.1
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets
- scripts/release/generate-third-party-notices.ps1 -Check
- scripts/release/test-create-preview-assets.ps1
- cargo xtask check
- cargo xtask test（Rust 584、harness 18、frontend 721）
- cargo xtask e2e-smoke