### PR TITLE
feat: 管理画面の操作を標準で有効化

### DIFF
--- a/crates/cn-operator/src/deploy.rs
+++ b/crates/cn-operator/src/deploy.rs
@@ -313,6 +313,11 @@ fn render_low_cost_tfvars(config: &ResolvedConfig, deploy: &DeployConfig) -> Str
         "safety_suspected_signal_visibility    = {}",
         hcl_string(suspected_visibility)
     );
+    let _ = writeln!(
+        out,
+        "safety_operator_review                 = {}",
+        safety.moderation.operator_review
+    );
     let _ = writeln!(out);
     let _ = writeln!(
         out,

--- a/crates/cn-operator/src/safety_config.rs
+++ b/crates/cn-operator/src/safety_config.rs
@@ -39,7 +39,7 @@ impl Default for SafetyConfig {
 /// runtime へは env（`COMMUNITY_NODE_SAFETY_SUSPECTED_THRESHOLD` /
 /// `COMMUNITY_NODE_SAFETY_SUSPECTED_SIGNAL_VISIBILITY` /
 /// `COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW`）として注入される宣言。
-#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SafetyModerationConfig {
     /// suspected 判定の classifier スコア閾値（1-100。未指定なら policy 既定 70 = 0.7）。
@@ -49,9 +49,23 @@ pub struct SafetyModerationConfig {
     /// 未指定なら既定 `local`（安全側。hard cap ではない。ADR 0028 §2.4 / §2.7）。
     #[serde(default)]
     pub suspected_signal_visibility: Option<SignalVisibility>,
-    /// operator レビュー（検知メタデータの直接編集）を有効化するか（既定 false。ADR 0028 §2.3）。
-    #[serde(default)]
+    /// operator レビュー（検知メタデータの直接編集）を有効化するか（既定 true。ADR 0028 §2.3）。
+    #[serde(default = "default_operator_review")]
     pub operator_review: bool,
+}
+
+impl Default for SafetyModerationConfig {
+    fn default() -> Self {
+        Self {
+            suspected_threshold: None,
+            suspected_signal_visibility: None,
+            operator_review: default_operator_review(),
+        }
+    }
+}
+
+const fn default_operator_review() -> bool {
+    true
 }
 
 /// risk signal の配布 visibility（`cn-safety` の `Visibility` と同じ語彙）。

--- a/crates/cn-operator/tests/deploy.rs
+++ b/crates/cn-operator/tests/deploy.rs
@@ -363,6 +363,7 @@ fn indexer_stack_full_config_emits_expected_tfvars() {
     assert!(tfvars.contains("safety_provider_known_csam_required   = true"));
     assert!(tfvars.contains("safety_provider_general               = \"openai-compatible-vlm\""));
     assert!(tfvars.contains("safety_emit_signed_events             = true"));
+    assert!(tfvars.contains("safety_operator_review                 = true"));
     assert!(tfvars.contains("safety_signing_key_secret_id = \"kukuri-cn-safety-signing-key\""));
     assert!(tfvars.contains("vlm_api_base_url     = \"http://192.0.2.10:8000\""));
     assert!(tfvars.contains("vlm_model            = \"inclusionAI/SingGuard-2b\""));

--- a/crates/cn-operator/tests/safety.rs
+++ b/crates/cn-operator/tests/safety.rs
@@ -25,6 +25,10 @@ fn safety_config_parses_structured_schema() {
     assert_eq!(safety.indexing.on_scan_error, SafetyErrorAction::Hold);
     assert!(!safety.storage.permanent_blob_storage);
     assert!(safety.events.emit_signed_moderation_events);
+    assert!(
+        safety.moderation.operator_review,
+        "operator review should default to enabled for the IAP admin UI"
+    );
     assert_eq!(
         safety
             .providers
@@ -518,8 +522,8 @@ fn safety_moderation_env_wiring_reaches_compose_and_terraform() {
     }
 
     // repo root の operator-config.yaml は運用者ローカルの実設定(.gitignore 済み)なので
-    // CI には存在しない。存在する環境(運用者の作業環境)でだけ、moderation 節が解析でき
-    // 既定どおり無効(参照専用)であることを確認する(#709 の「既定は無効のまま」)。
+    // CI には存在しない。存在する環境(運用者の作業環境)でだけ、moderation 節が解析でき、
+    // IAP 管理画面の標準配備どおり有効であることを確認する。
     if let Ok(production) = fs::read_to_string(format!("{root}/operator-config.yaml")) {
         let resolved = load_and_validate(&production).expect("operator-config parses");
         let moderation = &resolved
@@ -529,8 +533,8 @@ fn safety_moderation_env_wiring_reaches_compose_and_terraform() {
             .expect("safety section")
             .moderation;
         assert!(
-            !moderation.operator_review,
-            "operator_review の既定は無効(有効化は審査済みの設定変更で行う)"
+            moderation.operator_review,
+            "operator_review should be enabled"
         );
     }
 }

--- a/docker-compose.community-node.yml
+++ b/docker-compose.community-node.yml
@@ -118,13 +118,13 @@ services:
       # 公開鍵 hex、または明示識別子)の一致を起動時に検査する(#706)。cn-indexer と同じ値を渡す。
       COMMUNITY_NODE_SAFETY_SIGNING_KEY: ${COMMUNITY_NODE_SAFETY_SIGNING_KEY:-}
       COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID: ${COMMUNITY_NODE_SAFETY_ISSUER_NODE_ID:-}
-      # Admin listener is loopback-published below. Browser writes remain disabled unless
-      # COMMUNITY_NODE_ADMIN_ACTOR is explicitly configured.
+      # Admin listener is loopback-published below. IAP / loopback 境界内の標準配備では
+      # browser write を有効にし、固定 actor を append-only audit に記録する。
       COMMUNITY_NODE_ADMIN_BIND_ADDR: ${COMMUNITY_NODE_ADMIN_BIND_ADDR:-0.0.0.0:9090}
-      COMMUNITY_NODE_ADMIN_ACTOR: ${COMMUNITY_NODE_ADMIN_ACTOR:-}
+      COMMUNITY_NODE_ADMIN_ACTOR: ${COMMUNITY_NODE_ADMIN_ACTOR:-ops@kukuri.app}
       # 異議申し立ての運営者審査(検知情報の調整・訂正再発行)。運用者設定
-      # safety.moderation.operator_review から注入する(既定 false = 参照専用。#709)。
-      COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW: ${COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW:-}
+      # safety.moderation.operator_review から注入する(既定 true。#709)。
+      COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW: ${COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW:-true}
       COMMUNITY_NODE_GCP_PROJECT: ${COMMUNITY_NODE_GCP_PROJECT:-}
       # private channel indexing / index・trust read surface（#615）。flag は full-stack E2E
       # 完了まで既定 false（無効時は 404）。

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -201,7 +201,7 @@ terraform apply
 curl -fsS https://<api_domain>/healthz
 curl -fsS https://<relay_domain>/ping
 terraform output ssh_iap_command   # IAP 経由 SSH
-terraform output admin_iap_tunnel_command # read-only admin UI
+terraform output admin_iap_tunnel_command # IAP 内部 admin UI
 ```
 
 VM 内のサービスは `/var/lib/kukuri/community-node` の docker compose で動く。SSH は IAP のみ
@@ -210,9 +210,11 @@ VM 内のサービスは `/var/lib/kukuri/community-node` の docker compose で
 `iap.tunnelInstances.accessViaIAP` を含む IAM role が必要で、Caddy / public DNS には載せない。
 
 admin UI は状態、最新 readiness activation、admission mode、supported topics、直近 50 件の通報、
-Cloud Logging 導線を read-only で表示する。browser からの設定変更は、actor を記録する append-only
-audit contract、差分 preview、CSRF 防御を実装するまで有効化しない。変更は引き続き
-`operator-config.yaml` / `cn-cli` を SSoT とし、実行 command と結果を運用記録へ残す。
+Cloud Logging 導線を表示する。low-cost標準配備では `admin_actor = "ops@kukuri.app"` と
+`safety_operator_review = true` を既定にし、append-only audit、差分 preview、CSRF 防御の内側で
+browser writeを有効にする。actorを空にすればwrite endpointはfail-closedし、read-onlyになる。
+credentialや配備宣言は引き続き `operator-config.yaml` / Terraform / Secret Manager / `cn-cli` を
+SSoTとし、admin UIから変更しない。
 
 ### admission / 運用
 

--- a/docs/runbooks/community-node-production-rollout.md
+++ b/docs/runbooks/community-node-production-rollout.md
@@ -288,8 +288,8 @@ terraform output -raw admin_iap_tunnel_command
 この listener は Caddy / public DNS に接続せず、firewall は Google IAP TCP forwarding range のみを
 許可する。
 
-browser writeは `admin_actor` が非空のdeploymentだけで有効になる。本番low-cost環境では、共有の
-運用identityとして次をtfvarsへ設定する。IAP TCP forwardingはHTTP identity headerを注入しないため、
+browser writeは `admin_actor` が非空のdeploymentだけで有効になる。本番low-cost環境では次の共有
+運用identityを既定値とする。IAP TCP forwardingはHTTP identity headerを注入しないため、
 formや任意headerではなくdeployment値だけをaudit actorとして信用する。
 
 ```hcl
@@ -311,7 +311,7 @@ admin_actor = "ops@kukuri.app"
 report details、reporter contact、private channel secretを含めない。actor未設定時はread-only表示になり、
 write endpointは503でfail-closedする。
 
-異議申し立て審査の変更操作には `COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW=true` も必要である。無効時は
+異議申し立て審査の変更操作には、既定で有効な `COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW=true` も必要である。無効時は
 申し立て内容と対象のリスク判定を参照できるが、操作欄は参照専用になる。同じリスク判定へ複数の
 申し立てが届いても、一覧では一つの審査対象にまとめて表示する。
 
@@ -332,13 +332,14 @@ write endpointは503でfail-closedする。
 - capability / authority scope / image revision
 - private channel secret、invite code、allowlist、ban
 
-standard Composeでは `http://127.0.0.1:19090` がadmin UIで、`COMMUNITY_NODE_ADMIN_ACTOR` を空にすれば
-read-onlyになる。loopback以外へbindする場合は、先に同等の認証・firewall境界を用意する。
+standard Composeでは `http://127.0.0.1:19090` がadmin UIで、既定actorは `ops@kukuri.app`、
+operator reviewも既定有効である。`COMMUNITY_NODE_ADMIN_ACTOR` を空にすればread-onlyになる。
+loopback以外へbindする場合は、先に同等の認証・firewall境界を用意する。
 
 異議申し立て審査の変更操作は、`COMMUNITY_NODE_ADMIN_ACTOR` に加えて運用者設定
 `safety.moderation.operator_review`（terraform 変数 `safety_operator_review` →
-`COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW`）の有効化が必要（既定は無効 = 参照専用。#709）。
-有効化手順は `docs/runbooks/openai-compatible-vlm.md` の「appeal / operator レビュー運用」を参照。
+`COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW`）の有効化が必要（標準配備は既定有効。#709）。
+無効化・再有効化手順は `docs/runbooks/openai-compatible-vlm.md` の「appeal / operator レビュー運用」を参照。
 
 ### 5.3 public surface
 

--- a/docs/runbooks/openai-compatible-vlm.md
+++ b/docs/runbooks/openai-compatible-vlm.md
@@ -87,14 +87,10 @@ cargo test -p kukuri-cn-safety-vlm --test live_endpoint -- --ignored --nocapture
   一つの Postgres 取引で確定する。訂正版再発行は旧判定を認容（寄与なし）として終結させたまま
   根拠一覧に残し、訂正版を新規発行する（#710。利用者は再取得で終結を確認できる）。
   `cn-cli moderation reissue` の appeal を伴わない個別再発行は従来どおり旧判定へ失効時刻を刻む。
-- **審査の有効化手順（#709。既定は無効 = 参照専用）**: browser から直接変更しない。
-  1. `operator-config.yaml` の `safety.moderation.operator_review` を `true` にしてレビューを通す。
-  2. terraform（`infra/terraform/envs/low-cost`）の変数 `safety_operator_review` を `true` にして
-     適用する。生成される env に `COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW=true` が入り、
-     `cn-user-api` の再起動後に審査画面から変更操作ができるようになる。
-  3. 無効へ戻すときは両方を `false` に戻して適用する（未設定・false は参照専用）。
-  standard Compose 構成では `.env.community-node` に
-  `COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW=true` を設定する。
+- **審査の有効化状態（#709。標準配備は既定有効）**: `operator-config.yaml` の
+  `safety.moderation.operator_review` とterraformの `safety_operator_review` は既定で `true` とし、
+  生成envへ `COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW=true` を注入する。無効へ戻すときは両方を
+  `false` にして適用する。standard Composeでは環境変数を `false` にすると参照専用になる。
 - 障害調査や運営画面へ接続できない場合は `cn-cli moderation` で状態を確認できる:
 
 ```bash

--- a/infra/terraform/envs/ha/outputs.tf
+++ b/infra/terraform/envs/ha/outputs.tf
@@ -19,7 +19,7 @@ output "ssh_iap_command" {
 }
 
 output "admin_iap_tunnel_command" {
-  description = "read-only admin UI の IAP TCP tunnel コマンド。"
+  description = "operator admin UI の IAP TCP tunnel コマンド。"
   value       = module.vm.admin_iap_tunnel_command
 }
 

--- a/infra/terraform/envs/low-cost/outputs.tf
+++ b/infra/terraform/envs/low-cost/outputs.tf
@@ -19,7 +19,7 @@ output "ssh_iap_command" {
 }
 
 output "admin_iap_tunnel_command" {
-  description = "read-only admin UI の IAP TCP tunnel コマンド。"
+  description = "operator admin UI の IAP TCP tunnel コマンド。"
   value       = module.vm.admin_iap_tunnel_command
 }
 

--- a/infra/terraform/envs/low-cost/terraform.tfvars.example
+++ b/infra/terraform/envs/low-cost/terraform.tfvars.example
@@ -8,7 +8,8 @@ zone       = "asia-northeast1-a"
 api_domain   = "api.example.com"
 relay_domain = "iroh-relay.example.com"
 acme_email   = "ops@example.com"
-admin_actor  = "ops@example.com"
+admin_actor  = "ops@kukuri.app"
+safety_operator_review = true
 
 # Cloud DNS で A レコードを自動作成する場合は true + zone 名。
 # false の場合は terraform output static_ip を手動 DNS に設定する。

--- a/infra/terraform/envs/low-cost/variables.tf
+++ b/infra/terraform/envs/low-cost/variables.tf
@@ -51,7 +51,7 @@ variable "acme_email" {
 variable "admin_actor" {
   description = "IAP 内部 admin browser write の監査 actor。空なら write 無効。"
   type        = string
-  default     = ""
+  default     = "ops@kukuri.app"
 
   validation {
     condition = (
@@ -403,9 +403,9 @@ variable "safety_suspected_threshold" {
 }
 
 variable "safety_operator_review" {
-  description = "COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW。既定 false（審査画面は参照専用）。"
+  description = "COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW。既定 true（IAP 管理画面から審査操作を許可）。"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "safety_suspected_signal_visibility" {

--- a/infra/terraform/envs/managed-db/outputs.tf
+++ b/infra/terraform/envs/managed-db/outputs.tf
@@ -19,7 +19,7 @@ output "ssh_iap_command" {
 }
 
 output "admin_iap_tunnel_command" {
-  description = "read-only admin UI の IAP TCP tunnel コマンド。"
+  description = "operator admin UI の IAP TCP tunnel コマンド。"
   value       = module.vm.admin_iap_tunnel_command
 }
 

--- a/infra/terraform/modules/gcp-vm-compose/variables.tf
+++ b/infra/terraform/modules/gcp-vm-compose/variables.tf
@@ -259,7 +259,7 @@ variable "rate_limit_burst" {
 variable "admin_actor" {
   description = "IAP 内部 admin browser write の append-only audit に記録する deployment-controlled actor。空なら write を fail-closed で無効化する。"
   type        = string
-  default     = ""
+  default     = "ops@kukuri.app"
 
   validation {
     condition = (
@@ -503,9 +503,9 @@ variable "safety_suspected_threshold" {
 }
 
 variable "safety_operator_review" {
-  description = "COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW。異議申し立ての運営者審査（変更操作）を有効化する。既定 false（参照専用）。運用者設定 safety.moderation.operator_review と一致させる。"
+  description = "COMMUNITY_NODE_SAFETY_OPERATOR_REVIEW。異議申し立ての運営者審査（変更操作）を有効化する。既定 true。運用者設定 safety.moderation.operator_review と一致させる。"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "safety_suspected_signal_visibility" {


### PR DESCRIPTION
## 概要

- IAP / loopback 内部の管理画面でbrowser writeを標準有効化
- 監査actorの既定値をops@kukuri.appへ統一
- 異議申し立てのoperator reviewを標準有効化
- cn-operator、Compose、Terraform、運用手順の既定値を統一
- actorを空、またはoperator reviewをfalseにした場合の参照専用動作は維持

## 安全境界

- 管理画面はCaddyやpublic DNSへ公開しない
- 書き込みはappend-only audit、差分preview、CSRF防御の内側
- credentialや配備宣言は管理画面から変更しない
- actor未設定時はwrite endpointがfail-closedする

## 検証

- cargo fmt --all -- --check
- cargo test -p kukuri-cn-operator
- terraform fmt -check -recursive infra/terraform
- git diff --check

## 対象外

- Community Index検索不具合はIssue #741で別対応