### PR TITLE
[codex][fix] Community Node provider alertの誤検知を分離

### DIFF
--- a/crates/cn-indexer/src/ingest.rs
+++ b/crates/cn-indexer/src/ingest.rs
@@ -105,12 +105,20 @@ impl IngestPipeline {
         self
     }
 
-    /// スキャンを実行し、観測状態に分類（スキャン失敗 / プロバイダ利用不可）を記録する。
+    /// スキャンを実行し、観測状態に分類（スキャン失敗 / 外部プロバイダ利用不可）を記録する。
+    ///
+    /// media blob の未複製・ピア不在も verdict 上は `ProviderUnavailable` になるが、外部 safety
+    /// provider 障害ではない。scan 中に media fetch の利用不可カウンタが増えた場合は、専用の
+    /// `media_fetch_unavailable` だけに記録し、provider 障害カウンタへ重複計上しない。
     async fn scan_and_record_with_metrics(
         &self,
         request: &ProviderScanRequest,
         subject_author: &str,
     ) -> Result<SafetyScanOutcome> {
+        let media_fetch_unavailable_before = self
+            .metrics
+            .as_ref()
+            .map(|metrics| metrics.media_fetch_unavailable_count());
         let outcome = match self
             .safety
             .scan_and_record_for_author(request, subject_author)
@@ -125,8 +133,12 @@ impl IngestPipeline {
             }
         };
         if let Some(metrics) = &self.metrics {
+            let media_fetch_became_unavailable = media_fetch_unavailable_before
+                .is_some_and(|before| metrics.media_fetch_unavailable_count() > before);
             match outcome.report.verdict.reason_code {
-                ReasonCode::ProviderUnavailable => metrics.record_provider_unavailable(),
+                ReasonCode::ProviderUnavailable if !media_fetch_became_unavailable => {
+                    metrics.record_provider_unavailable();
+                }
                 ReasonCode::ScanFailed | ReasonCode::Unscanned => metrics.record_scan_error(),
                 _ => {}
             }

--- a/crates/cn-indexer/src/state.rs
+++ b/crates/cn-indexer/src/state.rs
@@ -37,7 +37,7 @@ pub struct IndexerStateSnapshot {
     pub skipped_non_allow: u64,
     /// スキャン失敗（scan_failed / unscanned / スキャン呼び出しの失敗）の件数。
     pub scan_errors: u64,
-    /// プロバイダ利用不可の件数。
+    /// media 取得不能を除く、外部 safety provider 利用不可の件数。
     pub provider_unavailable: u64,
     /// 索引から外した件数の累計。
     pub deindexed: u64,
@@ -131,6 +131,14 @@ impl IndexerRuntimeState {
 
     pub fn record_media_fetch_unavailable(&self) {
         self.media_fetch_unavailable.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// media 取得不能の現在値を返す。
+    ///
+    /// scan 前後の差分から、`ProviderUnavailable` が外部 provider ではなく media fetch 境界で
+    /// 発生したかを分類するために使う。常駐 worker は scope / entry を逐次 scan する。
+    pub(crate) fn media_fetch_unavailable_count(&self) -> u64 {
+        self.media_fetch_unavailable.load(Ordering::Relaxed)
     }
 
     pub fn record_media_fetch_timeout(&self) {

--- a/crates/cn-indexer/tests/ingestion_contracts.rs
+++ b/crates/cn-indexer/tests/ingestion_contracts.rs
@@ -9,13 +9,16 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use kukuri_blob_service::MemoryBlobService;
 use kukuri_cn_core::{IndexScopeKind, MemoryIndexEntryStore};
-use kukuri_cn_indexer::config::RelayConfig;
+use kukuri_cn_indexer::config::{MediaFetchConfig, RelayConfig};
 use kukuri_cn_indexer::ingest::IngestPipeline;
+use kukuri_cn_indexer::media_fetcher::BlobMediaFetcher;
 use kukuri_cn_indexer::participant::ScopeReplica;
 use kukuri_cn_indexer::projection::{IndexProjection, MemoryIndexProjection};
+use kukuri_cn_indexer::state::IndexerRuntimeState;
 use kukuri_cn_safety::provider::{
-    ProviderScanRequest, ProviderScanResult, ScanError, ScanOutcome, SubjectKind,
+    MediaFetcher, ProviderScanRequest, ProviderScanResult, ScanError, ScanOutcome, SubjectKind,
 };
 use kukuri_cn_safety::{
     MockSafetyProvider, ModerationEventSigner, RiskSignalTarget, SafetyCategory, SafetyProvider,
@@ -366,6 +369,89 @@ async fn media_scan_unavailable_fails_closed_and_post_is_not_indexed() -> Result
     Ok(())
 }
 
+/// 本番と同じ `MediaFetcher` 境界を通して media blob を取得する known-CSAM provider。
+///
+/// 本文は `NoKnownMatch`、media は fetch 成功後に `NoKnownMatch` を返す。fetch 失敗はそのまま
+/// provider error として返し、取得不能と外部 provider 障害の観測分類を検証できるようにする。
+struct FetchingProvider {
+    fetcher: Arc<dyn MediaFetcher>,
+}
+
+#[async_trait]
+impl SafetyProvider for FetchingProvider {
+    fn name(&self) -> &str {
+        "fetching-known-csam"
+    }
+
+    fn capabilities(&self) -> &[SafetyProviderCapability] {
+        &[SafetyProviderCapability::KnownCsamHashMatch]
+    }
+
+    async fn scan(&self, request: &ProviderScanRequest) -> Result<ProviderScanResult, ScanError> {
+        if let Some(media_hint) = request.media_hint.as_deref() {
+            self.fetcher
+                .fetch(media_hint, request.media_mime.as_deref())
+                .await?;
+        }
+        let mut result = ProviderScanResult::completed(
+            self.name(),
+            SafetyProviderCapability::KnownCsamHashMatch,
+        );
+        result.outcome = ScanOutcome::NoKnownMatch;
+        Ok(result)
+    }
+}
+
+#[tokio::test]
+async fn missing_media_is_not_counted_as_external_provider_unavailable() -> Result<()> {
+    // ピア不在などで media blob を取得できない場合も verdict は fail-closed の
+    // ProviderUnavailable になるが、外部 safety provider 障害の監視値には含めない。
+    let docs = Arc::new(MemoryDocsSync::default());
+    let projection = Arc::new(MemoryIndexProjection::new());
+    let topic = TopicId::new("rust");
+    let replica = topic_replica_id("rust");
+    persist_media_post(&docs, &replica, &topic, "missing media", true).await;
+
+    let metrics = Arc::new(IndexerRuntimeState::default());
+    let fetcher = BlobMediaFetcher::new(
+        Arc::new(MemoryBlobService::default()),
+        MediaFetchConfig::default(),
+    )
+    .with_metrics(Arc::clone(&metrics));
+    let provider = Arc::new(FetchingProvider {
+        fetcher: Arc::new(fetcher),
+    });
+
+    let signer = Secp256k1ModerationEventSigner::from_secret(TEST_SECRET).expect("signer");
+    let issuer = signer.issuer_node_id().to_string();
+    let store = Arc::new(MemorySafetyArtifactStore::new());
+    let orchestrator = SafetyOrchestrator::builder(
+        &issuer,
+        Arc::new(SystemScanClock),
+        Arc::new(UuidEventIdGenerator),
+    )
+    .provider(provider)
+    .build()
+    .expect("orchestrator");
+    let service = SafetyScanService::builder(Arc::new(orchestrator), store.clone())
+        .signer(Arc::new(signer))
+        .build()
+        .expect("service");
+    let (pipeline, _, _) = pipeline_with(&docs, &projection, (Arc::new(service), store));
+    let pipeline = pipeline.with_metrics(Arc::clone(&metrics));
+
+    let summary = pipeline
+        .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
+        .await?;
+    let snapshot = metrics.snapshot();
+
+    assert_eq!(summary.indexed, 0);
+    assert_eq!(summary.skipped_non_allow, 1);
+    assert_eq!(snapshot.media_fetch_unavailable, 1);
+    assert_eq!(snapshot.provider_unavailable, 0);
+    Ok(())
+}
+
 #[tokio::test]
 async fn missing_media_manifest_fails_closed_and_post_is_not_indexed() -> Result<()> {
     // manifest 参照が replica 上で解決できなければ scan 対象を確定できないため、post を
@@ -625,7 +711,9 @@ async fn provider_unavailable_is_never_allowed_and_not_indexed() -> Result<()> {
     let replica = topic_replica_id("rust");
     let object_id = persist_post(&docs, &replica, &topic, "provider is down").await;
 
+    let metrics = Arc::new(IndexerRuntimeState::default());
     let (pipeline, entries, _) = pipeline_with(&docs, &projection, provider_unavailable_service());
+    let pipeline = pipeline.with_metrics(Arc::clone(&metrics));
     let summary = pipeline
         .ingest_scope(IndexScopeKind::PublicTopic, "rust", &replica)
         .await?;
@@ -638,6 +726,8 @@ async fn provider_unavailable_is_never_allowed_and_not_indexed() -> Result<()> {
             .await?
     );
     assert!(!entries.contains(IndexScopeKind::PublicTopic, "rust", &object_id));
+    assert_eq!(metrics.snapshot().provider_unavailable, 1);
+    assert_eq!(metrics.snapshot().media_fetch_unavailable, 0);
     Ok(())
 }
 

--- a/docs/runbooks/community-node-gcp-terraform.md
+++ b/docs/runbooks/community-node-gcp-terraform.md
@@ -374,7 +374,9 @@ self-host VLM は次のどちらか一方の境界に固定し、runbook・netwo
 ### Cloud Monitoring / log retention
 
 - VM の `kukuri-monitor.timer` が5分ごとに disk使用率、Postgres/ArcadeDB/indexer health、
-  last ingest age、backoff、provider failure、relation最終成功時刻を custom metrics へ送る。
+  last ingest age、backoff、外部 safety provider failure、media fetch unavailable累計、
+  relation最終成功時刻を custom metrics へ送る。ピア不在・未複製によるmedia取得不能は
+  `media_fetch_unavailable_total` で観測するが、外部provider障害のpaging対象には含めない。
 - Terraform は各 custom metric descriptor と alert policy を作成する。通知を実配送するには、
   `monitoring_notification_channels` に既存 channel の resource name を設定して apply する。
 - 確認: `systemctl status kukuri-monitor.timer`、`systemctl start kukuri-monitor.service`、

--- a/infra/terraform/envs/low-cost/main.tf
+++ b/infra/terraform/envs/low-cost/main.tf
@@ -224,7 +224,11 @@ locals {
       unit         = "1"
     }
     provider_failure_detected = {
-      display_name = "Community Node provider failure detected"
+      display_name = "Community Node external safety provider failure detected"
+      unit         = "1"
+    }
+    media_fetch_unavailable_total = {
+      display_name = "Community Node media fetch unavailable total"
       unit         = "1"
     }
     relation_last_success_age_seconds = {
@@ -275,7 +279,7 @@ locals {
       }
       provider = {
         metric     = "provider_failure_detected"
-        display    = "Community Node safety provider failure"
+        display    = "Community Node external safety provider failure"
         comparison = "COMPARISON_GT"
         threshold  = 0.5
       }

--- a/infra/terraform/envs/low-cost/tests/deployment_summary.tftest.hcl
+++ b/infra/terraform/envs/low-cost/tests/deployment_summary.tftest.hcl
@@ -24,6 +24,21 @@ run "indexer_stack_enabled_summary" {
     condition     = output.deployment_profile_summary.index_moderation_trust == "provisioned (cn-indexer + ArcadeDB + relation analysis)"
     error_message = "deployment summary must report the enabled indexer stack as provisioned"
   }
+
+  assert {
+    condition     = google_monitoring_metric_descriptor.community_node["media_fetch_unavailable_total"].display_name == "Community Node media fetch unavailable total"
+    error_message = "media fetch unavailability must remain observable as a dedicated metric"
+  }
+
+  assert {
+    condition     = google_monitoring_alert_policy.community_node["provider"].display_name == "Community Node external safety provider failure"
+    error_message = "the provider alert must identify external safety provider failures"
+  }
+
+  assert {
+    condition     = !contains(keys(google_monitoring_alert_policy.community_node), "media_fetch_unavailable")
+    error_message = "peer-dependent media fetch unavailability must not create a paging alert"
+  }
 }
 
 run "indexer_stack_disabled_summary" {

--- a/infra/terraform/modules/gcp-vm-compose/templates/monitor.sh.tftpl
+++ b/infra/terraform/modules/gcp-vm-compose/templates/monitor.sh.tftpl
@@ -76,6 +76,12 @@ if [ "$provider_total" -gt "$previous_total" ]; then provider_failure=1; else pr
 printf '%s\n' "$provider_total" > "$provider_state"
 write_metric provider_failure_detected "$provider_failure"
 
+# Peer absence / incomplete replication is observable but is not an external safety provider
+# outage. Keep it as a non-paging metric so operators can distinguish the two causes.
+media_fetch_unavailable_total="$(printf '%s' "$status_json" | sed -n 's/.*"media_fetch_unavailable"[ ]*:[ ]*\([0-9][0-9]*\).*/\1/p')"
+media_fetch_unavailable_total="$${media_fetch_unavailable_total:-0}"
+write_metric media_fetch_unavailable_total "$media_fetch_unavailable_total"
+
 relation_timestamp="$(systemctl show kukuri-relation-analyze.service -p ExecMainExitTimestamp --value 2>/dev/null || true)"
 relation_epoch="$(date -d "$relation_timestamp" +%s 2>/dev/null || echo 0)"
 relation_status="$(systemctl show kukuri-relation-analyze.service -p ExecMainStatus --value 2>/dev/null || echo 1)"


### PR DESCRIPTION
## 概要
- media blobの未複製・ピア不在を外部safety provider障害カウンタから分離
- media取得不能を`media_fetch_unavailable_total`として非pagingで観測
- providerアラート名を外部safety provider障害と明示

## 種別
fix

## 挙動変更
取得不能なmediaは従来どおりfail-closedで索引しません。paging対象のみを外部provider障害に限定します。公開API・プロトコル・保存形式の変更はありません。

## 検証
- 回帰テストを修正前に失敗確認、修正後に成功
- `cargo test -p kukuri-cn-indexer --test ingestion_contracts`
- `cargo xtask cn-check`
- `cargo xtask cn-test`
- `cargo xtask check`
- `cargo xtask test`
- `cargo xtask oversized-files`
- `terraform -chdir=infra/terraform/envs/low-cost validate`
- `terraform -chdir=infra/terraform/envs/low-cost test`
- `terraform fmt -check -recursive`
- `cargo fmt --all -- --check`
- `git diff --check`

## リスク
scanはscope/entryごとに逐次実行される前提で、scan前後のmedia fetchカウンタ差分を使って分類します。外部provider障害は従来どおりpagingされます。

## 後続対応
マージ後にdigest固定のcn-indexer imageを作成し、Terraform plan/applyと本番監視確認を行います。