### PR TITLE
fix: propagate CN distance policy to Terraform

### DIFF
--- a/crates/cn-operator/src/config.rs
+++ b/crates/cn-operator/src/config.rs
@@ -304,6 +304,10 @@ pub struct DeployConfig {
     /// 自前 relay（`features.iroh_relay`）が無効な場合、deploy_indexer_stack=true では必須。
     #[serde(default)]
     pub indexer_external_relay_urls: Vec<String>,
+    /// distance opt-out が「遠い」と判定する node-local proximity 境界。
+    /// community index / local trust のどちらかを公開する場合は明示設定が必須。
+    #[serde(default)]
+    pub relation_distance_optout_min_proximity: Option<f64>,
     /// `COMMUNITY_NODE_CHANNEL_SECRET_KEY` を保持する Secret Manager secret ID（値ではない）。
     #[serde(default)]
     pub channel_secret_key_secret_id: Option<String>,
@@ -567,6 +571,19 @@ fn validate_deploy(resolved: &ResolvedConfig, deploy: &DeployConfig) -> Result<(
     }
     if let Some(model) = deploy.vlm_model.as_deref() {
         validate_deploy_string("deploy.vlm_model", model)?;
+    }
+
+    let read_surface_enabled = resolved.enabled(Capability::CommunityIndex)
+        || resolved.enabled(Capability::CommunityLocalTrust);
+    match deploy.relation_distance_optout_min_proximity {
+        Some(value) if value.is_finite() && value > 0.0 && value <= 1.0 => {}
+        Some(value) => bail!(
+            "deploy.relation_distance_optout_min_proximity は (0, 1] で指定してください (got `{value}`)"
+        ),
+        None if read_surface_enabled => bail!(
+            "community_index または community_local_trust が有効な場合、deploy.relation_distance_optout_min_proximity は必須です"
+        ),
+        None => {}
     }
 
     validate_indexer_stack(resolved, deploy)?;

--- a/crates/cn-operator/src/deploy.rs
+++ b/crates/cn-operator/src/deploy.rs
@@ -371,6 +371,15 @@ fn render_low_cost_tfvars(config: &ResolvedConfig, deploy: &DeployConfig) -> Str
         "trust_read_enabled  = {}",
         config.enabled(crate::Capability::CommunityLocalTrust)
     );
+    let relation_distance_optout_min_proximity = deploy
+        .relation_distance_optout_min_proximity
+        .map(|value| value.to_string())
+        .unwrap_or_default();
+    let _ = writeln!(
+        out,
+        "relation_distance_optout_min_proximity = {}",
+        hcl_string(&relation_distance_optout_min_proximity)
+    );
 
     // operator-config.yaml 自体を VM に配置して manifest endpoint / report_endpoint gating を
     // 有効化する。中身はこの tfvars には埋めず、Terraform 側の .tf で file() する。

--- a/crates/cn-operator/tests/deploy.rs
+++ b/crates/cn-operator/tests/deploy.rs
@@ -85,7 +85,7 @@ fn read_surface_flags_derive_from_planned_capabilities() {
     // community_index / community_local_trust を有効化（承認済み）した config では
     // 環境変数 gate の tfvars も true になる（実際の公開は readiness の有効化記録が関門）。
     let yaml = config_with_deploy(
-        "  relay_domain: relay.example-kukuri.net\n",
+        "  relay_domain: relay.example-kukuri.net\n  relation_distance_optout_min_proximity: 0.5\n",
         "  community_index: true\n  community_local_trust: true\n",
         true,
     );
@@ -95,6 +95,37 @@ fn read_surface_flags_derive_from_planned_capabilities() {
     let tfvars = generate_tfvars(&resolved).unwrap();
     assert!(tfvars.contains("index_query_enabled = true"));
     assert!(tfvars.contains("trust_read_enabled  = true"));
+    assert!(tfvars.contains("relation_distance_optout_min_proximity = \"0.5\""));
+}
+
+#[test]
+fn enabled_read_surface_requires_valid_relation_distance_policy() {
+    let missing = config_with_deploy(
+        "  relay_domain: relay.example-kukuri.net\n",
+        "  community_index: true\n",
+        true,
+    );
+    let err = load_and_validate(&missing).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("deploy.relation_distance_optout_min_proximity"),
+        "missing distance policy should be rejected: {err}"
+    );
+
+    for value in ["0", "1.1"] {
+        let yaml = config_with_deploy(
+            &format!(
+                "  relay_domain: relay.example-kukuri.net\n  relation_distance_optout_min_proximity: {value}\n"
+            ),
+            "  community_local_trust: true\n",
+            true,
+        );
+        let err = load_and_validate(&yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("(0, 1]"),
+            "invalid distance policy should be rejected: {err}"
+        );
+    }
 }
 
 #[test]
@@ -104,6 +135,7 @@ fn read_surface_flags_default_to_false() {
     let tfvars = generate_tfvars(&resolved).unwrap();
     assert!(tfvars.contains("index_query_enabled = false"));
     assert!(tfvars.contains("trust_read_enabled  = false"));
+    assert!(tfvars.contains("relation_distance_optout_min_proximity = \"\""));
 }
 
 #[test]

--- a/crates/cn-user-api/tests/manifest.rs
+++ b/crates/cn-user-api/tests/manifest.rs
@@ -140,6 +140,7 @@ deploy:
   acme_email: ops@example-kukuri.net
   jwt_secret_id: kukuri-cn-jwt-secret
   postgres_password_secret_id: kukuri-cn-postgres-password
+  relation_distance_optout_min_proximity: 0.5
 acknowledge_planned_capabilities: true
 "#;
 


### PR DESCRIPTION
## Summary
- add the node-local relation distance opt-out threshold to DeployConfig
- require a valid (0, 1] threshold when community index or local trust reads are enabled
- render the threshold into generated low-cost Terraform variables

## Validation
- cargo test -p kukuri-cn-operator
- cargo check -p kukuri-cn-operator --all-targets

## Release context
This fixes the fail-fast startup error observed while rolling out v0.1.5-preview.1 community-node images.