### PR TITLE
fix: 接続設定の横スクロールを防ぐ

### DIFF
--- a/apps/desktop/src/components/settings/ConnectivityPanel.tsx
+++ b/apps/desktop/src/components/settings/ConnectivityPanel.tsx
@@ -29,10 +29,10 @@ export function ConnectivityPanel({
   const { t } = useTranslation(['common', 'settings']);
 
   return (
-    <div className='space-y-4'>
-      <Card className='space-y-4'>
+    <div className='min-w-0 space-y-4'>
+      <Card className='min-w-0 max-w-full space-y-4'>
         <CardHeader className='items-start justify-between gap-3 md:flex'>
-          <div>
+          <div className='min-w-0'>
             <h3>{t('settings:connectivity.title')}</h3>
           </div>
           <StatusBadge label={view.summaryLabel} tone={view.status === 'error' ? 'destructive' : 'accent'} />
@@ -49,27 +49,28 @@ export function ConnectivityPanel({
         ) : null}
       </Card>
 
-      <Card className='space-y-4'>
+      <Card className='min-w-0 max-w-full space-y-4'>
         <CardHeader>
           <h3>{t('settings:connectivity.peerTickets')}</h3>
           <small>{t('settings:connectivity.manualConnectivity')}</small>
         </CardHeader>
 
-        <label className='flex flex-col gap-3'>
+        <label className='flex min-w-0 flex-col gap-3'>
           <span>{t('settings:connectivity.yourTicket')}</span>
           <Textarea
             readOnly
             value={view.localPeerTicket}
-            className='min-h-[88px] resize-y font-mono text-[0.8rem]'
+            className='min-h-[88px] min-w-0 max-w-full resize-y font-mono text-[0.8rem] [overflow-wrap:anywhere]'
           />
         </label>
 
-        <label className='flex flex-col gap-3'>
+        <label className='flex min-w-0 flex-col gap-3'>
           <span>{t('settings:connectivity.peerTicket')}</span>
           <Input
             value={view.peerTicketInput}
             onChange={(event) => onPeerTicketInputChange(event.target.value)}
             placeholder={t('settings:connectivity.peerTicketPlaceholder')}
+            className='min-w-0 max-w-full'
           />
         </label>
 
@@ -80,7 +81,7 @@ export function ConnectivityPanel({
         </SettingsActionRow>
       </Card>
 
-      <Card className='space-y-4'>
+      <Card className='min-w-0 max-w-full space-y-4'>
         <CardHeader>
           <h3>{t('settings:connectivity.topicConnectivity')}</h3>
           <small>{t('settings:connectivity.tracked', { count: view.topics.length })}</small>
@@ -88,11 +89,11 @@ export function ConnectivityPanel({
 
         {view.topics.length === 0 ? <Notice>{t('settings:connectivity.noTopicDiagnostics')}</Notice> : null}
 
-        <div className='space-y-3'>
+        <div className='min-w-0 space-y-3'>
           {view.topics.map((topic) => (
             <section
               key={topic.topic}
-              className='rounded-[20px] border border-[var(--border-subtle)] bg-[var(--surface-panel-soft)] p-4 shadow-[var(--shadow-dropdown)]'
+              className='min-w-0 max-w-full rounded-[20px] border border-[var(--border-subtle)] bg-[var(--surface-panel-soft)] p-4 shadow-[var(--shadow-dropdown)]'
             >
               <div className='flex flex-wrap items-start justify-between gap-3'>
                 <div className='min-w-0'>

--- a/apps/desktop/src/components/settings/SettingsDiagnosticList.tsx
+++ b/apps/desktop/src/components/settings/SettingsDiagnosticList.tsx
@@ -13,12 +13,12 @@ export function SettingsDiagnosticList({
 }: SettingsDiagnosticListProps) {
   return (
     <dl
-      className='gap-3'
+      className='min-w-0 max-w-full gap-3'
       style={
         columns === 2
           ? {
               display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(16rem, 1fr))',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(min(16rem, 100%), 1fr))',
             }
           : { display: 'grid' }
       }
@@ -33,7 +33,7 @@ export function SettingsDiagnosticList({
           </dt>
           <dd
             className={cn(
-              'mt-2 min-w-0 break-words text-sm leading-6 text-[var(--muted-foreground-soft)]',
+              'mt-2 min-w-0 [overflow-wrap:anywhere] text-sm leading-6 text-[var(--muted-foreground-soft)]',
               item.monospace && 'break-all font-mono text-[0.8rem]',
               item.tone === 'danger' && 'text-[var(--destructive)]'
             )}

--- a/apps/desktop/src/components/settings/SettingsMetricGrid.tsx
+++ b/apps/desktop/src/components/settings/SettingsMetricGrid.tsx
@@ -9,10 +9,10 @@ type SettingsMetricGridProps = {
 export function SettingsMetricGrid({ items }: SettingsMetricGridProps) {
   return (
     <dl
-      className='gap-3'
+      className='min-w-0 max-w-full gap-3'
       style={{
         display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(9rem, 1fr))',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(min(9rem, 100%), 1fr))',
       }}
     >
       {items.map((item) => (
@@ -34,7 +34,7 @@ export function SettingsMetricGrid({ items }: SettingsMetricGridProps) {
           </dt>
           <dd
             className={cn(
-              'mt-2 break-words text-lg font-semibold text-foreground',
+              'mt-2 [overflow-wrap:anywhere] text-lg font-semibold text-foreground',
               item.tone === 'danger' && 'text-[var(--destructive)]'
             )}
           >

--- a/apps/desktop/src/styles/shell-phase1-part4.css
+++ b/apps/desktop/src/styles/shell-phase1-part4.css
@@ -194,7 +194,8 @@
   min-width: 0;
   min-height: 0;
   height: 100%;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   overscroll-behavior: contain;
   padding-right: var(--space-2xs);
 }

--- a/apps/desktop/tests/playwright/shell.smoke.spec.ts
+++ b/apps/desktop/tests/playwright/shell.smoke.spec.ts
@@ -15,6 +15,9 @@ async function openComposerDialog(page: Page) {
 }
 
 const TOPIC_ID_PREFIX = 'kukuri:topic:';
+const LONG_PEER_ID = `12D3KooW${'a'.repeat(240)}`;
+const LONG_PEER_TICKET = `${LONG_PEER_ID}@192.0.2.10:7777,2001:db8::10:7777`;
+const LONG_ENDPOINT_DETAIL = `endpoint://${'b'.repeat(320)}@iroh-relay.kukuri.app:7842`;
 
 function topicDisplayName(topicId: string): string {
   return topicId.startsWith(TOPIC_ID_PREFIX) ? topicId.slice(TOPIC_ID_PREFIX.length) : topicId;
@@ -221,6 +224,95 @@ test('browser mock settings drawer keeps the close button clear of content and c
   await page.mouse.wheel(0, 960);
 
   await expect.poll(() => scrollContainer.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+});
+
+test('browser mock connectivity settings keep long identifiers within the content width', async ({
+  page,
+}) => {
+  await page.addInitScript(
+    ({ endpointDetail, peerId, peerTicket }) => {
+      let desktopApi = window.__KUKURI_DESKTOP__;
+
+      Object.defineProperty(window, '__KUKURI_DESKTOP__', {
+        configurable: true,
+        get: () => desktopApi,
+        set: (api: typeof desktopApi) => {
+          desktopApi = api;
+          if (!api) {
+            return;
+          }
+
+          const getSyncStatus = api.getSyncStatus.bind(api);
+          api.getSyncStatus = async () => {
+            const status = await getSyncStatus();
+            return {
+              ...status,
+              configured_peers: [peerId],
+              status_detail: endpointDetail,
+              discovery: {
+                ...status.discovery,
+                connected_peer_ids: [peerId],
+                local_endpoint_id: peerId,
+              },
+              topic_diagnostics: status.topic_diagnostics.map((diagnostic) => ({
+                ...diagnostic,
+                connected_peers: [peerId],
+                configured_peer_ids: [peerId],
+                docs_assist_peer_ids: [peerId],
+                status_detail: endpointDetail,
+              })),
+            };
+          };
+          api.getLocalPeerTicket = async () => peerTicket;
+        },
+      });
+    },
+    {
+      endpointDetail: LONG_ENDPOINT_DETAIL,
+      peerId: LONG_PEER_ID,
+      peerTicket: LONG_PEER_TICKET,
+    }
+  );
+
+  await page.setViewportSize({ width: 1024, height: 870 });
+  await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ademo&settings=connectivity');
+
+  const settingsDialog = page.getByRole('dialog', { name: 'Settings' });
+  const scrollContainer = settingsDialog.locator('.shell-settings-content');
+  const localPeerTicket = settingsDialog.getByRole('textbox', { name: 'Your Ticket' });
+  await expect(settingsDialog).toBeVisible();
+  await expect(localPeerTicket).toHaveValue(LONG_PEER_TICKET);
+  await expect(settingsDialog.getByText(LONG_ENDPOINT_DETAIL).first()).toBeVisible();
+  await expect(settingsDialog.getByText(LONG_PEER_ID).first()).toBeVisible();
+
+  for (const width of [1024, 1280, 1440, 700]) {
+    await page.setViewportSize({ width, height: 870 });
+
+    const layout = await scrollContainer.evaluate((element) => {
+      const contentRect = element.getBoundingClientRect();
+      const contentRight = contentRect.left + element.clientWidth;
+      const overflowingPanels = Array.from(element.querySelectorAll<HTMLElement>('.panel')).filter(
+        (panel) => panel.getBoundingClientRect().right > contentRight + 0.5
+      );
+
+      return {
+        contentFits: element.scrollWidth <= element.clientWidth,
+        horizontalOverflowPolicy: getComputedStyle(element).overflowX,
+        overflowingPanelCount: overflowingPanels.length,
+      };
+    });
+    const ticketFits = await localPeerTicket.evaluate(
+      (element) => element.scrollWidth <= element.clientWidth
+    );
+
+    expect(layout, `viewport width: ${width}`).toEqual({
+      contentFits: true,
+      horizontalOverflowPolicy: 'hidden',
+      overflowingPanelCount: 0,
+    });
+    expect(ticketFits, `peer ticket at viewport width: ${width}`).toBeTruthy();
+    await expect(settingsDialog.getByRole('button', { name: 'Import Peer' })).toBeVisible();
+  }
 });
 
 test('browser mock narrow shell keeps nav, context, and settings flows reachable without overflow', async ({


### PR DESCRIPTION
## 概要

- 接続設定コンテンツを縦スクロール専用にし、子要素の min-content 幅がドロワーを押し広げないようにしました。
- ピアID・ピアチケット・endpoint detail などの長い識別子を利用可能幅内で折り返します。
- 1024 / 1280 / 1440 / 700 px の各幅で、横方向の overflow が発生せず主要操作が表示されるブラウザ回帰テストを追加しました。

Closes #739

## 確認

- `cargo xtask desktop-ui-check`
- `cargo xtask check`
- `cargo xtask test`
- Windows 11 の Tauri 実機（1280×870）で、長いローカルチケットの折返し、縦スクロール、「ピアを追加」操作、横スクロール非表示を確認

## UI review

- Flow: 設定 → 接続 → 同期状態 / ピアチケット / トピック接続詳細を縦に閲覧
- Consistency: 既存のカード・入力・ボタン表現を維持
- Feedback / closure: 操作や状態表示の振る舞いは変更なし
- Error prevention / reversibility: 接続操作の契約は変更なし
- Control: 縦スクロールと狭幅時の主要操作への到達性を維持
- Memory load: 長い識別子を省略せず、同じカード内で読めるように折返し

![接続設定プレビュー](https://raw.githubusercontent.com/KingYoSun/kukuri/4e6f804c/apps/desktop/tests/playwright/__screenshots__/visual.spec.ts/settings-connectivity-wide-dark.png)
